### PR TITLE
[codex] compact mobile track editor

### DIFF
--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -54,15 +54,15 @@ export default function TrackMetadataEditor({
   }
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
+    <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
       <form
         onSubmit={(event) => {
           event.preventDefault();
         }}
-        className="flex flex-col h-full"
+        className="flex min-h-0 flex-col h-full"
       >
-        <div className="p-6 h-[104px] border-b flex-shrink-0 flex flex-col justify-center gap-1">
-          <h2 className="text-lg font-semibold truncate">{selectedFile.filename}</h2>
+        <div className="h-16 border-b flex-shrink-0 flex flex-col justify-center gap-1 px-4 md:h-[104px] md:p-6">
+          <h2 className="truncate text-base font-semibold md:text-lg">{selectedFile.filename}</h2>
           {(selectedFile.downloadStatus === "error" || selectedFile.status === "error") &&
             selectedFile.downloadError && (
               <p className="text-xs text-destructive truncate" aria-live="polite">
@@ -70,8 +70,8 @@ export default function TrackMetadataEditor({
               </p>
             )}
         </div>
-        <div className="flex-1 overflow-y-auto p-6 pb-28">
-          <div className="flex gap-4 flex-col lg:flex-row">
+        <div className="flex-1 min-h-0 overflow-y-auto p-3 pb-3 md:p-6 md:pb-28">
+          <div className="flex flex-col gap-3 lg:flex-row lg:gap-4">
             <Controller
               name="picture"
               control={control}
@@ -83,9 +83,9 @@ export default function TrackMetadataEditor({
                 />
               )}
             />
-            <div className="flex-1 grid grid-cols-1 gap-3">
+            <div className="flex-1 grid grid-cols-1 gap-2 md:gap-3">
               <div>
-                <label className="block text-sm font-medium mb-1">filename:</label>
+                <label className="mb-1 block text-xs font-medium md:text-sm">filename:</label>
                 <div
                   className={`flex items-center h-9 w-full rounded-md border border-input bg-transparent dark:bg-input/30 px-3 py-1 text-base shadow-sm transition-colors md:text-sm ${syncFilenames ? "opacity-50 cursor-not-allowed pointer-events-none" : "focus-within:ring-1 focus-within:ring-ring"}`}
                 >
@@ -104,42 +104,44 @@ export default function TrackMetadataEditor({
                 </div>
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">title:</label>
+                <label className="mb-1 block text-xs font-medium md:text-sm">title:</label>
                 <Input {...register("title")} placeholder="Bangarang" />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">artist:</label>
+                <label className="mb-1 block text-xs font-medium md:text-sm">artist:</label>
                 <Input {...register("artist")} placeholder="Skrillex" disabled={inAlbum} />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">album:</label>
+                <label className="mb-1 block text-xs font-medium md:text-sm">album:</label>
                 <Input {...register("album")} placeholder="Bangarang EP" disabled={inAlbum} />
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">year:</label>
-                <Input
-                  type="number"
-                  {...register("year", { valueAsNumber: true })}
-                  placeholder="2011"
-                  disabled={inAlbum}
-                  className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                />
+              <div className="grid grid-cols-[minmax(4.5rem,0.8fr)_minmax(0,1.4fr)_minmax(4.5rem,0.8fr)] gap-2">
+                <div>
+                  <label className="mb-1 block text-xs font-medium md:text-sm">year:</label>
+                  <Input
+                    type="number"
+                    {...register("year", { valueAsNumber: true })}
+                    placeholder="2011"
+                    disabled={inAlbum}
+                    className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium md:text-sm">genre:</label>
+                  <Input {...register("genre")} placeholder="Dubstep" disabled={inAlbum} />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium md:text-sm">track:</label>
+                  <Input
+                    type="number"
+                    {...register("trackNumber", { valueAsNumber: true })}
+                    placeholder="2"
+                    disabled={inAlbum && syncTrackNumbers}
+                    className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  />
+                </div>
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">genre:</label>
-                <Input {...register("genre")} placeholder="Dubstep" disabled={inAlbum} />
-              </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">track:</label>
-                <Input
-                  type="number"
-                  {...register("trackNumber", { valueAsNumber: true })}
-                  placeholder="2"
-                  disabled={inAlbum && syncTrackNumbers}
-                  className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                />
-              </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
+              <div className="grid grid-cols-2 gap-2 text-xs md:text-sm">
                 <div>
                   <span className="font-medium">duration: </span>
                   {`${Math.floor(selectedFile.metadata.duration / 60)}:${String(Math.round(selectedFile.metadata.duration % 60)).padStart(2, "0")}`}
@@ -160,7 +162,7 @@ export default function TrackMetadataEditor({
                     "download failed"}
                 </div>
               </div>
-              <div className="flex justify-end gap-2 pt-2">
+              <div className="flex justify-end gap-2 pt-1 md:pt-2">
                 <Button
                   type="button"
                   onClick={handleSubmit(onDownloadUpdatedFile)}

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -71,7 +71,7 @@ export default function TrackMetadataEditor({
             )}
         </div>
         <div className="flex-1 min-h-0 overflow-y-auto p-3 pb-3 md:p-6 md:pb-28">
-          <div className="flex min-h-full flex-col gap-3 lg:flex-row lg:gap-4">
+          <div className="flex min-h-full flex-col gap-3 lg:min-h-0 lg:flex-row lg:gap-4">
             <Controller
               name="picture"
               control={control}

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -71,7 +71,7 @@ export default function TrackMetadataEditor({
             )}
         </div>
         <div className="flex-1 min-h-0 overflow-y-auto p-3 pb-3 md:p-6 md:pb-28">
-          <div className="flex flex-col gap-3 lg:flex-row lg:gap-4">
+          <div className="flex min-h-full flex-col gap-3 lg:flex-row lg:gap-4">
             <Controller
               name="picture"
               control={control}
@@ -83,7 +83,7 @@ export default function TrackMetadataEditor({
                 />
               )}
             />
-            <div className="flex-1 grid grid-cols-1 gap-2 md:gap-3">
+            <div className="flex flex-1 flex-col gap-2 md:gap-3">
               <div>
                 <label className="mb-1 block text-xs font-medium md:text-sm">filename:</label>
                 <div
@@ -146,7 +146,7 @@ export default function TrackMetadataEditor({
                   <span className="font-medium">duration: </span>
                   {`${Math.floor(selectedFile.metadata.duration / 60)}:${String(Math.round(selectedFile.metadata.duration % 60)).padStart(2, "0")}`}
                 </div>
-                <div>
+                <div className="justify-self-end text-right">
                   <span className="font-medium">size: </span>
                   {selectedFile.file &&
                     selectedFile.status !== "error" &&
@@ -162,13 +162,14 @@ export default function TrackMetadataEditor({
                     "download failed"}
                 </div>
               </div>
-              <div className="flex justify-end gap-2 pt-1 md:pt-2">
+              <div className="flex min-h-0 flex-1 items-center justify-center gap-2 pt-1 md:flex-none md:justify-end md:pt-2">
                 <Button
                   type="button"
                   onClick={handleSubmit(onDownloadUpdatedFile)}
                   disabled={!audioReady}
+                  className="min-w-36"
                 >
-                  download
+                  download track
                 </Button>
               </div>
             </div>

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -61,8 +61,8 @@ export default function TrackMetadataEditor({
         }}
         className="flex min-h-0 flex-col h-full"
       >
-        <div className="h-16 border-b flex-shrink-0 flex flex-col justify-center gap-1 px-4 md:h-[104px] md:p-6">
-          <h2 className="truncate text-base font-semibold md:text-lg">{selectedFile.filename}</h2>
+        <div className="h-16 border-b flex-shrink-0 flex flex-col justify-center gap-1 px-4 lg:h-[104px] lg:p-6">
+          <h2 className="truncate text-base font-semibold lg:text-lg">{selectedFile.filename}</h2>
           {(selectedFile.downloadStatus === "error" || selectedFile.status === "error") &&
             selectedFile.downloadError && (
               <p className="text-xs text-destructive truncate" aria-live="polite">
@@ -70,7 +70,7 @@ export default function TrackMetadataEditor({
               </p>
             )}
         </div>
-        <div className="flex-1 min-h-0 overflow-y-auto p-3 pb-3 md:p-6 md:pb-28">
+        <div className="flex-1 min-h-0 overflow-y-auto p-3 pb-3 lg:p-6 lg:pb-28">
           <div className="flex min-h-full flex-col gap-3 lg:min-h-0 lg:flex-row lg:gap-4">
             <Controller
               name="picture"
@@ -83,7 +83,7 @@ export default function TrackMetadataEditor({
                 />
               )}
             />
-            <div className="flex flex-1 flex-col gap-2 md:gap-3">
+            <div className="flex flex-1 flex-col gap-2 lg:gap-3">
               <div>
                 <label className="mb-1 block text-xs font-medium md:text-sm">filename:</label>
                 <div
@@ -162,7 +162,7 @@ export default function TrackMetadataEditor({
                     "download failed"}
                 </div>
               </div>
-              <div className="flex min-h-0 flex-1 items-center justify-center gap-2 pt-1 md:flex-none md:justify-end md:pt-2">
+              <div className="flex min-h-0 flex-1 items-center justify-center gap-2 pt-1 lg:flex-none lg:justify-end lg:pt-2">
                 <Button
                   type="button"
                   onClick={handleSubmit(onDownloadUpdatedFile)}

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -1396,7 +1396,7 @@ export default function AudioTagger() {
             />
           )}
           {!libraryIsEmpty && activeView === "editor" && (
-            <div className="flex-shrink-0 border-t bg-background/95 p-3 md:pointer-events-none md:absolute md:inset-x-0 md:bottom-4 md:z-10 md:flex md:justify-center md:border-t-0 md:bg-transparent md:px-4 md:p-0">
+            <div className="flex-shrink-0 border-t bg-background/95 p-3 lg:pointer-events-none lg:absolute lg:inset-x-0 lg:bottom-4 lg:z-10 lg:flex lg:justify-center lg:border-t-0 lg:bg-transparent lg:px-4 lg:p-0">
               <div className="pointer-events-auto w-full max-w-3xl">
                 <AudioDownloader
                   onAudioDownload={handleAudioDownload}

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -1372,7 +1372,7 @@ export default function AudioTagger() {
           onDownloadAll={handleDownloadAll}
           onOpenSettings={() => setActiveView("settings")}
         />
-        <div className="relative order-1 h-screen flex flex-col overflow-hidden md:order-none md:h-auto md:min-h-0 md:flex-1">
+        <div className="relative order-1 h-svh flex flex-col overflow-hidden md:order-none md:h-auto md:min-h-0 md:flex-1">
           {activeView === "settings" ? (
             <SettingsPage settings={settings} onChange={handleSettingsChange} />
           ) : libraryIsEmpty ? (
@@ -1396,7 +1396,7 @@ export default function AudioTagger() {
             />
           )}
           {!libraryIsEmpty && activeView === "editor" && (
-            <div className="pointer-events-none absolute inset-x-0 bottom-4 z-10 flex justify-center px-4">
+            <div className="flex-shrink-0 border-t bg-background/95 p-3 md:pointer-events-none md:absolute md:inset-x-0 md:bottom-4 md:z-10 md:flex md:justify-center md:border-t-0 md:bg-transparent md:px-4 md:p-0">
               <div className="pointer-events-auto w-full max-w-3xl">
                 <AudioDownloader
                   onAudioDownload={handleAudioDownload}

--- a/components/audio/coverArt.tsx
+++ b/components/audio/coverArt.tsx
@@ -96,26 +96,28 @@ export default function CoverArt({
   return (
     <div
       className={
-        isCompact ? "flex-shrink-0 flex flex-col h-full" : "flex-shrink-0 grid grid-rows-2 gap-2"
+        isCompact
+          ? "flex-shrink-0 flex gap-2 md:h-full md:flex-col"
+          : "flex-shrink-0 flex gap-2 md:grid md:grid-rows-2"
       }
     >
-      <div className="relative">
+      <div className={isCompact ? "relative w-24 md:w-44" : "relative w-fit"}>
         {coverSrc ? (
           <img
             src={coverSrc}
             alt="album cover"
             className={
               isCompact
-                ? "w-44 h-44 object-cover rounded-lg border"
-                : "w-64 h-64 object-cover rounded-lg border"
+                ? "size-24 object-cover rounded-lg border md:size-44"
+                : "size-24 object-cover rounded-lg border md:size-64"
             }
           />
         ) : (
           <div
             className={
               isCompact
-                ? "w-44 h-44 bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs"
-                : "w-64 h-64 bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs"
+                ? "size-24 bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs md:size-44"
+                : "size-24 bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs md:size-64"
             }
           >
             no cover
@@ -128,7 +130,8 @@ export default function CoverArt({
                 type="button"
                 size="sm"
                 variant="secondary"
-                className="absolute top-2 right-2"
+                aria-label="crop cover art"
+                className="absolute top-2 right-2 size-10 p-0 md:size-8"
                 onClick={() => {
                   if (tempImageForCropping) {
                     URL.revokeObjectURL(tempImageForCropping);
@@ -141,7 +144,11 @@ export default function CoverArt({
                 <Crop className="h-4 w-4" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-auto p-4" side="right">
+            <PopoverContent
+              className="w-auto max-w-[calc(100svw-1rem)] p-3 md:p-4"
+              side="bottom"
+              align="start"
+            >
               {tempImageForCropping && (
                 <ImageCropper
                   src={tempImageForCropping}
@@ -153,7 +160,13 @@ export default function CoverArt({
           </Popover>
         )}
       </div>
-      <div className={isCompact ? "mt-auto pt-2" : "flex flex-col gap-2"}>
+      <div
+        className={
+          isCompact
+            ? "flex min-w-0 flex-1 md:mt-auto md:block md:flex-none md:pt-2"
+            : "flex min-w-0 flex-1 md:flex-none md:flex-col md:gap-2"
+        }
+      >
         <Input
           type="file"
           accept="image/*"
@@ -166,8 +179,8 @@ export default function CoverArt({
           variant="outline"
           className={
             isCompact
-              ? "w-44 h-10 border-dashed border-2 flex items-center gap-2 hover:bg-accent/50 cursor-pointer"
-              : "w-64 h-24 border-dashed border-2 flex flex-col gap-2 hover:bg-accent/50 cursor-pointer"
+              ? "h-24 w-full border-dashed border-2 flex flex-col items-center gap-1 px-2 hover:bg-accent/50 cursor-pointer md:h-10 md:w-44 md:flex-row md:gap-2 md:px-3"
+              : "h-24 w-full border-dashed border-2 flex flex-col gap-2 hover:bg-accent/50 cursor-pointer md:w-64"
           }
           onClick={() => fileInputRef.current?.click()}
         >
@@ -176,7 +189,9 @@ export default function CoverArt({
               isCompact ? "h-4 w-4 text-muted-foreground" : "h-6 w-6 text-muted-foreground"
             }
           />
-          <span className="text-muted-foreground text-xs">upload cover</span>
+          <span className="text-muted-foreground whitespace-nowrap text-[11px] md:text-xs">
+            upload cover
+          </span>
         </Button>
       </div>
     </div>

--- a/components/audio/coverArt.tsx
+++ b/components/audio/coverArt.tsx
@@ -98,10 +98,16 @@ export default function CoverArt({
       className={
         isCompact
           ? "flex-shrink-0 flex gap-2 md:h-full md:flex-col"
-          : "flex-shrink-0 flex items-start gap-2 md:grid md:grid-rows-2"
+          : "flex-shrink-0 flex flex-col items-center gap-2 md:grid md:grid-rows-2 md:items-start"
       }
     >
-      <div className={isCompact ? "relative w-24 md:w-44" : "relative w-fit"}>
+      <div
+        className={
+          isCompact
+            ? "relative w-24 md:w-44"
+            : "relative size-[min(80vw,clamp(7.5rem,calc(75svh-25.3125rem),19.25rem))] md:size-auto"
+        }
+      >
         {coverSrc ? (
           <img
             src={coverSrc}
@@ -109,7 +115,7 @@ export default function CoverArt({
             className={
               isCompact
                 ? "size-24 object-cover rounded-lg border md:size-44"
-                : "size-40 object-cover rounded-lg border md:size-64"
+                : "size-full object-cover rounded-lg border md:size-64"
             }
           />
         ) : (
@@ -117,7 +123,7 @@ export default function CoverArt({
             className={
               isCompact
                 ? "size-24 bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs md:size-44"
-                : "size-40 bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs md:size-64"
+                : "size-full bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs md:size-64"
             }
           >
             no cover
@@ -164,7 +170,7 @@ export default function CoverArt({
         className={
           isCompact
             ? "flex min-w-0 flex-1 md:mt-auto md:block md:flex-none md:pt-2"
-            : "flex min-w-0 flex-1 md:flex-none md:flex-col md:gap-2"
+            : "flex w-[min(80vw,clamp(7.5rem,calc(75svh-25.3125rem),19.25rem))] md:w-auto md:flex-none md:flex-col md:gap-2"
         }
       >
         <Input
@@ -180,7 +186,7 @@ export default function CoverArt({
           className={
             isCompact
               ? "h-24 w-full border-dashed border-2 flex flex-col items-center gap-1 px-2 hover:bg-accent/50 cursor-pointer md:h-10 md:w-44 md:flex-row md:gap-2 md:px-3"
-              : "h-10 w-full border-dashed border-2 flex gap-2 px-3 hover:bg-accent/50 cursor-pointer md:h-24 md:w-64 md:flex-col"
+              : "h-8 w-full border-dashed border-2 flex gap-2 px-3 hover:bg-accent/50 cursor-pointer md:h-24 md:w-64 md:flex-col"
           }
           onClick={() => fileInputRef.current?.click()}
         >

--- a/components/audio/coverArt.tsx
+++ b/components/audio/coverArt.tsx
@@ -98,7 +98,7 @@ export default function CoverArt({
       className={
         isCompact
           ? "flex-shrink-0 flex gap-2 md:h-full md:flex-col"
-          : "flex-shrink-0 flex gap-2 md:grid md:grid-rows-2"
+          : "flex-shrink-0 flex items-start gap-2 md:grid md:grid-rows-2"
       }
     >
       <div className={isCompact ? "relative w-24 md:w-44" : "relative w-fit"}>
@@ -109,7 +109,7 @@ export default function CoverArt({
             className={
               isCompact
                 ? "size-24 object-cover rounded-lg border md:size-44"
-                : "size-24 object-cover rounded-lg border md:size-64"
+                : "size-40 object-cover rounded-lg border md:size-64"
             }
           />
         ) : (
@@ -117,7 +117,7 @@ export default function CoverArt({
             className={
               isCompact
                 ? "size-24 bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs md:size-44"
-                : "size-24 bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs md:size-64"
+                : "size-40 bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs md:size-64"
             }
           >
             no cover
@@ -180,7 +180,7 @@ export default function CoverArt({
           className={
             isCompact
               ? "h-24 w-full border-dashed border-2 flex flex-col items-center gap-1 px-2 hover:bg-accent/50 cursor-pointer md:h-10 md:w-44 md:flex-row md:gap-2 md:px-3"
-              : "h-24 w-full border-dashed border-2 flex flex-col gap-2 hover:bg-accent/50 cursor-pointer md:w-64"
+              : "h-10 w-full border-dashed border-2 flex gap-2 px-3 hover:bg-accent/50 cursor-pointer md:h-24 md:w-64 md:flex-col"
           }
           onClick={() => fileInputRef.current?.click()}
         >

--- a/components/audio/coverArt.tsx
+++ b/components/audio/coverArt.tsx
@@ -98,14 +98,14 @@ export default function CoverArt({
       className={
         isCompact
           ? "flex-shrink-0 flex gap-2 md:h-full md:flex-col"
-          : "flex-shrink-0 flex flex-col items-center gap-2 md:grid md:grid-rows-2 md:items-start"
+          : "flex-shrink-0 flex flex-col items-center gap-2 lg:grid lg:grid-rows-2 lg:items-start"
       }
     >
       <div
         className={
           isCompact
             ? "relative w-24 md:w-44"
-            : "relative size-[min(80vw,clamp(7.5rem,calc(75svh-25.3125rem),19.25rem))] md:size-auto"
+            : "relative size-[min(80vw,clamp(7.5rem,calc(75svh-25.3125rem),19.25rem))] lg:size-auto"
         }
       >
         {coverSrc ? (
@@ -115,7 +115,7 @@ export default function CoverArt({
             className={
               isCompact
                 ? "size-24 object-cover rounded-lg border md:size-44"
-                : "size-full object-cover rounded-lg border md:size-64"
+                : "size-full object-cover rounded-lg border lg:size-64"
             }
           />
         ) : (
@@ -123,7 +123,7 @@ export default function CoverArt({
             className={
               isCompact
                 ? "size-24 bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs md:size-44"
-                : "size-full bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs md:size-64"
+                : "size-full bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs lg:size-64"
             }
           >
             no cover
@@ -170,7 +170,7 @@ export default function CoverArt({
         className={
           isCompact
             ? "flex min-w-0 flex-1 md:mt-auto md:block md:flex-none md:pt-2"
-            : "flex w-[min(80vw,clamp(7.5rem,calc(75svh-25.3125rem),19.25rem))] md:w-auto md:flex-none md:flex-col md:gap-2"
+            : "flex w-[min(80vw,clamp(7.5rem,calc(75svh-25.3125rem),19.25rem))] lg:w-auto lg:flex-none lg:flex-col lg:gap-2"
         }
       >
         <Input
@@ -186,7 +186,7 @@ export default function CoverArt({
           className={
             isCompact
               ? "h-24 w-full border-dashed border-2 flex flex-col items-center gap-1 px-2 hover:bg-accent/50 cursor-pointer md:h-10 md:w-44 md:flex-row md:gap-2 md:px-3"
-              : "h-8 w-full border-dashed border-2 flex gap-2 px-3 hover:bg-accent/50 cursor-pointer md:h-24 md:w-64 md:flex-col"
+              : "h-8 w-full border-dashed border-2 flex gap-2 px-3 hover:bg-accent/50 cursor-pointer lg:h-24 lg:w-64 lg:flex-col"
           }
           onClick={() => fileInputRef.current?.click()}
         >

--- a/components/ui/image-cropper.tsx
+++ b/components/ui/image-cropper.tsx
@@ -91,8 +91,9 @@ export default function ImageCropper({ src, onCrop, onCancel }: ImageCropperProp
 
   return (
     <div className="space-y-4">
-      <div className="w-80 h-80 flex items-center justify-center">
+      <div className="flex size-[min(20rem,calc(100svw-2.5rem))] items-center justify-center">
         <ReactCrop
+          className="max-h-full"
           crop={crop}
           onChange={(c) => setCrop(c)}
           onComplete={(c) => setCompletedCrop(c)}
@@ -103,7 +104,7 @@ export default function ImageCropper({ src, onCrop, onCancel }: ImageCropperProp
           <img
             ref={imgRef}
             alt="Crop preview"
-            style={{ maxWidth: "320px", maxHeight: "320px" }}
+            style={{ maxWidth: "100%", maxHeight: "100%" }}
             src={src}
             onLoad={onImageLoad}
           />


### PR DESCRIPTION
## Summary
- compact the mobile track editor so cover art, metadata fields, and the media URL entry fit in the editor viewport
- shrink mobile cover/upload controls while preserving desktop cover sizing
- anchor the crop button to the cover image and make the crop popover/cropper responsive on narrow phones

## Verification
- vp fmt . --check
- vp lint .
- vp check
- vp test
- vp build
- manual browser checks at 739x1600, 390x844, and 320x700 mobile viewports
- antagonistic review loop repeated until final review returned no feedback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the audio editing interface with a cleaner, more responsive layout.
  * Updated cover art controls with better crop, upload, and preview behavior across screen sizes.

* **Bug Fixes**
  * Adjusted spacing and container sizing for more consistent scrolling and viewport behavior.
  * Refined input and button styling for metadata fields, including track number and year entry.
  * Improved crop preview scaling so images fit more reliably within the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->