### PR TITLE
[codex] align settings sidebar state

### DIFF
--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -133,10 +133,21 @@ export default function AlbumSidebar({
 
   if (albums.length === 0 && looseTracks.length === 0) {
     return (
-      <div className="w-full flex-1 min-h-0 flex flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground px-4">
+      <div
+        className="w-full flex-1 min-h-0 flex flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground px-4"
+        onClick={onClearSelection}
+      >
         <p>no tracks yet</p>
         <p className="text-xs">create an empty album or upload tracks</p>
-        <Button type="button" variant="outline" size="sm" onClick={onAddAlbum}>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation();
+            onAddAlbum();
+          }}
+        >
           <Plus className="h-4 w-4" />
           add album
         </Button>
@@ -427,7 +438,10 @@ export default function AlbumSidebar({
               </div>
               <div className="flex flex-col">
                 {album.trackIds.length === 0 ? (
-                  <div className="text-xs text-muted-foreground px-4 py-3 text-center">
+                  <div
+                    className="text-xs text-muted-foreground px-4 py-3 text-center"
+                    onClick={onClearSelection}
+                  >
                     drag tracks here
                   </div>
                 ) : (

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -164,8 +164,8 @@ export default function TagSidebarPanel({
           {loading ? "Saving..." : "Save All"}
         </Button>
         <Button
-          variant={settingsOpen ? "secondary" : "outline"}
-          className="w-full justify-start"
+          variant={settingsOpen ? "ghost" : "outline"}
+          className={cn("w-full justify-start", settingsOpen && "bg-accent text-accent-foreground")}
           onClick={onOpenSettings}
         >
           <Settings />

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -164,8 +164,12 @@ export default function TagSidebarPanel({
           {loading ? "Saving..." : "Save All"}
         </Button>
         <Button
-          variant={settingsOpen ? "ghost" : "outline"}
-          className={cn("w-full justify-start", settingsOpen && "bg-accent text-accent-foreground")}
+          variant="outline"
+          className={cn(
+            "w-full justify-start",
+            settingsOpen &&
+              "border-transparent bg-accent text-accent-foreground shadow-none hover:bg-accent",
+          )}
           onClick={onOpenSettings}
         >
           <Settings />

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -975,6 +975,7 @@ export default function AudioTagger() {
   };
 
   const handleClearSelection = () => {
+    setActiveView("editor");
     setSelectedAlbumId(null);
     setSelectedFileId(null);
     setSelectedFileIds(new Set());


### PR DESCRIPTION
## Summary

- Align the active settings button highlight with selected sidebar tracks.
- Return from settings to the editor when the user clicks blank sidebar space, including empty library and empty album states.

## Root Cause

The settings button used the secondary button variant while track selection used accent styling. Blank sidebar clicks cleared selection but did not close settings, and empty-sidebar states did not all route through the same clear-selection path.

## Validation

- `vp fmt`
- `vp lint .`
- `vp check`
- `vp test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clicking the album creation button in the empty state no longer clears the current selection unexpectedly.
  * Clicking an empty album placeholder now properly clears the current selection.
  * Clearing a file or album selection now returns the interface to the editor view.

* **Style**
  * Updated the settings button’s active appearance to use more consistent outline styling with conditional visual emphasis when open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->