### PR TITLE
[codex] migrate sidebar to Trees

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "tagium",
       "dependencies": {
         "@imput/libav.js-encode-cli": "6.8.7",
+        "@pierre/trees": "^1.0.0-beta.4",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.3",
@@ -297,6 +298,8 @@
     "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.58.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-Y8FKBABrSPp9H0QkRLHDHOSUgM/309a3IvOVgPcVxYcX70wxJrk608CuTg7w+C6vEd724X5wJoNkBcGYfH7nNQ=="],
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.58.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bCn5rbiz5My+Bj7M09sDcnqW0QJyINRVxdZ65x1/Y2tGrMwherwK/lpk+HRQCKvXa8pcaQdF5KY5j54VGZLwNg=="],
+
+    "@pierre/trees": ["@pierre/trees@1.0.0-beta.4", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-OfT1yk9ne8Te5+GB5zUY8yqE6B8BqjBHQJleH4lu8ltwNpoocZl4vXt1AzlEExpxI/pp+AFX5QG+lR3JjtTEag=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -1079,6 +1082,10 @@
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "3.3.11", "picocolors": "1.1.1", "source-map-js": "1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
+
+    "preact-render-to-string": ["preact-render-to-string@6.6.5", "", { "peerDependencies": { "preact": ">=10 || >= 11.0.0-0" } }, "sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 

--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -1,25 +1,30 @@
 "use client";
 
-import type { DragEvent, MouseEvent as ReactMouseEvent } from "react";
-import { useState } from "react";
-import {
-  AlertCircle,
-  Check,
-  Download,
-  FileMusic,
-  Loader2,
-  Pencil,
-  Plus,
-  RefreshCw,
-  X,
-} from "lucide-react";
+import { prepareFileTreeInput } from "@pierre/trees";
+import { FileTree, useFileTree } from "@pierre/trees/react";
+import type {
+  FileTreeDropResult,
+  FileTreeRowDecorationContext,
+  FileTreeSortComparator,
+} from "@pierre/trees";
+import { Plus } from "lucide-react";
+import { useMemo, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { AlbumCoverThumb } from "./AlbumCoverThumb";
+import { LibraryTreeContextMenu } from "./LibraryTreeContextMenu";
+import { buildLibraryTree } from "./libraryTree";
+import {
+  getLibraryTreeModelDropPlacement,
+  getLibraryTreeModelDropTargetEntry,
+  handleLibraryTreeDrop,
+  handleLibraryTreeModelDrop,
+} from "./libraryTreeDrop";
+import { getNativeTreePath, isTreeOwnedClick, resolveSelection } from "./libraryTreeSelection";
+import type { LibraryTreeSelection } from "./libraryTreeSelection";
+import { LIBRARY_TREE_CSS, LIBRARY_TREE_STYLE } from "./libraryTreeStyles";
 import { AlbumGroup, TagiumFile } from "./types";
 
-const TRACK_DRAG_TYPE = "application/x-tagium-track";
-const ALBUM_DRAG_TYPE = "application/x-tagium-album";
+export type { LibraryTreeSelection } from "./libraryTreeSelection";
 
 interface AlbumSidebarProps {
   albums: AlbumGroup[];
@@ -28,9 +33,8 @@ interface AlbumSidebarProps {
   selectedAlbumId: string | null;
   selectedFileId: string | null;
   selectedFileIds: Set<string>;
-  onSelectAlbum: (albumId: string, event?: ReactMouseEvent) => void;
-  onSelectFile: (albumId: string, fileId: string, event?: ReactMouseEvent) => void;
-  onSelectLooseTrack: (fileId: string, event?: ReactMouseEvent) => void;
+  externalSelectionRevision: number;
+  onTreeSelectionChange: (selection: LibraryTreeSelection) => void;
   onClearSelection: () => void;
   onRemoveFile: (fileId: string) => void;
   onRetryDownload: (fileId: string) => void;
@@ -54,88 +58,251 @@ interface AlbumSidebarProps {
   onAudioUpload: (files: File[]) => void;
 }
 
-interface DragPayload {
-  trackId: string;
-  container: "album" | "loose";
-  albumId?: string;
+interface LibraryFileTreeProps extends AlbumSidebarProps {
+  tree: ReturnType<typeof buildLibraryTree>;
 }
 
-interface AlbumDragPayload {
-  albumId: string;
+function LibraryFileTree(props: LibraryFileTreeProps) {
+  const {
+    albums,
+    files,
+    onAudioUpload,
+    onMoveTrackToAlbum,
+    onMoveTrackToLoose,
+    onPromptCreateAlbumFromLooseTracks,
+    onReorderAlbums,
+    onTreeSelectionChange,
+    onUploadToAlbum,
+    selectedAlbumId,
+    selectedFileId,
+    selectedFileIds,
+    tree,
+  } = props;
+  const filesById = useMemo(() => new Map(files.map((file) => [file.id, file])), [files]);
+  const albumsById = useMemo(() => new Map(albums.map((album) => [album.id, album])), [albums]);
+  const treePointerHandlerRef = useRef<(event: PointerEvent) => void>(() => undefined);
+  const treePointerCleanupRef = useRef<(() => void) | null>(null);
+  const treeElementRef = useRef<HTMLDivElement | null>(null);
+  const treePointerYRef = useRef<number | null>(null);
+  const liveTreeStateRef = useRef({
+    albums,
+    filesById,
+    onMoveTrackToAlbum,
+    onMoveTrackToLoose,
+    onReorderAlbums,
+    onTreeSelectionChange,
+    tree,
+  });
+  liveTreeStateRef.current = {
+    albums,
+    filesById,
+    onMoveTrackToAlbum,
+    onMoveTrackToLoose,
+    onReorderAlbums,
+    onTreeSelectionChange,
+    tree,
+  };
+  treePointerHandlerRef.current = (event) => {
+    treePointerYRef.current = event.clientY;
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey) return;
+    const path = getNativeTreePath(event);
+    if (!path) return;
+    const live = liveTreeStateRef.current;
+    const entry = live.tree.entriesByPath.get(path);
+    if (entry?.type === "track" && selectedFileIds.has(entry.trackId)) return;
+    live.onTreeSelectionChange(resolveSelection([path], live.tree.entriesByPath));
+  };
+  const treeWrapperRef = useMemo(
+    () => (node: HTMLDivElement | null) => {
+      treePointerCleanupRef.current?.();
+      treePointerCleanupRef.current = null;
+      treeElementRef.current = node;
+      if (!node) return;
+
+      const handlePointerDown = (event: PointerEvent) => {
+        treePointerHandlerRef.current(event);
+      };
+      const handlePointerMove = (event: PointerEvent) => {
+        treePointerYRef.current = event.clientY;
+      };
+      node.addEventListener("pointerdown", handlePointerDown, { capture: true });
+      node.addEventListener("pointermove", handlePointerMove, { capture: true });
+      treePointerCleanupRef.current = () => {
+        node.removeEventListener("pointerdown", handlePointerDown, { capture: true });
+        node.removeEventListener("pointermove", handlePointerMove, { capture: true });
+      };
+    },
+    [],
+  );
+  const selectedPaths = useMemo(
+    () =>
+      tree.paths.filter((path) => {
+        const entry = tree.entriesByPath.get(path);
+        return entry?.type === "track" && selectedFileIds.has(entry.trackId);
+      }),
+    [selectedFileIds, tree.entriesByPath, tree.paths],
+  );
+  const preparedInput = useMemo(() => {
+    const orderByPath = new Map(tree.paths.map((path, index) => [path, index]));
+    const sort: FileTreeSortComparator = (left, right) =>
+      (orderByPath.get(left.path) ?? 0) - (orderByPath.get(right.path) ?? 0);
+    return prepareFileTreeInput(tree.paths, { sort });
+  }, [tree.paths]);
+  const initialSelectedPaths =
+    selectedPaths.length > 0
+      ? selectedPaths
+      : selectedFileId
+        ? [tree.pathByTrackId.get(selectedFileId)].filter((path): path is string => Boolean(path))
+        : selectedAlbumId
+          ? [tree.pathByAlbumId.get(selectedAlbumId)].filter((path): path is string =>
+              Boolean(path),
+            )
+          : [];
+  const { model } = useFileTree({
+    composition: {
+      contextMenu: {
+        buttonVisibility: "when-needed",
+        enabled: true,
+        triggerMode: "both",
+      },
+    },
+    dragAndDrop: {
+      canDrag: (paths) =>
+        paths.every((path) => Boolean(liveTreeStateRef.current.tree.entriesByPath.get(path))),
+      canDrop: (event) => {
+        const [draggedPath] = event.draggedPaths;
+        const draggedEntry = draggedPath
+          ? liveTreeStateRef.current.tree.entriesByPath.get(draggedPath)
+          : null;
+        if (!draggedEntry) return false;
+        if (draggedEntry.type === "album") {
+          const targetEntry = getLibraryTreeModelDropTargetEntry(
+            event,
+            liveTreeStateRef.current.tree,
+          );
+          return targetEntry?.type === "album";
+        }
+        return true;
+      },
+      onDropComplete: (event: FileTreeDropResult) => {
+        handleLibraryTreeModelDrop({
+          albums,
+          event,
+          handlers: {
+            onAudioUpload,
+            onMoveTrackToAlbum,
+            onMoveTrackToLoose,
+            onPromptCreateAlbumFromLooseTracks,
+            onReorderAlbums,
+            onSelectTracks: onTreeSelectionChange,
+            onUploadToAlbum,
+          },
+          placement: getLibraryTreeModelDropPlacement({
+            event,
+            pointerY: treePointerYRef.current,
+            treeElement: treeElementRef.current,
+          }),
+          tree,
+        });
+      },
+    },
+    flattenEmptyDirectories: false,
+    icons: "minimal",
+    initialExpansion: "open",
+    initialSelectedPaths,
+    itemHeight: 34,
+    onSelectionChange: (paths) => {
+      const live = liveTreeStateRef.current;
+      live.onTreeSelectionChange(resolveSelection(paths, live.tree.entriesByPath));
+    },
+    preparedInput,
+    renderRowDecoration: ({ item }: FileTreeRowDecorationContext) => {
+      const live = liveTreeStateRef.current;
+      const entry = live.tree.entriesByPath.get(item.path);
+      if (entry?.type !== "track") return null;
+      const track = live.filesById.get(entry.trackId);
+      if (!track) return null;
+      if (track.downloadStatus === "downloading") return { text: "...", title: "downloading" };
+      if (track.downloadStatus === "error" || track.status === "error") {
+        return {
+          text: "!",
+          title: track.downloadError ? `error: ${track.downloadError}` : "error",
+        };
+      }
+      if (track.status === "saved") return { text: "ok", title: "saved" };
+      return null;
+    },
+    unsafeCSS: LIBRARY_TREE_CSS,
+  });
+
+  return (
+    <div ref={treeWrapperRef} className="min-h-0 flex-1 flex flex-col">
+      <FileTree
+        model={model}
+        className="min-h-0 flex-1"
+        style={LIBRARY_TREE_STYLE}
+        onClick={(event) => {
+          if (!isTreeOwnedClick(event.nativeEvent)) {
+            props.onClearSelection();
+          }
+        }}
+        onDragOver={(event) => {
+          if (event.dataTransfer.types.includes("Files")) {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "copy";
+          }
+        }}
+        onDropCapture={(event) => {
+          handleLibraryTreeDrop({
+            albums,
+            event,
+            handlers: {
+              onAudioUpload,
+              onMoveTrackToAlbum,
+              onMoveTrackToLoose,
+              onPromptCreateAlbumFromLooseTracks,
+              onReorderAlbums,
+              onSelectTracks: onTreeSelectionChange,
+              onUploadToAlbum,
+            },
+            selectedPaths,
+            tree,
+          });
+        }}
+        renderContextMenu={(item, context) => (
+          <LibraryTreeContextMenu
+            albumsById={albumsById}
+            context={context}
+            filesById={filesById}
+            item={item}
+            onDownloadAlbum={props.onDownloadAlbum}
+            onEditAlbum={props.onEditAlbum}
+            onRemoveFile={props.onRemoveFile}
+            onRetryDownload={props.onRetryDownload}
+            tree={tree}
+          />
+        )}
+      />
+    </div>
+  );
 }
 
-function parseDragPayload(event: DragEvent) {
-  const rawPayload = event.dataTransfer.getData(TRACK_DRAG_TYPE);
-  if (!rawPayload) return null;
+export default function AlbumSidebar(props: AlbumSidebarProps) {
+  const tree = useMemo(
+    () =>
+      buildLibraryTree({
+        albums: props.albums,
+        files: props.files,
+        looseTrackIds: props.looseTrackIds,
+      }),
+    [props.albums, props.files, props.looseTrackIds],
+  );
 
-  try {
-    return JSON.parse(rawPayload) as DragPayload;
-  } catch {
-    return null;
-  }
-}
-
-function parseAlbumDragPayload(event: DragEvent) {
-  const rawPayload = event.dataTransfer.getData(ALBUM_DRAG_TYPE);
-  if (!rawPayload) return null;
-
-  try {
-    return JSON.parse(rawPayload) as AlbumDragPayload;
-  } catch {
-    return null;
-  }
-}
-
-function isCenteredDrop(event: DragEvent<HTMLElement>) {
-  const rect = event.currentTarget.getBoundingClientRect();
-  const position = (event.clientY - rect.top) / rect.height;
-  return position > 0.3 && position < 0.7;
-}
-
-function placementForRowDrop(event: DragEvent<HTMLElement>) {
-  const rect = event.currentTarget.getBoundingClientRect();
-  return event.clientY > rect.top + rect.height / 2 ? "after" : "before";
-}
-
-export default function AlbumSidebar({
-  albums,
-  looseTrackIds,
-  files,
-  selectedAlbumId,
-  selectedFileId,
-  selectedFileIds,
-  onSelectAlbum,
-  onSelectFile,
-  onSelectLooseTrack,
-  onClearSelection,
-  onRemoveFile,
-  onRetryDownload,
-  onAddAlbum,
-  onEditAlbum,
-  onDownloadAlbum,
-  onUploadToAlbum,
-  onMoveTrackToAlbum,
-  onMoveTrackToLoose,
-  onPromptCreateAlbumFromLooseTracks,
-  onReorderAlbums,
-  onAudioUpload,
-}: AlbumSidebarProps) {
-  const [draggedAlbumId, setDraggedAlbumId] = useState<string | null>(null);
-  const [dragOverAlbumIndex, setDragOverAlbumIndex] = useState<number | null>(null);
-  const filesById = new Map(files.map((file) => [file.id, file]));
-  const looseTracks = looseTrackIds
-    .map((trackId) => filesById.get(trackId))
-    .filter((track): track is TagiumFile => Boolean(track));
-
-  const isRetryableError = (track: TagiumFile) =>
-    Boolean(track.downloadRequest) &&
-    (track.downloadStatus === "error" || track.status === "error");
-
-  if (albums.length === 0 && looseTracks.length === 0) {
+  if (props.albums.length === 0 && props.looseTrackIds.length === 0) {
     return (
       <div
         className="w-full flex-1 min-h-0 flex flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground px-4"
-        onClick={onClearSelection}
+        onClick={props.onClearSelection}
       >
         <p>no tracks yet</p>
         <p className="text-xs">create an empty album or upload tracks</p>
@@ -145,7 +312,7 @@ export default function AlbumSidebar({
           size="sm"
           onClick={(event) => {
             event.stopPropagation();
-            onAddAlbum();
+            props.onAddAlbum();
           }}
         >
           <Plus className="h-4 w-4" />
@@ -159,417 +326,23 @@ export default function AlbumSidebar({
     <div className="w-full flex-1 min-h-0 flex flex-col">
       <div className="h-12 px-4 border-b flex items-center justify-between flex-shrink-0">
         <span className="font-semibold text-sm leading-none text-muted-foreground">
-          library ({files.length})
+          library ({props.files.length})
         </span>
-        <Button type="button" variant="ghost" size="icon" className="size-8" onClick={onAddAlbum}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={cn("size-8")}
+          onClick={props.onAddAlbum}
+        >
           <Plus className="h-4 w-4" />
         </Button>
       </div>
-
-      <div
-        className="flex-1 overflow-y-auto flex flex-col"
-        onClick={(event) => {
-          if (event.target === event.currentTarget) {
-            onClearSelection();
-          }
-        }}
-        onDragOver={(event) => {
-          event.preventDefault();
-          event.dataTransfer.dropEffect = "move";
-        }}
-        onDrop={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-
-          // Handle external file drops
-          const files = Array.from(event.dataTransfer.files);
-          if (files.length > 0) {
-            const audioFiles = files.filter((file) => file.type.startsWith("audio/"));
-            if (audioFiles.length > 0) {
-              onAudioUpload(audioFiles);
-              return;
-            }
-          }
-
-          // Handle track drag
-          const trackPayload = parseDragPayload(event);
-          if (trackPayload) {
-            onMoveTrackToLoose(trackPayload.trackId, "append");
-            return;
-          }
-        }}
-      >
-        {looseTracks.map((track) => (
-          <div
-            key={track.id}
-            className="relative group border-b"
-            onDragOver={(event) => {
-              if (event.dataTransfer.types.includes("Files")) return;
-
-              event.preventDefault();
-              event.stopPropagation();
-              const payload = parseDragPayload(event);
-              if (payload && payload.trackId !== track.id) {
-                event.dataTransfer.dropEffect = "move";
-              }
-            }}
-            onDrop={(event) => {
-              if (event.dataTransfer.files.length > 0) return;
-
-              event.preventDefault();
-              event.stopPropagation();
-              const payload = parseDragPayload(event);
-              if (!payload || payload.trackId === track.id) return;
-
-              if (payload.container === "loose" && isCenteredDrop(event)) {
-                onPromptCreateAlbumFromLooseTracks(payload.trackId, track.id);
-                return;
-              }
-              const placement = placementForRowDrop(event);
-              onMoveTrackToLoose(payload.trackId, placement, track.id);
-            }}
-          >
-            <Button
-              type="button"
-              variant="ghost"
-              draggable
-              onDragStart={(event) => {
-                const payload: DragPayload = {
-                  trackId: track.id,
-                  container: "loose",
-                };
-                event.dataTransfer.setData(TRACK_DRAG_TYPE, JSON.stringify(payload));
-                event.dataTransfer.effectAllowed = "move";
-              }}
-              className={cn(
-                "justify-start h-auto py-3 px-4 w-full text-left font-normal pr-8 rounded-none hover:bg-accent/30",
-                track.downloadStatus === "downloading" ? "opacity-65" : "",
-                selectedFileIds.has(track.id)
-                  ? "bg-accent text-accent-foreground"
-                  : selectedFileId === track.id
-                    ? "bg-accent/50 text-accent-foreground"
-                    : "",
-              )}
-              onClick={(e) => onSelectLooseTrack(track.id, e)}
-            >
-              <div className="flex flex-col gap-1 w-full min-w-0">
-                <div className="flex items-center gap-2 w-full overflow-hidden">
-                  <FileMusic className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
-                  <span className="truncate text-sm flex-1">{track.filename}</span>
-                  {track.downloadStatus === "downloading" && (
-                    <Loader2 className="h-3 w-3 text-muted-foreground flex-shrink-0 animate-spin" />
-                  )}
-                  {track.downloadStatus !== "downloading" && track.status === "saved" && (
-                    <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
-                  )}
-                  {(track.downloadStatus === "error" || track.status === "error") && (
-                    <AlertCircle
-                      className={cn(
-                        "h-3 w-3 text-red-500 flex-shrink-0",
-                        isRetryableError(track) ? "group-hover:opacity-0" : "",
-                      )}
-                    />
-                  )}
-                </div>
-                {(track.downloadStatus === "error" || track.status === "error") &&
-                  track.downloadError && (
-                    <span className="pl-7 text-xs text-destructive truncate" aria-live="polite">
-                      error: {track.downloadError}
-                    </span>
-                  )}
-              </div>
-            </Button>
-            {isRetryableError(track) && (
-              <button
-                type="button"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onRetryDownload(track.id);
-                }}
-                className="absolute right-7 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded-full cursor-pointer"
-                title="retry download"
-                aria-label={`retry download for ${track.filename}`}
-              >
-                <RefreshCw className="h-3 w-3 text-muted-foreground hover:text-primary" />
-              </button>
-            )}
-            <button
-              type="button"
-              onClick={(event) => {
-                event.stopPropagation();
-                onRemoveFile(track.id);
-              }}
-              className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
-              title="remove track"
-            >
-              <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
-            </button>
-          </div>
-        ))}
-
-        {albums.map((album, albumIndex) => {
-          const canDownloadAlbum =
-            album.trackIds.length > 0 &&
-            album.trackIds.every((trackId) => {
-              const file = filesById.get(trackId);
-              return file?.file && file.metadata;
-            });
-          return (
-            <div
-              key={album.id}
-              className={cn(
-                "border-b transition-all",
-                selectedAlbumId === album.id ? "bg-primary/5" : "",
-                draggedAlbumId === album.id ? "opacity-50" : "",
-                dragOverAlbumIndex === albumIndex ? "shadow-[inset_0_0_0_2px_var(--primary)]" : "",
-              )}
-              onDragOver={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-
-                const albumPayload = parseAlbumDragPayload(event);
-                if (albumPayload && albumPayload.albumId !== album.id) {
-                  event.dataTransfer.dropEffect = "move";
-                  const rect = event.currentTarget.getBoundingClientRect();
-                  const position = (event.clientY - rect.top) / rect.height;
-                  setDragOverAlbumIndex(position < 0.5 ? albumIndex : albumIndex + 1);
-                } else {
-                  setDragOverAlbumIndex(null);
-                }
-
-                const trackPayload = parseDragPayload(event);
-                if (trackPayload) {
-                  event.dataTransfer.dropEffect = "move";
-                }
-
-                // Handle external file drops
-                if (event.dataTransfer.types.includes("Files")) {
-                  event.dataTransfer.dropEffect = "copy";
-                }
-              }}
-              onDragLeave={() => {
-                setDragOverAlbumIndex(null);
-              }}
-              onDrop={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-
-                // Handle external file drops
-                const files = Array.from(event.dataTransfer.files);
-                if (files.length > 0) {
-                  const audioFiles = files.filter((file) => file.type.startsWith("audio/"));
-                  if (audioFiles.length > 0) {
-                    onUploadToAlbum(album.id, audioFiles);
-                    return;
-                  }
-                }
-
-                // Handle album reordering
-                const albumPayload = parseAlbumDragPayload(event);
-                if (albumPayload && albumPayload.albumId !== album.id) {
-                  const sourceIndex = albums.findIndex((a) => a.id === albumPayload.albumId);
-                  if (sourceIndex >= 0) {
-                    const rect = event.currentTarget.getBoundingClientRect();
-                    const position = (event.clientY - rect.top) / rect.height;
-                    let targetIndex = position < 0.5 ? albumIndex : albumIndex + 1;
-                    // Adjust target index if dragging from before the target
-                    if (sourceIndex < targetIndex) {
-                      targetIndex -= 1;
-                    }
-                    onReorderAlbums(albumPayload.albumId, targetIndex);
-                  }
-                  setDraggedAlbumId(null);
-                  setDragOverAlbumIndex(null);
-                  return;
-                }
-
-                // Handle track drag
-                const trackPayload = parseDragPayload(event);
-                if (trackPayload) {
-                  onMoveTrackToAlbum(trackPayload.trackId, album.id, "append");
-                  return;
-                }
-              }}
-            >
-              <div className="w-full flex items-center justify-between gap-1 px-3 py-3 border-b">
-                <button
-                  type="button"
-                  className="min-w-0 flex-1 flex items-center gap-2 text-left cursor-pointer"
-                  onClick={(e) => onSelectAlbum(album.id, e)}
-                  draggable
-                  onDragStart={(event) => {
-                    const payload: AlbumDragPayload = {
-                      albumId: album.id,
-                    };
-                    event.dataTransfer.setData(ALBUM_DRAG_TYPE, JSON.stringify(payload));
-                    event.dataTransfer.effectAllowed = "move";
-                    setDraggedAlbumId(album.id);
-                  }}
-                  onDragEnd={() => {
-                    setDraggedAlbumId(null);
-                    setDragOverAlbumIndex(null);
-                  }}
-                >
-                  <AlbumCoverThumb picture={album.cover} />
-                  <div className="min-w-0 flex-1">
-                    <div className="text-sm font-medium truncate leading-tight">{album.title}</div>
-                    <div className="text-xs text-muted-foreground truncate leading-tight">
-                      {album.artist || "unknown"} &middot; {album.trackIds.length} track
-                      {album.trackIds.length !== 1 ? "s" : ""}
-                    </div>
-                  </div>
-                </button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7"
-                  onClick={() => onDownloadAlbum(album.id)}
-                  disabled={!canDownloadAlbum}
-                  aria-label={`download ${album.title}`}
-                >
-                  <Download className="h-3.5 w-3.5" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7"
-                  onClick={() => onEditAlbum(album.id)}
-                  aria-label={`edit ${album.title}`}
-                >
-                  <Pencil className="h-3.5 w-3.5" />
-                </Button>
-              </div>
-              <div className="flex flex-col">
-                {album.trackIds.length === 0 ? (
-                  <div
-                    className="text-xs text-muted-foreground px-4 py-3 text-center"
-                    onClick={onClearSelection}
-                  >
-                    drag tracks here
-                  </div>
-                ) : (
-                  album.trackIds.map((trackId, index) => {
-                    const track = filesById.get(trackId);
-                    if (!track) return null;
-
-                    return (
-                      <div
-                        key={track.id}
-                        className="relative group border-t first:border-t-0"
-                        onDragOver={(event) => {
-                          if (event.dataTransfer.types.includes("Files")) return;
-
-                          event.preventDefault();
-                          event.stopPropagation();
-                          const payload = parseDragPayload(event);
-                          if (payload && payload.trackId !== track.id) {
-                            event.dataTransfer.dropEffect = "move";
-                          }
-                        }}
-                        onDrop={(event) => {
-                          if (event.dataTransfer.files.length > 0) return;
-
-                          event.preventDefault();
-                          event.stopPropagation();
-                          const payload = parseDragPayload(event);
-                          if (!payload || payload.trackId === track.id) return;
-                          const placement = placementForRowDrop(event);
-                          onMoveTrackToAlbum(payload.trackId, album.id, placement, track.id);
-                        }}
-                      >
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          draggable
-                          onDragStart={(event) => {
-                            const payload: DragPayload = {
-                              trackId: track.id,
-                              container: "album",
-                              albumId: album.id,
-                            };
-                            event.dataTransfer.setData(TRACK_DRAG_TYPE, JSON.stringify(payload));
-                            event.dataTransfer.effectAllowed = "move";
-                          }}
-                          className={cn(
-                            "justify-start h-auto py-2.5 px-4 w-full text-left font-normal pr-8 rounded-none hover:bg-accent/30",
-                            track.downloadStatus === "downloading" ? "opacity-65" : "",
-                            selectedFileIds.has(track.id)
-                              ? "bg-accent text-accent-foreground"
-                              : selectedFileId === track.id
-                                ? "bg-accent/50 text-accent-foreground"
-                                : "",
-                          )}
-                          onClick={(e) => onSelectFile(album.id, track.id, e)}
-                        >
-                          <div className="flex flex-col gap-1 w-full min-w-0">
-                            <div className="flex items-center gap-1.5 w-full overflow-hidden">
-                              <span className="min-w-3 text-[11px] text-muted-foreground">
-                                {index + 1}
-                              </span>
-                              <span className="truncate text-sm flex-1">{track.filename}</span>
-                              {track.downloadStatus === "downloading" && (
-                                <Loader2 className="h-3 w-3 text-muted-foreground flex-shrink-0 animate-spin" />
-                              )}
-                              {track.downloadStatus !== "downloading" &&
-                                track.status === "saved" && (
-                                  <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
-                                )}
-                              {(track.downloadStatus === "error" || track.status === "error") && (
-                                <AlertCircle
-                                  className={cn(
-                                    "h-3 w-3 text-red-500 flex-shrink-0",
-                                    isRetryableError(track) ? "group-hover:opacity-0" : "",
-                                  )}
-                                />
-                              )}
-                            </div>
-                            {(track.downloadStatus === "error" || track.status === "error") &&
-                              track.downloadError && (
-                                <span
-                                  className="pl-7 text-xs text-destructive truncate"
-                                  aria-live="polite"
-                                >
-                                  error: {track.downloadError}
-                                </span>
-                              )}
-                          </div>
-                        </Button>
-                        {isRetryableError(track) && (
-                          <button
-                            type="button"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              onRetryDownload(track.id);
-                            }}
-                            className="absolute right-7 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded-full cursor-pointer"
-                            title="retry download"
-                            aria-label={`retry download for ${track.filename}`}
-                          >
-                            <RefreshCw className="h-3 w-3 text-muted-foreground hover:text-primary" />
-                          </button>
-                        )}
-                        <button
-                          type="button"
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            onRemoveFile(track.id);
-                          }}
-                          className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
-                          title="remove track"
-                        >
-                          <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
-                        </button>
-                      </div>
-                    );
-                  })
-                )}
-              </div>
-            </div>
-          );
-        })}
-      </div>
+      <LibraryFileTree
+        key={`${tree.signature}\n${props.externalSelectionRevision}`}
+        {...props}
+        tree={tree}
+      />
     </div>
   );
 }

--- a/components/audio/LibraryTreeContextMenu.tsx
+++ b/components/audio/LibraryTreeContextMenu.tsx
@@ -1,0 +1,98 @@
+import { FileTree } from "@pierre/trees/react";
+import type { ContextMenuItem } from "@pierre/trees";
+import type { ComponentProps } from "react";
+import { buildLibraryTree } from "./libraryTree";
+import { AlbumGroup, TagiumFile } from "./types";
+
+const isRetryableError = (track: TagiumFile) =>
+  Boolean(track.downloadRequest) && (track.downloadStatus === "error" || track.status === "error");
+
+const canDownloadAlbum = (album: AlbumGroup, filesById: Map<string, TagiumFile>) =>
+  album.trackIds.length > 0 &&
+  album.trackIds.every((trackId) => {
+    const file = filesById.get(trackId);
+    return file?.file && file.metadata;
+  });
+
+export function LibraryTreeContextMenu({
+  albumsById,
+  context,
+  filesById,
+  item,
+  onDownloadAlbum,
+  onEditAlbum,
+  onRemoveFile,
+  onRetryDownload,
+  tree,
+}: {
+  albumsById: Map<string, AlbumGroup>;
+  context: Parameters<NonNullable<ComponentProps<typeof FileTree>["renderContextMenu"]>>[1];
+  filesById: Map<string, TagiumFile>;
+  item: ContextMenuItem;
+  onDownloadAlbum: (albumId: string) => void;
+  onEditAlbum: (albumId: string) => void;
+  onRemoveFile: (fileId: string) => void;
+  onRetryDownload: (fileId: string) => void;
+  tree: ReturnType<typeof buildLibraryTree>;
+}) {
+  const entry = tree.entriesByPath.get(item.path);
+  if (!entry) return null;
+
+  const runAction = (action: () => void) => {
+    context.close({ restoreFocus: false });
+    action();
+  };
+
+  if (entry.type === "album") {
+    const album = albumsById.get(entry.albumId);
+    if (!album) return null;
+
+    return (
+      <div className="min-w-44 rounded-md border bg-popover p-1 text-sm text-popover-foreground shadow-md">
+        <button
+          type="button"
+          className="w-full rounded-sm px-2 py-1.5 text-left hover:bg-accent"
+          onClick={() => runAction(() => onEditAlbum(entry.albumId))}
+        >
+          edit album
+        </button>
+        <button
+          type="button"
+          className="w-full rounded-sm px-2 py-1.5 text-left hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={!canDownloadAlbum(album, filesById)}
+          onClick={() => runAction(() => onDownloadAlbum(entry.albumId))}
+        >
+          download album
+        </button>
+      </div>
+    );
+  }
+
+  if (entry.type === "track") {
+    const track = filesById.get(entry.trackId);
+    if (!track) return null;
+
+    return (
+      <div className="min-w-44 rounded-md border bg-popover p-1 text-sm text-popover-foreground shadow-md">
+        {isRetryableError(track) && (
+          <button
+            type="button"
+            className="w-full rounded-sm px-2 py-1.5 text-left hover:bg-accent"
+            onClick={() => runAction(() => onRetryDownload(entry.trackId))}
+          >
+            retry download
+          </button>
+        )}
+        <button
+          type="button"
+          className="w-full rounded-sm px-2 py-1.5 text-left text-destructive hover:bg-destructive/10"
+          onClick={() => runAction(() => onRemoveFile(entry.trackId))}
+        >
+          remove track
+        </button>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import type { MouseEvent as ReactMouseEvent } from "react";
 import { useRef, useState } from "react";
 import { Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
-import AlbumSidebar from "./AlbumSidebar";
+import AlbumSidebar, { type LibraryTreeSelection } from "./AlbumSidebar";
 import { AlbumGroup, TagiumFile } from "./types";
 import { Button } from "../ui/button";
 
@@ -16,11 +15,10 @@ interface TagSidebarPanelProps {
   selectedAlbumId: string | null;
   selectedFileId: string | null;
   selectedFileIds: Set<string>;
+  externalSelectionRevision: number;
   settingsOpen: boolean;
   onAudioUpload: (files: File[]) => void;
-  onSelectAlbum: (albumId: string, event?: ReactMouseEvent) => void;
-  onSelectFile: (albumId: string, fileId: string, event?: ReactMouseEvent) => void;
-  onSelectLooseTrack: (fileId: string, event?: ReactMouseEvent) => void;
+  onTreeSelectionChange: (selection: LibraryTreeSelection) => void;
   onClearSelection: () => void;
   onRemoveFile: (fileId: string) => void;
   onRetryDownload: (fileId: string) => void;
@@ -53,11 +51,10 @@ export default function TagSidebarPanel({
   selectedAlbumId,
   selectedFileId,
   selectedFileIds,
+  externalSelectionRevision,
   settingsOpen,
   onAudioUpload,
-  onSelectAlbum,
-  onSelectFile,
-  onSelectLooseTrack,
+  onTreeSelectionChange,
   onClearSelection,
   onRemoveFile,
   onRetryDownload,
@@ -143,9 +140,8 @@ export default function TagSidebarPanel({
         selectedAlbumId={selectedAlbumId}
         selectedFileId={selectedFileId}
         selectedFileIds={selectedFileIds}
-        onSelectAlbum={onSelectAlbum}
-        onSelectFile={onSelectFile}
-        onSelectLooseTrack={onSelectLooseTrack}
+        externalSelectionRevision={externalSelectionRevision}
+        onTreeSelectionChange={onTreeSelectionChange}
         onClearSelection={onClearSelection}
         onRemoveFile={onRemoveFile}
         onRetryDownload={onRetryDownload}

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -1,5 +1,4 @@
 "use client";
-import type { MouseEvent as ReactMouseEvent } from "react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 import filenamify from "filenamify";
@@ -29,6 +28,7 @@ import {
   getLibraryDownloadEntries,
 } from "./downloadLibrary";
 import TagSidebarPanel from "./TagSidebarPanel";
+import type { LibraryTreeSelection } from "./AlbumSidebar";
 import LandingScreen from "./LandingScreen";
 import TrackMetadataEditor from "./TrackMetadataEditor";
 import SettingsPage from "./SettingsPage";
@@ -142,7 +142,7 @@ export default function AudioTagger() {
   const [selectedFileId, setSelectedFileId] = useState<string | null>(null);
   const [selectedAlbumId, setSelectedAlbumId] = useState<string | null>(null);
   const [selectedFileIds, setSelectedFileIds] = useState<Set<string>>(new Set());
-  const [lastSelectedFileId, setLastSelectedFileId] = useState<string | null>(null);
+  const [sidebarSelectionRevision, setSidebarSelectionRevision] = useState(0);
   const [loading, setLoading] = useState(false);
   const [albumDialogOpen, setAlbumDialogOpen] = useState(false);
   const [albumDialogMode, setAlbumDialogMode] = useState<"create" | "edit">("create");
@@ -153,6 +153,7 @@ export default function AudioTagger() {
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_APP_SETTINGS);
   const filesRef = useRef<TagiumFile[]>(files);
   const albumsRef = useRef<AlbumGroup[]>(albums);
+  const looseTrackIdsRef = useRef<string[]>(looseTrackIds);
   const selectedFileIdRef = useRef<string | null>(selectedFileId);
   const lastResetFileIdRef = useRef<string | null>(null);
   const formDirtyRef = useRef(false);
@@ -160,6 +161,7 @@ export default function AudioTagger() {
   const pendingImportKeysRef = useRef(new Set<string>());
   filesRef.current = files;
   albumsRef.current = albums;
+  looseTrackIdsRef.current = looseTrackIds;
   selectedFileIdRef.current = selectedFileId;
   const {
     register,
@@ -649,7 +651,6 @@ export default function AudioTagger() {
     setSelectedAlbumId(null);
     setSelectedFileId(id);
     setSelectedFileIds(new Set([id]));
-    setLastSelectedFileId(id);
 
     void (async () => {
       try {
@@ -700,7 +701,6 @@ export default function AudioTagger() {
     setSelectedAlbumId(albumId);
     setSelectedFileId(pendingFiles[0]?.id ?? null);
     setSelectedFileIds(new Set(pendingFiles[0] ? [pendingFiles[0].id] : []));
-    setLastSelectedFileId(pendingFiles[0]?.id ?? null);
 
     const coverUrl = set.coverUrl;
     if (coverUrl) {
@@ -937,123 +937,12 @@ export default function AudioTagger() {
       closeAlbumDialog();
     }
   };
-  const handleSelectAlbum = (albumId: string, event?: ReactMouseEvent) => {
+  const handleTreeSelectionChange = (selection: LibraryTreeSelection) => {
     setActiveView("editor");
     bufferCurrentFormMetadata();
-    const isMultiSelect = event?.ctrlKey || event?.metaKey;
-
-    if (isMultiSelect) {
-      setSelectedAlbumId(albumId);
-      const album = albums.find((entry) => entry.id === albumId);
-      const firstTrackId = album?.trackIds[0];
-      if (firstTrackId) {
-        setSelectedFileIds((prev) => {
-          const next = new Set(prev);
-          if (next.has(firstTrackId)) {
-            next.delete(firstTrackId);
-          } else {
-            next.add(firstTrackId);
-          }
-          return next;
-        });
-        setSelectedFileId(firstTrackId);
-        setLastSelectedFileId(firstTrackId);
-      }
-    } else {
-      setSelectedAlbumId(albumId);
-      const album = albums.find((entry) => entry.id === albumId);
-      const firstTrackId = album?.trackIds[0] ?? null;
-      setSelectedFileId(firstTrackId);
-      setSelectedFileIds(firstTrackId ? new Set([firstTrackId]) : new Set());
-      setLastSelectedFileId(firstTrackId);
-    }
-  };
-
-  const handleSelectFile = (albumId: string, fileId: string, event?: ReactMouseEvent) => {
-    setActiveView("editor");
-    bufferCurrentFormMetadata();
-    const isMultiSelect = event?.ctrlKey || event?.metaKey;
-    const isRangeSelect = event?.shiftKey && lastSelectedFileId;
-
-    if (isRangeSelect) {
-      const album = albums.find((entry) => entry.id === albumId);
-      if (!album) return;
-      const trackIds = album.trackIds;
-      const startIndex = trackIds.indexOf(lastSelectedFileId);
-      const endIndex = trackIds.indexOf(fileId);
-      if (startIndex >= 0 && endIndex >= 0) {
-        const minIndex = Math.min(startIndex, endIndex);
-        const maxIndex = Math.max(startIndex, endIndex);
-        const rangeIds = trackIds.slice(minIndex, maxIndex + 1);
-        setSelectedFileIds((prev) => {
-          const next = new Set(prev);
-          rangeIds.forEach((id) => next.add(id));
-          return next;
-        });
-        setSelectedFileId(fileId);
-        setLastSelectedFileId(fileId);
-      }
-    } else if (isMultiSelect) {
-      setSelectedAlbumId(albumId);
-      setSelectedFileIds((prev) => {
-        const next = new Set(prev);
-        if (next.has(fileId)) {
-          next.delete(fileId);
-        } else {
-          next.add(fileId);
-        }
-        return next;
-      });
-      setSelectedFileId(fileId);
-      setLastSelectedFileId(fileId);
-    } else {
-      setSelectedAlbumId(albumId);
-      setSelectedFileId(fileId);
-      setSelectedFileIds(new Set([fileId]));
-      setLastSelectedFileId(fileId);
-    }
-  };
-
-  const handleSelectLooseTrack = (fileId: string, event?: ReactMouseEvent) => {
-    setActiveView("editor");
-    bufferCurrentFormMetadata();
-    const isMultiSelect = event?.ctrlKey || event?.metaKey;
-    const isRangeSelect = event?.shiftKey && lastSelectedFileId;
-
-    if (isRangeSelect) {
-      const startIndex = looseTrackIds.indexOf(lastSelectedFileId);
-      const endIndex = looseTrackIds.indexOf(fileId);
-      if (startIndex >= 0 && endIndex >= 0) {
-        const minIndex = Math.min(startIndex, endIndex);
-        const maxIndex = Math.max(startIndex, endIndex);
-        const rangeIds = looseTrackIds.slice(minIndex, maxIndex + 1);
-        setSelectedFileIds((prev) => {
-          const next = new Set(prev);
-          rangeIds.forEach((id) => next.add(id));
-          return next;
-        });
-        setSelectedFileId(fileId);
-        setLastSelectedFileId(fileId);
-      }
-    } else if (isMultiSelect) {
-      setSelectedAlbumId(null);
-      setSelectedFileIds((prev) => {
-        const next = new Set(prev);
-        if (next.has(fileId)) {
-          next.delete(fileId);
-        } else {
-          next.add(fileId);
-        }
-        return next;
-      });
-      setSelectedFileId(fileId);
-      setLastSelectedFileId(fileId);
-    } else {
-      setSelectedAlbumId(null);
-      setSelectedFileId(fileId);
-      setSelectedFileIds(new Set([fileId]));
-      setLastSelectedFileId(fileId);
-    }
+    setSelectedAlbumId(selection.selectedAlbumId);
+    setSelectedFileId(selection.selectedFileId);
+    setSelectedFileIds(new Set(selection.selectedFileIds));
   };
 
   const handleClearSelection = useCallback(() => {
@@ -1062,7 +951,7 @@ export default function AudioTagger() {
     setSelectedAlbumId(null);
     setSelectedFileId(null);
     setSelectedFileIds(new Set());
-    setLastSelectedFileId(null);
+    setSidebarSelectionRevision((revision) => revision + 1);
   }, [bufferCurrentFormMetadata]);
 
   const handleRemoveSelectedFiles = useCallback(() => {
@@ -1088,7 +977,6 @@ export default function AudioTagger() {
     );
     setSelectedFileIds(new Set());
     setSelectedFileId(null);
-    setLastSelectedFileId(null);
   }, [selectedFileIds, settings.syncTrackNumbers]);
 
   const handleSelectAllFiles = useCallback(() => {
@@ -1097,8 +985,8 @@ export default function AudioTagger() {
     setSelectedFileIds(allFileIds);
     if (files.length > 0) {
       setSelectedFileId(files[0].id);
-      setLastSelectedFileId(files[0].id);
     }
+    setSidebarSelectionRevision((revision) => revision + 1);
   }, [files, bufferCurrentFormMetadata]);
 
   const handleReorderAlbums = (albumId: string, targetIndex: number) => {
@@ -1258,8 +1146,8 @@ export default function AudioTagger() {
     setActiveView("editor");
     bufferCurrentFormMetadata();
     const moved = moveTrackInSidebar(
-      albums,
-      looseTrackIds,
+      albumsRef.current,
+      looseTrackIdsRef.current,
       trackId,
       placement === "append" || !referenceTrackId
         ? {
@@ -1275,6 +1163,8 @@ export default function AudioTagger() {
           },
       settings,
     );
+    albumsRef.current = moved.albums;
+    looseTrackIdsRef.current = moved.looseTrackIds;
     setAlbums(moved.albums);
     setLooseTrackIds(moved.looseTrackIds);
     setSelectedAlbumId(targetAlbumId);
@@ -1293,8 +1183,8 @@ export default function AudioTagger() {
     setActiveView("editor");
     bufferCurrentFormMetadata();
     const moved = moveTrackInSidebar(
-      albums,
-      looseTrackIds,
+      albumsRef.current,
+      looseTrackIdsRef.current,
       trackId,
       placement === "append" || !referenceTrackId
         ? {
@@ -1308,6 +1198,8 @@ export default function AudioTagger() {
           },
       settings,
     );
+    albumsRef.current = moved.albums;
+    looseTrackIdsRef.current = moved.looseTrackIds;
     setAlbums(moved.albums);
     setLooseTrackIds(moved.looseTrackIds);
     setSelectedAlbumId(null);
@@ -1353,11 +1245,10 @@ export default function AudioTagger() {
           selectedAlbumId={selectedAlbumId}
           selectedFileId={selectedFileId}
           selectedFileIds={selectedFileIds}
+          externalSelectionRevision={sidebarSelectionRevision}
           settingsOpen={activeView === "settings"}
           onAudioUpload={handleAudioUpload}
-          onSelectAlbum={handleSelectAlbum}
-          onSelectFile={handleSelectFile}
-          onSelectLooseTrack={handleSelectLooseTrack}
+          onTreeSelectionChange={handleTreeSelectionChange}
           onClearSelection={handleClearSelection}
           onRemoveFile={handleRemoveFile}
           onRetryDownload={handleRetryDownload}

--- a/components/audio/libraryTree.test.ts
+++ b/components/audio/libraryTree.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildLibraryTree } from "./libraryTree";
+import type { AlbumGroup, TagiumFile } from "./types";
+
+const file = (id: string, filename: string): TagiumFile => ({
+  id,
+  filename,
+  status: "pending",
+  downloadStatus: "ready",
+  hasBufferedChanges: false,
+});
+
+const album = (id: string, title: string, trackIds: string[]): AlbumGroup => ({
+  id,
+  title,
+  artist: "",
+  genre: "",
+  trackIds,
+});
+
+describe("libraryTree", () => {
+  it("builds readable tree paths with stable id lookups", () => {
+    const tree = buildLibraryTree({
+      albums: [album("album-1", "Album/One", ["track-1", "track-2"])],
+      files: [file("track-1", "first.mp3"), file("track-2", "second.mp3")],
+      looseTrackIds: [],
+    });
+
+    expect(tree.paths).toEqual(["Album:One/", "Album:One/1. first.mp3", "Album:One/2. second.mp3"]);
+    expect(tree.pathByAlbumId.get("album-1")).toBe("Album:One/");
+    expect(tree.pathByTrackId.get("track-2")).toBe("Album:One/2. second.mp3");
+    expect(tree.entriesByPath.get("Album:One/2. second.mp3")).toMatchObject({
+      albumId: "album-1",
+      trackId: "track-2",
+      type: "track",
+    });
+  });
+
+  it("deduplicates visible path segments only where needed", () => {
+    const tree = buildLibraryTree({
+      albums: [album("album-1", "Same", ["track-1", "track-2"]), album("album-2", "Same", [])],
+      files: [file("track-1", "song.mp3"), file("track-2", "song.mp3")],
+      looseTrackIds: [],
+    });
+
+    expect(tree.paths).toEqual(["Same/", "Same/1. song.mp3", "Same/2. song.mp3", "Same (2)/"]);
+  });
+
+  it("keeps loose tracks at the root", () => {
+    const tree = buildLibraryTree({
+      albums: [album("album-1", "loose tracks", [])],
+      files: [file("track-1", "loose.mp3")],
+      looseTrackIds: ["track-1"],
+    });
+
+    expect(tree.paths).toEqual(["loose tracks/", "loose.mp3"]);
+    expect(tree.entriesByPath.get("loose.mp3")).toMatchObject({
+      albumId: null,
+      trackId: "track-1",
+      type: "track",
+    });
+    expect(tree.pathByAlbumId.get("album-1")).toBe("loose tracks/");
+  });
+
+  it("does not add a loose placeholder when albums exist", () => {
+    const tree = buildLibraryTree({
+      albums: [album("album-1", "album", ["track-1"])],
+      files: [file("track-1", "track.mp3")],
+      looseTrackIds: [],
+    });
+
+    expect(tree.paths).toEqual(["album/", "album/1. track.mp3"]);
+  });
+
+  it("keeps album folders stable before root loose tracks", () => {
+    const tree = buildLibraryTree({
+      albums: [album("album-1", "album", ["track-1"])],
+      files: [file("track-1", "track.mp3"), file("loose-1", "loose.mp3")],
+      looseTrackIds: ["loose-1"],
+    });
+
+    expect(tree.paths).toEqual(["album/", "album/1. track.mp3", "loose.mp3"]);
+  });
+});

--- a/components/audio/libraryTree.ts
+++ b/components/audio/libraryTree.ts
@@ -1,0 +1,121 @@
+import type { AlbumGroup, TagiumFile } from "./types";
+
+export type LibraryTreeEntry =
+  | {
+      type: "album";
+      albumId: string;
+      path: string;
+      trackIds: string[];
+    }
+  | {
+      type: "track";
+      albumId: string | null;
+      path: string;
+      trackId: string;
+    };
+
+interface BuildLibraryTreeInput {
+  albums: AlbumGroup[];
+  files: TagiumFile[];
+  looseTrackIds: string[];
+}
+
+export interface LibraryTreeModel {
+  entriesByPath: Map<string, LibraryTreeEntry>;
+  pathByAlbumId: Map<string, string>;
+  pathByTrackId: Map<string, string>;
+  paths: string[];
+  signature: string;
+}
+
+const sanitizePathSegment = (value: string, fallback: string) => {
+  const segment = value.replaceAll("/", ":").replace(/\s+/g, " ").trim();
+  if (segment.length > 0) return segment;
+  return fallback;
+};
+
+const uniqueSegment = (baseSegment: string, seenSegments: Set<string>) => {
+  let segment = baseSegment;
+  let index = 2;
+  while (seenSegments.has(segment.toLowerCase())) {
+    segment = `${baseSegment} (${index})`;
+    index += 1;
+  }
+  seenSegments.add(segment.toLowerCase());
+  return segment;
+};
+
+const trackSegment = (track: TagiumFile, index?: number) => {
+  const filename = sanitizePathSegment(track.filename, "untitled track.mp3");
+  if (index === undefined) return filename;
+  return `${index + 1}. ${filename}`;
+};
+
+export function buildLibraryTree({
+  albums,
+  files,
+  looseTrackIds,
+}: BuildLibraryTreeInput): LibraryTreeModel {
+  const filesById = new Map(files.map((file) => [file.id, file]));
+  const entriesByPath = new Map<string, LibraryTreeEntry>();
+  const pathByAlbumId = new Map<string, string>();
+  const pathByTrackId = new Map<string, string>();
+  const paths: string[] = [];
+  const rootSegments = new Set<string>();
+
+  for (const album of albums) {
+    const albumSegment = uniqueSegment(
+      sanitizePathSegment(album.title, "untitled album"),
+      rootSegments,
+    );
+    const albumPath = `${albumSegment}/`;
+    paths.push(albumPath);
+    pathByAlbumId.set(album.id, albumPath);
+    entriesByPath.set(albumPath, {
+      type: "album",
+      albumId: album.id,
+      path: albumPath,
+      trackIds: album.trackIds,
+    });
+
+    const albumTrackSegments = new Set<string>();
+    album.trackIds.forEach((trackId, index) => {
+      const track = filesById.get(trackId);
+      if (!track) return;
+
+      const path = `${albumPath}${uniqueSegment(trackSegment(track, index), albumTrackSegments)}`;
+      paths.push(path);
+      entriesByPath.set(path, {
+        type: "track",
+        albumId: album.id,
+        path,
+        trackId,
+      });
+      pathByTrackId.set(trackId, path);
+    });
+  }
+
+  const looseTracks = looseTrackIds
+    .map((trackId) => filesById.get(trackId))
+    .filter((track): track is TagiumFile => Boolean(track));
+
+  for (const track of looseTracks) {
+    const path = uniqueSegment(trackSegment(track), rootSegments);
+    paths.push(path);
+    entriesByPath.set(path, {
+      type: "track",
+      albumId: null,
+      path,
+      trackId: track.id,
+    });
+    pathByTrackId.set(track.id, path);
+  }
+
+  return {
+    entriesByPath,
+    pathByAlbumId,
+    pathByTrackId,
+    paths,
+    signature: paths.join("\n"),
+  };
+}

--- a/components/audio/libraryTreeDrop.test.ts
+++ b/components/audio/libraryTreeDrop.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from "vite-plus/test";
+import { moveTrackInSidebar } from "./albumOps";
+import { buildLibraryTree } from "./libraryTree";
+import { handleLibraryTreeDrop, handleLibraryTreeModelDrop } from "./libraryTreeDrop";
+import type { AlbumGroup, TagiumFile } from "./types";
+
+const file = (id: string): TagiumFile => ({
+  id,
+  filename: `${id}.mp3`,
+  status: "pending",
+  downloadStatus: "ready",
+  hasBufferedChanges: false,
+});
+
+const album = (id: string, title: string, trackIds: string[]): AlbumGroup => ({
+  id,
+  title,
+  artist: "",
+  genre: "",
+  trackIds,
+});
+
+const dropEvent = ({ draggedPath, targetPath }: { draggedPath: string; targetPath: string }) =>
+  ({
+    clientY: 10,
+    dataTransfer: {
+      files: [],
+      getData: () => draggedPath,
+    },
+    nativeEvent: {
+      composedPath: () => [
+        {
+          dataset: {
+            itemPath: targetPath,
+            type: "item",
+          },
+          getBoundingClientRect: () => ({
+            bottom: 20,
+            height: 20,
+            top: 0,
+          }),
+        },
+      ],
+    },
+    preventDefault: () => undefined,
+    stopPropagation: () => undefined,
+  }) as unknown as React.DragEvent<HTMLElement>;
+
+describe("libraryTreeDrop", () => {
+  it("emits all selected tracks in visible order for an album drop", () => {
+    const files = [file("track-a"), file("track-b"), file("track-c")];
+    const albums = [
+      album("source", "Source", ["track-a", "track-b"]),
+      album("target", "Target", []),
+    ];
+    const tree = buildLibraryTree({
+      albums,
+      files,
+      looseTrackIds: ["track-c"],
+    });
+    const movedTrackIds: string[] = [];
+    let selectedTrackId: string | null = null;
+
+    handleLibraryTreeDrop({
+      albums,
+      event: dropEvent({
+        draggedPath: tree.pathByTrackId.get("track-a") ?? "",
+        targetPath: tree.pathByAlbumId.get("target") ?? "",
+      }),
+      handlers: {
+        onAudioUpload: () => undefined,
+        onMoveTrackToAlbum: (trackId) => {
+          movedTrackIds.push(trackId);
+        },
+        onMoveTrackToLoose: () => undefined,
+        onPromptCreateAlbumFromLooseTracks: () => undefined,
+        onReorderAlbums: () => undefined,
+        onSelectTracks: (selection) => {
+          selectedTrackId = selection.selectedFileId;
+        },
+        onUploadToAlbum: () => undefined,
+      },
+      selectedPaths: [
+        tree.pathByTrackId.get("track-a") ?? "",
+        tree.pathByTrackId.get("track-b") ?? "",
+      ],
+      tree,
+    });
+
+    expect(movedTrackIds).toEqual(["track-a", "track-b"]);
+    expect(selectedTrackId).toBe("track-a");
+  });
+
+  it("keeps sequential multi-track moves when handlers compose from latest sidebar state", () => {
+    let currentAlbums = [
+      album("source", "Source", ["track-a", "track-b"]),
+      album("target", "Target", []),
+    ];
+    let currentLooseTrackIds: string[] = [];
+
+    for (const trackId of ["track-a", "track-b"]) {
+      const moved = moveTrackInSidebar(
+        currentAlbums,
+        currentLooseTrackIds,
+        trackId,
+        {
+          type: "album",
+          albumId: "target",
+          placement: "append",
+        },
+        { syncTrackNumbers: true },
+      );
+      currentAlbums = moved.albums;
+      currentLooseTrackIds = moved.looseTrackIds;
+    }
+
+    expect(currentAlbums.find((entry) => entry.id === "source")?.trackIds).toEqual([]);
+    expect(currentAlbums.find((entry) => entry.id === "target")?.trackIds).toEqual([
+      "track-a",
+      "track-b",
+    ]);
+  });
+
+  it("moves selected tracks to loose when dropped on tree background", () => {
+    const files = [file("track-a"), file("track-b")];
+    const albums = [album("source", "Source", ["track-a", "track-b"])];
+    const tree = buildLibraryTree({
+      albums,
+      files,
+      looseTrackIds: [],
+    });
+    const movedTrackIds: string[] = [];
+    let selectedTrackId: string | null = null;
+
+    handleLibraryTreeDrop({
+      albums,
+      event: dropEvent({
+        draggedPath: tree.pathByTrackId.get("track-a") ?? "",
+        targetPath: "",
+      }),
+      handlers: {
+        onAudioUpload: () => undefined,
+        onMoveTrackToAlbum: () => undefined,
+        onMoveTrackToLoose: (trackId) => {
+          movedTrackIds.push(trackId);
+        },
+        onPromptCreateAlbumFromLooseTracks: () => undefined,
+        onReorderAlbums: () => undefined,
+        onSelectTracks: (selection) => {
+          selectedTrackId = selection.selectedFileId;
+        },
+        onUploadToAlbum: () => undefined,
+      },
+      selectedPaths: [
+        tree.pathByTrackId.get("track-a") ?? "",
+        tree.pathByTrackId.get("track-b") ?? "",
+      ],
+      tree,
+    });
+
+    expect(movedTrackIds).toEqual(["track-a", "track-b"]);
+    expect(selectedTrackId).toBe("track-a");
+  });
+
+  it("keeps model-completed multi-track drops focused on the primary dragged track", () => {
+    const files = [file("track-a"), file("track-b"), file("track-c")];
+    const albums = [
+      album("source", "Source", ["track-a", "track-b"]),
+      album("target", "Target", ["track-c"]),
+    ];
+    const tree = buildLibraryTree({
+      albums,
+      files,
+      looseTrackIds: [],
+    });
+    const movedTrackIds: string[] = [];
+    let selectedTrackId: string | null = null;
+
+    handleLibraryTreeModelDrop({
+      albums,
+      event: {
+        draggedPaths: [
+          tree.pathByTrackId.get("track-a") ?? "",
+          tree.pathByTrackId.get("track-b") ?? "",
+        ],
+        operation: "move",
+        target: {
+          directoryPath: tree.pathByAlbumId.get("target") ?? "",
+          flattenedSegmentPath: null,
+          hoveredPath: tree.pathByAlbumId.get("target") ?? "",
+          kind: "directory",
+        },
+      },
+      handlers: {
+        onAudioUpload: () => undefined,
+        onMoveTrackToAlbum: (trackId) => {
+          movedTrackIds.push(trackId);
+        },
+        onMoveTrackToLoose: () => undefined,
+        onPromptCreateAlbumFromLooseTracks: () => undefined,
+        onReorderAlbums: () => undefined,
+        onSelectTracks: (selection) => {
+          selectedTrackId = selection.selectedFileId;
+        },
+        onUploadToAlbum: () => undefined,
+      },
+      tree,
+    });
+
+    expect(movedTrackIds).toEqual(["track-a", "track-b"]);
+    expect(selectedTrackId).toBe("track-a");
+  });
+
+  it("uses model-completed album drops to reorder relative to the target album", () => {
+    const albums = [
+      album("album-a", "Album A", []),
+      album("album-b", "Album B", []),
+      album("album-c", "Album C", []),
+    ];
+    const tree = buildLibraryTree({
+      albums,
+      files: [],
+      looseTrackIds: [],
+    });
+    let reordered: { albumId: string; targetIndex: number } | null = null;
+
+    handleLibraryTreeModelDrop({
+      albums,
+      event: {
+        draggedPaths: [tree.pathByAlbumId.get("album-a") ?? ""],
+        operation: "move",
+        target: {
+          directoryPath: tree.pathByAlbumId.get("album-b") ?? "",
+          flattenedSegmentPath: null,
+          hoveredPath: tree.pathByAlbumId.get("album-b") ?? "",
+          kind: "directory",
+        },
+      },
+      handlers: {
+        onAudioUpload: () => undefined,
+        onMoveTrackToAlbum: () => undefined,
+        onMoveTrackToLoose: () => undefined,
+        onPromptCreateAlbumFromLooseTracks: () => undefined,
+        onReorderAlbums: (albumId, targetIndex) => {
+          reordered = { albumId, targetIndex };
+        },
+        onSelectTracks: () => undefined,
+        onUploadToAlbum: () => undefined,
+      },
+      placement: "before",
+      tree,
+    });
+
+    expect(reordered).toEqual({ albumId: "album-a", targetIndex: 0 });
+  });
+
+  it("uses the hovered album track as the model-completed drop target", () => {
+    const files = [file("track-a"), file("track-b"), file("track-c")];
+    const albums = [
+      album("source", "Source", ["track-a", "track-b"]),
+      album("target", "Target", ["track-c"]),
+    ];
+    const tree = buildLibraryTree({
+      albums,
+      files,
+      looseTrackIds: [],
+    });
+    const moves: { placement: string; referenceTrackId?: string; trackId: string }[] = [];
+
+    handleLibraryTreeModelDrop({
+      albums,
+      event: {
+        draggedPaths: [
+          tree.pathByTrackId.get("track-a") ?? "",
+          tree.pathByTrackId.get("track-b") ?? "",
+        ],
+        operation: "batch",
+        target: {
+          directoryPath: tree.pathByAlbumId.get("target") ?? "",
+          flattenedSegmentPath: null,
+          hoveredPath: tree.pathByTrackId.get("track-c") ?? "",
+          kind: "directory",
+        },
+      },
+      handlers: {
+        onAudioUpload: () => undefined,
+        onMoveTrackToAlbum: (trackId, _albumId, placement, referenceTrackId) => {
+          moves.push({ placement, referenceTrackId, trackId });
+        },
+        onMoveTrackToLoose: () => undefined,
+        onPromptCreateAlbumFromLooseTracks: () => undefined,
+        onReorderAlbums: () => undefined,
+        onSelectTracks: () => undefined,
+        onUploadToAlbum: () => undefined,
+      },
+      placement: "before",
+      tree,
+    });
+
+    expect(moves).toEqual([
+      { placement: "before", referenceTrackId: "track-c", trackId: "track-a" },
+      { placement: "before", referenceTrackId: "track-c", trackId: "track-b" },
+    ]);
+  });
+
+  it("uses the hovered loose track as the model-completed root drop target", () => {
+    const files = [file("track-a"), file("track-b"), file("track-c")];
+    const albums = [album("source", "Source", ["track-a", "track-b"])];
+    const tree = buildLibraryTree({
+      albums,
+      files,
+      looseTrackIds: ["track-c"],
+    });
+    const moves: { placement: string; referenceTrackId?: string; trackId: string }[] = [];
+
+    handleLibraryTreeModelDrop({
+      albums,
+      event: {
+        draggedPaths: [
+          tree.pathByTrackId.get("track-a") ?? "",
+          tree.pathByTrackId.get("track-b") ?? "",
+        ],
+        operation: "batch",
+        target: {
+          directoryPath: null,
+          flattenedSegmentPath: null,
+          hoveredPath: tree.pathByTrackId.get("track-c") ?? "",
+          kind: "root",
+        },
+      },
+      handlers: {
+        onAudioUpload: () => undefined,
+        onMoveTrackToAlbum: () => undefined,
+        onMoveTrackToLoose: (trackId, placement, referenceTrackId) => {
+          moves.push({ placement, referenceTrackId, trackId });
+        },
+        onPromptCreateAlbumFromLooseTracks: () => undefined,
+        onReorderAlbums: () => undefined,
+        onSelectTracks: () => undefined,
+        onUploadToAlbum: () => undefined,
+      },
+      placement: "before",
+      tree,
+    });
+
+    expect(moves).toEqual([
+      { placement: "before", referenceTrackId: "track-c", trackId: "track-a" },
+      { placement: "before", referenceTrackId: "track-c", trackId: "track-b" },
+    ]);
+  });
+});

--- a/components/audio/libraryTreeDrop.ts
+++ b/components/audio/libraryTreeDrop.ts
@@ -1,0 +1,325 @@
+import type { FileTreeDropContext, FileTreeDropResult } from "@pierre/trees";
+import type { DragEvent } from "react";
+import type { LibraryTreeEntry, LibraryTreeModel } from "./libraryTree";
+import type { AlbumGroup } from "./types";
+
+type LibraryTreeDropPlacement = "before" | "after";
+
+export interface LibraryTreeDropHandlers {
+  onAudioUpload: (files: File[]) => void;
+  onMoveTrackToAlbum: (
+    trackId: string,
+    targetAlbumId: string,
+    placement: "before" | "after" | "append",
+    referenceTrackId?: string,
+  ) => void;
+  onMoveTrackToLoose: (
+    trackId: string,
+    placement: "before" | "after" | "append",
+    referenceTrackId?: string,
+  ) => void;
+  onPromptCreateAlbumFromLooseTracks: (sourceTrackId: string, targetTrackId: string) => void;
+  onReorderAlbums: (albumId: string, targetIndex: number) => void;
+  onSelectTracks: (selection: {
+    selectedAlbumId: string | null;
+    selectedFileId: string | null;
+    selectedFileIds: string[];
+  }) => void;
+  onUploadToAlbum: (albumId: string, files: File[]) => void;
+}
+
+export const getTreeRowElement = (event: DragEvent<HTMLElement>) =>
+  event.nativeEvent
+    .composedPath()
+    .find(
+      (target): target is HTMLElement =>
+        Boolean(target) &&
+        typeof target === "object" &&
+        "dataset" in target &&
+        (target as HTMLElement).dataset.type === "item",
+    ) ?? null;
+
+const getTreeEventPath = (event: DragEvent<HTMLElement>) =>
+  getTreeRowElement(event)?.dataset.itemPath ?? null;
+
+const placementForDrop = (event: DragEvent<HTMLElement>) => {
+  const row = getTreeRowElement(event);
+  if (!row) return "append";
+  const rect = row.getBoundingClientRect();
+  return event.clientY > rect.top + rect.height / 2 ? "after" : "before";
+};
+
+const isCenteredDrop = (event: DragEvent<HTMLElement>) => {
+  const row = getTreeRowElement(event);
+  if (!row) return false;
+  const rect = row.getBoundingClientRect();
+  const position = (event.clientY - rect.top) / rect.height;
+  return position > 0.3 && position < 0.7;
+};
+
+export function getLibraryTreeModelDropTargetEntry(
+  event: FileTreeDropContext,
+  tree: LibraryTreeModel,
+) {
+  let targetEntry: LibraryTreeEntry | undefined;
+  if (event.target.hoveredPath) {
+    targetEntry = tree.entriesByPath.get(event.target.hoveredPath);
+  }
+  if (!targetEntry && event.target.directoryPath) {
+    targetEntry = tree.entriesByPath.get(event.target.directoryPath);
+  }
+  return targetEntry;
+}
+
+export function getLibraryTreeModelDropPlacement({
+  event,
+  pointerY,
+  treeElement,
+}: {
+  event: FileTreeDropResult;
+  pointerY: number | null;
+  treeElement: HTMLElement | null;
+}): LibraryTreeDropPlacement {
+  if (pointerY === null || !event.target.hoveredPath || !treeElement) return "after";
+  const host = treeElement.querySelector("file-tree-container");
+  if (!host?.shadowRoot) return "after";
+
+  const rows = host.shadowRoot.querySelectorAll<HTMLElement>("[data-type='item']");
+  for (const row of rows) {
+    if (row.dataset.itemPath !== event.target.hoveredPath) continue;
+    const rect = row.getBoundingClientRect();
+    if (pointerY > rect.top + rect.height / 2) return "after";
+    return "before";
+  }
+  return "after";
+}
+
+const targetIndexForAlbumDrop = (
+  albums: AlbumGroup[],
+  sourceAlbumId: string,
+  targetAlbumId: string,
+  placement: "before" | "after" | "append",
+) => {
+  if (sourceAlbumId === targetAlbumId) return null;
+  const sourceIndex = albums.findIndex((album) => album.id === sourceAlbumId);
+  const targetIndex = albums.findIndex((album) => album.id === targetAlbumId);
+  if (sourceIndex < 0 || targetIndex < 0) return null;
+  const placedIndex = placement === "after" ? targetIndex + 1 : targetIndex;
+  if (sourceIndex < placedIndex) return placedIndex - 1;
+  return placedIndex;
+};
+
+const getDraggedTrackEntries = (
+  draggedEntry: Extract<LibraryTreeEntry, { type: "track" }>,
+  draggedPath: string,
+  selectedPaths: string[],
+  tree: LibraryTreeModel,
+) => {
+  const selectedPathSet = new Set(selectedPaths);
+  if (!selectedPathSet.has(draggedPath)) return [draggedEntry];
+
+  return selectedPaths
+    .map((selectedPath) => tree.entriesByPath.get(selectedPath))
+    .filter(
+      (entry): entry is Extract<LibraryTreeEntry, { type: "track" }> => entry?.type === "track",
+    );
+};
+
+const selectMovedTracks = (
+  handlers: LibraryTreeDropHandlers,
+  draggedEntry: Extract<LibraryTreeEntry, { type: "track" }>,
+  draggedEntries: Extract<LibraryTreeEntry, { type: "track" }>[],
+  selectedAlbumId: string | null,
+) => {
+  handlers.onSelectTracks({
+    selectedAlbumId,
+    selectedFileId: draggedEntry.trackId,
+    selectedFileIds: draggedEntries.map((entry) => entry.trackId),
+  });
+};
+
+export function handleLibraryTreeDrop({
+  albums,
+  event,
+  handlers,
+  selectedPaths,
+  tree,
+}: {
+  albums: AlbumGroup[];
+  event: DragEvent<HTMLElement>;
+  handlers: LibraryTreeDropHandlers;
+  selectedPaths: string[];
+  tree: LibraryTreeModel;
+}) {
+  const droppedFiles = Array.from(event.dataTransfer.files);
+  if (droppedFiles.length > 0) {
+    const audioFiles = droppedFiles.filter((file) => file.type.startsWith("audio/"));
+    if (audioFiles.length === 0) return;
+    const targetPath = getTreeEventPath(event);
+    const targetEntry = targetPath ? tree.entriesByPath.get(targetPath) : null;
+    const albumId =
+      targetEntry?.type === "album"
+        ? targetEntry.albumId
+        : targetEntry?.type === "track"
+          ? targetEntry.albumId
+          : null;
+    event.preventDefault();
+    event.stopPropagation();
+    if (albumId) {
+      handlers.onUploadToAlbum(albumId, audioFiles);
+      return;
+    }
+    handlers.onAudioUpload(audioFiles);
+    return;
+  }
+
+  const draggedPath = event.dataTransfer.getData("text/plain");
+  const draggedEntry = tree.entriesByPath.get(draggedPath);
+  const targetPath = getTreeEventPath(event);
+  const targetEntry = targetPath ? tree.entriesByPath.get(targetPath) : null;
+  if (!draggedEntry) return;
+
+  event.preventDefault();
+  event.stopPropagation();
+  if (!targetEntry) {
+    if (draggedEntry.type !== "track") return;
+    const draggedEntries = getDraggedTrackEntries(draggedEntry, draggedPath, selectedPaths, tree);
+    for (const entry of draggedEntries) {
+      handlers.onMoveTrackToLoose(entry.trackId, "append");
+    }
+    selectMovedTracks(handlers, draggedEntry, draggedEntries, null);
+    return;
+  }
+  if (draggedEntry.type === "album" && targetEntry.type === "album") {
+    const targetIndex = targetIndexForAlbumDrop(
+      albums,
+      draggedEntry.albumId,
+      targetEntry.albumId,
+      placementForDrop(event),
+    );
+    if (targetIndex === null) return;
+    handlers.onReorderAlbums(draggedEntry.albumId, targetIndex);
+    return;
+  }
+
+  if (draggedEntry.type !== "track") return;
+  const draggedEntries = getDraggedTrackEntries(draggedEntry, draggedPath, selectedPaths, tree);
+  if (
+    targetEntry.type === "track" &&
+    draggedEntries.some((entry) => entry.trackId === targetEntry.trackId)
+  ) {
+    return;
+  }
+  if (targetEntry.type === "album") {
+    for (const entry of draggedEntries) {
+      handlers.onMoveTrackToAlbum(entry.trackId, targetEntry.albumId, "append");
+    }
+    selectMovedTracks(handlers, draggedEntry, draggedEntries, targetEntry.albumId);
+    return;
+  }
+  if (targetEntry.type === "track" && targetEntry.albumId) {
+    const placement = placementForDrop(event);
+    const orderedEntries = placement === "after" ? [...draggedEntries].reverse() : draggedEntries;
+    for (const entry of orderedEntries) {
+      handlers.onMoveTrackToAlbum(
+        entry.trackId,
+        targetEntry.albumId,
+        placement,
+        targetEntry.trackId,
+      );
+    }
+    selectMovedTracks(handlers, draggedEntry, draggedEntries, targetEntry.albumId);
+    return;
+  }
+  if (targetEntry.type === "track" && !targetEntry.albumId) {
+    if (draggedEntries.length === 1 && !draggedEntry.albumId && isCenteredDrop(event)) {
+      handlers.onPromptCreateAlbumFromLooseTracks(draggedEntry.trackId, targetEntry.trackId);
+      return;
+    }
+    const placement = placementForDrop(event);
+    const orderedEntries = placement === "after" ? [...draggedEntries].reverse() : draggedEntries;
+    for (const entry of orderedEntries) {
+      handlers.onMoveTrackToLoose(entry.trackId, placement, targetEntry.trackId);
+    }
+    selectMovedTracks(handlers, draggedEntry, draggedEntries, null);
+  }
+}
+
+export function handleLibraryTreeModelDrop({
+  albums,
+  event,
+  handlers,
+  placement = "after",
+  tree,
+}: {
+  albums: AlbumGroup[];
+  event: FileTreeDropResult;
+  handlers: LibraryTreeDropHandlers;
+  placement?: LibraryTreeDropPlacement;
+  tree: LibraryTreeModel;
+}) {
+  const draggedEntries = event.draggedPaths
+    .map((draggedPath) => tree.entriesByPath.get(draggedPath))
+    .filter((entry): entry is LibraryTreeEntry => Boolean(entry));
+  const [draggedEntry] = draggedEntries;
+  const targetEntry = getLibraryTreeModelDropTargetEntry(event, tree);
+
+  if (!draggedEntry) return;
+  if (draggedEntry.type === "album") {
+    if (targetEntry?.type !== "album") return;
+    const targetIndex = targetIndexForAlbumDrop(
+      albums,
+      draggedEntry.albumId,
+      targetEntry.albumId,
+      placement,
+    );
+    if (targetIndex === null) return;
+    handlers.onReorderAlbums(draggedEntry.albumId, targetIndex);
+    return;
+  }
+
+  const draggedTrackEntries = draggedEntries.filter(
+    (entry): entry is Extract<LibraryTreeEntry, { type: "track" }> => entry.type === "track",
+  );
+  if (draggedTrackEntries.length === 0) return;
+
+  if (targetEntry?.type === "album") {
+    for (const entry of draggedTrackEntries) {
+      handlers.onMoveTrackToAlbum(entry.trackId, targetEntry.albumId, "append");
+    }
+    selectMovedTracks(handlers, draggedEntry, draggedTrackEntries, targetEntry.albumId);
+    return;
+  }
+
+  if (targetEntry?.type === "track" && targetEntry.albumId) {
+    if (draggedTrackEntries.some((entry) => entry.trackId === targetEntry.trackId)) return;
+    const orderedEntries =
+      placement === "after" ? [...draggedTrackEntries].reverse() : draggedTrackEntries;
+    for (const entry of orderedEntries) {
+      handlers.onMoveTrackToAlbum(
+        entry.trackId,
+        targetEntry.albumId,
+        placement,
+        targetEntry.trackId,
+      );
+    }
+    selectMovedTracks(handlers, draggedEntry, draggedTrackEntries, targetEntry.albumId);
+    return;
+  }
+
+  if (targetEntry?.type === "track" && !targetEntry.albumId) {
+    if (draggedTrackEntries.some((entry) => entry.trackId === targetEntry.trackId)) return;
+    const orderedEntries =
+      placement === "after" ? [...draggedTrackEntries].reverse() : draggedTrackEntries;
+    for (const entry of orderedEntries) {
+      handlers.onMoveTrackToLoose(entry.trackId, placement, targetEntry.trackId);
+    }
+    selectMovedTracks(handlers, draggedEntry, draggedTrackEntries, null);
+    return;
+  }
+
+  for (const entry of draggedTrackEntries) {
+    handlers.onMoveTrackToLoose(entry.trackId, "append");
+  }
+  selectMovedTracks(handlers, draggedEntry, draggedTrackEntries, null);
+}

--- a/components/audio/libraryTreeSelection.ts
+++ b/components/audio/libraryTreeSelection.ts
@@ -1,0 +1,66 @@
+import type { LibraryTreeEntry } from "./libraryTree";
+
+export interface LibraryTreeSelection {
+  selectedAlbumId: string | null;
+  selectedFileId: string | null;
+  selectedFileIds: string[];
+}
+
+export const resolveSelection = (
+  selectedPaths: readonly string[],
+  entriesByPath: Map<string, LibraryTreeEntry>,
+): LibraryTreeSelection => {
+  let selectedAlbumId: string | null = null;
+  let selectedFileId: string | null = null;
+  const selectedFileIds = new Set<string>();
+
+  for (const path of selectedPaths) {
+    const entry = entriesByPath.get(path);
+    if (!entry) continue;
+
+    if (entry.type === "album") {
+      selectedAlbumId = entry.albumId;
+      const [firstTrackId] = entry.trackIds;
+      if (firstTrackId) {
+        selectedFileIds.add(firstTrackId);
+        selectedFileId = firstTrackId;
+      }
+    }
+
+    if (entry.type === "track") {
+      selectedAlbumId = entry.albumId;
+      selectedFileIds.add(entry.trackId);
+      selectedFileId = entry.trackId;
+    }
+  }
+
+  return {
+    selectedAlbumId,
+    selectedFileId,
+    selectedFileIds: [...selectedFileIds],
+  };
+};
+
+export const getNativeTreePath = (event: Event) =>
+  event
+    .composedPath()
+    .find(
+      (target): target is HTMLElement =>
+        Boolean(target) &&
+        typeof target === "object" &&
+        "dataset" in target &&
+        (target as HTMLElement).dataset.type === "item",
+    )?.dataset.itemPath ?? null;
+
+export const isTreeOwnedClick = (event: Event) =>
+  event
+    .composedPath()
+    .some(
+      (target) =>
+        Boolean(target) &&
+        typeof target === "object" &&
+        "dataset" in target &&
+        ((target as HTMLElement).dataset.type === "item" ||
+          (target as HTMLElement).dataset.type === "context-menu-trigger" ||
+          (target as HTMLElement).dataset.type === "context-menu-anchor"),
+    );

--- a/components/audio/libraryTreeStyles.ts
+++ b/components/audio/libraryTreeStyles.ts
@@ -1,0 +1,33 @@
+import type { CSSProperties } from "react";
+
+export const LIBRARY_TREE_STYLE = {
+  "--trees-action-lane-width-override": "22px",
+  "--trees-bg-override": "var(--card)",
+  "--trees-bg-muted-override": "var(--accent)",
+  "--trees-border-color-override": "var(--border)",
+  "--trees-border-radius-override": "4px",
+  "--trees-fg-muted-override": "var(--muted-foreground)",
+  "--trees-fg-override": "var(--foreground)",
+  "--trees-focus-ring-color-override": "var(--ring)",
+  "--trees-font-family-override": "inherit",
+  "--trees-font-size-override": "14px",
+  "--trees-icon-width-override": "14px",
+  "--trees-item-margin-x-override": "8px",
+  "--trees-item-padding-x-override": "8px",
+  "--trees-level-gap-override": "10px",
+  "--trees-padding-inline-override": "0px",
+  "--trees-selected-bg-override": "var(--accent)",
+  "--trees-selected-fg-override": "var(--accent-foreground)",
+} as CSSProperties;
+
+export const LIBRARY_TREE_CSS = `
+  [data-type='item'] {
+    border-radius: 0;
+  }
+
+  [data-item-section='decoration'] {
+    min-width: 22px;
+    text-align: right;
+    font-size: 11px;
+  }
+`;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@imput/libav.js-encode-cli": "6.8.7",
+    "@pierre/trees": "^1.0.0-beta.4",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",


### PR DESCRIPTION
## Summary
- Replaces the custom album sidebar row rendering with Pierre's `@pierre/trees` file-tree surface.
- Moves album/track row actions into the Trees context menu/action lane while preserving add/download/settings shell controls.
- Adds readable tree path projection, drop handling helpers, and regression tests for path collisions, loose-root drops, and multi-selected moves.

## Validation
- `vp fmt`
- `vp lint`
- `vp check`
- `vp test run`
- Browser smoke on `http://localhost:3000/`: empty state loads, album creation renders a Trees shadow row, context menu/action trigger appears, no console errors.

## Notes
- Trees is path-first and has no custom label renderer, so Tagium keeps app state ID-based and uses readable synthetic paths plus lookup maps at the tree boundary.