### PR TITLE
[codex] sort imported tracks by track number

### DIFF
--- a/components/audio/albumOps.test.ts
+++ b/components/audio/albumOps.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mergeUploadedTracksIntoAlbums } from "./albumOps";
+import type { UploadedTrack } from "./mp3Utils";
+import type { AudioMetadata } from "./types";
+
+const metadata = (trackNumber?: number): AudioMetadata => ({
+  filename: "track",
+  title: "Track",
+  artist: "Artist",
+  album: "Album",
+  year: 2024,
+  genre: "",
+  duration: 0,
+  bitrate: 0,
+  sampleRate: 0,
+  picture: [],
+  trackNumber,
+});
+
+const upload = (
+  id: string,
+  albumSeed: UploadedTrack["albumSeed"],
+  trackNumber?: number,
+): UploadedTrack => ({
+  file: {
+    id,
+    file: new File(["a"], `${id}.mp3`, { type: "audio/mpeg" }),
+    originalFile: new File(["a"], `${id}.mp3`, { type: "audio/mpeg" }),
+    filename: `${id}.mp3`,
+    status: "pending",
+    downloadStatus: "ready",
+    hasBufferedChanges: false,
+    metadata: metadata(trackNumber),
+  },
+  albumSeed,
+});
+
+describe("albumOps", () => {
+  it("uses original import order as the forced album seed source", () => {
+    const originalUploads = [
+      upload("track-10", { title: "Tagged Album", artist: "Tagged Artist", genre: "Rock" }, 10),
+      upload("track-1", { title: "", artist: "", genre: "" }, 1),
+    ];
+    const sortedUploads = [originalUploads[1], originalUploads[0]];
+
+    const result = mergeUploadedTracksIntoAlbums([], sortedUploads, {
+      forceSingleAlbum: true,
+      albumSeedUploads: originalUploads,
+    });
+
+    expect(result.albums[0].title).toBe("Tagged Album");
+    expect(result.albums[0].artist).toBe("Tagged Artist");
+    expect(result.albums[0].genre).toBe("Rock");
+    expect(result.albums[0].trackIds).toEqual(["track-1", "track-10"]);
+  });
+});

--- a/components/audio/albumOps.ts
+++ b/components/audio/albumOps.ts
@@ -13,6 +13,7 @@ export interface AlbumMetadataInput {
 
 interface MergeUploadedTracksOptions {
   forceSingleAlbum?: boolean;
+  albumSeedUploads?: UploadedTrack[];
 }
 
 export type SidebarDropTarget =
@@ -45,7 +46,10 @@ export function mergeUploadedTracksIntoAlbums(
   const forceSingleAlbum = options.forceSingleAlbum ?? false;
 
   if (forceSingleAlbum && parsedUploads.length > 0) {
-    const firstSeed = parsedUploads[0].albumSeed;
+    const albumSeedUploads = options.albumSeedUploads ?? parsedUploads;
+    const firstSeed =
+      albumSeedUploads.find((upload) => upload.albumSeed.title.trim())?.albumSeed ??
+      albumSeedUploads[0].albumSeed;
     const albumTitle = firstSeed.title || `Album ${nextAlbums.length + 1}`;
 
     const createdAlbum: AlbumGroup = {

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -23,7 +23,13 @@ import {
 import TagSidebarPanel from "./TagSidebarPanel";
 import LandingScreen from "./LandingScreen";
 import TrackMetadataEditor from "./TrackMetadataEditor";
-import { parseUploadedTracks, toGenreString, writeMetadataToFile } from "./mp3Utils";
+import {
+  parseUploadedTracks,
+  sortTrackIdsByTrackNumber,
+  sortUploadedTracksByTrackNumber,
+  toGenreString,
+  writeMetadataToFile,
+} from "./mp3Utils";
 import type { SoundCloudSet } from "./soundcloudSet";
 import { AlbumGroup, AudioMetadata, ImportedAlbumMetadata, TagiumFile } from "./types";
 const EMPTY_ALBUM_DRAFT: AlbumMetadataDraft = {
@@ -340,8 +346,9 @@ export default function AudioTagger() {
       try {
         const parsedUploads = await parseUploadedTracks(uniqueUploadedFiles);
         if (parsedUploads.length === 0) return;
+        const orderedUploads = sortUploadedTracksByTrackNumber(parsedUploads);
 
-        const nextFiles = [...filesRef.current, ...parsedUploads.map((upload) => upload.file)];
+        const nextFiles = [...filesRef.current, ...orderedUploads.map((upload) => upload.file)];
         filesRef.current = nextFiles;
         setFiles(nextFiles);
 
@@ -354,10 +361,16 @@ export default function AudioTagger() {
         let firstSelectedAlbumId: string | null = null;
 
         if (hasTargetAlbum && targetAlbumId) {
-          const uploadedTrackIds = parsedUploads.map((upload) => upload.file.id);
+          const uploadedTrackIds = orderedUploads.map((upload) => upload.file.id);
           const nextAlbums = currentAlbums.map((album) =>
             album.id === targetAlbumId
-              ? { ...album, trackIds: asUniqueTrackIds([...album.trackIds, ...uploadedTrackIds]) }
+              ? {
+                  ...album,
+                  trackIds: sortTrackIdsByTrackNumber(
+                    asUniqueTrackIds([...album.trackIds, ...uploadedTrackIds]),
+                    nextFiles,
+                  ),
+                }
               : album,
           );
           albumsRef.current = nextAlbums;
@@ -371,7 +384,7 @@ export default function AudioTagger() {
             filesRef.current = taggedFiles;
             setFiles(taggedFiles);
           }
-          setSelectedFileId(parsedUploads[0].file.id);
+          setSelectedFileId(orderedUploads[0].file.id);
           setSelectedAlbumId(targetAlbumId);
         } else if (importedAlbum) {
           let importedCover: AudioMetadata["picture"] | undefined;
@@ -390,7 +403,7 @@ export default function AudioTagger() {
             artist: importedAlbum.artist,
             genre: importedAlbum.genre,
             cover: importedCover ?? embeddedCover,
-            trackIds: parsedUploads.map((upload) => upload.file.id),
+            trackIds: orderedUploads.map((upload) => upload.file.id),
             year: importedAlbum.year,
             syncTrackNumbers: true,
             syncFilenames: false,
@@ -405,11 +418,12 @@ export default function AudioTagger() {
           );
           filesRef.current = taggedFiles;
           setFiles(taggedFiles);
-          setSelectedFileId(parsedUploads[0].file.id);
+          setSelectedFileId(orderedUploads[0].file.id);
           setSelectedAlbumId(downloadedAlbum.id);
         } else {
-          const merged = mergeUploadedTracksIntoAlbums(currentAlbums, parsedUploads, {
+          const merged = mergeUploadedTracksIntoAlbums(currentAlbums, orderedUploads, {
             forceSingleAlbum,
+            albumSeedUploads: parsedUploads,
           });
           firstSelectedAlbumId = merged.firstSelectedAlbumId;
           albumsRef.current = merged.albums;
@@ -419,7 +433,7 @@ export default function AudioTagger() {
               asUniqueTrackIds([...prevLooseTrackIds, ...merged.unassignedTrackIds]),
             );
           }
-          const firstUploadedTrack = parsedUploads[0];
+          const firstUploadedTrack = orderedUploads[0];
           const firstTrackIsLoose = !forceSingleAlbum && !firstUploadedTrack.albumSeed.title.trim();
           setSelectedFileId(firstUploadedTrack.file.id);
           setSelectedAlbumId(firstTrackIsLoose ? null : firstSelectedAlbumId);

--- a/components/audio/mp3Utils.test.ts
+++ b/components/audio/mp3Utils.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  parseTrackTagNumber,
+  sortTrackIdsByTrackNumber,
+  sortUploadedTracksByTrackNumber,
+  type UploadedTrack,
+} from "./mp3Utils";
+import type { AudioMetadata } from "./types";
+
+const metadata = (trackNumber?: number): AudioMetadata => ({
+  filename: "track",
+  title: "Track",
+  artist: "Artist",
+  album: "Album",
+  year: 2024,
+  genre: "",
+  duration: 0,
+  bitrate: 0,
+  sampleRate: 0,
+  picture: [],
+  trackNumber,
+});
+
+const upload = (id: string, trackNumber?: number): UploadedTrack => ({
+  file: {
+    id,
+    file: new File(["a"], `${id}.mp3`, { type: "audio/mpeg" }),
+    originalFile: new File(["a"], `${id}.mp3`, { type: "audio/mpeg" }),
+    filename: `${id}.mp3`,
+    status: "pending",
+    downloadStatus: "ready",
+    hasBufferedChanges: false,
+    metadata: metadata(trackNumber),
+  },
+  albumSeed: {
+    title: "Album",
+    artist: "Artist",
+    genre: "",
+  },
+});
+
+const failedUpload = (id: string): UploadedTrack => ({
+  file: {
+    id,
+    file: new File(["a"], `${id}.mp3`, { type: "audio/mpeg" }),
+    originalFile: new File(["a"], `${id}.mp3`, { type: "audio/mpeg" }),
+    filename: `${id}.mp3`,
+    status: "error",
+    downloadStatus: "ready",
+    downloadError: "Invalid ID3 tag",
+    hasBufferedChanges: false,
+  },
+  albumSeed: {
+    title: "",
+    artist: "",
+    genre: "",
+  },
+});
+
+describe("mp3Utils", () => {
+  it("parses only valid positive integer track tags", () => {
+    expect(parseTrackTagNumber(undefined)).toBeUndefined();
+    expect(parseTrackTagNumber("")).toBeUndefined();
+    expect(parseTrackTagNumber("1")).toBe(1);
+    expect(parseTrackTagNumber(" 2 ")).toBe(2);
+    expect(parseTrackTagNumber("03/12")).toBe(3);
+    expect(parseTrackTagNumber("0")).toBeUndefined();
+    expect(parseTrackTagNumber("-1")).toBeUndefined();
+    expect(parseTrackTagNumber("1.5")).toBeUndefined();
+    expect(parseTrackTagNumber("1abc")).toBeUndefined();
+    expect(parseTrackTagNumber("abc1")).toBeUndefined();
+    expect(parseTrackTagNumber("/12")).toBeUndefined();
+    expect(parseTrackTagNumber("Infinity")).toBeUndefined();
+  });
+
+  it("sorts uploaded tracks by valid track number with invalid tracks at the end", () => {
+    const uploads = [
+      upload("missing-track"),
+      upload("track-3", 3),
+      upload("track-1", 1),
+      upload("zero-track", 0),
+      upload("track-2", 2),
+      failedUpload("parse-failure"),
+    ];
+
+    const result = sortUploadedTracksByTrackNumber(uploads);
+
+    expect(result.map((entry) => entry.file.id)).toEqual([
+      "track-1",
+      "track-2",
+      "track-3",
+      "missing-track",
+      "zero-track",
+      "parse-failure",
+    ]);
+  });
+
+  it("keeps stable order for duplicate and invalid uploaded track numbers", () => {
+    const uploads = [
+      upload("track-2-a", 2),
+      upload("negative-track", -1),
+      upload("track-2-b", 2),
+      upload("missing-track"),
+      upload("track-1", 1),
+    ];
+
+    const result = sortUploadedTracksByTrackNumber(uploads);
+
+    expect(result.map((entry) => entry.file.id)).toEqual([
+      "track-1",
+      "track-2-a",
+      "track-2-b",
+      "negative-track",
+      "missing-track",
+    ]);
+  });
+
+  it("does not mutate parsed uploads", () => {
+    const uploads = [upload("track-2", 2), upload("track-1", 1)];
+
+    sortUploadedTracksByTrackNumber(uploads);
+
+    expect(uploads.map((entry) => entry.file.id)).toEqual(["track-2", "track-1"]);
+  });
+
+  it("sorts existing album track ids by file track number", () => {
+    const files = [
+      upload("existing-track-9", 9).file,
+      upload("imported-track-1", 1).file,
+      upload("invalid-track", 0).file,
+      failedUpload("parse-failure").file,
+      upload("imported-track-2", 2).file,
+    ];
+
+    const result = sortTrackIdsByTrackNumber(
+      [
+        "existing-track-9",
+        "invalid-track",
+        "parse-failure",
+        "imported-track-1",
+        "imported-track-2",
+      ],
+      files,
+    );
+
+    expect(result).toEqual([
+      "imported-track-1",
+      "imported-track-2",
+      "existing-track-9",
+      "invalid-track",
+      "parse-failure",
+    ]);
+  });
+});

--- a/components/audio/mp3Utils.ts
+++ b/components/audio/mp3Utils.ts
@@ -35,6 +35,16 @@ export interface UploadedTrack {
   };
 }
 
+export const parseTrackTagNumber = (value: string | undefined) => {
+  if (!value) return undefined;
+  const [head] = value.split("/");
+  const trimmed = head?.trim();
+  if (!trimmed) return undefined;
+  if (!/^\d+$/.test(trimmed)) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  return parsed < 1 ? undefined : parsed;
+};
+
 const parseTagNumber = (value: string | undefined) => {
   if (!value) return undefined;
   const [head] = value.split("/");
@@ -45,6 +55,43 @@ const parseTagNumber = (value: string | undefined) => {
 export const toGenreString = (genre: AudioMetadata["genre"] | undefined) => {
   if (!genre) return "";
   return Array.isArray(genre) ? genre.join(", ") : genre;
+};
+
+const getValidTrackNumber = (trackNumber: AudioMetadata["trackNumber"]) => {
+  if (!trackNumber) return undefined;
+  if (!Number.isInteger(trackNumber)) return undefined;
+  if (trackNumber < 1) return undefined;
+  return trackNumber;
+};
+
+const compareTrackNumbers = (
+  leftTrackNumber: AudioMetadata["trackNumber"],
+  rightTrackNumber: AudioMetadata["trackNumber"],
+) => {
+  const leftValidTrackNumber = getValidTrackNumber(leftTrackNumber);
+  const rightValidTrackNumber = getValidTrackNumber(rightTrackNumber);
+
+  if (leftValidTrackNumber !== undefined && rightValidTrackNumber !== undefined) {
+    return leftValidTrackNumber - rightValidTrackNumber;
+  }
+  if (leftValidTrackNumber !== undefined) return -1;
+  if (rightValidTrackNumber !== undefined) return 1;
+  return 0;
+};
+
+export const sortUploadedTracksByTrackNumber = (uploads: UploadedTrack[]) =>
+  [...uploads].sort((left, right) => {
+    return compareTrackNumbers(left.file.metadata?.trackNumber, right.file.metadata?.trackNumber);
+  });
+
+export const sortTrackIdsByTrackNumber = (trackIds: string[], files: TagiumFile[]) => {
+  const filesById = new Map(files.map((file) => [file.id, file]));
+  return [...trackIds].sort((leftId, rightId) => {
+    return compareTrackNumbers(
+      filesById.get(leftId)?.metadata?.trackNumber,
+      filesById.get(rightId)?.metadata?.trackNumber,
+    );
+  });
 };
 
 const getDuration = async (file: File) =>
@@ -96,7 +143,7 @@ export async function parseUploadedTracks(uploadedFiles: File[]) {
         bitrate: 0,
         sampleRate: 0,
         picture: pictureData,
-        trackNumber: parseTagNumber(mp3tag.tags.track),
+        trackNumber: parseTrackTagNumber(mp3tag.tags.track),
       };
 
       parsedUploads.push({


### PR DESCRIPTION
## Summary

Sort local multi-file imports by valid embedded track number so track 1 appears first and invalid or missing track numbers fall to the end of the album.

## Details

- Parse uploaded track tags with stricter positive-integer semantics.
- Reorder imported album track IDs using stable track-number sorting.
- Preserve original import order as the metadata seed source when creating a forced single album.
- Add focused tests for parsing, sorting, target-album ordering, and forced-album seed behavior.

## Validation

- `vp fmt`
- `vp lint`
- `vp check`
- `vp test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio imports now keep tracks ordered by track number when adding files or creating albums.
  * Album metadata now uses the earliest seeded track info more consistently, preserving the original import order.

* **Bug Fixes**
  * Improved handling of track numbers so invalid, missing, or non-numeric values are placed after valid tracks.
  * Album track lists now stay in the correct order after merging new uploads.

* **Tests**
  * Added coverage for track-number parsing and sorting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->