### PR TITLE
[codex] improve mobile editor layout

### DIFF
--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -113,7 +113,7 @@ export default function TagSidebarPanel({
   return (
     <div
       className={cn(
-        "w-full md:w-72 flex-shrink-0 flex flex-col border-b md:border-b-0 md:border-r bg-card overflow-hidden max-h-[45vh] md:max-h-none transition-colors duration-200",
+        "order-2 min-h-screen w-full flex-shrink-0 flex flex-col border-t bg-card overflow-hidden transition-colors duration-200 md:order-none md:min-h-0 md:w-72 md:border-t-0 md:border-r",
         isDraggingFile && "bg-primary/5 shadow-[inset_0_0_0_2px_var(--primary)]",
       )}
       onDragEnter={handleSidebarDragEnter}

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -167,7 +167,7 @@ export default function TagSidebarPanel({
         <Button
           variant="outline"
           className={cn(
-            "w-full justify-start",
+            "h-auto w-full flex-col justify-center gap-1 py-3 text-center",
             settingsOpen &&
               "border-transparent bg-accent text-accent-foreground shadow-none hover:bg-accent",
           )}

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -1344,7 +1344,7 @@ export default function AudioTagger() {
             : undefined
         }
       />
-      <div className="h-screen flex flex-col md:flex-row overflow-hidden bg-background">
+      <div className="min-h-screen flex flex-col bg-background md:h-screen md:flex-row md:overflow-hidden">
         <TagSidebarPanel
           loading={loading}
           files={files}
@@ -1372,7 +1372,7 @@ export default function AudioTagger() {
           onDownloadAll={handleDownloadAll}
           onOpenSettings={() => setActiveView("settings")}
         />
-        <div className="relative min-h-0 flex-1 flex flex-col overflow-hidden">
+        <div className="relative order-1 h-screen flex flex-col overflow-hidden md:order-none md:h-auto md:min-h-0 md:flex-1">
           {activeView === "settings" ? (
             <SettingsPage settings={settings} onChange={handleSettingsChange} />
           ) : libraryIsEmpty ? (


### PR DESCRIPTION
## Summary
- Put the mobile editor/drop area before the library while keeping desktop side-by-side.
- Make the mobile editor/drop area occupy one viewport height.
- Move the mobile library below that first viewport and keep the URL downloader visible inside the editor.

## Validation
- `vp fmt`
- `vp lint`
- `vp check`
- `vp test`
- `bun run build`
- Browser smoke at 390x844: landing URL visible, editor/drop pane is 844px tall, library starts at 844px, non-empty editor URL overlay is visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the audio tagging screen’s responsive layout for better full-screen behavior and scrolling on different device sizes.
  * Adjusted the sidebar and settings button layout to display more cleanly on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->