### PR TITLE
feat: add Cobalt audio downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,20 @@ For production, deploy Cobalt from upstream source and point Tagium at it with `
 If the Cobalt instance is private, set `COBALT_API_KEY` on Tagium and configure Cobalt API auth for the same key source.
 Set `COBALT_ALLOWED_ORIGIN` to the public Tagium origin when the request URL origin differs from the browser origin behind your host.
 The Tagium proxy enforces same-origin browser requests and limits each client to 120 download requests per minute.
+
+## Cloudflare deploy env
+
+`nitro.config.ts` configures the shared Cobalt API URL in Nitro's generated Wrangler config:
+
+```sh
+COBALT_API_URL=https://tagium-cobalt.fly.dev/
+```
+
+Set the API key as a Cloudflare secret, not in git:
+
+```sh
+wrangler secret put COBALT_API_KEY
+```
+
+Preview deployments should leave `COBALT_ALLOWED_ORIGIN` unset so each preview URL can use the same-origin fallback.
+Production can set `COBALT_ALLOWED_ORIGIN` to the final public Tagium origin once the domain is fixed.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # Tagium
 
 simple mp3tag editing for music fans
+
+## Cobalt audio downloads
+
+Run a self-hosted Cobalt API instance and expose its URL to the Tagium server:
+
+```sh
+pnpm --dir ../oss/cobalt install
+bun run dev:cobalt
+COBALT_API_URL=http://localhost:9000/ bun dev
+```
+
+Tagium requests MP3 audio through its own `/api/cobalt/audio` endpoint, which calls Cobalt server-side and streams the file back to the browser.
+SoundCloud set URLs are resolved by Tagium, downloaded track-by-track through Cobalt, then imported as one album.
+
+For production, deploy Cobalt from upstream source and point Tagium at it with `COBALT_API_URL`.
+If the Cobalt instance is private, set `COBALT_API_KEY` on Tagium and configure Cobalt API auth for the same key source.
+Set `COBALT_ALLOWED_ORIGIN` to the public Tagium origin when the request URL origin differs from the browser origin behind your host.
+The Tagium proxy enforces same-origin browser requests and limits each client to 120 download requests per minute.

--- a/components/audio/AudioDownloader.tsx
+++ b/components/audio/AudioDownloader.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useState } from "react";
+import { Download, Loader2, Link } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { downloadCobaltAudio, type AudioDownloadBitrate } from "./cobaltDownload";
+import { isSoundCloudSetUrl, resolveSoundCloudSet, toImportedAlbumMetadata } from "./soundcloudSet";
+import { ImportedAlbumMetadata } from "./types";
+
+const bitrateOptions: AudioDownloadBitrate[] = ["320", "256", "128", "96", "64"];
+
+const getDownloadErrorMessage = (error: Error) => {
+  if (error.message.includes("COBALT_API_URL is not configured.")) {
+    return "Set COBALT_API_URL on the Tagium server.";
+  }
+
+  if (error.message.includes("error.api.unreachable")) {
+    return "Cobalt API unreachable. Run bun run dev:cobalt and set COBALT_API_URL.";
+  }
+
+  if (error.message.includes("error.api.timed_out")) {
+    return "Cobalt API timed out.";
+  }
+
+  if (error.message.includes("error.tunnel.probe")) {
+    return "Cobalt tunnel failed before download.";
+  }
+
+  return error.message;
+};
+
+interface AudioDownloaderProps {
+  onAudioUpload: (audio: File[]) => void | Promise<void>;
+  onAlbumDownload: (audio: File[], album: ImportedAlbumMetadata) => void | Promise<void>;
+}
+
+export default function AudioDownloader({ onAudioUpload, onAlbumDownload }: AudioDownloaderProps) {
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [audioBitrate, setAudioBitrate] = useState<AudioDownloadBitrate>("320");
+  const [downloading, setDownloading] = useState(false);
+  const [progress, setProgress] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const canDownload = sourceUrl.trim().length > 0 && !downloading;
+
+  const handleDownload = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedUrl = sourceUrl.trim();
+    if (trimmedUrl.length === 0) {
+      return;
+    }
+
+    setDownloading(true);
+    setProgress(null);
+    setError(null);
+
+    try {
+      if (isSoundCloudSetUrl(trimmedUrl)) {
+        const set = await resolveSoundCloudSet(trimmedUrl);
+        const downloadedFiles: File[] = [];
+
+        for (const [index, track] of set.tracks.entries()) {
+          setProgress(`${index + 1}/${set.tracks.length}`);
+          downloadedFiles.push(
+            await downloadCobaltAudio({
+              sourceUrl: track.url,
+              audioBitrate,
+            }),
+          );
+        }
+
+        await onAlbumDownload(downloadedFiles, toImportedAlbumMetadata(set));
+        setSourceUrl("");
+        return;
+      }
+
+      const file = await downloadCobaltAudio({
+        sourceUrl: trimmedUrl,
+        audioBitrate,
+      });
+      await onAudioUpload([file]);
+      setSourceUrl("");
+    } catch (caughtError) {
+      let message = "Download failed.";
+      if (caughtError instanceof Error) {
+        message = getDownloadErrorMessage(caughtError);
+      }
+      setError(message);
+    } finally {
+      setProgress(null);
+      setDownloading(false);
+    }
+  };
+
+  return (
+    <form className="flex flex-col gap-2" onSubmit={handleDownload}>
+      <div className="flex items-center gap-2">
+        <div className="relative min-w-0 flex-1">
+          <Link className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={sourceUrl}
+            onChange={(event) => setSourceUrl(event.target.value)}
+            placeholder="Paste media URL"
+            className="pl-9"
+            disabled={downloading}
+          />
+        </div>
+        <select
+          value={audioBitrate}
+          onChange={(event) => setAudioBitrate(event.target.value as AudioDownloadBitrate)}
+          className="border-input bg-background h-9 rounded-md border px-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 dark:bg-input/30"
+          disabled={downloading}
+          aria-label="Audio bitrate"
+        >
+          {bitrateOptions.map((bitrate) => (
+            <option key={bitrate} value={bitrate}>
+              {bitrate}
+            </option>
+          ))}
+        </select>
+        <Button type="submit" size="icon" disabled={!canDownload} aria-label="Download audio">
+          {downloading && <Loader2 className="animate-spin" />}
+          {!downloading && <Download />}
+        </Button>
+      </div>
+      {progress && <p className="text-xs text-muted-foreground">Downloading {progress}</p>}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </form>
+  );
+}

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -2,8 +2,9 @@
 
 import type { MouseEvent as ReactMouseEvent } from "react";
 import AudioUpload from "./audioUpload";
+import AudioDownloader from "./AudioDownloader";
 import AlbumSidebar from "./AlbumSidebar";
-import { AlbumGroup, TagiumFile } from "./types";
+import { AlbumGroup, ImportedAlbumMetadata, TagiumFile } from "./types";
 import { Button } from "../ui/button";
 import { Card, CardHeader } from "@/components/ui/card";
 
@@ -16,6 +17,7 @@ interface TagSidebarPanelProps {
   selectedFileId: string | null;
   selectedFileIds: Set<string>;
   onAudioUpload: (files: File[]) => void;
+  onAlbumDownload: (files: File[], album: ImportedAlbumMetadata) => void;
   onSelectAlbum: (albumId: string, event?: ReactMouseEvent) => void;
   onSelectFile: (albumId: string, fileId: string, event?: ReactMouseEvent) => void;
   onSelectLooseTrack: (fileId: string, event?: ReactMouseEvent) => void;
@@ -50,6 +52,7 @@ export default function TagSidebarPanel({
   selectedFileId,
   selectedFileIds,
   onAudioUpload,
+  onAlbumDownload,
   onSelectAlbum,
   onSelectFile,
   onSelectLooseTrack,
@@ -68,7 +71,8 @@ export default function TagSidebarPanel({
   return (
     <div className="w-80 flex-shrink-0 flex flex-col gap-4">
       <Card className="h-full flex flex-col overflow-hidden py-0 gap-2">
-        <CardHeader className="p-6 border-b h-[104px]">
+        <CardHeader className="p-6 border-b gap-3">
+          <AudioDownloader onAudioUpload={onAudioUpload} onAlbumDownload={onAlbumDownload} />
           <AudioUpload onAudioUpload={onAudioUpload} />
         </CardHeader>
         <AlbumSidebar

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type { MouseEvent as ReactMouseEvent } from "react";
-import { useEffect, useLayoutEffect, useMemo, useState, useCallback } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 import filenamify from "filenamify";
 import AlbumMetadataDialog, { AlbumMetadataDraft } from "./AlbumMetadataDialog";
@@ -16,7 +16,7 @@ import { applyAlbumSharedTagsToFiles, applyTrackOrderNumbersToFiles } from "./fi
 import TagSidebarPanel from "./TagSidebarPanel";
 import TrackMetadataEditor from "./TrackMetadataEditor";
 import { parseUploadedTracks, toGenreString, writeMetadataToFile } from "./mp3Utils";
-import { AlbumGroup, AudioMetadata, TagiumFile } from "./types";
+import { AlbumGroup, AudioMetadata, ImportedAlbumMetadata, TagiumFile } from "./types";
 const EMPTY_ALBUM_DRAFT: AlbumMetadataDraft = {
   title: "",
   artist: "",
@@ -27,6 +27,29 @@ const EMPTY_ALBUM_DRAFT: AlbumMetadataDraft = {
   syncFilenames: true,
 };
 const asUniqueTrackIds = (trackIds: string[]) => [...new Set(trackIds)];
+const getFileImportKey = (file: File) => `${file.name}:${file.size}:${file.lastModified}`;
+const fetchImportedCover = async (coverUrl: string): Promise<AudioMetadata["picture"]> => {
+  const response = await fetch(coverUrl);
+
+  if (!response.ok) {
+    throw new Error(`Album cover request failed (${response.status})`);
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (!contentType) {
+    throw new Error("Album cover response missing content type.");
+  }
+
+  return [
+    {
+      format: contentType,
+      type: 3,
+      data: new Uint8Array(await response.arrayBuffer()),
+      description: "Album cover",
+    },
+  ];
+};
+
 export default function AudioTagger() {
   const [files, setFiles] = useState<TagiumFile[]>([]);
   const [albums, setAlbums] = useState<AlbumGroup[]>([]);
@@ -41,6 +64,12 @@ export default function AudioTagger() {
   const [albumDraft, setAlbumDraft] = useState<AlbumMetadataDraft>(EMPTY_ALBUM_DRAFT);
   const [editingAlbumId, setEditingAlbumId] = useState<string | null>(null);
   const [createSeedTrackIds, setCreateSeedTrackIds] = useState<string[]>([]);
+  const filesRef = useRef<TagiumFile[]>(files);
+  const albumsRef = useRef<AlbumGroup[]>(albums);
+  const importQueueRef = useRef(Promise.resolve());
+  const pendingImportKeysRef = useRef(new Set<string>());
+  filesRef.current = files;
+  albumsRef.current = albums;
   const { register, handleSubmit, control, setValue, reset } = useForm<AudioMetadata>();
   const selectedFile = useMemo(
     () => files.find((file) => file.id === selectedFileId) ?? null,
@@ -58,7 +87,7 @@ export default function AudioTagger() {
   useEffect(() => {
     const fileIdSet = new Set(files.map((file) => file.id));
     setLooseTrackIds((prevLooseTrackIds) =>
-      prevLooseTrackIds.filter((trackId) => fileIdSet.has(trackId)),
+      asUniqueTrackIds(prevLooseTrackIds.filter((trackId) => fileIdSet.has(trackId))),
     );
   }, [files]);
   useEffect(() => {
@@ -136,61 +165,126 @@ export default function AudioTagger() {
       console.error("Failed to update tags:", error);
     }
   };
-  const handleAudioUpload = async (uploadedFiles: File[], targetAlbumId?: string) => {
-    setLoading(true);
-    try {
-      const parsedUploads = await parseUploadedTracks(uploadedFiles);
-      if (parsedUploads.length === 0) return;
-      setFiles((prevFiles) => [...prevFiles, ...parsedUploads.map((upload) => upload.file)]);
-      const hasTargetAlbum = Boolean(
-        targetAlbumId && albums.some((album) => album.id === targetAlbumId),
+  const handleAudioUpload = async (
+    uploadedFiles: File[],
+    targetAlbumId?: string,
+    importedAlbum?: ImportedAlbumMetadata,
+  ) => {
+    const runImport = async () => {
+      const existingImportKeys = new Set(
+        filesRef.current.map((file) => getFileImportKey(file.originalFile)),
       );
-      const forceSingleAlbum = !hasTargetAlbum && parsedUploads.length > 1;
-      let firstSelectedAlbumId: string | null = null;
-      if (hasTargetAlbum && targetAlbumId) {
-        const uploadedTrackIds = parsedUploads.map((upload) => upload.file.id);
-        let nextAlbums: AlbumGroup[] = [];
-        setAlbums((prevAlbums) => {
-          nextAlbums = prevAlbums.map((album) =>
+      const reservedImportKeys: string[] = [];
+      const uniqueUploadedFiles = uploadedFiles.filter((file) => {
+        const importKey = getFileImportKey(file);
+        if (existingImportKeys.has(importKey) || pendingImportKeysRef.current.has(importKey)) {
+          return false;
+        }
+        existingImportKeys.add(importKey);
+        pendingImportKeysRef.current.add(importKey);
+        reservedImportKeys.push(importKey);
+        return true;
+      });
+
+      if (uniqueUploadedFiles.length === 0) return;
+
+      setLoading(true);
+      try {
+        const parsedUploads = await parseUploadedTracks(uniqueUploadedFiles);
+        if (parsedUploads.length === 0) return;
+
+        const nextFiles = [...filesRef.current, ...parsedUploads.map((upload) => upload.file)];
+        filesRef.current = nextFiles;
+        setFiles(nextFiles);
+
+        const currentAlbums = albumsRef.current;
+        const hasTargetAlbum = Boolean(
+          targetAlbumId && currentAlbums.some((album) => album.id === targetAlbumId),
+        );
+        const forceSingleAlbum =
+          !hasTargetAlbum && (parsedUploads.length > 1 || Boolean(importedAlbum));
+        let firstSelectedAlbumId: string | null = null;
+
+        if (hasTargetAlbum && targetAlbumId) {
+          const uploadedTrackIds = parsedUploads.map((upload) => upload.file.id);
+          const nextAlbums = currentAlbums.map((album) =>
             album.id === targetAlbumId
-              ? { ...album, trackIds: [...album.trackIds, ...uploadedTrackIds] }
+              ? { ...album, trackIds: asUniqueTrackIds([...album.trackIds, ...uploadedTrackIds]) }
               : album,
           );
-          return nextAlbums;
-        });
-        const targetAlbum = nextAlbums.find((album) => album.id === targetAlbumId);
-        if (targetAlbum) {
-          setFiles((prevFiles) => applyAlbumSharedTagsToFiles(prevFiles, targetAlbum));
-          if (targetAlbum.syncTrackNumbers) {
-            setFiles((prevFiles) =>
-              applyTrackOrderNumbersToFiles(prevFiles, nextAlbums, [targetAlbumId]),
-            );
+          albumsRef.current = nextAlbums;
+          setAlbums(nextAlbums);
+          const targetAlbum = nextAlbums.find((album) => album.id === targetAlbumId);
+          if (targetAlbum) {
+            let taggedFiles = applyAlbumSharedTagsToFiles(filesRef.current, targetAlbum);
+            if (targetAlbum.syncTrackNumbers) {
+              taggedFiles = applyTrackOrderNumbersToFiles(taggedFiles, nextAlbums, [targetAlbumId]);
+            }
+            filesRef.current = taggedFiles;
+            setFiles(taggedFiles);
           }
-        }
-        setSelectedFileId(parsedUploads[0].file.id);
-        setSelectedAlbumId(targetAlbumId);
-      } else {
-        setAlbums((prevAlbums) => {
-          const merged = mergeUploadedTracksIntoAlbums(prevAlbums, parsedUploads, {
+          setSelectedFileId(parsedUploads[0].file.id);
+          setSelectedAlbumId(targetAlbumId);
+        } else if (importedAlbum) {
+          let importedCover: AudioMetadata["picture"] | undefined;
+          if (importedAlbum.coverUrl) {
+            try {
+              importedCover = await fetchImportedCover(importedAlbum.coverUrl);
+            } catch (error) {
+              console.warn("Failed to import album cover:", error);
+            }
+          }
+          const embeddedCover = parsedUploads.find((upload) => upload.albumSeed.cover)?.albumSeed
+            .cover;
+          const downloadedAlbum: AlbumGroup = {
+            id: crypto.randomUUID(),
+            title: importedAlbum.title,
+            artist: importedAlbum.artist,
+            genre: importedAlbum.genre,
+            cover: importedCover ?? embeddedCover,
+            trackIds: parsedUploads.map((upload) => upload.file.id),
+            year: importedAlbum.year,
+            syncTrackNumbers: true,
+            syncFilenames: false,
+          };
+          const nextAlbums = [...currentAlbums, downloadedAlbum];
+          albumsRef.current = nextAlbums;
+          setAlbums(nextAlbums);
+          const taggedFiles = applyTrackOrderNumbersToFiles(
+            applyAlbumSharedTagsToFiles(filesRef.current, downloadedAlbum),
+            nextAlbums,
+            [downloadedAlbum.id],
+          );
+          filesRef.current = taggedFiles;
+          setFiles(taggedFiles);
+          setSelectedFileId(parsedUploads[0].file.id);
+          setSelectedAlbumId(downloadedAlbum.id);
+        } else {
+          const merged = mergeUploadedTracksIntoAlbums(currentAlbums, parsedUploads, {
             forceSingleAlbum,
           });
           firstSelectedAlbumId = merged.firstSelectedAlbumId;
+          albumsRef.current = merged.albums;
+          setAlbums(merged.albums);
           if (!forceSingleAlbum && merged.unassignedTrackIds.length > 0) {
-            setLooseTrackIds((prevLooseTrackIds) => [
-              ...prevLooseTrackIds,
-              ...merged.unassignedTrackIds,
-            ]);
+            setLooseTrackIds((prevLooseTrackIds) =>
+              asUniqueTrackIds([...prevLooseTrackIds, ...merged.unassignedTrackIds]),
+            );
           }
-          return merged.albums;
-        });
-        const firstUploadedTrack = parsedUploads[0];
-        const firstTrackIsLoose = !forceSingleAlbum && !firstUploadedTrack.albumSeed.title.trim();
-        setSelectedFileId(firstUploadedTrack.file.id);
-        setSelectedAlbumId(firstTrackIsLoose ? null : firstSelectedAlbumId);
+          const firstUploadedTrack = parsedUploads[0];
+          const firstTrackIsLoose = !forceSingleAlbum && !firstUploadedTrack.albumSeed.title.trim();
+          setSelectedFileId(firstUploadedTrack.file.id);
+          setSelectedAlbumId(firstTrackIsLoose ? null : firstSelectedAlbumId);
+        }
+      } finally {
+        reservedImportKeys.forEach((importKey) => pendingImportKeysRef.current.delete(importKey));
+        setLoading(false);
       }
-    } finally {
-      setLoading(false);
-    }
+    };
+
+    const queuedImport = importQueueRef.current.then(runImport, runImport);
+    importQueueRef.current = queuedImport.catch(() => undefined);
+    await queuedImport;
   };
   const handleSaveAll = async () => {
     if (files.length === 0) return;
@@ -659,6 +753,9 @@ export default function AudioTagger() {
           selectedFileId={selectedFileId}
           selectedFileIds={selectedFileIds}
           onAudioUpload={handleAudioUpload}
+          onAlbumDownload={(downloadedFiles, album) =>
+            handleAudioUpload(downloadedFiles, undefined, album)
+          }
           onSelectAlbum={handleSelectAlbum}
           onSelectFile={handleSelectFile}
           onSelectLooseTrack={handleSelectLooseTrack}

--- a/components/audio/audioUpload.tsx
+++ b/components/audio/audioUpload.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
-import { useRef } from "react";
+import { useId, useRef } from "react";
 import { Upload } from "lucide-react";
 
 interface AudioUploadProps {
@@ -11,6 +11,7 @@ interface AudioUploadProps {
 
 export default function AudioUpload({ onAudioUpload }: AudioUploadProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const inputId = useId();
 
   const handleAudioUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
@@ -34,7 +35,7 @@ export default function AudioUpload({ onAudioUpload }: AudioUploadProps) {
     <div className="w-full">
       <Input
         type="file"
-        id="audio"
+        id={inputId}
         className="hidden"
         accept="audio/*"
         onChange={handleAudioUpload}
@@ -45,6 +46,7 @@ export default function AudioUpload({ onAudioUpload }: AudioUploadProps) {
         variant="outline"
         className="w-full cursor-pointer border-dashed border-2 h-12 hover:bg-accent/50 flex flex-col gap-2"
         onClick={handleButtonClick}
+        aria-label="Upload audio files"
       >
         <Upload className="h-6 w-6 text-muted-foreground" />
       </Button>

--- a/components/audio/cobaltDownload.ts
+++ b/components/audio/cobaltDownload.ts
@@ -1,0 +1,40 @@
+export type AudioDownloadBitrate = "320" | "256" | "128" | "96" | "64";
+
+interface CobaltAudioDownloadRequest {
+  sourceUrl: string;
+  audioBitrate: AudioDownloadBitrate;
+}
+
+const getStableLastModified = (sourceUrl: string) =>
+  Array.from(sourceUrl).reduce((hash, character) => {
+    return (hash * 31 + character.charCodeAt(0)) % 2_147_483_647;
+  }, 1);
+
+export async function downloadCobaltAudio({ sourceUrl, audioBitrate }: CobaltAudioDownloadRequest) {
+  const response = await fetch("/api/cobalt/audio", {
+    method: "POST",
+    headers: {
+      Accept: "audio/mpeg",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      url: sourceUrl,
+      audioBitrate,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+
+  const filename = response.headers.get("X-Tagium-Filename");
+  if (!filename) {
+    throw new Error("Tagium audio proxy missing filename.");
+  }
+
+  const blob = await response.blob();
+  return new File([blob], decodeURIComponent(filename), {
+    type: blob.type,
+    lastModified: getStableLastModified(sourceUrl),
+  });
+}

--- a/components/audio/soundcloudSet.ts
+++ b/components/audio/soundcloudSet.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import { ImportedAlbumMetadata } from "./types";
+
+const soundCloudSetSchema = z.object({
+  title: z.string(),
+  artist: z.string(),
+  genre: z.string(),
+  year: z.number().optional(),
+  coverUrl: z.string().optional(),
+  tracks: z.array(
+    z.object({
+      title: z.string(),
+      url: z.string().url(),
+      duration: z.number().optional(),
+      trackNumber: z.number(),
+    }),
+  ),
+});
+
+export type SoundCloudSet = z.infer<typeof soundCloudSetSchema>;
+
+export const isSoundCloudSetUrl = (url: string) => {
+  try {
+    const parsedUrl = new URL(url);
+    const isSoundCloudHost =
+      parsedUrl.hostname === "soundcloud.com" || parsedUrl.hostname.endsWith(".soundcloud.com");
+    return isSoundCloudHost && parsedUrl.pathname.includes("/sets/");
+  } catch {
+    return false;
+  }
+};
+
+export const resolveSoundCloudSet = async (url: string) => {
+  const endpoint = new URL("/api/soundcloud-set", window.location.origin);
+  endpoint.searchParams.set("url", url);
+
+  const response = await fetch(endpoint);
+  if (!response.ok) {
+    throw new Error(`SoundCloud set request failed (${response.status})`);
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (!contentType?.includes("application/json")) {
+    throw new Error("SoundCloud set route returned non-JSON. Restart Tagium dev server.");
+  }
+
+  return soundCloudSetSchema.parse(await response.json());
+};
+
+export const toImportedAlbumMetadata = (set: SoundCloudSet): ImportedAlbumMetadata => ({
+  title: set.title,
+  artist: set.artist,
+  genre: set.genre,
+  year: set.year,
+  coverUrl: set.coverUrl,
+});

--- a/components/audio/types.ts
+++ b/components/audio/types.ts
@@ -43,3 +43,11 @@ export interface AlbumGroup {
   syncTrackNumbers: boolean;
   syncFilenames: boolean;
 }
+
+export interface ImportedAlbumMetadata {
+  title: string;
+  artist: string;
+  genre: string;
+  year?: number;
+  coverUrl?: string;
+}

--- a/nitro.config.ts
+++ b/nitro.config.ts
@@ -2,6 +2,7 @@ import { defineNitroConfig } from "nitro/config";
 
 export default defineNitroConfig({
   compatibilityDate: "2026-04-08",
+  serverDir: "server",
   preset: "cloudflare_module",
   cloudflare: {
     deployConfig: true,

--- a/nitro.config.ts
+++ b/nitro.config.ts
@@ -7,5 +7,11 @@ export default defineNitroConfig({
   cloudflare: {
     deployConfig: true,
     nodeCompat: true,
+    wrangler: {
+      keep_vars: true,
+      vars: {
+        COBALT_API_URL: "https://tagium-cobalt.fly.dev/",
+      },
+    },
   },
 });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vp dev",
+    "dev:cobalt": "API_URL=http://localhost:9000/ pnpm --dir ../oss/cobalt/api start",
     "build": "tsc -b && vp build",
     "lint": "vp lint .",
     "lint:fix": "vp lint . --fix",

--- a/server/api/cobalt/audio.post.ts
+++ b/server/api/cobalt/audio.post.ts
@@ -7,7 +7,7 @@
  * and returns the downloaded audio bytes to the browser.
  */
 import { defineHandler } from "nitro";
-import { env } from "node:process";
+import { env as processEnv } from "node:process";
 import { z } from "zod";
 
 enum CobaltResponseType {
@@ -51,28 +51,45 @@ const cobaltResponseSchema = z.discriminatedUnion("status", [
 ]);
 
 type CobaltResponse = z.infer<typeof cobaltResponseSchema>;
+type CobaltRuntimeEnv = {
+  COBALT_ALLOWED_ORIGIN?: string;
+  COBALT_API_KEY?: string;
+  COBALT_API_URL?: string;
+};
+type CloudflareRequest = Request & {
+  runtime?: {
+    cloudflare?: {
+      env?: CobaltRuntimeEnv;
+    };
+  };
+};
 
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_REQUESTS = 120;
 const COBALT_REQUEST_TIMEOUT_MS = 300_000;
 const rateLimitBuckets = new Map<string, { startedAt: number; count: number }>();
 
-const getCobaltApiUrl = () => {
-  if (!env.COBALT_API_URL) {
+const getRuntimeEnv = (request: Request): CobaltRuntimeEnv => ({
+  ...processEnv,
+  ...(request as CloudflareRequest).runtime?.cloudflare?.env,
+});
+
+const getCobaltApiUrl = (runtimeEnv: CobaltRuntimeEnv) => {
+  if (!runtimeEnv.COBALT_API_URL) {
     throw new Error("COBALT_API_URL is not configured.");
   }
 
-  return env.COBALT_API_URL;
+  return runtimeEnv.COBALT_API_URL;
 };
 
-const getCobaltHeaders = () => {
+const getCobaltHeaders = (runtimeEnv: CobaltRuntimeEnv) => {
   const headers: Record<string, string> = {
     Accept: "application/json",
     "Content-Type": "application/json",
   };
 
-  if (env.COBALT_API_KEY) {
-    headers.Authorization = `Api-Key ${env.COBALT_API_KEY}`;
+  if (runtimeEnv.COBALT_API_KEY) {
+    headers.Authorization = `Api-Key ${runtimeEnv.COBALT_API_KEY}`;
   }
 
   return headers;
@@ -88,9 +105,13 @@ const getRequestOrigin = (request: Request) => {
   return origin;
 };
 
-const getAllowedOrigin = (request: Request, requestOrigin: string) => {
-  if (env.COBALT_ALLOWED_ORIGIN) {
-    return env.COBALT_ALLOWED_ORIGIN;
+const getAllowedOrigin = (
+  request: Request,
+  requestOrigin: string,
+  runtimeEnv: CobaltRuntimeEnv,
+) => {
+  if (runtimeEnv.COBALT_ALLOWED_ORIGIN) {
+    return runtimeEnv.COBALT_ALLOWED_ORIGIN;
   }
 
   return new URL(request.url, requestOrigin).origin;
@@ -105,13 +126,13 @@ const getClientKey = (request: Request) => {
   return "unknown";
 };
 
-const enforceSameOrigin = (request: Request) => {
+const enforceSameOrigin = (request: Request, runtimeEnv: CobaltRuntimeEnv) => {
   const requestOrigin = getRequestOrigin(request);
   if (!requestOrigin) {
     return new Response("Download requests require an Origin header.", { status: 403 });
   }
 
-  const allowedOrigin = getAllowedOrigin(request, requestOrigin);
+  const allowedOrigin = getAllowedOrigin(request, requestOrigin, runtimeEnv);
   if (requestOrigin !== allowedOrigin) {
     return new Response("Download origin is not allowed.", { status: 403 });
   }
@@ -147,16 +168,20 @@ const parseCobaltJson = async (response: Response) => {
   return cobaltResponseSchema.parse(await response.json());
 };
 
-const requestCobaltAudio = async (url: string, audioBitrate: string) => {
+const requestCobaltAudio = async (
+  runtimeEnv: CobaltRuntimeEnv,
+  url: string,
+  audioBitrate: string,
+) => {
   let response: Response;
 
   try {
-    const endpoint = new URL("/", getCobaltApiUrl());
+    const endpoint = new URL("/", getCobaltApiUrl(runtimeEnv));
     response = await fetch(endpoint, {
       method: "POST",
       redirect: "manual",
       signal: AbortSignal.timeout(COBALT_REQUEST_TIMEOUT_MS),
-      headers: getCobaltHeaders(),
+      headers: getCobaltHeaders(runtimeEnv),
       body: JSON.stringify({
         url,
         downloadMode: "audio",
@@ -237,7 +262,8 @@ const parseAudioRequest = async (request: Request) => {
 
 export default defineHandler(async (event) => {
   try {
-    const forbidden = enforceSameOrigin(event.req);
+    const runtimeEnv = getRuntimeEnv(event.req);
+    const forbidden = enforceSameOrigin(event.req, runtimeEnv);
     if (forbidden) {
       return forbidden;
     }
@@ -252,7 +278,7 @@ export default defineHandler(async (event) => {
       return new Response("Invalid audio download request.", { status: 400 });
     }
 
-    const cobaltResponse = await requestCobaltAudio(body.url, body.audioBitrate);
+    const cobaltResponse = await requestCobaltAudio(runtimeEnv, body.url, body.audioBitrate);
 
     if (cobaltResponse.status === CobaltResponseType.Error) {
       return cobaltErrorResponse(cobaltResponse.error.code);

--- a/server/api/cobalt/audio.post.ts
+++ b/server/api/cobalt/audio.post.ts
@@ -1,0 +1,290 @@
+/*
+ * Adapted from imputnet/cobalt:
+ * - web/src/lib/types/api.ts
+ * - web/src/lib/api/api.ts
+ *
+ * Changes: runs server-side in Tagium, uses server env for Cobalt URL/auth,
+ * and returns the downloaded audio bytes to the browser.
+ */
+import { defineHandler } from "nitro";
+import { env } from "node:process";
+import { z } from "zod";
+
+enum CobaltResponseType {
+  Error = "error",
+  Picker = "picker",
+  Redirect = "redirect",
+  Tunnel = "tunnel",
+  LocalProcessing = "local-processing",
+}
+
+const audioRequestSchema = z.object({
+  url: z.string().url(),
+  audioBitrate: z.enum(["320", "256", "128", "96", "64"]),
+});
+
+const cobaltResponseSchema = z.discriminatedUnion("status", [
+  z.object({
+    status: z.literal(CobaltResponseType.Error),
+    error: z.object({
+      code: z.string(),
+    }),
+  }),
+  z.object({
+    status: z.literal(CobaltResponseType.Picker),
+    audio: z.string().url().optional(),
+    audioFilename: z.string().optional(),
+  }),
+  z.object({
+    status: z.literal(CobaltResponseType.Redirect),
+    url: z.string().url(),
+    filename: z.string(),
+  }),
+  z.object({
+    status: z.literal(CobaltResponseType.Tunnel),
+    url: z.string().url(),
+    filename: z.string(),
+  }),
+  z.object({
+    status: z.literal(CobaltResponseType.LocalProcessing),
+  }),
+]);
+
+type CobaltResponse = z.infer<typeof cobaltResponseSchema>;
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 120;
+const COBALT_REQUEST_TIMEOUT_MS = 300_000;
+const rateLimitBuckets = new Map<string, { startedAt: number; count: number }>();
+
+const getCobaltApiUrl = () => {
+  if (!env.COBALT_API_URL) {
+    throw new Error("COBALT_API_URL is not configured.");
+  }
+
+  return env.COBALT_API_URL;
+};
+
+const getCobaltHeaders = () => {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  };
+
+  if (env.COBALT_API_KEY) {
+    headers.Authorization = `Api-Key ${env.COBALT_API_KEY}`;
+  }
+
+  return headers;
+};
+
+const getRequestOrigin = (request: Request) => {
+  const origin = request.headers.get("origin");
+
+  if (!origin) {
+    return undefined;
+  }
+
+  return origin;
+};
+
+const getAllowedOrigin = (request: Request, requestOrigin: string) => {
+  if (env.COBALT_ALLOWED_ORIGIN) {
+    return env.COBALT_ALLOWED_ORIGIN;
+  }
+
+  return new URL(request.url, requestOrigin).origin;
+};
+
+const getClientKey = (request: Request) => {
+  const cloudflareIp = request.headers.get("cf-connecting-ip");
+  if (cloudflareIp) {
+    return cloudflareIp;
+  }
+
+  return "unknown";
+};
+
+const enforceSameOrigin = (request: Request) => {
+  const requestOrigin = getRequestOrigin(request);
+  if (!requestOrigin) {
+    return new Response("Download requests require an Origin header.", { status: 403 });
+  }
+
+  const allowedOrigin = getAllowedOrigin(request, requestOrigin);
+  if (requestOrigin !== allowedOrigin) {
+    return new Response("Download origin is not allowed.", { status: 403 });
+  }
+
+  return undefined;
+};
+
+const enforceRateLimit = (request: Request) => {
+  const clientKey = getClientKey(request);
+  const now = Date.now();
+  const bucket = rateLimitBuckets.get(clientKey);
+
+  if (!bucket || now - bucket.startedAt >= RATE_LIMIT_WINDOW_MS) {
+    rateLimitBuckets.set(clientKey, { startedAt: now, count: 1 });
+    return undefined;
+  }
+
+  if (bucket.count >= RATE_LIMIT_MAX_REQUESTS) {
+    return new Response("Download rate limit exceeded.", { status: 429 });
+  }
+
+  bucket.count += 1;
+  return undefined;
+};
+
+const parseCobaltJson = async (response: Response) => {
+  const contentType = response.headers.get("content-type") ?? "";
+
+  if (!contentType.includes("application/json")) {
+    throw new Error(`Cobalt API returned non-JSON (${response.status}).`);
+  }
+
+  return cobaltResponseSchema.parse(await response.json());
+};
+
+const requestCobaltAudio = async (url: string, audioBitrate: string) => {
+  let response: Response;
+
+  try {
+    const endpoint = new URL("/", getCobaltApiUrl());
+    response = await fetch(endpoint, {
+      method: "POST",
+      redirect: "manual",
+      signal: AbortSignal.timeout(COBALT_REQUEST_TIMEOUT_MS),
+      headers: getCobaltHeaders(),
+      body: JSON.stringify({
+        url,
+        downloadMode: "audio",
+        audioFormat: "mp3",
+        audioBitrate,
+        alwaysProxy: true,
+        localProcessing: "disabled",
+        filenameStyle: "pretty",
+      }),
+    });
+  } catch (error) {
+    let code = "error.api.unreachable";
+    if (error instanceof Error && error.message.includes("timed out")) {
+      code = "error.api.timed_out";
+    }
+
+    return {
+      status: CobaltResponseType.Error,
+      error: { code },
+    } satisfies CobaltResponse;
+  }
+
+  try {
+    return await parseCobaltJson(response);
+  } catch (error) {
+    let code = "error.api.invalid_response";
+    if (error instanceof Error) {
+      code = error.message;
+    }
+
+    return {
+      status: CobaltResponseType.Error,
+      error: { code },
+    } satisfies CobaltResponse;
+  }
+};
+
+const probeCobaltTunnel = async (url: string) => {
+  const response = await fetch(`${url}&p=1`).catch(() => undefined);
+  return response?.status === 200;
+};
+
+const fetchAudioResponse = async (url: string, filename: string) => {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Cobalt file request failed (${response.status}).`);
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (!contentType) {
+    throw new Error("Cobalt file response missing content type.");
+  }
+
+  return new Response(response.body, {
+    headers: {
+      "Content-Type": contentType,
+      "X-Tagium-Filename": encodeURIComponent(filename),
+    },
+  });
+};
+
+const cobaltErrorResponse = (message: string) =>
+  new Response(message, {
+    status: 502,
+    headers: {
+      "Content-Type": "text/plain;charset=UTF-8",
+    },
+  });
+
+const parseAudioRequest = async (request: Request) => {
+  try {
+    return audioRequestSchema.parse(await request.json());
+  } catch {
+    return undefined;
+  }
+};
+
+export default defineHandler(async (event) => {
+  try {
+    const forbidden = enforceSameOrigin(event.req);
+    if (forbidden) {
+      return forbidden;
+    }
+
+    const limited = enforceRateLimit(event.req);
+    if (limited) {
+      return limited;
+    }
+
+    const body = await parseAudioRequest(event.req);
+    if (!body) {
+      return new Response("Invalid audio download request.", { status: 400 });
+    }
+
+    const cobaltResponse = await requestCobaltAudio(body.url, body.audioBitrate);
+
+    if (cobaltResponse.status === CobaltResponseType.Error) {
+      return cobaltErrorResponse(cobaltResponse.error.code);
+    }
+
+    if (cobaltResponse.status === CobaltResponseType.LocalProcessing) {
+      return cobaltErrorResponse(
+        "Cobalt returned local processing; use a server-side tunnel instance.",
+      );
+    }
+
+    if (cobaltResponse.status === CobaltResponseType.Picker) {
+      if (!cobaltResponse.audio || !cobaltResponse.audioFilename) {
+        return cobaltErrorResponse("Cobalt returned multiple items without a single audio file.");
+      }
+
+      return fetchAudioResponse(cobaltResponse.audio, cobaltResponse.audioFilename);
+    }
+
+    if (cobaltResponse.status === CobaltResponseType.Tunnel) {
+      const tunnelIsReady = await probeCobaltTunnel(cobaltResponse.url);
+      if (!tunnelIsReady) {
+        return cobaltErrorResponse("error.tunnel.probe");
+      }
+    }
+
+    return fetchAudioResponse(cobaltResponse.url, cobaltResponse.filename);
+  } catch (error) {
+    if (error instanceof Error) {
+      return cobaltErrorResponse(error.message);
+    }
+
+    return cobaltErrorResponse("Download failed.");
+  }
+});

--- a/server/api/soundcloud-set.get.ts
+++ b/server/api/soundcloud-set.get.ts
@@ -1,0 +1,162 @@
+/*
+ * SoundCloud client id discovery adapted from imputnet/cobalt:
+ * api/src/processing/services/soundcloud.js
+ */
+import { defineHandler } from "nitro";
+import { z } from "zod";
+
+const cachedClient = {
+  version: "",
+  id: "",
+};
+const TRACK_RESOLVE_CONCURRENCY = 4;
+
+const soundCloudTrackSchema = z.object({
+  id: z.number(),
+  kind: z.literal("track"),
+  title: z.string().optional(),
+  permalink_url: z.string().url().optional(),
+  duration: z.number().optional(),
+});
+const soundCloudTrackListEntrySchema = z.unknown().transform((entry) => {
+  const parsedEntry = soundCloudTrackSchema.safeParse(entry);
+  return parsedEntry.success ? parsedEntry.data : undefined;
+});
+
+const soundCloudPlaylistSchema = z.object({
+  kind: z.literal("playlist"),
+  title: z.string(),
+  genre: z.string().optional(),
+  display_date: z.string().optional(),
+  artwork_url: z.string().nullable().optional(),
+  user: z
+    .object({
+      username: z.string().optional(),
+    })
+    .optional(),
+  tracks: z.array(soundCloudTrackListEntrySchema),
+});
+const soundCloudResolvedTrackSchema = soundCloudTrackSchema.extend({
+  title: z.string(),
+  permalink_url: z.string().url(),
+});
+
+const findClientId = async () => {
+  const html = await fetch("https://soundcloud.com/").then((response) => response.text());
+  const version = html
+    .match(/<script>window\.__sc_version="[0-9]{10}"<\/script>/)?.[0]
+    .match(/[0-9]{10}/)?.[0];
+
+  if (version && cachedClient.version === version) {
+    return cachedClient.id;
+  }
+
+  const hydratedClientId = html.match(
+    /"hydratable"\s*:\s*"apiClient"\s*,\s*"data"\s*:\s*\{\s*"id"\s*:\s*"([^"]+)"/,
+  )?.[1];
+
+  if (hydratedClientId) {
+    cachedClient.version = version ?? "";
+    cachedClient.id = hydratedClientId;
+    return hydratedClientId;
+  }
+
+  for (const script of html.matchAll(/<script.+src="(.+)">/g)) {
+    const scriptUrl = script[1];
+    if (!scriptUrl?.startsWith("https://a-v2.sndcdn.com/")) {
+      continue;
+    }
+
+    const scriptText = await fetch(scriptUrl).then((response) => response.text());
+    const scriptClientId = scriptText.match(/,client_id:"([A-Za-z0-9]{32})",/)?.[1];
+    if (scriptClientId) {
+      cachedClient.version = version ?? "";
+      cachedClient.id = scriptClientId;
+      return scriptClientId;
+    }
+  }
+
+  throw new Error("soundcloud.client_id");
+};
+
+const getCoverUrl = (artworkUrl: string | null | undefined) => {
+  if (!artworkUrl) {
+    return undefined;
+  }
+
+  return artworkUrl.replace(/-large/, "-t1080x1080");
+};
+
+const getYear = (displayDate: string | undefined) => {
+  const year = Number.parseInt(displayDate?.slice(0, 4) ?? "", 10);
+  return Number.isNaN(year) ? undefined : year;
+};
+
+const resolveTrack = async (clientId: string, track: z.infer<typeof soundCloudTrackSchema>) => {
+  if (track.title && track.permalink_url) {
+    return soundCloudResolvedTrackSchema.parse(track);
+  }
+
+  const trackUrl = new URL(`https://api-v2.soundcloud.com/tracks/${track.id}`);
+  trackUrl.searchParams.set("client_id", clientId);
+  return soundCloudResolvedTrackSchema.parse(
+    await fetch(trackUrl).then((response) => response.json()),
+  );
+};
+
+const resolveTracks = async (clientId: string, tracks: z.infer<typeof soundCloudTrackSchema>[]) => {
+  const resolvedTracks: z.infer<typeof soundCloudResolvedTrackSchema>[] = [];
+
+  for (let index = 0; index < tracks.length; index += TRACK_RESOLVE_CONCURRENCY) {
+    const chunk = tracks.slice(index, index + TRACK_RESOLVE_CONCURRENCY);
+    const settledTracks = await Promise.allSettled(
+      chunk.map((track) => resolveTrack(clientId, track)),
+    );
+
+    for (const settledTrack of settledTracks) {
+      if (settledTrack.status === "fulfilled") {
+        resolvedTracks.push(settledTrack.value);
+      }
+    }
+  }
+
+  if (resolvedTracks.length === 0) {
+    throw new Error("soundcloud.no_resolvable_tracks");
+  }
+
+  return resolvedTracks;
+};
+
+export default defineHandler(async (event) => {
+  const requestUrl = new URL(event.req.url, "http://tagium.local");
+  const sourceUrl = requestUrl.searchParams.get("url");
+
+  if (!sourceUrl) {
+    throw new Error("soundcloud.url_required");
+  }
+
+  const clientId = await findClientId();
+  const resolveUrl = new URL("https://api-v2.soundcloud.com/resolve");
+  resolveUrl.searchParams.set("url", sourceUrl);
+  resolveUrl.searchParams.set("client_id", clientId);
+
+  const playlist = soundCloudPlaylistSchema.parse(
+    await fetch(resolveUrl).then((response) => response.json()),
+  );
+  const trackEntries = playlist.tracks.filter((track) => track !== undefined);
+  const tracks = await resolveTracks(clientId, trackEntries);
+
+  return {
+    title: playlist.title.trim(),
+    artist: playlist.user?.username?.trim() ?? "",
+    genre: playlist.genre?.trim() ?? "",
+    year: getYear(playlist.display_date),
+    coverUrl: getCoverUrl(playlist.artwork_url),
+    tracks: tracks.map((track, index) => ({
+      title: track.title.trim(),
+      url: track.permalink_url,
+      duration: track.duration,
+      trackNumber: index + 1,
+    })),
+  };
+});

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -16,5 +16,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "nitro.config.ts", "server"]
 }


### PR DESCRIPTION
## Summary
- add a Tagium server-side Cobalt audio proxy and client downloader UI
- support SoundCloud set resolution/import as album metadata
- serialize/dedupe imports, including stable duplicate keys for downloaded files
- document local/prod Cobalt setup

## Verification
- vp fmt
- vp lint .
- vp check
- vp test
- curl malformed /api/cobalt/audio request returns 400 text/plain

## Review loop
- antagonistic review rounds found and fixed stale import state, timeout/rate/security setup, SoundCloud set parsing/concurrency, request validation, and downloaded duplicate-key issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Download audio from media URLs with adjustable bitrate selection (64–320 kbps).
  * Import SoundCloud playlists as complete albums with metadata.
  * Rate limiting enforced: 120 downloads per minute per client.

* **Documentation**
  * Added guide for self-hosting Cobalt API and configuring Tagium to use it.

* **Accessibility**
  * Improved file upload input accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->