### PR TITLE
[codex] make downloads transparent

### DIFF
--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -10,6 +10,7 @@ import {
   Loader2,
   Pencil,
   Plus,
+  RefreshCw,
   Upload,
   X,
 } from "lucide-react";
@@ -34,6 +35,7 @@ interface AlbumSidebarProps {
   onSelectLooseTrack: (fileId: string, event?: ReactMouseEvent) => void;
   onClearSelection: () => void;
   onRemoveFile: (fileId: string) => void;
+  onRetryDownload: (fileId: string) => void;
   onAddAlbum: () => void;
   onEditAlbum: (albumId: string) => void;
   onDownloadAlbum: (albumId: string) => void;
@@ -109,6 +111,7 @@ export default function AlbumSidebar({
   onSelectLooseTrack,
   onClearSelection,
   onRemoveFile,
+  onRetryDownload,
   onAddAlbum,
   onEditAlbum,
   onDownloadAlbum,
@@ -141,6 +144,10 @@ export default function AlbumSidebar({
     event.currentTarget.value = "";
     setUploadTargetAlbumId(null);
   };
+
+  const isRetryableError = (track: TagiumFile) =>
+    Boolean(track.downloadRequest) &&
+    (track.downloadStatus === "error" || track.status === "error");
 
   if (albums.length === 0 && looseTracks.length === 0) {
     return (
@@ -268,7 +275,12 @@ export default function AlbumSidebar({
                     <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
                   )}
                   {(track.downloadStatus === "error" || track.status === "error") && (
-                    <AlertCircle className="h-3 w-3 text-red-500 flex-shrink-0" />
+                    <AlertCircle
+                      className={cn(
+                        "h-3 w-3 text-red-500 flex-shrink-0",
+                        isRetryableError(track) ? "group-hover:opacity-0" : "",
+                      )}
+                    />
                   )}
                 </div>
                 {(track.downloadStatus === "error" || track.status === "error") &&
@@ -279,6 +291,20 @@ export default function AlbumSidebar({
                   )}
               </div>
             </Button>
+            {isRetryableError(track) && (
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onRetryDownload(track.id);
+                }}
+                className="absolute right-7 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded-full cursor-pointer"
+                title="Retry download"
+                aria-label={`Retry download for ${track.filename}`}
+              >
+                <RefreshCw className="h-3 w-3 text-muted-foreground hover:text-primary" />
+              </button>
+            )}
             <button
               type="button"
               onClick={(event) => {
@@ -503,7 +529,12 @@ export default function AlbumSidebar({
                                   <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
                                 )}
                               {(track.downloadStatus === "error" || track.status === "error") && (
-                                <AlertCircle className="h-3 w-3 text-red-500 flex-shrink-0" />
+                                <AlertCircle
+                                  className={cn(
+                                    "h-3 w-3 text-red-500 flex-shrink-0",
+                                    isRetryableError(track) ? "group-hover:opacity-0" : "",
+                                  )}
+                                />
                               )}
                             </div>
                             {(track.downloadStatus === "error" || track.status === "error") &&
@@ -517,6 +548,20 @@ export default function AlbumSidebar({
                               )}
                           </div>
                         </Button>
+                        {isRetryableError(track) && (
+                          <button
+                            type="button"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              onRetryDownload(track.id);
+                            }}
+                            className="absolute right-7 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded-full cursor-pointer"
+                            title="Retry download"
+                            aria-label={`Retry download for ${track.filename}`}
+                          >
+                            <RefreshCw className="h-3 w-3 text-muted-foreground hover:text-primary" />
+                          </button>
+                        )}
                         <button
                           type="button"
                           onClick={(event) => {

--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -2,7 +2,17 @@
 
 import type { ChangeEvent, DragEvent, MouseEvent as ReactMouseEvent } from "react";
 import { useRef, useState } from "react";
-import { AlertCircle, Check, Download, FileMusic, Pencil, Plus, Upload, X } from "lucide-react";
+import {
+  AlertCircle,
+  Check,
+  Download,
+  FileMusic,
+  Loader2,
+  Pencil,
+  Plus,
+  Upload,
+  X,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -237,6 +247,7 @@ export default function AlbumSidebar({
               }}
               className={cn(
                 "justify-start h-auto py-2 px-2.5 w-full text-left font-normal pr-8 rounded-lg border bg-card/70",
+                track.downloadStatus === "downloading" ? "opacity-65" : "",
                 selectedFileIds.has(track.id)
                   ? "bg-accent text-accent-foreground border-primary/40"
                   : selectedFileId === track.id
@@ -245,16 +256,27 @@ export default function AlbumSidebar({
               )}
               onClick={(e) => onSelectLooseTrack(track.id, e)}
             >
-              <div className="flex items-center gap-2 w-full overflow-hidden">
-                <span className="w-5 text-[11px] text-muted-foreground">{index + 1}</span>
-                <FileMusic className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
-                <span className="truncate text-sm flex-1">{track.filename}</span>
-                {track.status === "saved" && (
-                  <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
-                )}
-                {track.status === "error" && (
-                  <AlertCircle className="h-3 w-3 text-red-500 flex-shrink-0" />
-                )}
+              <div className="flex flex-col gap-1 w-full min-w-0">
+                <div className="flex items-center gap-2 w-full overflow-hidden">
+                  <span className="w-5 text-[11px] text-muted-foreground">{index + 1}</span>
+                  <FileMusic className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+                  <span className="truncate text-sm flex-1">{track.filename}</span>
+                  {track.downloadStatus === "downloading" && (
+                    <Loader2 className="h-3 w-3 text-muted-foreground flex-shrink-0 animate-spin" />
+                  )}
+                  {track.downloadStatus !== "downloading" && track.status === "saved" && (
+                    <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
+                  )}
+                  {(track.downloadStatus === "error" || track.status === "error") && (
+                    <AlertCircle className="h-3 w-3 text-red-500 flex-shrink-0" />
+                  )}
+                </div>
+                {(track.downloadStatus === "error" || track.status === "error") &&
+                  track.downloadError && (
+                    <span className="pl-7 text-xs text-destructive truncate" aria-live="polite">
+                      error: {track.downloadError}
+                    </span>
+                  )}
               </div>
             </Button>
             <button
@@ -271,227 +293,249 @@ export default function AlbumSidebar({
           </div>
         ))}
 
-        {albums.map((album, albumIndex) => (
-          <div
-            key={album.id}
-            className={cn(
-              "rounded-lg border bg-card/70 transition-all",
-              selectedAlbumId === album.id ? "border-primary/40 shadow-sm" : "",
-              draggedAlbumId === album.id ? "opacity-50" : "",
-              dragOverAlbumIndex === albumIndex ? "ring-2 ring-primary" : "",
-            )}
-            onDragOver={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
+        {albums.map((album, albumIndex) => {
+          const canDownloadAlbum = album.trackIds.every((trackId) => filesById.get(trackId)?.file);
+          return (
+            <div
+              key={album.id}
+              className={cn(
+                "rounded-lg border bg-card/70 transition-all",
+                selectedAlbumId === album.id ? "border-primary/40 shadow-sm" : "",
+                draggedAlbumId === album.id ? "opacity-50" : "",
+                dragOverAlbumIndex === albumIndex ? "ring-2 ring-primary" : "",
+              )}
+              onDragOver={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
 
-              const albumPayload = parseAlbumDragPayload(event);
-              if (albumPayload && albumPayload.albumId !== album.id) {
-                event.dataTransfer.dropEffect = "move";
-                const rect = event.currentTarget.getBoundingClientRect();
-                const position = (event.clientY - rect.top) / rect.height;
-                setDragOverAlbumIndex(position < 0.5 ? albumIndex : albumIndex + 1);
-              } else {
-                setDragOverAlbumIndex(null);
-              }
-
-              const trackPayload = parseDragPayload(event);
-              if (trackPayload) {
-                event.dataTransfer.dropEffect = "move";
-              }
-
-              // Handle external file drops
-              if (event.dataTransfer.types.includes("Files")) {
-                event.dataTransfer.dropEffect = "copy";
-              }
-            }}
-            onDragLeave={() => {
-              setDragOverAlbumIndex(null);
-            }}
-            onDrop={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-
-              // Handle external file drops
-              const files = Array.from(event.dataTransfer.files);
-              if (files.length > 0) {
-                const audioFiles = files.filter((file) => file.type.startsWith("audio/"));
-                if (audioFiles.length > 0) {
-                  onUploadToAlbum(album.id, audioFiles);
-                  return;
-                }
-              }
-
-              // Handle album reordering
-              const albumPayload = parseAlbumDragPayload(event);
-              if (albumPayload && albumPayload.albumId !== album.id) {
-                const sourceIndex = albums.findIndex((a) => a.id === albumPayload.albumId);
-                if (sourceIndex >= 0) {
+                const albumPayload = parseAlbumDragPayload(event);
+                if (albumPayload && albumPayload.albumId !== album.id) {
+                  event.dataTransfer.dropEffect = "move";
                   const rect = event.currentTarget.getBoundingClientRect();
                   const position = (event.clientY - rect.top) / rect.height;
-                  let targetIndex = position < 0.5 ? albumIndex : albumIndex + 1;
-                  // Adjust target index if dragging from before the target
-                  if (sourceIndex < targetIndex) {
-                    targetIndex -= 1;
-                  }
-                  onReorderAlbums(albumPayload.albumId, targetIndex);
+                  setDragOverAlbumIndex(position < 0.5 ? albumIndex : albumIndex + 1);
+                } else {
+                  setDragOverAlbumIndex(null);
                 }
-                setDraggedAlbumId(null);
-                setDragOverAlbumIndex(null);
-                return;
-              }
 
-              // Handle track drag
-              const trackPayload = parseDragPayload(event);
-              if (trackPayload) {
-                onMoveTrackToAlbum(trackPayload.trackId, album.id, "append");
-                return;
-              }
-            }}
-          >
-            <div className="w-full flex items-center justify-between gap-1 px-2 py-1 border-b">
-              <button
-                type="button"
-                className="min-w-0 flex-1 flex items-center gap-2 px-1 py-1 text-left hover:bg-accent/30 rounded cursor-pointer"
-                onClick={(e) => onSelectAlbum(album.id, e)}
-                draggable
-                onDragStart={(event) => {
-                  const payload: AlbumDragPayload = {
-                    albumId: album.id,
-                  };
-                  event.dataTransfer.setData(ALBUM_DRAG_TYPE, JSON.stringify(payload));
-                  event.dataTransfer.effectAllowed = "move";
-                  setDraggedAlbumId(album.id);
-                }}
-                onDragEnd={() => {
+                const trackPayload = parseDragPayload(event);
+                if (trackPayload) {
+                  event.dataTransfer.dropEffect = "move";
+                }
+
+                // Handle external file drops
+                if (event.dataTransfer.types.includes("Files")) {
+                  event.dataTransfer.dropEffect = "copy";
+                }
+              }}
+              onDragLeave={() => {
+                setDragOverAlbumIndex(null);
+              }}
+              onDrop={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+
+                // Handle external file drops
+                const files = Array.from(event.dataTransfer.files);
+                if (files.length > 0) {
+                  const audioFiles = files.filter((file) => file.type.startsWith("audio/"));
+                  if (audioFiles.length > 0) {
+                    onUploadToAlbum(album.id, audioFiles);
+                    return;
+                  }
+                }
+
+                // Handle album reordering
+                const albumPayload = parseAlbumDragPayload(event);
+                if (albumPayload && albumPayload.albumId !== album.id) {
+                  const sourceIndex = albums.findIndex((a) => a.id === albumPayload.albumId);
+                  if (sourceIndex >= 0) {
+                    const rect = event.currentTarget.getBoundingClientRect();
+                    const position = (event.clientY - rect.top) / rect.height;
+                    let targetIndex = position < 0.5 ? albumIndex : albumIndex + 1;
+                    // Adjust target index if dragging from before the target
+                    if (sourceIndex < targetIndex) {
+                      targetIndex -= 1;
+                    }
+                    onReorderAlbums(albumPayload.albumId, targetIndex);
+                  }
                   setDraggedAlbumId(null);
                   setDragOverAlbumIndex(null);
-                }}
-              >
-                <AlbumCoverThumb picture={album.cover} />
-                <div className="min-w-0 flex-1">
-                  <div className="text-sm font-medium truncate leading-tight">{album.title}</div>
-                  <div className="text-xs text-muted-foreground truncate leading-tight">
-                    {album.artist || "Unknown"} &middot; {album.trackIds.length} track
-                    {album.trackIds.length !== 1 ? "s" : ""}
-                  </div>
-                </div>
-              </button>
-              <span className="text-xs text-muted-foreground">{album.trackIds.length}</span>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={() => triggerAlbumUpload(album.id)}
-                aria-label={`Upload tracks to ${album.title}`}
-              >
-                <Upload className="h-3.5 w-3.5" />
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={() => onDownloadAlbum(album.id)}
-                aria-label={`Download ${album.title}`}
-              >
-                <Download className="h-3.5 w-3.5" />
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={() => onEditAlbum(album.id)}
-                aria-label={`Edit ${album.title}`}
-              >
-                <Pencil className="h-3.5 w-3.5" />
-              </Button>
-            </div>
-            <div className="p-1 flex flex-col gap-1">
-              {album.trackIds.length === 0 ? (
-                <div className="text-xs text-muted-foreground px-2 py-3 text-center border border-dashed rounded-md">
-                  drag tracks here
-                </div>
-              ) : (
-                album.trackIds.map((trackId, index) => {
-                  const track = filesById.get(trackId);
-                  if (!track) return null;
+                  return;
+                }
 
-                  return (
-                    <div
-                      key={track.id}
-                      className="relative group"
-                      onDragOver={(event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        const payload = parseDragPayload(event);
-                        if (payload && payload.trackId !== track.id) {
-                          event.dataTransfer.dropEffect = "move";
-                        }
-                      }}
-                      onDrop={(event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        const payload = parseDragPayload(event);
-                        if (!payload || payload.trackId === track.id) return;
-                        const placement = placementForRowDrop(event);
-                        onMoveTrackToAlbum(payload.trackId, album.id, placement, track.id);
-                      }}
-                    >
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        draggable
-                        onDragStart={(event) => {
-                          const payload: DragPayload = {
-                            trackId: track.id,
-                            container: "album",
-                            albumId: album.id,
-                          };
-                          event.dataTransfer.setData(TRACK_DRAG_TYPE, JSON.stringify(payload));
-                          event.dataTransfer.effectAllowed = "move";
-                        }}
-                        className={cn(
-                          "justify-start h-auto py-2 px-2.5 w-full text-left font-normal pr-8",
-                          selectedFileIds.has(track.id)
-                            ? "bg-accent text-accent-foreground border-primary/40"
-                            : selectedFileId === track.id
-                              ? "bg-accent/50 text-accent-foreground"
-                              : "",
-                        )}
-                        onClick={(e) => onSelectFile(album.id, track.id, e)}
-                      >
-                        <div className="flex items-center gap-2 w-full overflow-hidden">
-                          <span className="w-5 text-[11px] text-muted-foreground">{index + 1}</span>
-                          <FileMusic className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
-                          <span className="truncate text-sm flex-1">{track.filename}</span>
-                          {track.status === "saved" && (
-                            <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
-                          )}
-                          {track.status === "error" && (
-                            <AlertCircle className="h-3 w-3 text-red-500 flex-shrink-0" />
-                          )}
-                        </div>
-                      </Button>
-                      <button
-                        type="button"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          onRemoveFile(track.id);
-                        }}
-                        className="absolute right-1.5 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
-                        title="Remove track"
-                      >
-                        <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
-                      </button>
+                // Handle track drag
+                const trackPayload = parseDragPayload(event);
+                if (trackPayload) {
+                  onMoveTrackToAlbum(trackPayload.trackId, album.id, "append");
+                  return;
+                }
+              }}
+            >
+              <div className="w-full flex items-center justify-between gap-1 px-2 py-1 border-b">
+                <button
+                  type="button"
+                  className="min-w-0 flex-1 flex items-center gap-2 px-1 py-1 text-left hover:bg-accent/30 rounded cursor-pointer"
+                  onClick={(e) => onSelectAlbum(album.id, e)}
+                  draggable
+                  onDragStart={(event) => {
+                    const payload: AlbumDragPayload = {
+                      albumId: album.id,
+                    };
+                    event.dataTransfer.setData(ALBUM_DRAG_TYPE, JSON.stringify(payload));
+                    event.dataTransfer.effectAllowed = "move";
+                    setDraggedAlbumId(album.id);
+                  }}
+                  onDragEnd={() => {
+                    setDraggedAlbumId(null);
+                    setDragOverAlbumIndex(null);
+                  }}
+                >
+                  <AlbumCoverThumb picture={album.cover} />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium truncate leading-tight">{album.title}</div>
+                    <div className="text-xs text-muted-foreground truncate leading-tight">
+                      {album.artist || "Unknown"} &middot; {album.trackIds.length} track
+                      {album.trackIds.length !== 1 ? "s" : ""}
                     </div>
-                  );
-                })
-              )}
+                  </div>
+                </button>
+                <span className="text-xs text-muted-foreground">{album.trackIds.length}</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={() => triggerAlbumUpload(album.id)}
+                  aria-label={`Upload tracks to ${album.title}`}
+                >
+                  <Upload className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={() => onDownloadAlbum(album.id)}
+                  disabled={!canDownloadAlbum}
+                  aria-label={`Download ${album.title}`}
+                >
+                  <Download className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={() => onEditAlbum(album.id)}
+                  aria-label={`Edit ${album.title}`}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+              <div className="p-1 flex flex-col gap-1">
+                {album.trackIds.length === 0 ? (
+                  <div className="text-xs text-muted-foreground px-2 py-3 text-center border border-dashed rounded-md">
+                    drag tracks here
+                  </div>
+                ) : (
+                  album.trackIds.map((trackId, index) => {
+                    const track = filesById.get(trackId);
+                    if (!track) return null;
+
+                    return (
+                      <div
+                        key={track.id}
+                        className="relative group"
+                        onDragOver={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          const payload = parseDragPayload(event);
+                          if (payload && payload.trackId !== track.id) {
+                            event.dataTransfer.dropEffect = "move";
+                          }
+                        }}
+                        onDrop={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          const payload = parseDragPayload(event);
+                          if (!payload || payload.trackId === track.id) return;
+                          const placement = placementForRowDrop(event);
+                          onMoveTrackToAlbum(payload.trackId, album.id, placement, track.id);
+                        }}
+                      >
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          draggable
+                          onDragStart={(event) => {
+                            const payload: DragPayload = {
+                              trackId: track.id,
+                              container: "album",
+                              albumId: album.id,
+                            };
+                            event.dataTransfer.setData(TRACK_DRAG_TYPE, JSON.stringify(payload));
+                            event.dataTransfer.effectAllowed = "move";
+                          }}
+                          className={cn(
+                            "justify-start h-auto py-2 px-2.5 w-full text-left font-normal pr-8",
+                            track.downloadStatus === "downloading" ? "opacity-65" : "",
+                            selectedFileIds.has(track.id)
+                              ? "bg-accent text-accent-foreground border-primary/40"
+                              : selectedFileId === track.id
+                                ? "bg-accent/50 text-accent-foreground"
+                                : "",
+                          )}
+                          onClick={(e) => onSelectFile(album.id, track.id, e)}
+                        >
+                          <div className="flex flex-col gap-1 w-full min-w-0">
+                            <div className="flex items-center gap-2 w-full overflow-hidden">
+                              <span className="w-5 text-[11px] text-muted-foreground">
+                                {index + 1}
+                              </span>
+                              <FileMusic className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+                              <span className="truncate text-sm flex-1">{track.filename}</span>
+                              {track.downloadStatus === "downloading" && (
+                                <Loader2 className="h-3 w-3 text-muted-foreground flex-shrink-0 animate-spin" />
+                              )}
+                              {track.downloadStatus !== "downloading" &&
+                                track.status === "saved" && (
+                                  <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
+                                )}
+                              {(track.downloadStatus === "error" || track.status === "error") && (
+                                <AlertCircle className="h-3 w-3 text-red-500 flex-shrink-0" />
+                              )}
+                            </div>
+                            {(track.downloadStatus === "error" || track.status === "error") &&
+                              track.downloadError && (
+                                <span
+                                  className="pl-7 text-xs text-destructive truncate"
+                                  aria-live="polite"
+                                >
+                                  error: {track.downloadError}
+                                </span>
+                              )}
+                          </div>
+                        </Button>
+                        <button
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            onRemoveFile(track.id);
+                          }}
+                          className="absolute right-1.5 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
+                          title="Remove track"
+                        >
+                          <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
+                        </button>
+                      </div>
+                    );
+                  })
+                )}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/components/audio/AudioDownloader.tsx
+++ b/components/audio/AudioDownloader.tsx
@@ -5,19 +5,24 @@ import { useState } from "react";
 import { Download, Loader2, Link } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { downloadCobaltAudio, type AudioDownloadBitrate } from "./cobaltDownload";
+import type { AudioDownloadBitrate } from "./cobaltDownload";
 import { getDownloadErrorMessage } from "./downloadErrorMessage";
-import { isSoundCloudSetUrl, resolveSoundCloudSet, toImportedAlbumMetadata } from "./soundcloudSet";
-import { ImportedAlbumMetadata } from "./types";
+import { isSoundCloudSetUrl, resolveSoundCloudSet, type SoundCloudSet } from "./soundcloudSet";
 
 const bitrateOptions: AudioDownloadBitrate[] = ["320", "256", "128", "96", "64"];
 
 interface AudioDownloaderProps {
-  onAudioUpload: (audio: File[]) => void | Promise<void>;
-  onAlbumDownload: (audio: File[], album: ImportedAlbumMetadata) => void | Promise<void>;
+  onAudioDownload: (sourceUrl: string, bitrate: AudioDownloadBitrate) => void | Promise<void>;
+  onSoundCloudSetDownload: (
+    set: SoundCloudSet,
+    bitrate: AudioDownloadBitrate,
+  ) => void | Promise<void>;
 }
 
-export default function AudioDownloader({ onAudioUpload, onAlbumDownload }: AudioDownloaderProps) {
+export default function AudioDownloader({
+  onAudioDownload,
+  onSoundCloudSetDownload,
+}: AudioDownloaderProps) {
   const [sourceUrl, setSourceUrl] = useState("");
   const [audioBitrate, setAudioBitrate] = useState<AudioDownloadBitrate>("320");
   const [downloading, setDownloading] = useState(false);
@@ -40,28 +45,13 @@ export default function AudioDownloader({ onAudioUpload, onAlbumDownload }: Audi
     try {
       if (isSoundCloudSetUrl(trimmedUrl)) {
         const set = await resolveSoundCloudSet(trimmedUrl);
-        const downloadedFiles: File[] = [];
-
-        for (const [index, track] of set.tracks.entries()) {
-          setProgress(`${index + 1}/${set.tracks.length}`);
-          downloadedFiles.push(
-            await downloadCobaltAudio({
-              sourceUrl: track.url,
-              audioBitrate,
-            }),
-          );
-        }
-
-        await onAlbumDownload(downloadedFiles, toImportedAlbumMetadata(set));
+        setProgress(`${set.tracks.length} tracks`);
+        await onSoundCloudSetDownload(set, audioBitrate);
         setSourceUrl("");
         return;
       }
 
-      const file = await downloadCobaltAudio({
-        sourceUrl: trimmedUrl,
-        audioBitrate,
-      });
-      await onAudioUpload([file]);
+      await onAudioDownload(trimmedUrl, audioBitrate);
       setSourceUrl("");
     } catch (caughtError) {
       let message = "Download failed.";

--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -3,19 +3,26 @@
 import { useRef, useState } from "react";
 import { Music4, Link2, Download, Loader2, Upload } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { downloadCobaltAudio, type AudioDownloadBitrate } from "./cobaltDownload";
+import type { AudioDownloadBitrate } from "./cobaltDownload";
 import { getDownloadErrorMessage } from "./downloadErrorMessage";
-import { isSoundCloudSetUrl, resolveSoundCloudSet, toImportedAlbumMetadata } from "./soundcloudSet";
-import type { ImportedAlbumMetadata } from "./types";
+import { isSoundCloudSetUrl, resolveSoundCloudSet, type SoundCloudSet } from "./soundcloudSet";
 
 const BITRATE_OPTIONS: AudioDownloadBitrate[] = ["320", "256", "128", "96", "64"];
 
 interface LandingScreenProps {
   onAudioUpload: (files: File[]) => void | Promise<void>;
-  onAlbumDownload: (files: File[], album: ImportedAlbumMetadata) => void | Promise<void>;
+  onAudioDownload: (sourceUrl: string, bitrate: AudioDownloadBitrate) => void | Promise<void>;
+  onSoundCloudSetDownload: (
+    set: SoundCloudSet,
+    bitrate: AudioDownloadBitrate,
+  ) => void | Promise<void>;
 }
 
-export default function LandingScreen({ onAudioUpload, onAlbumDownload }: LandingScreenProps) {
+export default function LandingScreen({
+  onAudioUpload,
+  onAudioDownload,
+  onSoundCloudSetDownload,
+}: LandingScreenProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragCounterRef = useRef(0);
   const [isDragging, setIsDragging] = useState(false);
@@ -67,20 +74,13 @@ export default function LandingScreen({ onAudioUpload, onAlbumDownload }: Landin
     try {
       if (isSoundCloudSetUrl(trimmed)) {
         const set = await resolveSoundCloudSet(trimmed);
-        const downloadedFiles: File[] = [];
-        for (const [i, track] of set.tracks.entries()) {
-          setProgress(`${i + 1} / ${set.tracks.length}`);
-          downloadedFiles.push(
-            await downloadCobaltAudio({ sourceUrl: track.url, audioBitrate: bitrate }),
-          );
-        }
-        await onAlbumDownload(downloadedFiles, toImportedAlbumMetadata(set));
+        setProgress(`${set.tracks.length} tracks`);
+        await onSoundCloudSetDownload(set, bitrate);
         setUrl("");
         return;
       }
 
-      const file = await downloadCobaltAudio({ sourceUrl: trimmed, audioBitrate: bitrate });
-      await onAudioUpload([file]);
+      await onAudioDownload(trimmed, bitrate);
       setUrl("");
     } catch (err) {
       if (err instanceof Error) {

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -25,6 +25,7 @@ interface TagSidebarPanelProps {
   onSelectLooseTrack: (fileId: string, event?: ReactMouseEvent) => void;
   onClearSelection: () => void;
   onRemoveFile: (fileId: string) => void;
+  onRetryDownload: (fileId: string) => void;
   onAddAlbum: () => void;
   onEditAlbum: (albumId: string) => void;
   onDownloadAlbum: (albumId: string) => void;
@@ -61,6 +62,7 @@ export default function TagSidebarPanel({
   onSelectLooseTrack,
   onClearSelection,
   onRemoveFile,
+  onRetryDownload,
   onAddAlbum,
   onEditAlbum,
   onDownloadAlbum,
@@ -97,6 +99,7 @@ export default function TagSidebarPanel({
         onSelectLooseTrack={onSelectLooseTrack}
         onClearSelection={onClearSelection}
         onRemoveFile={onRemoveFile}
+        onRetryDownload={onRetryDownload}
         onAddAlbum={onAddAlbum}
         onEditAlbum={onEditAlbum}
         onDownloadAlbum={onDownloadAlbum}

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -4,7 +4,9 @@ import type { MouseEvent as ReactMouseEvent } from "react";
 import AudioUpload from "./audioUpload";
 import AudioDownloader from "./AudioDownloader";
 import AlbumSidebar from "./AlbumSidebar";
-import { AlbumGroup, ImportedAlbumMetadata, TagiumFile } from "./types";
+import type { AudioDownloadBitrate } from "./cobaltDownload";
+import type { SoundCloudSet } from "./soundcloudSet";
+import { AlbumGroup, TagiumFile } from "./types";
 import { Button } from "../ui/button";
 
 interface TagSidebarPanelProps {
@@ -16,7 +18,8 @@ interface TagSidebarPanelProps {
   selectedFileId: string | null;
   selectedFileIds: Set<string>;
   onAudioUpload: (files: File[]) => void;
-  onAlbumDownload: (files: File[], album: ImportedAlbumMetadata) => void;
+  onAudioDownload: (sourceUrl: string, bitrate: AudioDownloadBitrate) => void;
+  onSoundCloudSetDownload: (set: SoundCloudSet, bitrate: AudioDownloadBitrate) => void;
   onSelectAlbum: (albumId: string, event?: ReactMouseEvent) => void;
   onSelectFile: (albumId: string, fileId: string, event?: ReactMouseEvent) => void;
   onSelectLooseTrack: (fileId: string, event?: ReactMouseEvent) => void;
@@ -51,7 +54,8 @@ export default function TagSidebarPanel({
   selectedFileId,
   selectedFileIds,
   onAudioUpload,
-  onAlbumDownload,
+  onAudioDownload,
+  onSoundCloudSetDownload,
   onSelectAlbum,
   onSelectFile,
   onSelectLooseTrack,
@@ -74,7 +78,10 @@ export default function TagSidebarPanel({
       </div>
 
       <div className="px-3 py-3 border-b flex flex-col gap-2 flex-shrink-0">
-        <AudioDownloader onAudioUpload={onAudioUpload} onAlbumDownload={onAlbumDownload} />
+        <AudioDownloader
+          onAudioDownload={onAudioDownload}
+          onSoundCloudSetDownload={onSoundCloudSetDownload}
+        />
         <AudioUpload onAudioUpload={onAudioUpload} />
       </div>
 

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -43,6 +43,7 @@ export default function TrackMetadataEditor({
   const watchedTitle = useWatch({ control, name: "title" });
   const syncFilenames = selectedFileAlbum?.syncFilenames ?? false;
   const inAlbum = !!selectedFileAlbum;
+  const audioReady = Boolean(selectedFile?.file);
 
   if (!selectedFile || !selectedFile.metadata) {
     return (
@@ -60,6 +61,12 @@ export default function TrackMetadataEditor({
       <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col h-full">
         <div className="p-6 h-[104px] border-b flex-shrink-0 flex flex-col justify-center gap-1">
           <h2 className="text-lg font-semibold truncate">{selectedFile.filename}</h2>
+          {(selectedFile.downloadStatus === "error" || selectedFile.status === "error") &&
+            selectedFile.downloadError && (
+              <p className="text-xs text-destructive truncate" aria-live="polite">
+                error: {selectedFile.downloadError}
+              </p>
+            )}
         </div>
         <div className="flex-1 overflow-y-auto p-6">
           <div className="flex gap-4 flex-col lg:flex-row">
@@ -137,7 +144,18 @@ export default function TrackMetadataEditor({
                 </div>
                 <div>
                   <span className="font-medium">size: </span>
-                  {(selectedFile.file.size / (1024 * 1024)).toFixed(2)} MB
+                  {selectedFile.file &&
+                    selectedFile.status !== "error" &&
+                    `${(selectedFile.file.size / (1024 * 1024)).toFixed(2)} MB`}
+                  {selectedFile.file &&
+                    selectedFile.status === "error" &&
+                    `${(selectedFile.file.size / (1024 * 1024)).toFixed(2)} MB (metadata failed)`}
+                  {!selectedFile.file &&
+                    selectedFile.downloadStatus === "downloading" &&
+                    "downloading"}
+                  {!selectedFile.file &&
+                    selectedFile.downloadStatus === "error" &&
+                    "download failed"}
                 </div>
               </div>
             </div>
@@ -148,6 +166,7 @@ export default function TrackMetadataEditor({
             variant="outline"
             type="button"
             onClick={() => onDownloadUpdatedFile(selectedFile)}
+            disabled={!audioReady}
           >
             Download
           </Button>

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -4,6 +4,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } fr
 import { SubmitHandler, useForm } from "react-hook-form";
 import filenamify from "filenamify";
 import AlbumMetadataDialog, { AlbumMetadataDraft } from "./AlbumMetadataDialog";
+import { downloadCobaltAudio, type AudioDownloadBitrate } from "./cobaltDownload";
 import {
   createAlbumFromTracks,
   mergeUploadedTracksIntoAlbums,
@@ -12,11 +13,18 @@ import {
   updateAlbumMetadata,
   reorderAlbums,
 } from "./albumOps";
-import { applyAlbumSharedTagsToFiles, applyTrackOrderNumbersToFiles } from "./fileMetadataOps";
+import {
+  applyAlbumSharedTagsToFiles,
+  applyTrackOrderNumbersToFiles,
+  prepareDownloadedTrackHydration,
+  resolveDownloadedTrackHydrationWrite,
+  resolveDownloadedTrackHydrationWriteError,
+} from "./fileMetadataOps";
 import TagSidebarPanel from "./TagSidebarPanel";
 import LandingScreen from "./LandingScreen";
 import TrackMetadataEditor from "./TrackMetadataEditor";
 import { parseUploadedTracks, toGenreString, writeMetadataToFile } from "./mp3Utils";
+import type { SoundCloudSet } from "./soundcloudSet";
 import { AlbumGroup, AudioMetadata, ImportedAlbumMetadata, TagiumFile } from "./types";
 const EMPTY_ALBUM_DRAFT: AlbumMetadataDraft = {
   title: "",
@@ -29,6 +37,62 @@ const EMPTY_ALBUM_DRAFT: AlbumMetadataDraft = {
 };
 const asUniqueTrackIds = (trackIds: string[]) => [...new Set(trackIds)];
 const getFileImportKey = (file: File) => `${file.name}:${file.size}:${file.lastModified}`;
+const filenameFromTitle = (title: string) => {
+  const filename = filenamify(title.trim(), { replacement: "-" });
+  if (filename) return `${filename}.mp3`;
+  return "downloading-track.mp3";
+};
+const titleFromSourceUrl = (sourceUrl: string) => {
+  try {
+    const url = new URL(sourceUrl);
+    const [lastPathPart] = url.pathname.split("/").filter(Boolean).slice(-1);
+    if (lastPathPart) return decodeURIComponent(lastPathPart).replaceAll("-", " ");
+    return url.hostname;
+  } catch {
+    return "Downloading audio";
+  }
+};
+const createDownloadMetadata = ({
+  title,
+  artist,
+  album,
+  genre,
+  year,
+  duration,
+  trackNumber,
+}: {
+  title: string;
+  artist: string;
+  album: string;
+  genre: string;
+  year?: number;
+  duration?: number;
+  trackNumber?: number;
+}): AudioMetadata => ({
+  filename: filenameFromTitle(title).replace(/\.mp3$/i, ""),
+  title,
+  artist,
+  album,
+  year,
+  genre,
+  duration: duration ?? 0,
+  bitrate: 0,
+  sampleRate: 0,
+  picture: [],
+  trackNumber,
+});
+const createPendingDownloadTrack = (
+  id: string,
+  metadata: AudioMetadata,
+  hasBufferedChanges: boolean,
+): TagiumFile => ({
+  id,
+  filename: `${metadata.filename}.mp3`,
+  status: "pending",
+  downloadStatus: "downloading",
+  hasBufferedChanges,
+  metadata,
+});
 const fetchImportedCover = async (coverUrl: string): Promise<AudioMetadata["picture"]> => {
   const response = await fetch(coverUrl);
 
@@ -67,11 +131,24 @@ export default function AudioTagger() {
   const [createSeedTrackIds, setCreateSeedTrackIds] = useState<string[]>([]);
   const filesRef = useRef<TagiumFile[]>(files);
   const albumsRef = useRef<AlbumGroup[]>(albums);
+  const selectedFileIdRef = useRef<string | null>(selectedFileId);
+  const lastResetFileIdRef = useRef<string | null>(null);
+  const formDirtyRef = useRef(false);
   const importQueueRef = useRef(Promise.resolve());
   const pendingImportKeysRef = useRef(new Set<string>());
   filesRef.current = files;
   albumsRef.current = albums;
-  const { register, handleSubmit, control, setValue, reset } = useForm<AudioMetadata>();
+  selectedFileIdRef.current = selectedFileId;
+  const {
+    register,
+    handleSubmit,
+    control,
+    setValue,
+    reset,
+    getValues,
+    formState: { dirtyFields },
+  } = useForm<AudioMetadata>();
+  formDirtyRef.current = Object.keys(dirtyFields).length > 0;
   const selectedFile = useMemo(
     () => files.find((file) => file.id === selectedFileId) ?? null,
     [files, selectedFileId],
@@ -82,6 +159,11 @@ export default function AudioTagger() {
   );
   useLayoutEffect(() => {
     if (selectedFile?.metadata) {
+      const selectedFileChanged = lastResetFileIdRef.current !== selectedFile.id;
+      if (!selectedFileChanged && formDirtyRef.current) {
+        return;
+      }
+      lastResetFileIdRef.current = selectedFile.id;
       reset(selectedFile.metadata);
     }
   }, [selectedFile, reset]);
@@ -121,37 +203,97 @@ export default function AudioTagger() {
   }, [albums, files, looseTrackIds, selectedAlbumId, selectedFileId]);
 
   const handleTagUpdate = async (fileToUpdate: TagiumFile, newTags: AudioMetadata) => {
+    const latestFileToUpdate =
+      filesRef.current.find((file) => file.id === fileToUpdate.id) ?? fileToUpdate;
+
+    if (!latestFileToUpdate.file) {
+      const metadata = {
+        ...newTags,
+        year: Number.isNaN(newTags.year as number) ? undefined : newTags.year,
+        trackNumber: Number.isNaN(newTags.trackNumber as number) ? undefined : newTags.trackNumber,
+        duration: latestFileToUpdate.metadata?.duration || 0,
+        bitrate: latestFileToUpdate.metadata?.bitrate || 0,
+        sampleRate: latestFileToUpdate.metadata?.sampleRate || 0,
+        picture: newTags.picture || [],
+      };
+      const nextFiles = filesRef.current.map((file) =>
+        file.id === fileToUpdate.id
+          ? {
+              ...file,
+              filename: newTags.filename ? `${newTags.filename}.mp3` : file.filename,
+              metadata,
+              status: "pending" as const,
+              hasBufferedChanges: true,
+            }
+          : file,
+      );
+      filesRef.current = nextFiles;
+      setFiles(nextFiles);
+      if (selectedFileIdRef.current === fileToUpdate.id) {
+        reset(metadata);
+      }
+      return;
+    }
+
     try {
-      const updatedFile = await writeMetadataToFile(fileToUpdate, newTags);
-      setFiles((prevFiles) =>
-        prevFiles.map((file) =>
-          file.id === fileToUpdate.id
-            ? {
-                ...file,
-                file: updatedFile,
-                filename: updatedFile.name,
-                metadata: {
-                  ...newTags,
-                  year: Number.isNaN(newTags.year as number) ? undefined : newTags.year,
-                  trackNumber: Number.isNaN(newTags.trackNumber as number)
-                    ? undefined
-                    : newTags.trackNumber,
-                  duration: file.metadata?.duration || 0,
-                  bitrate: file.metadata?.bitrate || 0,
-                  sampleRate: file.metadata?.sampleRate || 0,
-                  picture: newTags.picture || [],
-                },
-                status: "saved",
-              }
-            : file,
-        ),
+      const updatedFile = await writeMetadataToFile(latestFileToUpdate, newTags);
+      const metadata = {
+        ...newTags,
+        year: Number.isNaN(newTags.year as number) ? undefined : newTags.year,
+        trackNumber: Number.isNaN(newTags.trackNumber as number) ? undefined : newTags.trackNumber,
+        duration: latestFileToUpdate.metadata?.duration || 0,
+        bitrate: latestFileToUpdate.metadata?.bitrate || 0,
+        sampleRate: latestFileToUpdate.metadata?.sampleRate || 0,
+        picture: newTags.picture || [],
+      };
+      const nextFiles = filesRef.current.map((file) =>
+        file.id === fileToUpdate.id
+          ? {
+              ...file,
+              file: updatedFile,
+              filename: updatedFile.name,
+              metadata,
+              status: "saved" as const,
+              downloadStatus: "ready" as const,
+              downloadError: undefined,
+              hasBufferedChanges: false,
+            }
+          : file,
       );
+      filesRef.current = nextFiles;
+      setFiles(nextFiles);
+      if (selectedFileIdRef.current === fileToUpdate.id) {
+        reset(metadata);
+      }
     } catch (error) {
-      setFiles((prevFiles) =>
-        prevFiles.map((file) =>
-          file.id === fileToUpdate.id ? { ...file, status: "error" } : file,
-        ),
+      let message = "Unable to save metadata.";
+      if (error instanceof Error) {
+        message = error.message;
+      }
+      const nextFiles = filesRef.current.map((file) =>
+        file.id === fileToUpdate.id
+          ? {
+              ...file,
+              status: "error" as const,
+              metadata: {
+                ...newTags,
+                year: Number.isNaN(newTags.year as number) ? undefined : newTags.year,
+                trackNumber: Number.isNaN(newTags.trackNumber as number)
+                  ? undefined
+                  : newTags.trackNumber,
+                duration: file.metadata?.duration || 0,
+                bitrate: file.metadata?.bitrate || 0,
+                sampleRate: file.metadata?.sampleRate || 0,
+                picture: newTags.picture || [],
+              },
+              filename: newTags.filename ? `${newTags.filename}.mp3` : file.filename,
+              downloadError: message,
+              hasBufferedChanges: true,
+            }
+          : file,
       );
+      filesRef.current = nextFiles;
+      setFiles(nextFiles);
       throw error;
     }
   };
@@ -173,7 +315,10 @@ export default function AudioTagger() {
   ) => {
     const runImport = async () => {
       const existingImportKeys = new Set(
-        filesRef.current.map((file) => getFileImportKey(file.originalFile)),
+        filesRef.current
+          .map((file) => file.originalFile)
+          .filter((file): file is File => Boolean(file))
+          .map((file) => getFileImportKey(file)),
       );
       const reservedImportKeys: string[] = [];
       const uniqueUploadedFiles = uploadedFiles.filter((file) => {
@@ -287,6 +432,213 @@ export default function AudioTagger() {
     importQueueRef.current = queuedImport.catch(() => undefined);
     await queuedImport;
   };
+  const replaceFileById = (fileId: string, nextFile: TagiumFile) => {
+    const nextFiles = filesRef.current.map((file) => (file.id === fileId ? nextFile : file));
+    filesRef.current = nextFiles;
+    setFiles(nextFiles);
+  };
+  const markDownloadError = (fileId: string, error: unknown) => {
+    let message = "Download failed.";
+    if (error instanceof Error) {
+      message = error.message;
+    }
+    const nextFiles = filesRef.current.map((file) =>
+      file.id === fileId
+        ? {
+            ...file,
+            status: "error" as const,
+            downloadStatus: "error" as const,
+            downloadError: message,
+          }
+        : file,
+    );
+    filesRef.current = nextFiles;
+    setFiles(nextFiles);
+  };
+  const hydrateDownloadedTrack = async (fileId: string, downloadedFile: File) => {
+    const [parsedUpload] = await parseUploadedTracks([downloadedFile]);
+    if (!parsedUpload) {
+      throw new Error("Downloaded track could not be parsed.");
+    }
+
+    const currentFile = filesRef.current.find((file) => file.id === fileId);
+    if (!currentFile) return;
+
+    const parsedFile = parsedUpload.file;
+    const formMetadata =
+      selectedFileIdRef.current === fileId && formDirtyRef.current && currentFile.metadata
+        ? getValues()
+        : undefined;
+    let { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
+      currentFile,
+      parsedFile,
+      formMetadata,
+    );
+
+    if (metadataToWrite) {
+      try {
+        const updatedFile = await writeMetadataToFile(hydratedFile, metadataToWrite);
+        const latestFile = filesRef.current.find((file) => file.id === fileId);
+        if (!latestFile) return;
+        const latestFormMetadata =
+          selectedFileIdRef.current === fileId && formDirtyRef.current ? getValues() : undefined;
+        hydratedFile = resolveDownloadedTrackHydrationWrite(
+          currentFile,
+          latestFile,
+          parsedFile,
+          hydratedFile,
+          updatedFile,
+          metadataToWrite,
+          latestFormMetadata,
+        );
+      } catch (error) {
+        const latestFile = filesRef.current.find((file) => file.id === fileId);
+        if (!latestFile) return;
+        let message = "Downloaded, but metadata could not be applied.";
+        if (error instanceof Error) {
+          message = error.message;
+        }
+        hydratedFile = resolveDownloadedTrackHydrationWriteError(
+          currentFile,
+          latestFile,
+          parsedFile,
+          hydratedFile,
+          message,
+        );
+      }
+    }
+
+    replaceFileById(fileId, hydratedFile);
+  };
+  const handleAudioDownload = (sourceUrl: string, audioBitrate: AudioDownloadBitrate) => {
+    const id = crypto.randomUUID();
+    const title = titleFromSourceUrl(sourceUrl);
+    const pendingFile = createPendingDownloadTrack(
+      id,
+      createDownloadMetadata({
+        title,
+        artist: "",
+        album: "",
+        genre: "",
+      }),
+      false,
+    );
+    const nextFiles = [...filesRef.current, pendingFile];
+    filesRef.current = nextFiles;
+    setFiles(nextFiles);
+    setLooseTrackIds((prevLooseTrackIds) => asUniqueTrackIds([...prevLooseTrackIds, id]));
+    setSelectedAlbumId(null);
+    setSelectedFileId(id);
+    setSelectedFileIds(new Set([id]));
+    setLastSelectedFileId(id);
+
+    void (async () => {
+      try {
+        const downloadedFile = await downloadCobaltAudio({ sourceUrl, audioBitrate });
+        await hydrateDownloadedTrack(id, downloadedFile);
+      } catch (error) {
+        markDownloadError(id, error);
+      }
+    })();
+  };
+  const handleSoundCloudSetDownload = (set: SoundCloudSet, audioBitrate: AudioDownloadBitrate) => {
+    const albumId = crypto.randomUUID();
+    const pendingFiles = set.tracks.map((track) =>
+      createPendingDownloadTrack(
+        crypto.randomUUID(),
+        createDownloadMetadata({
+          title: track.title,
+          artist: set.artist,
+          album: set.title,
+          genre: set.genre,
+          year: set.year,
+          duration: track.duration,
+          trackNumber: track.trackNumber,
+        }),
+        true,
+      ),
+    );
+    const album: AlbumGroup = {
+      id: albumId,
+      title: set.title,
+      artist: set.artist,
+      genre: set.genre,
+      trackIds: pendingFiles.map((file) => file.id),
+      year: set.year,
+      syncTrackNumbers: true,
+      syncFilenames: false,
+    };
+    const nextFiles = [...filesRef.current, ...pendingFiles];
+    const nextAlbums = [...albumsRef.current, album];
+    filesRef.current = nextFiles;
+    albumsRef.current = nextAlbums;
+    setFiles(nextFiles);
+    setAlbums(nextAlbums);
+    setSelectedAlbumId(albumId);
+    setSelectedFileId(pendingFiles[0]?.id ?? null);
+    setSelectedFileIds(new Set(pendingFiles[0] ? [pendingFiles[0].id] : []));
+    setLastSelectedFileId(pendingFiles[0]?.id ?? null);
+
+    const coverUrl = set.coverUrl;
+    if (coverUrl) {
+      void (async () => {
+        try {
+          const cover = await fetchImportedCover(coverUrl);
+          const coveredAlbums = albumsRef.current.map((currentAlbum) =>
+            currentAlbum.id === albumId ? { ...currentAlbum, cover } : currentAlbum,
+          );
+          albumsRef.current = coveredAlbums;
+          setAlbums(coveredAlbums);
+          const trackIdSet = new Set(album.trackIds);
+          const coveredFiles = filesRef.current.map((file) =>
+            trackIdSet.has(file.id) && file.metadata
+              ? {
+                  ...file,
+                  metadata: {
+                    ...file.metadata,
+                    picture: cover,
+                  },
+                  status: file.status === "saved" ? "pending" : file.status,
+                  hasBufferedChanges: true,
+                }
+              : file,
+          );
+          filesRef.current = coveredFiles;
+          setFiles(coveredFiles);
+          await Promise.all(
+            coveredFiles
+              .filter((file) => trackIdSet.has(file.id) && Boolean(file.file) && file.metadata)
+              .map(async (file) => {
+                if (!file.metadata) return;
+                try {
+                  await handleTagUpdate(file, file.metadata);
+                } catch {
+                  // handleTagUpdate records the per-track error state.
+                }
+              }),
+          );
+        } catch (error) {
+          console.warn("Failed to import album cover:", error);
+        }
+      })();
+    }
+
+    pendingFiles.forEach((pendingFile, index) => {
+      const track = set.tracks[index];
+      if (!track) return;
+      void (async () => {
+        try {
+          const downloadedFile = await downloadCobaltAudio({
+            sourceUrl: track.url,
+            audioBitrate,
+          });
+          await hydrateDownloadedTrack(pendingFile.id, downloadedFile);
+        } catch (error) {
+          markDownloadError(pendingFile.id, error);
+        }
+      })();
+    });
+  };
   const handleSaveAll = async () => {
     if (files.length === 0) return;
     setLoading(true);
@@ -296,6 +648,9 @@ export default function AudioTagger() {
         syncedFiles = applyAlbumSharedTagsToFiles(syncedFiles, album);
       }
       for (const file of syncedFiles) {
+        if (!file.file && !file.hasBufferedChanges) {
+          continue;
+        }
         if (file.metadata) {
           await handleTagUpdate(file, file.metadata);
         }
@@ -311,14 +666,18 @@ export default function AudioTagger() {
     reader.onload = () => {
       const arrayBuffer = reader.result as ArrayBuffer;
       const uint8Array = new Uint8Array(arrayBuffer);
-      setValue("picture", [
-        {
-          format: file.type,
-          type: 3,
-          data: uint8Array,
-          description: "Uploaded cover",
-        },
-      ]);
+      setValue(
+        "picture",
+        [
+          {
+            format: file.type,
+            type: 3,
+            data: uint8Array,
+            description: "Uploaded cover",
+          },
+        ],
+        { shouldDirty: true },
+      );
     };
     reader.readAsArrayBuffer(file);
   };
@@ -327,7 +686,8 @@ export default function AudioTagger() {
     if (!album) return;
     const albumFiles = album.trackIds
       .map((id) => files.find((f) => f.id === id))
-      .filter((f): f is TagiumFile => Boolean(f));
+      .filter((f): f is TagiumFile & { file: File } => Boolean(f?.file));
+    if (albumFiles.length !== album.trackIds.length) return;
     const { zip } = await import("fflate");
     const entries: Record<string, [Uint8Array, { level: 0 }]> = {};
     await Promise.all(
@@ -346,6 +706,7 @@ export default function AudioTagger() {
     });
   };
   const handleDownloadUpdatedFile = (file: TagiumFile) => {
+    if (!file.file) return;
     const url = URL.createObjectURL(file.file);
     const anchor = document.createElement("a");
     anchor.href = url;
@@ -726,9 +1087,8 @@ export default function AudioTagger() {
     return (
       <LandingScreen
         onAudioUpload={handleAudioUpload}
-        onAlbumDownload={(downloadedFiles, album) =>
-          handleAudioUpload(downloadedFiles, undefined, album)
-        }
+        onAudioDownload={handleAudioDownload}
+        onSoundCloudSetDownload={handleSoundCloudSetDownload}
       />
     );
   }
@@ -766,9 +1126,8 @@ export default function AudioTagger() {
           selectedFileId={selectedFileId}
           selectedFileIds={selectedFileIds}
           onAudioUpload={handleAudioUpload}
-          onAlbumDownload={(downloadedFiles, album) =>
-            handleAudioUpload(downloadedFiles, undefined, album)
-          }
+          onAudioDownload={handleAudioDownload}
+          onSoundCloudSetDownload={handleSoundCloudSetDownload}
           onSelectAlbum={handleSelectAlbum}
           onSelectFile={handleSelectFile}
           onSelectLooseTrack={handleSelectLooseTrack}

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -85,11 +85,13 @@ const createPendingDownloadTrack = (
   id: string,
   metadata: AudioMetadata,
   hasBufferedChanges: boolean,
+  downloadRequest: TagiumFile["downloadRequest"],
 ): TagiumFile => ({
   id,
   filename: `${metadata.filename}.mp3`,
   status: "pending",
   downloadStatus: "downloading",
+  downloadRequest,
   hasBufferedChanges,
   metadata,
 });
@@ -522,6 +524,7 @@ export default function AudioTagger() {
         genre: "",
       }),
       false,
+      { sourceUrl, audioBitrate },
     );
     const nextFiles = [...filesRef.current, pendingFile];
     filesRef.current = nextFiles;
@@ -556,6 +559,7 @@ export default function AudioTagger() {
           trackNumber: track.trackNumber,
         }),
         true,
+        { sourceUrl: track.url, audioBitrate },
       ),
     );
     const album: AlbumGroup = {
@@ -638,6 +642,33 @@ export default function AudioTagger() {
         }
       })();
     });
+  };
+  const handleRetryDownload = (fileId: string) => {
+    const fileToRetry = filesRef.current.find((file) => file.id === fileId);
+    const downloadRequest = fileToRetry?.downloadRequest;
+    if (!fileToRetry || !downloadRequest) return;
+
+    const nextFiles = filesRef.current.map((file) =>
+      file.id === fileId
+        ? {
+            ...file,
+            status: "pending" as const,
+            downloadStatus: "downloading" as const,
+            downloadError: undefined,
+          }
+        : file,
+    );
+    filesRef.current = nextFiles;
+    setFiles(nextFiles);
+
+    void (async () => {
+      try {
+        const downloadedFile = await downloadCobaltAudio(downloadRequest);
+        await hydrateDownloadedTrack(fileId, downloadedFile);
+      } catch (error) {
+        markDownloadError(fileId, error);
+      }
+    })();
   };
   const handleSaveAll = async () => {
     if (files.length === 0) return;
@@ -1133,6 +1164,7 @@ export default function AudioTagger() {
           onSelectLooseTrack={handleSelectLooseTrack}
           onClearSelection={handleClearSelection}
           onRemoveFile={handleRemoveFile}
+          onRetryDownload={handleRetryDownload}
           onAddAlbum={handleOpenCreateAlbumDialog}
           onEditAlbum={handleOpenEditAlbumDialog}
           onDownloadAlbum={handleDownloadAlbum}

--- a/components/audio/fileMetadataOps.test.ts
+++ b/components/audio/fileMetadataOps.test.ts
@@ -1,5 +1,39 @@
 import { describe, expect, it } from "vite-plus/test";
-import { applyAlbumSharedTagsToFiles, applyTrackOrderNumbersToFiles } from "./fileMetadataOps";
+import {
+  applyAlbumSharedTagsToFiles,
+  applyTrackOrderNumbersToFiles,
+  prepareDownloadedTrackHydration,
+  resolveDownloadedTrackHydrationWrite,
+  resolveDownloadedTrackHydrationWriteError,
+} from "./fileMetadataOps";
+import { AudioMetadata, TagiumFile } from "./types";
+
+const metadata = (overrides: Partial<AudioMetadata> = {}): AudioMetadata => ({
+  filename: "track",
+  title: "Track",
+  artist: "Artist",
+  album: "Album",
+  year: 2024,
+  genre: "",
+  duration: 0,
+  bitrate: 0,
+  sampleRate: 0,
+  picture: [],
+  trackNumber: undefined,
+  ...overrides,
+});
+
+const readyFile = (overrides: Partial<TagiumFile> = {}): TagiumFile => ({
+  id: "track-1",
+  file: new File(["a"], "track-1.mp3", { type: "audio/mpeg" }),
+  originalFile: new File(["a"], "track-1.mp3", { type: "audio/mpeg" }),
+  filename: "track-1.mp3",
+  status: "pending",
+  downloadStatus: "ready",
+  hasBufferedChanges: false,
+  metadata: metadata({ filename: "track-1", title: "Track 1" }),
+  ...overrides,
+});
 
 describe("fileMetadataOps", () => {
   it("applies synced track numbers and resets saved files to pending", () => {
@@ -10,6 +44,8 @@ describe("fileMetadataOps", () => {
         originalFile: new File(["a"], "track-1.mp3", { type: "audio/mpeg" }),
         filename: "track-1.mp3",
         status: "saved" as const,
+        downloadStatus: "ready" as const,
+        hasBufferedChanges: false,
         metadata: {
           filename: "track-1",
           title: "Track 1",
@@ -30,6 +66,8 @@ describe("fileMetadataOps", () => {
         originalFile: new File(["b"], "track-2.mp3", { type: "audio/mpeg" }),
         filename: "track-2.mp3",
         status: "pending" as const,
+        downloadStatus: "ready" as const,
+        hasBufferedChanges: false,
         metadata: {
           filename: "track-2",
           title: "Track 2",
@@ -61,6 +99,7 @@ describe("fileMetadataOps", () => {
     const result = applyTrackOrderNumbersToFiles(files, albums, ["album-1"]);
 
     expect(result[0].status).toBe("pending");
+    expect(result[0].hasBufferedChanges).toBe(true);
     expect(result[0].metadata?.trackNumber).toBe(2);
     expect(result[1].metadata?.trackNumber).toBe(1);
   });
@@ -82,6 +121,8 @@ describe("fileMetadataOps", () => {
         originalFile: new File(["a"], "track-1.mp3", { type: "audio/mpeg" }),
         filename: "track-1.mp3",
         status: "saved" as const,
+        downloadStatus: "ready" as const,
+        hasBufferedChanges: false,
         metadata: {
           filename: "track-1",
           title: "Track 1",
@@ -111,10 +152,384 @@ describe("fileMetadataOps", () => {
     const [updatedFile] = applyAlbumSharedTagsToFiles(files, album);
 
     expect(updatedFile.status).toBe("pending");
+    expect(updatedFile.hasBufferedChanges).toBe(true);
     expect(updatedFile.metadata?.artist).toBe("New Artist");
     expect(updatedFile.metadata?.album).toBe("New Album");
     expect(updatedFile.metadata?.genre).toBe("Ambient");
     expect(updatedFile.metadata?.trackNumber).toBe(9);
     expect(updatedFile.metadata?.picture).toEqual(originalCover);
+  });
+
+  it("keeps buffered metadata while hydrating downloaded technical fields", () => {
+    const parsedCover = [
+      {
+        format: "image/jpeg",
+        type: 3,
+        description: "parsed cover",
+        data: new Uint8Array([4, 5, 6]),
+      },
+    ];
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      filename: "edited-title.mp3",
+      downloadStatus: "downloading",
+      hasBufferedChanges: true,
+      metadata: metadata({
+        filename: "edited-title",
+        title: "Edited Title",
+        album: "Edited Album",
+      }),
+    });
+    const parsedFile = readyFile({
+      filename: "parsed-title.mp3",
+      metadata: metadata({
+        filename: "parsed-title",
+        title: "Parsed Title",
+        duration: 123,
+        bitrate: 320,
+        sampleRate: 44100,
+        picture: parsedCover,
+      }),
+    });
+
+    const result = prepareDownloadedTrackHydration(currentFile, parsedFile);
+
+    expect(result.metadataToWrite?.title).toBe("Edited Title");
+    expect(result.hydratedFile.filename).toBe("edited-title.mp3");
+    expect(result.hydratedFile.metadata?.album).toBe("Edited Album");
+    expect(result.hydratedFile.metadata?.duration).toBe(123);
+    expect(result.hydratedFile.metadata?.bitrate).toBe(320);
+    expect(result.hydratedFile.metadata?.sampleRate).toBe(44100);
+    expect(result.hydratedFile.metadata?.picture).toEqual(parsedCover);
+    expect(result.hydratedFile.status).toBe("pending");
+    expect(result.hydratedFile.downloadStatus).toBe("ready");
+  });
+
+  it("keeps later buffered edits when stale hydration write resolves", () => {
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      filename: "old-edit.mp3",
+      downloadStatus: "downloading",
+      hasBufferedChanges: true,
+      metadata: metadata({ filename: "old-edit", title: "Old Edit" }),
+    });
+    const parsedFile = readyFile({
+      filename: "parsed-title.mp3",
+      metadata: metadata({
+        filename: "parsed-title",
+        title: "Parsed Title",
+        duration: 88,
+        bitrate: 320,
+        sampleRate: 44100,
+      }),
+    });
+    const { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
+      currentFile,
+      parsedFile,
+    );
+    const latestFile = {
+      ...currentFile,
+      filename: "new-edit.mp3",
+      metadata: metadata({ filename: "new-edit", title: "New Edit" }),
+    };
+    const updatedFile = new File(["updated"], "old-edit.mp3", { type: "audio/mpeg" });
+
+    const result = resolveDownloadedTrackHydrationWrite(
+      currentFile,
+      latestFile,
+      parsedFile,
+      hydratedFile,
+      updatedFile,
+      metadataToWrite!,
+    );
+
+    expect(result.file).toBe(updatedFile);
+    expect(result.filename).toBe("new-edit.mp3");
+    expect(result.metadata?.title).toBe("New Edit");
+    expect(result.metadata?.duration).toBe(88);
+    expect(result.metadata?.bitrate).toBe(320);
+    expect(result.metadata?.sampleRate).toBe(44100);
+    expect(result.status).toBe("pending");
+    expect(result.hasBufferedChanges).toBe(true);
+    expect(result.downloadStatus).toBe("ready");
+  });
+
+  it("marks buffered pending saves as saved when hydration write succeeds", () => {
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      filename: "saved-while-downloading.mp3",
+      downloadStatus: "downloading",
+      hasBufferedChanges: true,
+      metadata: metadata({
+        filename: "saved-while-downloading",
+        title: "Saved While Downloading",
+      }),
+    });
+    const parsedFile = readyFile({
+      metadata: metadata({
+        filename: "parsed-title",
+        title: "Parsed Title",
+        duration: 101,
+        bitrate: 320,
+        sampleRate: 44100,
+      }),
+    });
+    const { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
+      currentFile,
+      parsedFile,
+    );
+    const updatedFile = new File(["updated"], "saved-while-downloading.mp3", {
+      type: "audio/mpeg",
+    });
+
+    const result = resolveDownloadedTrackHydrationWrite(
+      currentFile,
+      currentFile,
+      parsedFile,
+      hydratedFile,
+      updatedFile,
+      metadataToWrite!,
+    );
+
+    expect(result.file).toBe(updatedFile);
+    expect(result.filename).toBe("saved-while-downloading.mp3");
+    expect(result.metadata?.title).toBe("Saved While Downloading");
+    expect(result.metadata?.duration).toBe(101);
+    expect(result.status).toBe("saved");
+    expect(result.hasBufferedChanges).toBe(false);
+  });
+
+  it("keeps latest dirty form metadata when hydration write resolves", () => {
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      filename: "first-form-edit.mp3",
+      downloadStatus: "downloading",
+      hasBufferedChanges: false,
+      metadata: metadata({ filename: "placeholder", title: "Placeholder" }),
+    });
+    const parsedFile = readyFile({
+      metadata: metadata({
+        filename: "parsed-title",
+        title: "Parsed Title",
+        duration: 95,
+        bitrate: 320,
+        sampleRate: 44100,
+      }),
+    });
+    const firstFormMetadata = metadata({
+      filename: "first-form-edit",
+      title: "First Form Edit",
+    });
+    const { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
+      currentFile,
+      parsedFile,
+      firstFormMetadata,
+    );
+    const latestFormMetadata = metadata({
+      filename: "second-form-edit",
+      title: "Second Form Edit",
+    });
+    const updatedFile = new File(["updated"], "first-form-edit.mp3", { type: "audio/mpeg" });
+
+    const result = resolveDownloadedTrackHydrationWrite(
+      currentFile,
+      currentFile,
+      parsedFile,
+      hydratedFile,
+      updatedFile,
+      metadataToWrite!,
+      latestFormMetadata,
+    );
+
+    expect(result.file).toBe(updatedFile);
+    expect(result.filename).toBe("second-form-edit.mp3");
+    expect(result.metadata?.title).toBe("Second Form Edit");
+    expect(result.metadata?.duration).toBe(95);
+    expect(result.metadata?.bitrate).toBe(320);
+    expect(result.status).toBe("pending");
+    expect(result.hasBufferedChanges).toBe(true);
+  });
+
+  it("keeps buffered metadata and error message when hydration write fails", () => {
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      filename: "edited-title.mp3",
+      downloadStatus: "downloading",
+      hasBufferedChanges: true,
+      metadata: metadata({ filename: "edited-title", title: "Edited Title" }),
+    });
+    const parsedFile = readyFile({
+      filename: "parsed-title.mp3",
+      metadata: metadata({
+        filename: "parsed-title",
+        title: "Parsed Title",
+        duration: 92,
+        bitrate: 256,
+        sampleRate: 48000,
+      }),
+    });
+    const { hydratedFile } = prepareDownloadedTrackHydration(currentFile, parsedFile);
+
+    const result = resolveDownloadedTrackHydrationWriteError(
+      currentFile,
+      currentFile,
+      parsedFile,
+      hydratedFile,
+      "Unable to save metadata",
+    );
+
+    expect(result.file).toBe(parsedFile.file);
+    expect(result.filename).toBe("edited-title.mp3");
+    expect(result.metadata?.title).toBe("Edited Title");
+    expect(result.metadata?.duration).toBe(92);
+    expect(result.metadata?.bitrate).toBe(256);
+    expect(result.metadata?.sampleRate).toBe(48000);
+    expect(result.status).toBe("error");
+    expect(result.downloadStatus).toBe("ready");
+    expect(result.downloadError).toBe("Unable to save metadata");
+    expect(result.hasBufferedChanges).toBe(true);
+  });
+
+  it("keeps later edits when stale hydration write fails", () => {
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      filename: "old-edit.mp3",
+      downloadStatus: "downloading",
+      hasBufferedChanges: true,
+      metadata: metadata({ filename: "old-edit", title: "Old Edit" }),
+    });
+    const latestFile = {
+      ...currentFile,
+      filename: "new-edit.mp3",
+      metadata: metadata({ filename: "new-edit", title: "New Edit" }),
+    };
+    const parsedFile = readyFile({
+      filename: "parsed-title.mp3",
+      metadata: metadata({
+        filename: "parsed-title",
+        title: "Parsed Title",
+        duration: 93,
+        bitrate: 128,
+        sampleRate: 32000,
+      }),
+    });
+    const { hydratedFile } = prepareDownloadedTrackHydration(currentFile, parsedFile);
+
+    const result = resolveDownloadedTrackHydrationWriteError(
+      currentFile,
+      latestFile,
+      parsedFile,
+      hydratedFile,
+      "Unable to save metadata",
+    );
+
+    expect(result.file).toBe(parsedFile.file);
+    expect(result.filename).toBe("new-edit.mp3");
+    expect(result.metadata?.title).toBe("New Edit");
+    expect(result.metadata?.duration).toBe(93);
+    expect(result.metadata?.bitrate).toBe(128);
+    expect(result.metadata?.sampleRate).toBe(32000);
+    expect(result.status).toBe("error");
+    expect(result.downloadError).toBe("Unable to save metadata");
+  });
+
+  it("uses dirty form metadata during hydration while preserving parsed technical fields", () => {
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      downloadStatus: "downloading",
+      hasBufferedChanges: false,
+      metadata: metadata({ filename: "placeholder", title: "Placeholder" }),
+    });
+    const parsedFile = readyFile({
+      metadata: metadata({
+        filename: "parsed-title",
+        title: "Parsed Title",
+        duration: 45,
+        bitrate: 256,
+        sampleRate: 48000,
+      }),
+    });
+    const formMetadata = metadata({ filename: "form-title", title: "Form Title" });
+
+    const { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
+      currentFile,
+      parsedFile,
+      formMetadata,
+    );
+
+    expect(metadataToWrite?.title).toBe("Form Title");
+    expect(hydratedFile.filename).toBe("form-title.mp3");
+    expect(hydratedFile.metadata?.title).toBe("Form Title");
+    expect(hydratedFile.metadata?.duration).toBe(45);
+    expect(hydratedFile.metadata?.bitrate).toBe(256);
+    expect(hydratedFile.metadata?.sampleRate).toBe(48000);
+    expect(hydratedFile.hasBufferedChanges).toBe(true);
+  });
+
+  it("uses dirty form cover during hydration", () => {
+    const parsedCover = [
+      {
+        format: "image/jpeg",
+        type: 3,
+        description: "parsed cover",
+        data: new Uint8Array([1]),
+      },
+    ];
+    const formCover = [
+      {
+        format: "image/png",
+        type: 3,
+        description: "uploaded cover",
+        data: new Uint8Array([2]),
+      },
+    ];
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      downloadStatus: "downloading",
+      hasBufferedChanges: false,
+      metadata: metadata({ picture: [] }),
+    });
+    const parsedFile = readyFile({
+      metadata: metadata({ picture: parsedCover }),
+    });
+    const formMetadata = metadata({ picture: formCover });
+
+    const { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
+      currentFile,
+      parsedFile,
+      formMetadata,
+    );
+
+    expect(metadataToWrite?.picture).toEqual(formCover);
+    expect(hydratedFile.metadata?.picture).toEqual(formCover);
+    expect(hydratedFile.hasBufferedChanges).toBe(true);
+  });
+
+  it("preserves parse failure messages during hydration", () => {
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      downloadStatus: "downloading",
+      metadata: metadata({ filename: "placeholder", title: "Placeholder" }),
+    });
+    const parsedFile = readyFile({
+      status: "error",
+      downloadError: "Invalid ID3 tag",
+      metadata: undefined,
+    });
+
+    const { hydratedFile } = prepareDownloadedTrackHydration(currentFile, parsedFile);
+
+    expect(hydratedFile.status).toBe("error");
+    expect(hydratedFile.downloadStatus).toBe("ready");
+    expect(hydratedFile.downloadError).toBe("Invalid ID3 tag");
   });
 });

--- a/components/audio/fileMetadataOps.ts
+++ b/components/audio/fileMetadataOps.ts
@@ -1,5 +1,29 @@
 import filenamify from "filenamify";
-import { AlbumGroup, TagiumFile } from "./types";
+import { AlbumGroup, AudioMetadata, TagiumFile } from "./types";
+
+export interface DownloadedTrackHydration {
+  hydratedFile: TagiumFile;
+  metadataToWrite?: AudioMetadata;
+}
+
+const mergeLatestMetadataWithHydratedTechnicalFields = (
+  latestFile: TagiumFile,
+  hydratedFile: TagiumFile,
+) => {
+  if (!latestFile.metadata) return hydratedFile.metadata;
+  if (!hydratedFile.metadata) return latestFile.metadata;
+
+  return {
+    ...latestFile.metadata,
+    duration: hydratedFile.metadata.duration,
+    bitrate: hydratedFile.metadata.bitrate,
+    sampleRate: hydratedFile.metadata.sampleRate,
+    picture:
+      latestFile.metadata.picture.length > 0
+        ? latestFile.metadata.picture
+        : hydratedFile.metadata.picture,
+  };
+};
 
 export function applyTrackOrderNumbersToFiles(
   files: TagiumFile[],
@@ -25,6 +49,7 @@ export function applyTrackOrderNumbersToFiles(
     return {
       ...file,
       status: file.status === "saved" ? "pending" : file.status,
+      hasBufferedChanges: true,
       metadata: {
         ...file.metadata,
         trackNumber,
@@ -49,6 +74,7 @@ export function applyAlbumSharedTagsToFiles(files: TagiumFile[], album: AlbumGro
       ...file,
       filename: syncedFilename ?? file.filename,
       status: file.status === "saved" ? "pending" : file.status,
+      hasBufferedChanges: true,
       metadata: {
         ...file.metadata,
         artist: album.artist,
@@ -61,4 +87,111 @@ export function applyAlbumSharedTagsToFiles(files: TagiumFile[], album: AlbumGro
       },
     };
   });
+}
+
+export function prepareDownloadedTrackHydration(
+  currentFile: TagiumFile,
+  parsedFile: TagiumFile,
+  formMetadata?: AudioMetadata,
+): DownloadedTrackHydration {
+  const parsedMetadata = parsedFile.metadata;
+  const bufferedMetadata = formMetadata ?? currentFile.metadata;
+  const shouldApplyBufferedMetadata = currentFile.hasBufferedChanges || Boolean(formMetadata);
+  const nextMetadata =
+    shouldApplyBufferedMetadata && bufferedMetadata
+      ? {
+          ...bufferedMetadata,
+          duration: parsedMetadata?.duration ?? bufferedMetadata.duration,
+          bitrate: parsedMetadata?.bitrate ?? bufferedMetadata.bitrate,
+          sampleRate: parsedMetadata?.sampleRate ?? bufferedMetadata.sampleRate,
+          picture:
+            bufferedMetadata.picture.length > 0
+              ? bufferedMetadata.picture
+              : (parsedMetadata?.picture ?? []),
+        }
+      : (parsedMetadata ?? currentFile.metadata);
+
+  const hydratedFile: TagiumFile = {
+    ...currentFile,
+    file: parsedFile.file,
+    originalFile: parsedFile.originalFile,
+    filename:
+      shouldApplyBufferedMetadata && nextMetadata?.filename
+        ? `${nextMetadata.filename}.mp3`
+        : parsedFile.filename,
+    metadata: nextMetadata,
+    downloadStatus: "ready",
+    downloadError: parsedFile.downloadError,
+    status: shouldApplyBufferedMetadata ? "pending" : parsedFile.status,
+    hasBufferedChanges: shouldApplyBufferedMetadata,
+  };
+
+  return {
+    hydratedFile,
+    metadataToWrite: shouldApplyBufferedMetadata ? nextMetadata : undefined,
+  };
+}
+
+export function resolveDownloadedTrackHydrationWrite(
+  currentFile: TagiumFile,
+  latestFile: TagiumFile,
+  parsedFile: TagiumFile,
+  hydratedFile: TagiumFile,
+  updatedFile: File,
+  metadataToWrite: AudioMetadata,
+  latestFormMetadata?: AudioMetadata,
+) {
+  if (latestFile !== currentFile || latestFormMetadata) {
+    const nextFile = latestFormMetadata
+      ? {
+          ...latestFile,
+          filename: `${latestFormMetadata.filename}.mp3`,
+          metadata: latestFormMetadata,
+        }
+      : latestFile;
+
+    return {
+      ...nextFile,
+      file: updatedFile,
+      originalFile: parsedFile.originalFile,
+      metadata: mergeLatestMetadataWithHydratedTechnicalFields(nextFile, hydratedFile),
+      downloadStatus: "ready" as const,
+      downloadError: undefined,
+      status: "pending" as const,
+      hasBufferedChanges: true,
+    };
+  }
+
+  return {
+    ...hydratedFile,
+    file: updatedFile,
+    filename: updatedFile.name,
+    metadata: {
+      ...metadataToWrite,
+      filename: metadataToWrite.filename,
+    },
+    status: "saved" as const,
+    hasBufferedChanges: false,
+  };
+}
+
+export function resolveDownloadedTrackHydrationWriteError(
+  currentFile: TagiumFile,
+  latestFile: TagiumFile,
+  parsedFile: TagiumFile,
+  hydratedFile: TagiumFile,
+  errorMessage: string,
+) {
+  const nextFile = latestFile !== currentFile ? latestFile : hydratedFile;
+
+  return {
+    ...nextFile,
+    file: parsedFile.file,
+    originalFile: parsedFile.originalFile,
+    metadata: mergeLatestMetadataWithHydratedTechnicalFields(nextFile, hydratedFile),
+    downloadStatus: "ready" as const,
+    downloadError: errorMessage,
+    status: "error" as const,
+    hasBufferedChanges: true,
+  };
 }

--- a/components/audio/mp3Utils.ts
+++ b/components/audio/mp3Utils.ts
@@ -106,6 +106,8 @@ export async function parseUploadedTracks(uploadedFiles: File[]) {
           originalFile: file,
           filename: file.name,
           status: "pending",
+          downloadStatus: "ready",
+          hasBufferedChanges: false,
           metadata,
         },
         albumSeed: {
@@ -124,6 +126,9 @@ export async function parseUploadedTracks(uploadedFiles: File[]) {
           originalFile: file,
           filename: file.name,
           status: "error",
+          downloadStatus: "ready",
+          downloadError: error instanceof Error ? error.message : "Unable to parse audio metadata.",
+          hasBufferedChanges: false,
         },
         albumSeed: {
           title: "",
@@ -138,6 +143,10 @@ export async function parseUploadedTracks(uploadedFiles: File[]) {
 }
 
 export async function writeMetadataToFile(fileToUpdate: TagiumFile, newTags: AudioMetadata) {
+  if (!fileToUpdate.file) {
+    throw new Error("Audio file is still downloading.");
+  }
+
   const MP3Tag = (await import("mp3tag.js")).default;
   const arrayBuffer = await fileToUpdate.file.arrayBuffer();
   const mp3tag = new MP3Tag(arrayBuffer, true) as unknown as MP3TagReader;

--- a/components/audio/types.ts
+++ b/components/audio/types.ts
@@ -25,9 +25,12 @@ export type AudioMetadata = z.infer<typeof audioMetadataSchema>;
 
 export interface TagiumFile {
   id: string;
-  file: File;
-  originalFile: File;
+  file?: File;
+  originalFile?: File;
   status: "pending" | "saved" | "error";
+  downloadStatus: "downloading" | "ready" | "error";
+  downloadError?: string;
+  hasBufferedChanges: boolean;
   filename: string;
   metadata?: AudioMetadata;
 }

--- a/components/audio/types.ts
+++ b/components/audio/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { AudioDownloadBitrate } from "./cobaltDownload";
 
 export const audioMetadataSchema = z.object({
   filename: z.string(),
@@ -30,6 +31,10 @@ export interface TagiumFile {
   status: "pending" | "saved" | "error";
   downloadStatus: "downloading" | "ready" | "error";
   downloadError?: string;
+  downloadRequest?: {
+    sourceUrl: string;
+    audioBitrate: AudioDownloadBitrate;
+  };
   hasBufferedChanges: boolean;
   filename: string;
   metadata?: AudioMetadata;


### PR DESCRIPTION
## Summary
- switch URL and SoundCloud set imports into the editor immediately with placeholder tracks
- allow metadata edits while audio blobs are still downloading and apply buffered edits on hydration
- surface download/metadata errors and add regression coverage for hydration races and pending saves

## Validation
- bunx vp fmt --check
- bunx vp lint .
- bunx vp check
- bunx vp test run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for downloading individual audio tracks and SoundCloud sets with progress feedback.
  * Added retry actions for failed track downloads.

* **Bug Fixes**
  * Improved download and error states across track lists, editor panels, and the landing screen.
  * Better preserves edits when downloaded tracks are updated, and prevents saving items that are still unavailable.
  * Added clearer messages for download and metadata failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->