### PR TITLE
[codex] unify download actions

### DIFF
--- a/components/audio/AlbumMetadataDialog.tsx
+++ b/components/audio/AlbumMetadataDialog.tsx
@@ -58,7 +58,7 @@ export default function AlbumMetadataDialog({
             format: file.type,
             type: 3,
             data: uint8Array,
-            description: "Uploaded cover",
+            description: "uploaded cover",
           },
         ],
       });
@@ -92,7 +92,7 @@ export default function AlbumMetadataDialog({
           <DialogHeader className="border-b p-5">
             <DialogTitle>{mode === "create" ? "create album" : "edit album"}</DialogTitle>
             <DialogDescription className="sr-only">
-              Edit album metadata including cover art.
+              edit album metadata including cover art.
             </DialogDescription>
           </DialogHeader>
           <div className="p-5 overflow-y-auto">

--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -287,8 +287,8 @@ export default function AlbumSidebar({
                   onRetryDownload(track.id);
                 }}
                 className="absolute right-7 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded-full cursor-pointer"
-                title="Retry download"
-                aria-label={`Retry download for ${track.filename}`}
+                title="retry download"
+                aria-label={`retry download for ${track.filename}`}
               >
                 <RefreshCw className="h-3 w-3 text-muted-foreground hover:text-primary" />
               </button>
@@ -300,7 +300,7 @@ export default function AlbumSidebar({
                 onRemoveFile(track.id);
               }}
               className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
-              title="Remove track"
+              title="remove track"
             >
               <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
             </button>
@@ -308,7 +308,12 @@ export default function AlbumSidebar({
         ))}
 
         {albums.map((album, albumIndex) => {
-          const canDownloadAlbum = album.trackIds.every((trackId) => filesById.get(trackId)?.file);
+          const canDownloadAlbum =
+            album.trackIds.length > 0 &&
+            album.trackIds.every((trackId) => {
+              const file = filesById.get(trackId);
+              return file?.file && file.metadata;
+            });
           return (
             <div
               key={album.id}
@@ -409,7 +414,7 @@ export default function AlbumSidebar({
                   <div className="min-w-0 flex-1">
                     <div className="text-sm font-medium truncate leading-tight">{album.title}</div>
                     <div className="text-xs text-muted-foreground truncate leading-tight">
-                      {album.artist || "Unknown"} &middot; {album.trackIds.length} track
+                      {album.artist || "unknown"} &middot; {album.trackIds.length} track
                       {album.trackIds.length !== 1 ? "s" : ""}
                     </div>
                   </div>
@@ -421,7 +426,7 @@ export default function AlbumSidebar({
                   className="h-7 w-7"
                   onClick={() => onDownloadAlbum(album.id)}
                   disabled={!canDownloadAlbum}
-                  aria-label={`Download ${album.title}`}
+                  aria-label={`download ${album.title}`}
                 >
                   <Download className="h-3.5 w-3.5" />
                 </Button>
@@ -431,7 +436,7 @@ export default function AlbumSidebar({
                   size="icon"
                   className="h-7 w-7"
                   onClick={() => onEditAlbum(album.id)}
-                  aria-label={`Edit ${album.title}`}
+                  aria-label={`edit ${album.title}`}
                 >
                   <Pencil className="h-3.5 w-3.5" />
                 </Button>
@@ -539,8 +544,8 @@ export default function AlbumSidebar({
                               onRetryDownload(track.id);
                             }}
                             className="absolute right-7 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded-full cursor-pointer"
-                            title="Retry download"
-                            aria-label={`Retry download for ${track.filename}`}
+                            title="retry download"
+                            aria-label={`retry download for ${track.filename}`}
                           >
                             <RefreshCw className="h-3 w-3 text-muted-foreground hover:text-primary" />
                           </button>
@@ -552,7 +557,7 @@ export default function AlbumSidebar({
                             onRemoveFile(track.id);
                           }}
                           className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
-                          title="Remove track"
+                          title="remove track"
                         >
                           <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
                         </button>

--- a/components/audio/AudioDownloader.tsx
+++ b/components/audio/AudioDownloader.tsx
@@ -23,10 +23,11 @@ export default function AudioDownloader({
   const canDownload = sourceUrl.trim().length > 0 && !downloading;
 
   const handleDownload = async () => {
-    const trimmedUrl = sourceUrl.trim();
-    if (trimmedUrl.length === 0) {
+    if (!canDownload) {
       return;
     }
+
+    const trimmedUrl = sourceUrl.trim();
 
     setDownloading(true);
     setProgress(null);
@@ -44,7 +45,7 @@ export default function AudioDownloader({
       await onAudioDownload(trimmedUrl);
       setSourceUrl("");
     } catch (caughtError) {
-      let message = "Download failed.";
+      let message = "download failed.";
       if (caughtError instanceof Error) {
         message = getDownloadErrorMessage(caughtError);
       }
@@ -64,7 +65,7 @@ export default function AudioDownloader({
             type="url"
             name="media-url"
             autoComplete="url"
-            aria-label="Media URL"
+            aria-label="media url"
             value={sourceUrl}
             onChange={(event) => setSourceUrl(event.target.value)}
             onKeyDown={(event) => {
@@ -73,7 +74,7 @@ export default function AudioDownloader({
                 void handleDownload();
               }
             }}
-            placeholder="Paste media URL"
+            placeholder="paste media url"
             className="pl-9"
             disabled={downloading}
           />
@@ -82,7 +83,7 @@ export default function AudioDownloader({
           type="button"
           size="icon"
           disabled={!canDownload}
-          aria-label="Download audio"
+          aria-label="download audio"
           onClick={() => void handleDownload()}
         >
           {downloading && <Loader2 className="animate-spin" />}
@@ -91,7 +92,7 @@ export default function AudioDownloader({
       </div>
       {progress && (
         <p className="text-xs text-muted-foreground" aria-live="polite">
-          Downloading {progress}
+          downloading {progress}
         </p>
       )}
       {error && (

--- a/components/audio/FileList.tsx
+++ b/components/audio/FileList.tsx
@@ -62,7 +62,7 @@ export default function FileList({
                   onRemoveFile(file.id);
                 }}
                 className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
-                title="Remove file"
+                title="remove file"
               >
                 <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
               </button>

--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -79,7 +79,7 @@ export default function LandingScreen({
       if (err instanceof Error) {
         setError(getDownloadErrorMessage(err));
       } else {
-        setError("Download failed.");
+        setError("download failed.");
       }
     } finally {
       setProgress(null);
@@ -133,7 +133,7 @@ export default function LandingScreen({
           )}
           <div className="text-center">
             <p className="text-lg font-semibold text-foreground">
-              {isDragging ? "Drop to import" : "Drop your MP3s here"}
+              {isDragging ? "drop to import" : "drop your mp3s here"}
             </p>
             <p className="text-sm text-muted-foreground mt-1">or click to browse files</p>
           </div>
@@ -141,7 +141,7 @@ export default function LandingScreen({
 
         <div className="w-full flex items-center gap-4 text-sm text-muted-foreground">
           <div className="flex-1 h-px bg-border" />
-          <span>or import from a URL</span>
+          <span>or import from a url</span>
           <div className="flex-1 h-px bg-border" />
         </div>
 
@@ -154,12 +154,12 @@ export default function LandingScreen({
                 name="landing-media-url"
                 autoComplete="url"
                 value={url}
-                aria-label="Media URL"
+                aria-label="media url"
                 onChange={(e) => {
                   setUrl(e.target.value);
                   setError(null);
                 }}
-                placeholder="SoundCloud or YouTube URL"
+                placeholder="soundcloud or youtube url"
                 disabled={downloading}
                 className="w-full h-10 rounded-lg border border-input bg-transparent pl-9 pr-3 text-sm shadow-sm outline-none focus:ring-2 focus:ring-ring transition-shadow disabled:opacity-50 placeholder:text-muted-foreground"
               />
@@ -167,7 +167,7 @@ export default function LandingScreen({
             <button
               type="submit"
               disabled={!url.trim() || downloading}
-              aria-label="Download audio"
+              aria-label="download audio"
               className="h-10 w-10 rounded-lg bg-primary text-primary-foreground flex items-center justify-center flex-shrink-0 disabled:opacity-40 hover:bg-primary/90 transition-colors"
             >
               {downloading ? (
@@ -180,7 +180,7 @@ export default function LandingScreen({
 
           {progress && (
             <p className="text-xs text-muted-foreground text-center" aria-live="polite">
-              Downloading track {progress}
+              downloading track {progress}
             </p>
           )}
           {error && (

--- a/components/audio/SettingsPage.tsx
+++ b/components/audio/SettingsPage.tsx
@@ -61,7 +61,7 @@ export default function SettingsPage({ settings, onChange }: SettingsPageProps) 
                   })
                 }
                 className="border-input bg-background h-9 rounded-md border px-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] dark:bg-input/30"
-                aria-label="Download bitrate"
+                aria-label="download bitrate"
               >
                 {AUDIO_BITRATE_OPTIONS.map((bitrate) => (
                   <option key={bitrate} value={bitrate}>

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -41,7 +41,7 @@ interface TagSidebarPanelProps {
   ) => void;
   onPromptCreateAlbumFromLooseTracks: (sourceTrackId: string, targetTrackId: string) => void;
   onReorderAlbums: (albumId: string, targetIndex: number) => void;
-  onSaveAll: () => void;
+  onDownloadAll: () => void;
   onOpenSettings: () => void;
 }
 
@@ -69,11 +69,12 @@ export default function TagSidebarPanel({
   onMoveTrackToLoose,
   onPromptCreateAlbumFromLooseTracks,
   onReorderAlbums,
-  onSaveAll,
+  onDownloadAll,
   onOpenSettings,
 }: TagSidebarPanelProps) {
   const dragCounterRef = useRef(0);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
+  const canDownloadAll = files.length > 0 && files.every((file) => file.file && file.metadata);
 
   const isFileDrag = (event: React.DragEvent<HTMLDivElement>) =>
     event.dataTransfer.types.includes("Files");
@@ -160,8 +161,8 @@ export default function TagSidebarPanel({
       />
 
       <div className="px-3 py-3 border-t flex-shrink-0 flex flex-col gap-2">
-        <Button className="w-full" onClick={onSaveAll} disabled={files.length === 0 || loading}>
-          {loading ? "Saving..." : "Save All"}
+        <Button className="w-full" onClick={onDownloadAll} disabled={!canDownloadAll || loading}>
+          {loading ? "downloading..." : "download all"}
         </Button>
         <Button
           variant="outline"

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -20,9 +20,8 @@ interface TrackMetadataEditorProps {
   register: UseFormRegister<AudioMetadata>;
   control: Control<AudioMetadata>;
   handleSubmit: UseFormHandleSubmit<AudioMetadata>;
-  onSubmit: SubmitHandler<AudioMetadata>;
   onTrackCoverUpload: (file: File) => void;
-  onDownloadUpdatedFile: (file: TagiumFile) => void;
+  onDownloadUpdatedFile: SubmitHandler<AudioMetadata>;
   selectedFileAlbum: AlbumGroup | undefined;
   syncFilenames: boolean;
   syncTrackNumbers: boolean;
@@ -34,7 +33,6 @@ export default function TrackMetadataEditor({
   register,
   control,
   handleSubmit,
-  onSubmit,
   onTrackCoverUpload,
   onDownloadUpdatedFile,
   selectedFileAlbum,
@@ -49,7 +47,7 @@ export default function TrackMetadataEditor({
     return (
       <div className="flex-1 flex items-center justify-center bg-muted/5">
         <div className="text-center">
-          <p className="text-muted-foreground">Select a track to edit its tags</p>
+          <p className="text-muted-foreground">select a track to edit its tags</p>
         </div>
       </div>
     );
@@ -57,7 +55,12 @@ export default function TrackMetadataEditor({
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
-      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col h-full">
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+        }}
+        className="flex flex-col h-full"
+      >
         <div className="p-6 h-[104px] border-b flex-shrink-0 flex flex-col justify-center gap-1">
           <h2 className="text-lg font-semibold truncate">{selectedFile.filename}</h2>
           {(selectedFile.downloadStatus === "error" || selectedFile.status === "error") &&
@@ -159,14 +162,12 @@ export default function TrackMetadataEditor({
               </div>
               <div className="flex justify-end gap-2 pt-2">
                 <Button
-                  variant="outline"
                   type="button"
-                  onClick={() => onDownloadUpdatedFile(selectedFile)}
+                  onClick={handleSubmit(onDownloadUpdatedFile)}
                   disabled={!audioReady}
                 >
-                  Download
+                  download
                 </Button>
-                <Button type="submit">Save Changes</Button>
               </div>
             </div>
           </div>

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -21,6 +21,13 @@ import {
   resolveDownloadedTrackHydrationWrite,
   resolveDownloadedTrackHydrationWriteError,
 } from "./fileMetadataOps";
+import {
+  allTracksReadyForDownload,
+  createLibraryDownloadFilename,
+  createZipBlob,
+  downloadBlob,
+  getLibraryDownloadEntries,
+} from "./downloadLibrary";
 import TagSidebarPanel from "./TagSidebarPanel";
 import LandingScreen from "./LandingScreen";
 import TrackMetadataEditor from "./TrackMetadataEditor";
@@ -60,7 +67,7 @@ const titleFromSourceUrl = (sourceUrl: string) => {
     if (lastPathPart) return decodeURIComponent(lastPathPart).replaceAll("-", " ");
     return url.hostname;
   } catch {
-    return "Downloading audio";
+    return "downloading audio";
   }
 };
 const createDownloadMetadata = ({
@@ -110,12 +117,12 @@ const fetchImportedCover = async (coverUrl: string): Promise<AudioMetadata["pict
   const response = await fetch(coverUrl);
 
   if (!response.ok) {
-    throw new Error(`Album cover request failed (${response.status})`);
+    throw new Error(`album cover request failed (${response.status})`);
   }
 
   const contentType = response.headers.get("content-type");
   if (!contentType) {
-    throw new Error("Album cover response missing content type.");
+    throw new Error("album cover response missing content type.");
   }
 
   return [
@@ -123,7 +130,7 @@ const fetchImportedCover = async (coverUrl: string): Promise<AudioMetadata["pict
       format: contentType,
       type: 3,
       data: new Uint8Array(await response.arrayBuffer()),
-      description: "Album cover",
+      description: "album cover",
     },
   ];
 };
@@ -281,7 +288,7 @@ export default function AudioTagger() {
         reset(metadata);
       }
     } catch (error) {
-      let message = "Unable to save metadata.";
+      let message = "unable to save metadata.";
       if (error instanceof Error) {
         message = error.message;
       }
@@ -312,22 +319,85 @@ export default function AudioTagger() {
       throw error;
     }
   };
-  const onSubmit: SubmitHandler<AudioMetadata> = async (data) => {
-    if (!selectedFile) return;
-    const submittedData = settings.syncFilenames
-      ? { ...data, filename: filenamify(data.title, { replacement: "-" }) }
-      : data;
-    try {
-      await handleTagUpdate(selectedFile, submittedData);
-    } catch (error) {
-      console.error("Failed to update tags:", error);
+  const getSubmittedMetadata = useCallback(
+    (data: AudioMetadata) =>
+      settings.syncFilenames
+        ? { ...data, filename: filenamify(data.title, { replacement: "-" }) }
+        : data,
+    [settings.syncFilenames],
+  );
+
+  const applyCurrentFormMetadataToFiles = useCallback(
+    (filesToSync: TagiumFile[], trackIds?: string[]) => {
+      const selectedId = selectedFileIdRef.current;
+      if (!selectedId || !formDirtyRef.current) return filesToSync;
+      if (trackIds && !trackIds.includes(selectedId)) return filesToSync;
+
+      const submittedData = getSubmittedMetadata(getValues());
+      return filesToSync.map((file) =>
+        file.id === selectedId
+          ? {
+              ...file,
+              filename: submittedData.filename ? `${submittedData.filename}.mp3` : file.filename,
+              metadata: submittedData,
+              status: file.status === "saved" ? "pending" : file.status,
+              hasBufferedChanges: true,
+            }
+          : file,
+      );
+    },
+    [getSubmittedMetadata, getValues],
+  );
+
+  const bufferCurrentFormMetadata = useCallback(
+    (trackIds?: string[]) => {
+      const nextFiles = applyCurrentFormMetadataToFiles(filesRef.current, trackIds);
+      if (nextFiles === filesRef.current) return;
+      filesRef.current = nextFiles;
+      setFiles(nextFiles);
+    },
+    [applyCurrentFormMetadataToFiles],
+  );
+
+  const prepareFilesForExport = (albumIds?: string[]) => {
+    const albumsToSync = albumIds
+      ? albumsRef.current.filter((album) => albumIds.includes(album.id))
+      : albumsRef.current;
+    const trackIds = albumIds ? albumsToSync.flatMap((album) => album.trackIds) : undefined;
+    let syncedFiles = applyCurrentFormMetadataToFiles(filesRef.current, trackIds);
+
+    for (const album of albumsToSync) {
+      syncedFiles = applyAlbumSharedTagsToFiles(syncedFiles, album);
+    }
+    if (settings.syncTrackNumbers) {
+      syncedFiles = applyTrackOrderNumbersToFiles(
+        syncedFiles,
+        albumsRef.current,
+        albumsToSync.map((album) => album.id),
+      );
+    }
+    if (settings.syncFilenames) {
+      syncedFiles = applySyncedFilenamesToFiles(syncedFiles, trackIds);
+    }
+    filesRef.current = syncedFiles;
+    setFiles(syncedFiles);
+    return syncedFiles;
+  };
+
+  const writeFilesForExport = async (filesToExport: TagiumFile[]) => {
+    for (const file of filesToExport) {
+      if (!file.file) continue;
+      if (!file.metadata) continue;
+      await handleTagUpdate(file, file.metadata);
     }
   };
+
   const handleAudioUpload = async (
     uploadedFiles: File[],
     targetAlbumId?: string,
     importedAlbum?: ImportedAlbumMetadata,
   ) => {
+    bufferCurrentFormMetadata();
     const runImport = async () => {
       setActiveView("editor");
       const existingImportKeys = new Set(
@@ -403,7 +473,7 @@ export default function AudioTagger() {
             try {
               importedCover = await fetchImportedCover(importedAlbum.coverUrl);
             } catch (error) {
-              console.warn("Failed to import album cover:", error);
+              console.warn("failed to import album cover:", error);
             }
           }
           const embeddedCover = parsedUploads.find((upload) => upload.albumSeed.cover)?.albumSeed
@@ -484,7 +554,7 @@ export default function AudioTagger() {
     setFiles(nextFiles);
   };
   const markDownloadError = (fileId: string, error: unknown) => {
-    let message = "Download failed.";
+    let message = "download failed.";
     if (error instanceof Error) {
       message = error.message;
     }
@@ -504,7 +574,7 @@ export default function AudioTagger() {
   const hydrateDownloadedTrack = async (fileId: string, downloadedFile: File) => {
     const [parsedUpload] = await parseUploadedTracks([downloadedFile]);
     if (!parsedUpload) {
-      throw new Error("Downloaded track could not be parsed.");
+      throw new Error("downloaded track could not be parsed.");
     }
 
     const currentFile = filesRef.current.find((file) => file.id === fileId);
@@ -540,7 +610,7 @@ export default function AudioTagger() {
       } catch (error) {
         const latestFile = filesRef.current.find((file) => file.id === fileId);
         if (!latestFile) return;
-        let message = "Downloaded, but metadata could not be applied.";
+        let message = "downloaded, but metadata could not be applied.";
         if (error instanceof Error) {
           message = error.message;
         }
@@ -557,6 +627,7 @@ export default function AudioTagger() {
     replaceFileById(fileId, hydratedFile);
   };
   const handleAudioDownload = (sourceUrl: string) => {
+    bufferCurrentFormMetadata();
     setActiveView("editor");
     const id = crypto.randomUUID();
     const title = titleFromSourceUrl(sourceUrl);
@@ -593,6 +664,7 @@ export default function AudioTagger() {
     })();
   };
   const handleSoundCloudSetDownload = (set: SoundCloudSet) => {
+    bufferCurrentFormMetadata();
     setActiveView("editor");
     const albumId = crypto.randomUUID();
     const pendingFiles = set.tracks.map((track) =>
@@ -669,7 +741,7 @@ export default function AudioTagger() {
               }),
           );
         } catch (error) {
-          console.warn("Failed to import album cover:", error);
+          console.warn("failed to import album cover:", error);
         }
       })();
     }
@@ -717,34 +789,25 @@ export default function AudioTagger() {
       }
     })();
   };
-  const handleSaveAll = async () => {
+  const handleDownloadAll = async () => {
     if (files.length === 0) return;
+    if (!allTracksReadyForDownload(filesRef.current)) return;
     setLoading(true);
     try {
-      let syncedFiles = files;
-      for (const album of albums) {
-        syncedFiles = applyAlbumSharedTagsToFiles(syncedFiles, album);
-      }
-      if (settings.syncTrackNumbers) {
-        syncedFiles = applyTrackOrderNumbersToFiles(
-          syncedFiles,
-          albums,
-          albums.map((album) => album.id),
-        );
-      }
-      if (settings.syncFilenames) {
-        syncedFiles = applySyncedFilenamesToFiles(syncedFiles);
-      }
-      for (const file of syncedFiles) {
-        if (!file.file && !file.hasBufferedChanges) {
-          continue;
-        }
-        if (file.metadata) {
-          await handleTagUpdate(file, file.metadata);
-        }
-      }
+      const syncedFiles = prepareFilesForExport();
+      await writeFilesForExport(syncedFiles);
+
+      const entries = getLibraryDownloadEntries({
+        albums,
+        looseTrackIds,
+        files: filesRef.current,
+      });
+      if (entries.length === 0) return;
+
+      const blob = await createZipBlob(entries);
+      downloadBlob(blob, createLibraryDownloadFilename());
     } catch (error) {
-      console.error("Error saving all files:", error);
+      console.error("error downloading all files:", error);
     } finally {
       setLoading(false);
     }
@@ -779,7 +842,7 @@ export default function AudioTagger() {
             format: file.type,
             type: 3,
             data: uint8Array,
-            description: "Uploaded cover",
+            description: "uploaded cover",
           },
         ],
         { shouldDirty: true },
@@ -788,37 +851,53 @@ export default function AudioTagger() {
     reader.readAsArrayBuffer(file);
   };
   const handleDownloadAlbum = async (albumId: string) => {
-    const album = albums.find((a) => a.id === albumId);
+    const album = albumsRef.current.find((a) => a.id === albumId);
     if (!album) return;
-    const albumFiles = album.trackIds
-      .map((id) => files.find((f) => f.id === id))
-      .filter((f): f is TagiumFile & { file: File } => Boolean(f?.file));
-    if (albumFiles.length !== album.trackIds.length) return;
-    const { zip } = await import("fflate");
-    const entries: Record<string, [Uint8Array, { level: 0 }]> = {};
-    await Promise.all(
-      albumFiles.map(async (file) => {
-        entries[file.filename] = [new Uint8Array(await file.file.arrayBuffer()), { level: 0 }];
-      }),
-    );
-    zip(entries, (_err, data) => {
-      const blob = new Blob([data.buffer as ArrayBuffer], { type: "application/zip" });
-      const url = URL.createObjectURL(blob);
-      const anchor = document.createElement("a");
-      anchor.href = url;
-      anchor.download = `${album.title}.zip`;
-      anchor.click();
-      URL.revokeObjectURL(url);
-    });
+    setLoading(true);
+    try {
+      const syncedFiles = prepareFilesForExport([albumId]);
+      const albumFiles = album.trackIds
+        .map((id) => syncedFiles.find((file) => file.id === id))
+        .filter((file): file is TagiumFile & { file: File; metadata: AudioMetadata } =>
+          Boolean(file?.file && file.metadata),
+        );
+      if (albumFiles.length !== album.trackIds.length) return;
+      await writeFilesForExport(albumFiles);
+
+      const entries = getLibraryDownloadEntries({
+        albums: [album],
+        looseTrackIds: [],
+        files: filesRef.current,
+        albumRoot: "",
+        includeUnassignedFiles: false,
+      });
+      if (entries.length === 0) return;
+
+      const blob = await createZipBlob(entries);
+      const albumFilename = filenamify(album.title, { replacement: "-" });
+      if (albumFilename) {
+        downloadBlob(blob, `${albumFilename}.zip`);
+        return;
+      }
+      downloadBlob(blob, "album.zip");
+    } catch (error) {
+      console.error("error downloading album:", error);
+    } finally {
+      setLoading(false);
+    }
   };
-  const handleDownloadUpdatedFile = (file: TagiumFile) => {
-    if (!file.file) return;
-    const url = URL.createObjectURL(file.file);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = file.filename;
-    anchor.click();
-    URL.revokeObjectURL(url);
+  const handleDownloadUpdatedFile: SubmitHandler<AudioMetadata> = async (data) => {
+    if (!selectedFile) return;
+    const fileId = selectedFile.id;
+    const submittedData = getSubmittedMetadata(data);
+    try {
+      await handleTagUpdate(selectedFile, submittedData);
+      const updatedFile = filesRef.current.find((file) => file.id === fileId);
+      if (!updatedFile?.file) return;
+      downloadBlob(updatedFile.file, updatedFile.filename);
+    } catch (error) {
+      console.error("failed to update tags before download:", error);
+    }
   };
   const handleRemoveFile = (idToRemove: string) => {
     const affectedAlbumIds = albumsRef.current
@@ -860,6 +939,7 @@ export default function AudioTagger() {
   };
   const handleSelectAlbum = (albumId: string, event?: ReactMouseEvent) => {
     setActiveView("editor");
+    bufferCurrentFormMetadata();
     const isMultiSelect = event?.ctrlKey || event?.metaKey;
 
     if (isMultiSelect) {
@@ -891,6 +971,7 @@ export default function AudioTagger() {
 
   const handleSelectFile = (albumId: string, fileId: string, event?: ReactMouseEvent) => {
     setActiveView("editor");
+    bufferCurrentFormMetadata();
     const isMultiSelect = event?.ctrlKey || event?.metaKey;
     const isRangeSelect = event?.shiftKey && lastSelectedFileId;
 
@@ -935,6 +1016,7 @@ export default function AudioTagger() {
 
   const handleSelectLooseTrack = (fileId: string, event?: ReactMouseEvent) => {
     setActiveView("editor");
+    bufferCurrentFormMetadata();
     const isMultiSelect = event?.ctrlKey || event?.metaKey;
     const isRangeSelect = event?.shiftKey && lastSelectedFileId;
 
@@ -974,13 +1056,14 @@ export default function AudioTagger() {
     }
   };
 
-  const handleClearSelection = () => {
+  const handleClearSelection = useCallback(() => {
     setActiveView("editor");
+    bufferCurrentFormMetadata();
     setSelectedAlbumId(null);
     setSelectedFileId(null);
     setSelectedFileIds(new Set());
     setLastSelectedFileId(null);
-  };
+  }, [bufferCurrentFormMetadata]);
 
   const handleRemoveSelectedFiles = useCallback(() => {
     const idsToRemove = Array.from(selectedFileIds);
@@ -1009,13 +1092,14 @@ export default function AudioTagger() {
   }, [selectedFileIds, settings.syncTrackNumbers]);
 
   const handleSelectAllFiles = useCallback(() => {
+    bufferCurrentFormMetadata();
     const allFileIds = new Set(files.map((file) => file.id));
     setSelectedFileIds(allFileIds);
     if (files.length > 0) {
       setSelectedFileId(files[0].id);
       setLastSelectedFileId(files[0].id);
     }
-  }, [files]);
+  }, [files, bufferCurrentFormMetadata]);
 
   const handleReorderAlbums = (albumId: string, targetIndex: number) => {
     setAlbums((prevAlbums) => reorderAlbums(prevAlbums, albumId, targetIndex));
@@ -1054,11 +1138,11 @@ export default function AudioTagger() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedFileIds, handleSelectAllFiles, handleRemoveSelectedFiles]);
+  }, [selectedFileIds, handleSelectAllFiles, handleRemoveSelectedFiles, handleClearSelection]);
 
   const openCreateAlbumDialog = (seedTrackIds: string[]) => {
     const uniqueSeedTrackIds = asUniqueTrackIds(seedTrackIds);
-    const seedTrack = files.find((file) => file.id === uniqueSeedTrackIds[0]);
+    const seedTrack = filesRef.current.find((file) => file.id === uniqueSeedTrackIds[0]);
     setAlbumDialogMode("create");
     setEditingAlbumId(null);
     setCreateSeedTrackIds(uniqueSeedTrackIds);
@@ -1077,10 +1161,12 @@ export default function AudioTagger() {
     setAlbumDialogOpen(true);
   };
   const handleOpenCreateAlbumDialog = () => {
+    bufferCurrentFormMetadata();
     openCreateAlbumDialog([]);
   };
   const handlePromptCreateAlbumFromLooseTracks = (sourceTrackId: string, targetTrackId: string) => {
     if (sourceTrackId === targetTrackId) return;
+    bufferCurrentFormMetadata();
     const idSet = new Set([sourceTrackId, targetTrackId]);
     const orderedIds = looseTrackIds.filter((trackId) => idSet.has(trackId));
     if (orderedIds.length < 2) return;
@@ -1105,7 +1191,7 @@ export default function AudioTagger() {
     setAlbumDialogOpen(false);
   };
   const saveAlbumDialog = () => {
-    const title = albumDraft.title.trim() || "Untitled Album";
+    const title = albumDraft.title.trim() || "untitled album";
     const artist = albumDraft.artist.trim();
     const genre = albumDraft.genre.trim();
     const metadata = {
@@ -1170,6 +1256,7 @@ export default function AudioTagger() {
     referenceTrackId?: string,
   ) => {
     setActiveView("editor");
+    bufferCurrentFormMetadata();
     const moved = moveTrackInSidebar(
       albums,
       looseTrackIds,
@@ -1204,6 +1291,7 @@ export default function AudioTagger() {
     referenceTrackId?: string,
   ) => {
     setActiveView("editor");
+    bufferCurrentFormMetadata();
     const moved = moveTrackInSidebar(
       albums,
       looseTrackIds,
@@ -1281,7 +1369,7 @@ export default function AudioTagger() {
           onMoveTrackToLoose={handleMoveTrackToLoose}
           onPromptCreateAlbumFromLooseTracks={handlePromptCreateAlbumFromLooseTracks}
           onReorderAlbums={handleReorderAlbums}
-          onSaveAll={handleSaveAll}
+          onDownloadAll={handleDownloadAll}
           onOpenSettings={() => setActiveView("settings")}
         />
         <div className="relative min-h-0 flex-1 flex flex-col overflow-hidden">
@@ -1300,7 +1388,6 @@ export default function AudioTagger() {
               register={register}
               control={control}
               handleSubmit={handleSubmit}
-              onSubmit={onSubmit}
               onTrackCoverUpload={handleTrackCoverUpload}
               onDownloadUpdatedFile={handleDownloadUpdatedFile}
               selectedFileAlbum={selectedFileAlbum}

--- a/components/audio/audioUpload.tsx
+++ b/components/audio/audioUpload.tsx
@@ -46,7 +46,7 @@ export default function AudioUpload({ onAudioUpload }: AudioUploadProps) {
         variant="outline"
         className="w-full cursor-pointer border-dashed border-2 h-12 hover:bg-accent/50 flex flex-col gap-2"
         onClick={handleButtonClick}
-        aria-label="Upload audio files"
+        aria-label="upload audio files"
       >
         <Upload className="h-6 w-6 text-muted-foreground" />
       </Button>

--- a/components/audio/cobaltDownload.ts
+++ b/components/audio/cobaltDownload.ts
@@ -122,7 +122,7 @@ const fetchTunnelFile = async (url: string, filename: string, lastModified: numb
   }
   const blob = await response.blob();
   if (blob.size === 0) {
-    throw new Error("Cobalt tunnel response was empty.");
+    throw new Error("cobalt tunnel response was empty.");
   }
 
   return new File([blob], filename, {
@@ -178,12 +178,12 @@ const processLocalAudio = async (
   );
   const outputFormat = plan.output.filename.split(".").pop();
   if (!outputFormat) {
-    throw new Error("Cobalt local processing response missing output format.");
+    throw new Error("cobalt local processing response missing output format.");
   }
 
   const audioFile = inputFiles[0];
   if (!audioFile) {
-    throw new Error("Cobalt local processing response missing audio tunnel.");
+    throw new Error("cobalt local processing response missing audio tunnel.");
   }
 
   const blob = await runLocalProcessingWorker([audioFile], makeAudioArgs(plan), {
@@ -239,7 +239,7 @@ const tagCobaltAudioFile = async (
       {
         format: coverFile.type,
         type: 3,
-        description: "Cover",
+        description: "cover",
         data: Array.from(new Uint8Array(await coverFile.arrayBuffer())),
       },
     ];
@@ -247,7 +247,7 @@ const tagCobaltAudioFile = async (
 
   mp3tag.save?.();
   if (mp3tag.error || !mp3tag.buffer) {
-    throw new Error(mp3tag.error ?? "Unable to save metadata");
+    throw new Error(mp3tag.error ?? "unable to save metadata");
   }
 
   return new File([new Uint8Array(mp3tag.buffer)], plan.output.filename, {

--- a/components/audio/cobaltLocalProcessingWorker.js
+++ b/components/audio/cobaltLocalProcessingWorker.js
@@ -66,7 +66,7 @@ const render = async (libav, request) => {
       { type: request.output.type },
     );
     if (blob.size === 0) {
-      throw new Error("Cobalt local processing produced an empty file.");
+      throw new Error("cobalt local processing produced an empty file.");
     }
 
     return blob;
@@ -98,7 +98,7 @@ self.onmessage = async (event) => {
       },
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Cobalt local processing failed.";
+    const message = error instanceof Error ? error.message : "cobalt local processing failed.";
     self.postMessage({
       cobaltLocalProcessing: {
         error: message,

--- a/components/audio/downloadErrorMessage.ts
+++ b/components/audio/downloadErrorMessage.ts
@@ -1,18 +1,18 @@
 export const getDownloadErrorMessage = (error: Error) => {
   if (error.message.includes("COBALT_API_URL is not configured.")) {
-    return "Audio downloads are not configured on this server.";
+    return "audio downloads are not configured on this server.";
   }
 
   if (error.message.includes("error.api.unreachable")) {
-    return "Audio downloads are temporarily unavailable.";
+    return "audio downloads are temporarily unavailable.";
   }
 
   if (error.message.includes("error.api.timed_out")) {
-    return "Audio download timed out.";
+    return "audio download timed out.";
   }
 
   if (error.message.includes("error.tunnel.probe")) {
-    return "Audio download was not ready. Try again.";
+    return "audio download was not ready. try again.";
   }
 
   return error.message;

--- a/components/audio/downloadLibrary.test.ts
+++ b/components/audio/downloadLibrary.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  allTracksReadyForDownload,
+  createLibraryDownloadFilename,
+  getLibraryDownloadEntries,
+} from "./downloadLibrary";
+import type { AlbumGroup, AudioMetadata, TagiumFile } from "./types";
+
+const metadata = (filename: string): AudioMetadata => ({
+  filename: filename.replace(/\.mp3$/i, ""),
+  title: filename,
+  artist: "",
+  album: "",
+  year: undefined,
+  genre: "",
+  duration: 0,
+  bitrate: 0,
+  sampleRate: 0,
+  picture: [],
+  trackNumber: undefined,
+});
+
+const file = (id: string, filename: string, contents = id): TagiumFile => ({
+  id,
+  filename,
+  file: new File([contents], filename, { type: "audio/mpeg" }),
+  originalFile: new File([contents], filename, { type: "audio/mpeg" }),
+  status: "saved",
+  downloadStatus: "ready",
+  hasBufferedChanges: false,
+  metadata: metadata(filename),
+});
+
+const missingFile = (id: string, filename: string): TagiumFile => ({
+  id,
+  filename,
+  status: "pending",
+  downloadStatus: "downloading",
+  hasBufferedChanges: false,
+});
+
+const missingMetadata = (id: string, filename: string): TagiumFile => ({
+  id,
+  filename,
+  file: new File([id], filename, { type: "audio/mpeg" }),
+  originalFile: new File([id], filename, { type: "audio/mpeg" }),
+  status: "error",
+  downloadStatus: "ready",
+  hasBufferedChanges: false,
+});
+
+const album = (id: string, title: string, trackIds: string[]): AlbumGroup => ({
+  id,
+  title,
+  artist: "",
+  genre: "",
+  trackIds,
+});
+
+describe("downloadLibrary", () => {
+  it("creates timestamped library download filenames", () => {
+    expect(createLibraryDownloadFilename(new Date(2026, 0, 2, 3, 4, 5))).toBe(
+      "tagium-download-20260102-030405.zip",
+    );
+  });
+
+  it("builds album and singles entries in sidebar order", () => {
+    const files = [
+      file("loose-1", "single.mp3"),
+      file("album-1", "first.mp3"),
+      file("album-2", "second.mp3"),
+    ];
+
+    const entries = getLibraryDownloadEntries({
+      albums: [album("album", "Album One", ["album-1", "album-2"])],
+      looseTrackIds: ["loose-1"],
+      files,
+    });
+
+    expect(entries.map((entry) => entry.path)).toEqual([
+      "albums/Album One/first.mp3",
+      "albums/Album One/second.mp3",
+      "singles/single.mp3",
+    ]);
+  });
+
+  it("can nest a single album export at the zip root", () => {
+    const entries = getLibraryDownloadEntries({
+      albums: [album("album", "Single Track Album", ["track"])],
+      looseTrackIds: [],
+      files: [file("track", "song.mp3")],
+      albumRoot: "",
+    });
+
+    expect(entries.map((entry) => entry.path)).toEqual(["Single Track Album/song.mp3"]);
+  });
+
+  it("can scope a single album export without unrelated tracks", () => {
+    const entries = getLibraryDownloadEntries({
+      albums: [album("album", "Album", ["track"])],
+      looseTrackIds: [],
+      files: [file("track", "song.mp3"), file("other", "other.mp3")],
+      albumRoot: "",
+      includeUnassignedFiles: false,
+    });
+
+    expect(entries.map((entry) => entry.path)).toEqual(["Album/song.mp3"]);
+  });
+
+  it("does not reserve folder names for empty albums", () => {
+    const entries = getLibraryDownloadEntries({
+      albums: [album("empty", "Album", []), album("full", "Album", ["track"])],
+      looseTrackIds: [],
+      files: [file("track", "song.mp3")],
+    });
+
+    expect(entries.map((entry) => entry.path)).toEqual(["albums/Album/song.mp3"]);
+  });
+
+  it("detects and skips tracks that are not ready for download", () => {
+    const files = [file("ready", "ready.mp3"), missingFile("missing", "missing.mp3")];
+
+    const entries = getLibraryDownloadEntries({
+      albums: [album("album", "Album", ["ready", "missing"])],
+      looseTrackIds: [],
+      files,
+    });
+
+    expect(allTracksReadyForDownload(files)).toBe(false);
+    expect(entries.map((entry) => entry.path)).toEqual(["albums/Album/ready.mp3"]);
+  });
+
+  it("requires metadata before tracks are ready for download", () => {
+    const unreadyFile = missingMetadata("missing", "missing.mp3");
+    const entries = getLibraryDownloadEntries({
+      albums: [album("album", "Album", ["missing"])],
+      looseTrackIds: [],
+      files: [unreadyFile],
+    });
+
+    expect(allTracksReadyForDownload([file("ready", "ready.mp3")])).toBe(true);
+    expect(allTracksReadyForDownload([unreadyFile])).toBe(false);
+    expect(entries).toEqual([]);
+  });
+
+  it("sanitizes and deduplicates zip paths", () => {
+    const files = [
+      file("a", "../track.mp3"),
+      file("b", "../track.mp3"),
+      file("c", "loose/name.mp3"),
+    ];
+
+    const entries = getLibraryDownloadEntries({
+      albums: [album("one", "../Album", ["a"]), album("two", "../Album", ["b"])],
+      looseTrackIds: ["c"],
+      files,
+    });
+
+    expect(entries.map((entry) => entry.path)).toEqual([
+      "albums/-Album/-track.mp3",
+      "albums/-Album-2/-track.mp3",
+      "singles/loose-name.mp3",
+    ]);
+  });
+});

--- a/components/audio/downloadLibrary.ts
+++ b/components/audio/downloadLibrary.ts
@@ -1,0 +1,149 @@
+import filenamify from "filenamify";
+import type { AlbumGroup, TagiumFile } from "./types";
+
+export interface DownloadZipEntry {
+  path: string;
+  file: File;
+}
+
+export const allTracksReadyForDownload = (files: TagiumFile[]) =>
+  files.every((file) => Boolean(file.file && file.metadata));
+
+const padTimePart = (value: number) => String(value).padStart(2, "0");
+
+export const createDownloadTimestamp = (date: Date) =>
+  `${date.getFullYear()}${padTimePart(date.getMonth() + 1)}${padTimePart(date.getDate())}-${padTimePart(date.getHours())}${padTimePart(date.getMinutes())}${padTimePart(date.getSeconds())}`;
+
+export const createLibraryDownloadFilename = (date = new Date()) =>
+  `tagium-download-${createDownloadTimestamp(date)}.zip`;
+
+export const downloadBlob = (blob: Blob, filename: string) => {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+};
+
+const createZipData = async (entries: Record<string, [Uint8Array, { level: 0 }]>) => {
+  const { zip } = await import("fflate");
+  return new Promise<Uint8Array>((resolve, reject) => {
+    zip(entries, (error, data) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(data);
+    });
+  });
+};
+
+export async function createZipBlob(entries: DownloadZipEntry[]) {
+  const zipEntries: Record<string, [Uint8Array, { level: 0 }]> = {};
+  await Promise.all(
+    entries.map(async (entry) => {
+      zipEntries[entry.path] = [new Uint8Array(await entry.file.arrayBuffer()), { level: 0 }];
+    }),
+  );
+  const data = await createZipData(zipEntries);
+  return new Blob([data.buffer as ArrayBuffer], { type: "application/zip" });
+}
+
+const cleanPathPart = (value: string, fallback: string) => {
+  const cleaned = filenamify(value.trim(), { replacement: "-" });
+  if (cleaned) return cleaned;
+  return fallback;
+};
+
+const uniquePath = (path: string, usedPaths: Set<string>) => {
+  if (!usedPaths.has(path)) {
+    usedPaths.add(path);
+    return path;
+  }
+
+  const lastSlashIndex = path.lastIndexOf("/");
+  const folderPath = lastSlashIndex >= 0 ? path.slice(0, lastSlashIndex + 1) : "";
+  const filename = lastSlashIndex >= 0 ? path.slice(lastSlashIndex + 1) : path;
+  const extensionIndex = filename.lastIndexOf(".");
+  const basename = extensionIndex > 0 ? filename.slice(0, extensionIndex) : filename;
+  const extension = extensionIndex > 0 ? filename.slice(extensionIndex) : "";
+  let count = 2;
+  let nextPath = `${folderPath}${basename}-${count}${extension}`;
+
+  while (usedPaths.has(nextPath)) {
+    count++;
+    nextPath = `${folderPath}${basename}-${count}${extension}`;
+  }
+
+  usedPaths.add(nextPath);
+  return nextPath;
+};
+
+const addTrackEntry = (
+  entries: DownloadZipEntry[],
+  usedPaths: Set<string>,
+  folderPath: string,
+  track: TagiumFile | undefined,
+) => {
+  if (!track?.file || !track.metadata) return;
+  const filename = cleanPathPart(track.filename, "track.mp3");
+  entries.push({
+    path: uniquePath(`${folderPath}/${filename}`, usedPaths),
+    file: track.file,
+  });
+};
+
+export function getLibraryDownloadEntries({
+  albums,
+  looseTrackIds,
+  files,
+  albumRoot = "albums",
+  includeUnassignedFiles = true,
+}: {
+  albums: AlbumGroup[];
+  looseTrackIds: string[];
+  files: TagiumFile[];
+  albumRoot?: string;
+  includeUnassignedFiles?: boolean;
+}) {
+  const filesById = new Map(files.map((file) => [file.id, file]));
+  const includedTrackIds = new Set<string>();
+  const usedPaths = new Set<string>();
+  const usedFolders = new Set<string>();
+  const entries: DownloadZipEntry[] = [];
+
+  for (const album of albums) {
+    const albumTracks = album.trackIds
+      .map((trackId) => filesById.get(trackId))
+      .filter((track): track is TagiumFile & { file: File } =>
+        Boolean(track?.file && track.metadata),
+      );
+
+    album.trackIds.forEach((trackId) => includedTrackIds.add(trackId));
+    if (albumTracks.length === 0) continue;
+
+    const albumFolder = uniquePath(
+      `${albumRoot}${albumRoot ? "/" : ""}${cleanPathPart(album.title, "untitled-album")}`,
+      usedFolders,
+    );
+
+    for (const track of albumTracks) {
+      addTrackEntry(entries, usedPaths, albumFolder, track);
+    }
+  }
+
+  for (const trackId of looseTrackIds) {
+    includedTrackIds.add(trackId);
+    addTrackEntry(entries, usedPaths, "singles", filesById.get(trackId));
+  }
+
+  if (includeUnassignedFiles) {
+    for (const file of files) {
+      if (includedTrackIds.has(file.id)) continue;
+      addTrackEntry(entries, usedPaths, "singles", file);
+    }
+  }
+
+  return entries;
+}

--- a/components/audio/mp3Utils.ts
+++ b/components/audio/mp3Utils.ts
@@ -165,7 +165,7 @@ export async function parseUploadedTracks(uploadedFiles: File[]) {
         },
       });
     } catch (error) {
-      console.error(`Error parsing metadata for ${file.name}:`, error);
+      console.error(`error parsing metadata for ${file.name}:`, error);
       parsedUploads.push({
         file: {
           id,
@@ -174,7 +174,7 @@ export async function parseUploadedTracks(uploadedFiles: File[]) {
           filename: file.name,
           status: "error",
           downloadStatus: "ready",
-          downloadError: error instanceof Error ? error.message : "Unable to parse audio metadata.",
+          downloadError: error instanceof Error ? error.message : "unable to parse audio metadata.",
           hasBufferedChanges: false,
         },
         albumSeed: {
@@ -191,7 +191,7 @@ export async function parseUploadedTracks(uploadedFiles: File[]) {
 
 export async function writeMetadataToFile(fileToUpdate: TagiumFile, newTags: AudioMetadata) {
   if (!fileToUpdate.file) {
-    throw new Error("Audio file is still downloading.");
+    throw new Error("audio file is still downloading.");
   }
 
   const MP3Tag = (await import("mp3tag.js")).default;
@@ -229,7 +229,7 @@ export async function writeMetadataToFile(fileToUpdate: TagiumFile, newTags: Aud
 
   mp3tag.save?.();
   if (mp3tag.error || !mp3tag.buffer) {
-    throw new Error(mp3tag.error || "Unable to save metadata");
+    throw new Error(mp3tag.error || "unable to save metadata");
   }
 
   return new File(

--- a/components/audio/soundcloudSet.ts
+++ b/components/audio/soundcloudSet.ts
@@ -36,12 +36,12 @@ export const resolveSoundCloudSet = async (url: string) => {
 
   const response = await fetch(endpoint);
   if (!response.ok) {
-    throw new Error(`SoundCloud set request failed (${response.status})`);
+    throw new Error(`soundcloud set request failed (${response.status})`);
   }
 
   const contentType = response.headers.get("content-type");
   if (!contentType?.includes("application/json")) {
-    throw new Error("SoundCloud set route returned non-JSON. Restart Tagium dev server.");
+    throw new Error("soundcloud set route returned non-json. restart tagium dev server.");
   }
 
   return soundCloudSetSchema.parse(await response.json());


### PR DESCRIPTION
## what changed

- Collapse separate save/download track actions into one explicit lowercase `download` action.
- Make album and library downloads write current metadata before exporting.
- Add timestamped `tagium-download-YYYYMMDD-HHMMSS.zip` library exports with `albums/` and `singles/` paths.
- Preserve dirty in-memory edits across selection, upload, download, drag, and create-album flows.
- Add ZIP path/readiness helpers and focused tests.

## preview

https://codex-unify-download-actions-flamboh-tagium.oliver-boorstein.workers.dev

## why

Tagium stores edited files in memory, so a separate user-facing save action created a stale-download path and extra cognitive load. Export is the real commit point.

## validation

- `vp fmt`
- `vp lint`
- `vp check`
- `vp test`
- `git diff --check`

## review notes

Metadata example placeholders keep their original casing, e.g. `Skrillex`.
