### PR TITLE
[codex] Migrate sidebar drag and drop to dnd-kit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "tagium",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@imput/libav.js-encode-cli": "6.8.7",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.15",
@@ -111,6 +113,14 @@
     "@bundled-es-modules/statuses": ["@bundled-es-modules/statuses@1.0.1", "", { "dependencies": { "statuses": "2.0.2" } }, "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg=="],
 
     "@bundled-es-modules/tough-cookie": ["@bundled-es-modules/tough-cookie@0.1.6", "", { "dependencies": { "@types/tough-cookie": "4.0.5", "tough-cookie": "4.1.4" } }, "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.49.0", "", { "dependencies": { "commander": "11.1.0", "dotenv": "17.2.1", "eciesjs": "0.4.15", "execa": "5.1.1", "fdir": "6.5.0", "ignore": "5.3.2", "object-treeify": "1.1.33", "picomatch": "4.0.3", "which": "4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-M1cyP6YstFQCjih54SAxCqHLMMi8QqV8tenpgGE48RTXWD7vfMYJiw/6xcCDpS2h28AcLpTsFCZA863Ge9yxzA=="],
 

--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -289,7 +289,7 @@ export default function AlbumSidebar({
             <DroppableTrackContainer
               id={LOOSE_CONTAINER_ID}
               data={{ type: "container", container: "loose" }}
-              className={looseTracks.length === 0 ? "min-h-0" : ""}
+              className={looseTracks.length === 0 && activeDrag?.type === "track" ? "min-h-12" : ""}
             >
               {looseTracks.map((track) => (
                 <SortableTrackRow

--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -6,6 +6,7 @@ import {
   DndContext,
   DragOverlay,
   type DragEndEvent,
+  type DragOverEvent,
   type DragStartEvent,
   KeyboardSensor,
   MouseSensor,
@@ -20,6 +21,7 @@ import {
 } from "@dnd-kit/sortable";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { AlbumSidebarEmptyState } from "./AlbumSidebarEmptyState";
 import {
   albumIdFromDrop,
   albumContainerId,
@@ -100,6 +102,7 @@ export default function AlbumSidebar({
 }: AlbumSidebarProps) {
   const [activeDrag, setActiveDrag] = useState<SidebarDragData | null>(null);
   const dragStartYRef = useRef<number | null>(null);
+  const recentLooseTargetRef = useRef<{ trackId: string; expiresAt: number } | null>(null);
   const sensors = useSensors(
     useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 6 } }),
@@ -126,7 +129,19 @@ export default function AlbumSidebar({
 
   const handleDragStart = (event: DragStartEvent) => {
     setActiveDrag((event.active.data.current as SidebarDragData | undefined) ?? null);
+    recentLooseTargetRef.current = null;
     dragStartYRef.current = dragStartY(event.activatorEvent);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    const active = event.active.data.current as SidebarDragData | undefined;
+    const over = event.over?.data.current as SidebarDropData | undefined;
+    if (active?.type !== "track") return;
+    if (active.container !== "loose") return;
+    if (over?.type !== "track") return;
+    if (over.container !== "loose") return;
+    if (over.trackId === active.trackId) return;
+    recentLooseTargetRef.current = { trackId: over.trackId, expiresAt: Date.now() + 700 };
   };
 
   const trackIdsForDrop = (drop: Extract<SidebarDropData, { type: "track" }>) => {
@@ -191,6 +206,16 @@ export default function AlbumSidebar({
     }
 
     if (over.type === "container" && over.container === "loose") {
+      const recentLooseTarget = recentLooseTargetRef.current;
+      if (
+        active.container === "loose" &&
+        event.over?.id !== LOOSE_APPEND_CONTAINER_ID &&
+        recentLooseTarget &&
+        recentLooseTarget.expiresAt > Date.now()
+      ) {
+        onPromptCreateAlbumFromLooseTracks(active.trackId, recentLooseTarget.trackId);
+        return;
+      }
       onMoveTrackToLoose(active.trackId, "append");
     }
   };
@@ -204,6 +229,7 @@ export default function AlbumSidebar({
       handleTrackDragEnd(event, active, over);
     }
     dragStartYRef.current = null;
+    recentLooseTargetRef.current = null;
     setActiveDrag(null);
   };
 
@@ -218,27 +244,7 @@ export default function AlbumSidebar({
   };
 
   if (albums.length === 0 && looseTracks.length === 0) {
-    return (
-      <div
-        className="w-full flex-1 min-h-0 flex flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground px-4"
-        onClick={onClearSelection}
-      >
-        <p>no tracks yet</p>
-        <p className="text-xs">create an empty album or upload tracks</p>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={(event) => {
-            event.stopPropagation();
-            onAddAlbum();
-          }}
-        >
-          <Plus className="h-4 w-4" />
-          add album
-        </Button>
-      </div>
-    );
+    return <AlbumSidebarEmptyState onAddAlbum={onAddAlbum} onClearSelection={onClearSelection} />;
   }
 
   return (
@@ -256,8 +262,10 @@ export default function AlbumSidebar({
         sensors={sensors}
         collisionDetection={sidebarCollisionDetection}
         onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
         onDragCancel={() => {
           dragStartYRef.current = null;
+          recentLooseTargetRef.current = null;
           setActiveDrag(null);
         }}
         onDragEnd={handleDragEnd}
@@ -281,6 +289,7 @@ export default function AlbumSidebar({
             <DroppableTrackContainer
               id={LOOSE_CONTAINER_ID}
               data={{ type: "container", container: "loose" }}
+              className={looseTracks.length === 0 ? "min-h-0" : ""}
             >
               {looseTracks.map((track) => (
                 <SortableTrackRow

--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import type { MouseEvent as ReactMouseEvent } from "react";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import {
   DndContext,
+  DragOverlay,
   type DragEndEvent,
   type DragStartEvent,
   KeyboardSensor,
@@ -26,9 +27,11 @@ import {
   dragStartY,
   DroppableTrackContainer,
   isCenteredLooseDrop,
+  LOOSE_APPEND_CONTAINER_ID,
   LOOSE_CONTAINER_ID,
   rowPlacement,
   sidebarCollisionDetection,
+  SidebarDragPreview,
   SortableAlbumCard,
   SortableTrackRow,
   trackItemId,
@@ -95,6 +98,7 @@ export default function AlbumSidebar({
   onReorderAlbums,
   onAudioUpload,
 }: AlbumSidebarProps) {
+  const [activeDrag, setActiveDrag] = useState<SidebarDragData | null>(null);
   const dragStartYRef = useRef<number | null>(null);
   const sensors = useSensors(
     useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
@@ -102,6 +106,11 @@ export default function AlbumSidebar({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
   const filesById = new Map(files.map((file) => [file.id, file]));
+  const activeTrack = activeDrag?.type === "track" ? filesById.get(activeDrag.trackId) : undefined;
+  const activeAlbum =
+    activeDrag?.type === "album"
+      ? albums.find((album) => album.id === activeDrag.albumId)
+      : undefined;
   const looseTracks = looseTrackIds
     .map((trackId) => filesById.get(trackId))
     .filter((track): track is TagiumFile => Boolean(track));
@@ -116,6 +125,7 @@ export default function AlbumSidebar({
   };
 
   const handleDragStart = (event: DragStartEvent) => {
+    setActiveDrag((event.active.data.current as SidebarDragData | undefined) ?? null);
     dragStartYRef.current = dragStartY(event.activatorEvent);
   };
 
@@ -194,6 +204,7 @@ export default function AlbumSidebar({
       handleTrackDragEnd(event, active, over);
     }
     dragStartYRef.current = null;
+    setActiveDrag(null);
   };
 
   const handleFileDrop = (event: React.DragEvent, onUpload: (files: File[]) => void) => {
@@ -247,11 +258,12 @@ export default function AlbumSidebar({
         onDragStart={handleDragStart}
         onDragCancel={() => {
           dragStartYRef.current = null;
+          setActiveDrag(null);
         }}
         onDragEnd={handleDragEnd}
       >
         <div
-          className="flex-1 overflow-y-auto flex flex-col"
+          className="flex-1 overflow-y-auto overflow-x-hidden flex flex-col"
           onClick={(event) => {
             if (event.target === event.currentTarget) onClearSelection();
           }}
@@ -359,7 +371,17 @@ export default function AlbumSidebar({
               );
             })}
           </SortableContext>
+          <DroppableTrackContainer
+            id={LOOSE_APPEND_CONTAINER_ID}
+            data={{ type: "container", container: "loose" }}
+            className="flex-1 min-h-16"
+          />
         </div>
+        <DragOverlay dropAnimation={null}>
+          {activeDrag ? (
+            <SidebarDragPreview active={activeDrag} album={activeAlbum} track={activeTrack} />
+          ) : null}
+        </DragOverlay>
       </DndContext>
     </div>
   );

--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -1,25 +1,41 @@
 "use client";
 
-import type { DragEvent, MouseEvent as ReactMouseEvent } from "react";
-import { useState } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { useRef } from "react";
 import {
-  AlertCircle,
-  Check,
-  Download,
-  FileMusic,
-  Loader2,
-  Pencil,
-  Plus,
-  RefreshCw,
-  X,
-} from "lucide-react";
+  DndContext,
+  type DragEndEvent,
+  type DragStartEvent,
+  KeyboardSensor,
+  MouseSensor,
+  useSensor,
+  useSensors,
+  TouchSensor,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import { AlbumCoverThumb } from "./AlbumCoverThumb";
-import { AlbumGroup, TagiumFile } from "./types";
-
-const TRACK_DRAG_TYPE = "application/x-tagium-track";
-const ALBUM_DRAG_TYPE = "application/x-tagium-album";
+import {
+  albumIdFromDrop,
+  albumContainerId,
+  albumItemId,
+  dragStartY,
+  DroppableTrackContainer,
+  isCenteredLooseDrop,
+  LOOSE_CONTAINER_ID,
+  rowPlacement,
+  sidebarCollisionDetection,
+  SortableAlbumCard,
+  SortableTrackRow,
+  trackItemId,
+  type SidebarDragData,
+  type SidebarDropData,
+} from "./AlbumSidebarDnd";
+import type { AlbumGroup, TagiumFile } from "./types";
 
 interface AlbumSidebarProps {
   albums: AlbumGroup[];
@@ -54,48 +70,7 @@ interface AlbumSidebarProps {
   onAudioUpload: (files: File[]) => void;
 }
 
-interface DragPayload {
-  trackId: string;
-  container: "album" | "loose";
-  albumId?: string;
-}
-
-interface AlbumDragPayload {
-  albumId: string;
-}
-
-function parseDragPayload(event: DragEvent) {
-  const rawPayload = event.dataTransfer.getData(TRACK_DRAG_TYPE);
-  if (!rawPayload) return null;
-
-  try {
-    return JSON.parse(rawPayload) as DragPayload;
-  } catch {
-    return null;
-  }
-}
-
-function parseAlbumDragPayload(event: DragEvent) {
-  const rawPayload = event.dataTransfer.getData(ALBUM_DRAG_TYPE);
-  if (!rawPayload) return null;
-
-  try {
-    return JSON.parse(rawPayload) as AlbumDragPayload;
-  } catch {
-    return null;
-  }
-}
-
-function isCenteredDrop(event: DragEvent<HTMLElement>) {
-  const rect = event.currentTarget.getBoundingClientRect();
-  const position = (event.clientY - rect.top) / rect.height;
-  return position > 0.3 && position < 0.7;
-}
-
-function placementForRowDrop(event: DragEvent<HTMLElement>) {
-  const rect = event.currentTarget.getBoundingClientRect();
-  return event.clientY > rect.top + rect.height / 2 ? "after" : "before";
-}
+const isFileDrag = (event: React.DragEvent) => event.dataTransfer.types.includes("Files");
 
 export default function AlbumSidebar({
   albums,
@@ -120,8 +95,12 @@ export default function AlbumSidebar({
   onReorderAlbums,
   onAudioUpload,
 }: AlbumSidebarProps) {
-  const [draggedAlbumId, setDraggedAlbumId] = useState<string | null>(null);
-  const [dragOverAlbumIndex, setDragOverAlbumIndex] = useState<number | null>(null);
+  const dragStartYRef = useRef<number | null>(null);
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
   const filesById = new Map(files.map((file) => [file.id, file]));
   const looseTracks = looseTrackIds
     .map((trackId) => filesById.get(trackId))
@@ -130,6 +109,102 @@ export default function AlbumSidebar({
   const isRetryableError = (track: TagiumFile) =>
     Boolean(track.downloadRequest) &&
     (track.downloadStatus === "error" || track.status === "error");
+  const selectedTone = (trackId: string) => {
+    if (selectedFileIds.has(trackId)) return "primary";
+    if (selectedFileId === trackId) return "secondary";
+    return null;
+  };
+
+  const handleDragStart = (event: DragStartEvent) => {
+    dragStartYRef.current = dragStartY(event.activatorEvent);
+  };
+
+  const trackIdsForDrop = (drop: Extract<SidebarDropData, { type: "track" }>) => {
+    if (drop.container === "loose") return looseTrackIds;
+
+    const album = albums.find((entry) => entry.id === drop.albumId);
+    if (album) return album.trackIds;
+    return [];
+  };
+
+  const handleAlbumDragEnd = (active: SidebarDragData, over: SidebarDropData) => {
+    if (active.type !== "album") return;
+
+    const targetAlbumId = albumIdFromDrop(over);
+
+    if (targetAlbumId && targetAlbumId !== active.albumId) {
+      const sourceIndex = albums.findIndex((album) => album.id === active.albumId);
+      const targetIndex = albums.findIndex((album) => album.id === targetAlbumId);
+      if (sourceIndex < 0 || targetIndex < 0) return;
+      onReorderAlbums(active.albumId, targetIndex);
+    }
+  };
+
+  const handleTrackDragEnd = (
+    event: DragEndEvent,
+    active: SidebarDragData,
+    over: SidebarDropData,
+  ) => {
+    if (active.type !== "track") return;
+
+    if (over.type === "track") {
+      if (over.trackId === active.trackId) return;
+
+      const placement = rowPlacement(
+        event,
+        active.trackId,
+        over.trackId,
+        trackIdsForDrop(over),
+        dragStartYRef.current,
+      );
+      if (over.container === "loose") {
+        if (active.container === "loose" && isCenteredLooseDrop(event, dragStartYRef.current)) {
+          onPromptCreateAlbumFromLooseTracks(active.trackId, over.trackId);
+          return;
+        }
+        onMoveTrackToLoose(active.trackId, placement, over.trackId);
+        return;
+      }
+
+      onMoveTrackToAlbum(active.trackId, over.albumId, placement, over.trackId);
+      return;
+    }
+
+    if (over.type === "album") {
+      onMoveTrackToAlbum(active.trackId, over.albumId, "append");
+      return;
+    }
+
+    if (over.type === "container" && over.container === "album") {
+      onMoveTrackToAlbum(active.trackId, over.albumId, "append");
+      return;
+    }
+
+    if (over.type === "container" && over.container === "loose") {
+      onMoveTrackToLoose(active.trackId, "append");
+    }
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const active = event.active.data.current as SidebarDragData | undefined;
+    const over = event.over?.data.current as SidebarDropData | undefined;
+
+    if (active && over) {
+      handleAlbumDragEnd(active, over);
+      handleTrackDragEnd(event, active, over);
+    }
+    dragStartYRef.current = null;
+  };
+
+  const handleFileDrop = (event: React.DragEvent, onUpload: (files: File[]) => void) => {
+    const droppedFiles = Array.from(event.dataTransfer.files);
+    if (droppedFiles.length === 0) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    const audioFiles = droppedFiles.filter((file) => file.type.startsWith("audio/"));
+    if (audioFiles.length > 0) onUpload(audioFiles);
+  };
 
   if (albums.length === 0 && looseTracks.length === 0) {
     return (
@@ -166,410 +241,126 @@ export default function AlbumSidebar({
         </Button>
       </div>
 
-      <div
-        className="flex-1 overflow-y-auto flex flex-col"
-        onClick={(event) => {
-          if (event.target === event.currentTarget) {
-            onClearSelection();
-          }
+      <DndContext
+        sensors={sensors}
+        collisionDetection={sidebarCollisionDetection}
+        onDragStart={handleDragStart}
+        onDragCancel={() => {
+          dragStartYRef.current = null;
         }}
-        onDragOver={(event) => {
-          event.preventDefault();
-          event.dataTransfer.dropEffect = "move";
-        }}
-        onDrop={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-
-          // Handle external file drops
-          const files = Array.from(event.dataTransfer.files);
-          if (files.length > 0) {
-            const audioFiles = files.filter((file) => file.type.startsWith("audio/"));
-            if (audioFiles.length > 0) {
-              onAudioUpload(audioFiles);
-              return;
-            }
-          }
-
-          // Handle track drag
-          const trackPayload = parseDragPayload(event);
-          if (trackPayload) {
-            onMoveTrackToLoose(trackPayload.trackId, "append");
-            return;
-          }
-        }}
+        onDragEnd={handleDragEnd}
       >
-        {looseTracks.map((track) => (
-          <div
-            key={track.id}
-            className="relative group border-b"
-            onDragOver={(event) => {
-              if (event.dataTransfer.types.includes("Files")) return;
-
-              event.preventDefault();
-              event.stopPropagation();
-              const payload = parseDragPayload(event);
-              if (payload && payload.trackId !== track.id) {
-                event.dataTransfer.dropEffect = "move";
-              }
-            }}
-            onDrop={(event) => {
-              if (event.dataTransfer.files.length > 0) return;
-
-              event.preventDefault();
-              event.stopPropagation();
-              const payload = parseDragPayload(event);
-              if (!payload || payload.trackId === track.id) return;
-
-              if (payload.container === "loose" && isCenteredDrop(event)) {
-                onPromptCreateAlbumFromLooseTracks(payload.trackId, track.id);
-                return;
-              }
-              const placement = placementForRowDrop(event);
-              onMoveTrackToLoose(payload.trackId, placement, track.id);
-            }}
+        <div
+          className="flex-1 overflow-y-auto flex flex-col"
+          onClick={(event) => {
+            if (event.target === event.currentTarget) onClearSelection();
+          }}
+          onDragOver={(event) => {
+            if (!isFileDrag(event)) return;
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "copy";
+          }}
+          onDrop={(event) => handleFileDrop(event, onAudioUpload)}
+        >
+          <SortableContext
+            items={looseTracks.map((track) => trackItemId(track.id))}
+            strategy={verticalListSortingStrategy}
           >
-            <Button
-              type="button"
-              variant="ghost"
-              draggable
-              onDragStart={(event) => {
-                const payload: DragPayload = {
-                  trackId: track.id,
-                  container: "loose",
-                };
-                event.dataTransfer.setData(TRACK_DRAG_TYPE, JSON.stringify(payload));
-                event.dataTransfer.effectAllowed = "move";
-              }}
-              className={cn(
-                "justify-start h-auto py-3 px-4 w-full text-left font-normal pr-8 rounded-none hover:bg-accent/30",
-                track.downloadStatus === "downloading" ? "opacity-65" : "",
-                selectedFileIds.has(track.id)
-                  ? "bg-accent text-accent-foreground"
-                  : selectedFileId === track.id
-                    ? "bg-accent/50 text-accent-foreground"
-                    : "",
-              )}
-              onClick={(e) => onSelectLooseTrack(track.id, e)}
+            <DroppableTrackContainer
+              id={LOOSE_CONTAINER_ID}
+              data={{ type: "container", container: "loose" }}
             >
-              <div className="flex flex-col gap-1 w-full min-w-0">
-                <div className="flex items-center gap-2 w-full overflow-hidden">
-                  <FileMusic className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
-                  <span className="truncate text-sm flex-1">{track.filename}</span>
-                  {track.downloadStatus === "downloading" && (
-                    <Loader2 className="h-3 w-3 text-muted-foreground flex-shrink-0 animate-spin" />
-                  )}
-                  {track.downloadStatus !== "downloading" && track.status === "saved" && (
-                    <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
-                  )}
-                  {(track.downloadStatus === "error" || track.status === "error") && (
-                    <AlertCircle
-                      className={cn(
-                        "h-3 w-3 text-red-500 flex-shrink-0",
-                        isRetryableError(track) ? "group-hover:opacity-0" : "",
-                      )}
-                    />
-                  )}
-                </div>
-                {(track.downloadStatus === "error" || track.status === "error") &&
-                  track.downloadError && (
-                    <span className="pl-7 text-xs text-destructive truncate" aria-live="polite">
-                      error: {track.downloadError}
-                    </span>
-                  )}
-              </div>
-            </Button>
-            {isRetryableError(track) && (
-              <button
-                type="button"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onRetryDownload(track.id);
-                }}
-                className="absolute right-7 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded-full cursor-pointer"
-                title="retry download"
-                aria-label={`retry download for ${track.filename}`}
-              >
-                <RefreshCw className="h-3 w-3 text-muted-foreground hover:text-primary" />
-              </button>
-            )}
-            <button
-              type="button"
-              onClick={(event) => {
-                event.stopPropagation();
-                onRemoveFile(track.id);
-              }}
-              className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
-              title="remove track"
-            >
-              <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
-            </button>
-          </div>
-        ))}
+              {looseTracks.map((track) => (
+                <SortableTrackRow
+                  key={track.id}
+                  track={track}
+                  container="loose"
+                  selectedTone={selectedTone(track.id)}
+                  muted={track.downloadStatus === "downloading"}
+                  retryable={isRetryableError(track)}
+                  onSelect={(event) => onSelectLooseTrack(track.id, event)}
+                  onRetry={() => onRetryDownload(track.id)}
+                  onRemove={() => onRemoveFile(track.id)}
+                />
+              ))}
+            </DroppableTrackContainer>
+          </SortableContext>
 
-        {albums.map((album, albumIndex) => {
-          const canDownloadAlbum =
-            album.trackIds.length > 0 &&
-            album.trackIds.every((trackId) => {
-              const file = filesById.get(trackId);
-              return file?.file && file.metadata;
-            });
-          return (
-            <div
-              key={album.id}
-              className={cn(
-                "border-b transition-all",
-                selectedAlbumId === album.id ? "bg-primary/5" : "",
-                draggedAlbumId === album.id ? "opacity-50" : "",
-                dragOverAlbumIndex === albumIndex ? "shadow-[inset_0_0_0_2px_var(--primary)]" : "",
-              )}
-              onDragOver={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-
-                const albumPayload = parseAlbumDragPayload(event);
-                if (albumPayload && albumPayload.albumId !== album.id) {
-                  event.dataTransfer.dropEffect = "move";
-                  const rect = event.currentTarget.getBoundingClientRect();
-                  const position = (event.clientY - rect.top) / rect.height;
-                  setDragOverAlbumIndex(position < 0.5 ? albumIndex : albumIndex + 1);
-                } else {
-                  setDragOverAlbumIndex(null);
-                }
-
-                const trackPayload = parseDragPayload(event);
-                if (trackPayload) {
-                  event.dataTransfer.dropEffect = "move";
-                }
-
-                // Handle external file drops
-                if (event.dataTransfer.types.includes("Files")) {
-                  event.dataTransfer.dropEffect = "copy";
-                }
-              }}
-              onDragLeave={() => {
-                setDragOverAlbumIndex(null);
-              }}
-              onDrop={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-
-                // Handle external file drops
-                const files = Array.from(event.dataTransfer.files);
-                if (files.length > 0) {
-                  const audioFiles = files.filter((file) => file.type.startsWith("audio/"));
-                  if (audioFiles.length > 0) {
-                    onUploadToAlbum(album.id, audioFiles);
-                    return;
-                  }
-                }
-
-                // Handle album reordering
-                const albumPayload = parseAlbumDragPayload(event);
-                if (albumPayload && albumPayload.albumId !== album.id) {
-                  const sourceIndex = albums.findIndex((a) => a.id === albumPayload.albumId);
-                  if (sourceIndex >= 0) {
-                    const rect = event.currentTarget.getBoundingClientRect();
-                    const position = (event.clientY - rect.top) / rect.height;
-                    let targetIndex = position < 0.5 ? albumIndex : albumIndex + 1;
-                    // Adjust target index if dragging from before the target
-                    if (sourceIndex < targetIndex) {
-                      targetIndex -= 1;
-                    }
-                    onReorderAlbums(albumPayload.albumId, targetIndex);
-                  }
-                  setDraggedAlbumId(null);
-                  setDragOverAlbumIndex(null);
-                  return;
-                }
-
-                // Handle track drag
-                const trackPayload = parseDragPayload(event);
-                if (trackPayload) {
-                  onMoveTrackToAlbum(trackPayload.trackId, album.id, "append");
-                  return;
-                }
-              }}
-            >
-              <div className="w-full flex items-center justify-between gap-1 px-3 py-3 border-b">
-                <button
-                  type="button"
-                  className="min-w-0 flex-1 flex items-center gap-2 text-left cursor-pointer"
-                  onClick={(e) => onSelectAlbum(album.id, e)}
-                  draggable
-                  onDragStart={(event) => {
-                    const payload: AlbumDragPayload = {
-                      albumId: album.id,
-                    };
-                    event.dataTransfer.setData(ALBUM_DRAG_TYPE, JSON.stringify(payload));
-                    event.dataTransfer.effectAllowed = "move";
-                    setDraggedAlbumId(album.id);
+          <SortableContext
+            items={albums.map((album) => albumItemId(album.id))}
+            strategy={verticalListSortingStrategy}
+          >
+            {albums.map((album) => {
+              const canDownloadAlbum =
+                album.trackIds.length > 0 &&
+                album.trackIds.every((trackId) => {
+                  const file = filesById.get(trackId);
+                  return file?.file && file.metadata;
+                });
+              return (
+                <SortableAlbumCard
+                  key={album.id}
+                  album={album}
+                  selected={selectedAlbumId === album.id}
+                  canDownload={canDownloadAlbum}
+                  onSelect={(event) => onSelectAlbum(album.id, event)}
+                  onEdit={() => onEditAlbum(album.id)}
+                  onDownload={() => onDownloadAlbum(album.id)}
+                  onFileDragOver={(event) => {
+                    if (!isFileDrag(event)) return;
+                    event.preventDefault();
+                    event.stopPropagation();
+                    event.dataTransfer.dropEffect = "copy";
                   }}
-                  onDragEnd={() => {
-                    setDraggedAlbumId(null);
-                    setDragOverAlbumIndex(null);
-                  }}
+                  onFileDrop={(event) =>
+                    handleFileDrop(event, (audioFiles) => onUploadToAlbum(album.id, audioFiles))
+                  }
                 >
-                  <AlbumCoverThumb picture={album.cover} />
-                  <div className="min-w-0 flex-1">
-                    <div className="text-sm font-medium truncate leading-tight">{album.title}</div>
-                    <div className="text-xs text-muted-foreground truncate leading-tight">
-                      {album.artist || "unknown"} &middot; {album.trackIds.length} track
-                      {album.trackIds.length !== 1 ? "s" : ""}
-                    </div>
-                  </div>
-                </button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7"
-                  onClick={() => onDownloadAlbum(album.id)}
-                  disabled={!canDownloadAlbum}
-                  aria-label={`download ${album.title}`}
-                >
-                  <Download className="h-3.5 w-3.5" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7"
-                  onClick={() => onEditAlbum(album.id)}
-                  aria-label={`edit ${album.title}`}
-                >
-                  <Pencil className="h-3.5 w-3.5" />
-                </Button>
-              </div>
-              <div className="flex flex-col">
-                {album.trackIds.length === 0 ? (
-                  <div
-                    className="text-xs text-muted-foreground px-4 py-3 text-center"
-                    onClick={onClearSelection}
+                  <SortableContext
+                    items={album.trackIds.map((trackId) => trackItemId(trackId))}
+                    strategy={verticalListSortingStrategy}
                   >
-                    drag tracks here
-                  </div>
-                ) : (
-                  album.trackIds.map((trackId, index) => {
-                    const track = filesById.get(trackId);
-                    if (!track) return null;
-
-                    return (
-                      <div
-                        key={track.id}
-                        className="relative group border-t first:border-t-0"
-                        onDragOver={(event) => {
-                          if (event.dataTransfer.types.includes("Files")) return;
-
-                          event.preventDefault();
-                          event.stopPropagation();
-                          const payload = parseDragPayload(event);
-                          if (payload && payload.trackId !== track.id) {
-                            event.dataTransfer.dropEffect = "move";
-                          }
-                        }}
-                        onDrop={(event) => {
-                          if (event.dataTransfer.files.length > 0) return;
-
-                          event.preventDefault();
-                          event.stopPropagation();
-                          const payload = parseDragPayload(event);
-                          if (!payload || payload.trackId === track.id) return;
-                          const placement = placementForRowDrop(event);
-                          onMoveTrackToAlbum(payload.trackId, album.id, placement, track.id);
-                        }}
-                      >
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          draggable
-                          onDragStart={(event) => {
-                            const payload: DragPayload = {
-                              trackId: track.id,
-                              container: "album",
-                              albumId: album.id,
-                            };
-                            event.dataTransfer.setData(TRACK_DRAG_TYPE, JSON.stringify(payload));
-                            event.dataTransfer.effectAllowed = "move";
-                          }}
-                          className={cn(
-                            "justify-start h-auto py-2.5 px-4 w-full text-left font-normal pr-8 rounded-none hover:bg-accent/30",
-                            track.downloadStatus === "downloading" ? "opacity-65" : "",
-                            selectedFileIds.has(track.id)
-                              ? "bg-accent text-accent-foreground"
-                              : selectedFileId === track.id
-                                ? "bg-accent/50 text-accent-foreground"
-                                : "",
-                          )}
-                          onClick={(e) => onSelectFile(album.id, track.id, e)}
+                    <DroppableTrackContainer
+                      id={albumContainerId(album.id)}
+                      data={{ type: "container", container: "album", albumId: album.id }}
+                    >
+                      {album.trackIds.length === 0 ? (
+                        <div
+                          className="text-xs text-muted-foreground px-4 py-3 text-center"
+                          onClick={onClearSelection}
                         >
-                          <div className="flex flex-col gap-1 w-full min-w-0">
-                            <div className="flex items-center gap-1.5 w-full overflow-hidden">
-                              <span className="min-w-3 text-[11px] text-muted-foreground">
-                                {index + 1}
-                              </span>
-                              <span className="truncate text-sm flex-1">{track.filename}</span>
-                              {track.downloadStatus === "downloading" && (
-                                <Loader2 className="h-3 w-3 text-muted-foreground flex-shrink-0 animate-spin" />
-                              )}
-                              {track.downloadStatus !== "downloading" &&
-                                track.status === "saved" && (
-                                  <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
-                                )}
-                              {(track.downloadStatus === "error" || track.status === "error") && (
-                                <AlertCircle
-                                  className={cn(
-                                    "h-3 w-3 text-red-500 flex-shrink-0",
-                                    isRetryableError(track) ? "group-hover:opacity-0" : "",
-                                  )}
-                                />
-                              )}
-                            </div>
-                            {(track.downloadStatus === "error" || track.status === "error") &&
-                              track.downloadError && (
-                                <span
-                                  className="pl-7 text-xs text-destructive truncate"
-                                  aria-live="polite"
-                                >
-                                  error: {track.downloadError}
-                                </span>
-                              )}
-                          </div>
-                        </Button>
-                        {isRetryableError(track) && (
-                          <button
-                            type="button"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              onRetryDownload(track.id);
-                            }}
-                            className="absolute right-7 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded-full cursor-pointer"
-                            title="retry download"
-                            aria-label={`retry download for ${track.filename}`}
-                          >
-                            <RefreshCw className="h-3 w-3 text-muted-foreground hover:text-primary" />
-                          </button>
-                        )}
-                        <button
-                          type="button"
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            onRemoveFile(track.id);
-                          }}
-                          className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
-                          title="remove track"
-                        >
-                          <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
-                        </button>
-                      </div>
-                    );
-                  })
-                )}
-              </div>
-            </div>
-          );
-        })}
-      </div>
+                          drag tracks here
+                        </div>
+                      ) : (
+                        album.trackIds.map((trackId, index) => {
+                          const track = filesById.get(trackId);
+                          if (!track) return null;
+
+                          return (
+                            <SortableTrackRow
+                              key={track.id}
+                              track={track}
+                              index={index + 1}
+                              container="album"
+                              albumId={album.id}
+                              selectedTone={selectedTone(track.id)}
+                              muted={track.downloadStatus === "downloading"}
+                              retryable={isRetryableError(track)}
+                              onSelect={(event) => onSelectFile(album.id, track.id, event)}
+                              onRetry={() => onRetryDownload(track.id)}
+                              onRemove={() => onRemoveFile(track.id)}
+                            />
+                          );
+                        })
+                      )}
+                    </DroppableTrackContainer>
+                  </SortableContext>
+                </SortableAlbumCard>
+              );
+            })}
+          </SortableContext>
+        </div>
+      </DndContext>
     </div>
   );
 }

--- a/components/audio/AlbumSidebarDnd.tsx
+++ b/components/audio/AlbumSidebarDnd.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import {
+  closestCorners,
+  type CollisionDetection,
+  type DragEndEvent,
+  pointerWithin,
+  rectIntersection,
+  useDroppable,
+} from "@dnd-kit/core";
+import { useSortable } from "@dnd-kit/sortable";
+import {
+  AlertCircle,
+  Check,
+  Download,
+  FileMusic,
+  GripVertical,
+  Loader2,
+  Pencil,
+  RefreshCw,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { AlbumCoverThumb } from "./AlbumCoverThumb";
+import type { AlbumGroup, TagiumFile } from "./types";
+
+export const LOOSE_CONTAINER_ID = "container:loose";
+
+export type SidebarDragData =
+  | { type: "album"; albumId: string }
+  | { type: "track"; trackId: string; container: "album"; albumId: string }
+  | { type: "track"; trackId: string; container: "loose" };
+
+export type SidebarDropData =
+  | SidebarDragData
+  | { type: "container"; container: "loose" }
+  | { type: "container"; container: "album"; albumId: string };
+
+export const albumItemId = (albumId: string) => `album:${albumId}`;
+export const albumContainerId = (albumId: string) => `container:album:${albumId}`;
+export const trackItemId = (trackId: string) => `track:${trackId}`;
+
+export const sidebarCollisionDetection: CollisionDetection = (args) => {
+  const pointerCollisions = pointerWithin(args);
+  if (pointerCollisions.length > 0) return pointerCollisions;
+
+  const intersections = rectIntersection(args);
+  if (intersections.length > 0) return intersections;
+
+  return closestCorners(args);
+};
+
+export const dragStartY = (event: Event) => {
+  const sourceEvent = event as Event & {
+    changedTouches?: TouchList;
+    clientY?: number;
+    touches?: TouchList;
+  };
+  if (sourceEvent.clientY !== undefined) return sourceEvent.clientY;
+  if (sourceEvent.touches?.[0]) return sourceEvent.touches[0].clientY;
+  if (sourceEvent.changedTouches?.[0]) return sourceEvent.changedTouches[0].clientY;
+  return null;
+};
+
+export const albumIdFromDrop = (drop: SidebarDropData) => {
+  if (drop.type === "album") return drop.albumId;
+  if (drop.type === "track" && drop.container === "album") return drop.albumId;
+  if (drop.type === "container" && drop.container === "album") return drop.albumId;
+  return null;
+};
+
+export const rowPlacement = (
+  event: DragEndEvent,
+  sourceTrackId: string,
+  targetTrackId: string,
+  trackIds: string[],
+  initialY: number | null,
+) => {
+  const rect = event.over?.rect;
+  if (!rect) return "after";
+  if (initialY === null) {
+    const sourceIndex = trackIds.indexOf(sourceTrackId);
+    const targetIndex = trackIds.indexOf(targetTrackId);
+    if (sourceIndex >= 0 && targetIndex >= 0 && sourceIndex > targetIndex) return "before";
+    if (sourceIndex < 0) return "before";
+    return "after";
+  }
+
+  const y = initialY + event.delta.y;
+  return y > rect.top + rect.height / 2 ? "after" : "before";
+};
+
+export const isCenteredLooseDrop = (event: DragEndEvent, initialY: number | null) => {
+  const rect = event.over?.rect;
+  if (!rect) return false;
+  if (initialY === null) return false;
+  const y = initialY + event.delta.y;
+  const position = (y - rect.top) / rect.height;
+  return position > 0.3 && position < 0.7;
+};
+
+const artistLabel = (artist: string) => {
+  if (artist) return artist;
+  return "unknown";
+};
+
+type TrackRowBaseProps = {
+  track: TagiumFile;
+  selectedTone: "primary" | "secondary" | null;
+  muted: boolean;
+  retryable: boolean;
+  onSelect: (event: ReactMouseEvent) => void;
+  onRemove: () => void;
+  onRetry: () => void;
+};
+
+type TrackRowProps =
+  | (TrackRowBaseProps & { container: "album"; albumId: string; index: number })
+  | (TrackRowBaseProps & { container: "loose"; albumId?: never; index?: never });
+
+const sortableStyle = (
+  transform: { x: number; y: number; scaleX: number; scaleY: number } | null,
+  transition: string | undefined,
+) => ({
+  transform: transform
+    ? `translate3d(${Math.round(transform.x)}px, ${Math.round(transform.y)}px, 0) scaleX(${transform.scaleX}) scaleY(${transform.scaleY})`
+    : undefined,
+  transition,
+});
+
+export function SortableTrackRow({
+  track,
+  index,
+  container,
+  albumId,
+  selectedTone,
+  muted,
+  retryable,
+  onSelect,
+  onRemove,
+  onRetry,
+}: TrackRowProps) {
+  const {
+    attributes,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: trackItemId(track.id),
+    data:
+      container === "album"
+        ? ({ type: "track", trackId: track.id, container, albumId } satisfies SidebarDragData)
+        : ({ type: "track", trackId: track.id, container } satisfies SidebarDragData),
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        "relative group border-t first:border-t-0",
+        container === "loose" ? "border-b border-t-0 first:border-t-0" : "",
+        isDragging ? "z-10 opacity-60" : "",
+      )}
+      style={sortableStyle(transform, transition)}
+    >
+      <button
+        type="button"
+        ref={setActivatorNodeRef}
+        className="absolute left-1 top-1/2 z-10 flex size-9 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground opacity-60 transition-opacity hover:bg-accent hover:opacity-100 focus-visible:opacity-100 touch-none"
+        aria-label={`drag ${track.filename}`}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-3.5 w-3.5" />
+      </button>
+      <Button
+        type="button"
+        variant="ghost"
+        className={cn(
+          "justify-start h-auto py-2.5 pl-9 pr-8 w-full text-left font-normal rounded-none hover:bg-accent/30",
+          container === "loose" ? "py-3" : "",
+          muted ? "opacity-65" : "",
+          selectedTone === "primary" ? "bg-accent text-accent-foreground" : "",
+          selectedTone === "secondary" ? "bg-accent/50 text-accent-foreground" : "",
+        )}
+        onClick={onSelect}
+      >
+        <div className="flex flex-col gap-1 w-full min-w-0">
+          <div className="flex items-center gap-1.5 w-full overflow-hidden">
+            {container === "loose" ? (
+              <FileMusic className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+            ) : (
+              <span className="min-w-3 text-[11px] text-muted-foreground">{index}</span>
+            )}
+            <span className="truncate text-sm flex-1">{track.filename}</span>
+            {track.downloadStatus === "downloading" && (
+              <Loader2 className="h-3 w-3 text-muted-foreground flex-shrink-0 animate-spin" />
+            )}
+            {track.downloadStatus !== "downloading" && track.status === "saved" && (
+              <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
+            )}
+            {(track.downloadStatus === "error" || track.status === "error") && (
+              <AlertCircle
+                className={cn(
+                  "h-3 w-3 text-red-500 flex-shrink-0",
+                  retryable ? "group-hover:opacity-0" : "",
+                )}
+              />
+            )}
+          </div>
+          {(track.downloadStatus === "error" || track.status === "error") &&
+            track.downloadError && (
+              <span className="pl-7 text-xs text-destructive truncate" aria-live="polite">
+                error: {track.downloadError}
+              </span>
+            )}
+        </div>
+      </Button>
+      {retryable && (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onRetry();
+          }}
+          className="absolute right-7 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded-full cursor-pointer"
+          title="retry download"
+          aria-label={`retry download for ${track.filename}`}
+        >
+          <RefreshCw className="h-3 w-3 text-muted-foreground hover:text-primary" />
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={(event) => {
+          event.stopPropagation();
+          onRemove();
+        }}
+        className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
+        title="remove track"
+      >
+        <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
+      </button>
+    </div>
+  );
+}
+
+type AlbumCardProps = {
+  album: AlbumGroup;
+  selected: boolean;
+  canDownload: boolean;
+  children: ReactNode;
+  onSelect: (event: ReactMouseEvent) => void;
+  onEdit: () => void;
+  onDownload: () => void;
+  onFileDragOver: (event: React.DragEvent<HTMLDivElement>) => void;
+  onFileDrop: (event: React.DragEvent<HTMLDivElement>) => void;
+};
+
+export function SortableAlbumCard({
+  album,
+  selected,
+  canDownload,
+  children,
+  onSelect,
+  onEdit,
+  onDownload,
+  onFileDragOver,
+  onFileDrop,
+}: AlbumCardProps) {
+  const {
+    attributes,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: albumItemId(album.id),
+    data: { type: "album", albumId: album.id } satisfies SidebarDragData,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        "border-b transition-all",
+        selected ? "bg-primary/5" : "",
+        isDragging ? "z-10 opacity-60" : "",
+      )}
+      style={sortableStyle(transform, transition)}
+      onDragOver={onFileDragOver}
+      onDrop={onFileDrop}
+    >
+      <div className="w-full flex items-center justify-between gap-1 px-3 py-3 border-b">
+        <button
+          type="button"
+          ref={setActivatorNodeRef}
+          className="flex size-9 items-center justify-center rounded-md text-muted-foreground opacity-60 transition-opacity hover:bg-accent hover:opacity-100 focus-visible:opacity-100 touch-none"
+          aria-label={`drag ${album.title}`}
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          className="min-w-0 flex-1 flex items-center gap-2 text-left cursor-pointer"
+          onClick={onSelect}
+        >
+          <AlbumCoverThumb picture={album.cover} />
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-medium truncate leading-tight">{album.title}</div>
+            <div className="text-xs text-muted-foreground truncate leading-tight">
+              {artistLabel(album.artist)} &middot; {album.trackIds.length} track
+              {album.trackIds.length !== 1 ? "s" : ""}
+            </div>
+          </div>
+        </button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={onDownload}
+          disabled={!canDownload}
+          aria-label={`download ${album.title}`}
+        >
+          <Download className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={onEdit}
+          aria-label={`edit ${album.title}`}
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function DroppableTrackContainer({
+  id,
+  data,
+  children,
+}: {
+  id: string;
+  data: SidebarDropData;
+  children: ReactNode;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id, data });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        "flex flex-col min-h-8 transition-shadow",
+        isOver ? "shadow-[inset_0_0_0_2px_var(--primary)]" : "",
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/audio/AlbumSidebarDnd.tsx
+++ b/components/audio/AlbumSidebarDnd.tsx
@@ -15,7 +15,6 @@ import {
   Check,
   Download,
   FileMusic,
-  GripVertical,
   Loader2,
   Pencil,
   RefreshCw,
@@ -27,6 +26,7 @@ import { AlbumCoverThumb } from "./AlbumCoverThumb";
 import type { AlbumGroup, TagiumFile } from "./types";
 
 export const LOOSE_CONTAINER_ID = "container:loose";
+export const LOOSE_APPEND_CONTAINER_ID = "container:loose:append";
 
 export type SidebarDragData =
   | { type: "album"; albumId: string }
@@ -101,10 +101,7 @@ export const isCenteredLooseDrop = (event: DragEndEvent, initialY: number | null
   return position > 0.3 && position < 0.7;
 };
 
-const artistLabel = (artist: string) => {
-  if (artist) return artist;
-  return "unknown";
-};
+const artistLabel = (artist: string) => (artist ? artist : "unknown");
 
 type TrackRowBaseProps = {
   track: TagiumFile;
@@ -125,7 +122,7 @@ const sortableStyle = (
   transition: string | undefined,
 ) => ({
   transform: transform
-    ? `translate3d(${Math.round(transform.x)}px, ${Math.round(transform.y)}px, 0) scaleX(${transform.scaleX}) scaleY(${transform.scaleY})`
+    ? `translate3d(0, ${Math.round(transform.y)}px, 0) scaleX(${transform.scaleX}) scaleY(${transform.scaleY})`
     : undefined,
   transition,
 });
@@ -168,27 +165,20 @@ export function SortableTrackRow({
       )}
       style={sortableStyle(transform, transition)}
     >
-      <button
-        type="button"
-        ref={setActivatorNodeRef}
-        className="absolute left-1 top-1/2 z-10 flex size-9 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground opacity-60 transition-opacity hover:bg-accent hover:opacity-100 focus-visible:opacity-100 touch-none"
-        aria-label={`drag ${track.filename}`}
-        {...attributes}
-        {...listeners}
-      >
-        <GripVertical className="h-3.5 w-3.5" />
-      </button>
       <Button
         type="button"
+        ref={setActivatorNodeRef}
         variant="ghost"
         className={cn(
-          "justify-start h-auto py-2.5 pl-9 pr-8 w-full text-left font-normal rounded-none hover:bg-accent/30",
+          "justify-start h-auto py-2.5 px-4 pr-8 w-full text-left font-normal rounded-none hover:bg-accent/30",
           container === "loose" ? "py-3" : "",
           muted ? "opacity-65" : "",
           selectedTone === "primary" ? "bg-accent text-accent-foreground" : "",
           selectedTone === "secondary" ? "bg-accent/50 text-accent-foreground" : "",
         )}
         onClick={onSelect}
+        {...attributes}
+        {...listeners}
       >
         <div className="flex flex-col gap-1 w-full min-w-0">
           <div className="flex items-center gap-1.5 w-full overflow-hidden">
@@ -302,17 +292,10 @@ export function SortableAlbumCard({
         <button
           type="button"
           ref={setActivatorNodeRef}
-          className="flex size-9 items-center justify-center rounded-md text-muted-foreground opacity-60 transition-opacity hover:bg-accent hover:opacity-100 focus-visible:opacity-100 touch-none"
-          aria-label={`drag ${album.title}`}
-          {...attributes}
-          {...listeners}
-        >
-          <GripVertical className="h-3.5 w-3.5" />
-        </button>
-        <button
-          type="button"
           className="min-w-0 flex-1 flex items-center gap-2 text-left cursor-pointer"
           onClick={onSelect}
+          {...attributes}
+          {...listeners}
         >
           <AlbumCoverThumb picture={album.cover} />
           <div className="min-w-0 flex-1">
@@ -354,10 +337,12 @@ export function DroppableTrackContainer({
   id,
   data,
   children,
+  className,
 }: {
   id: string;
   data: SidebarDropData;
-  children: ReactNode;
+  children?: ReactNode;
+  className?: string;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id, data });
 
@@ -367,9 +352,46 @@ export function DroppableTrackContainer({
       className={cn(
         "flex flex-col min-h-8 transition-shadow",
         isOver ? "shadow-[inset_0_0_0_2px_var(--primary)]" : "",
+        className,
       )}
     >
       {children}
     </div>
   );
+}
+
+export function SidebarDragPreview({
+  active,
+  album,
+  track,
+}: {
+  active: SidebarDragData;
+  album?: AlbumGroup;
+  track?: TagiumFile;
+}) {
+  if (active.type === "album" && album) {
+    return (
+      <div className="flex w-64 max-w-[calc(100vw-2rem)] items-center gap-2 rounded-md border bg-card px-3 py-3 text-left shadow-lg">
+        <AlbumCoverThumb picture={album.cover} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium leading-tight">{album.title}</div>
+          <div className="truncate text-xs text-muted-foreground leading-tight">
+            {artistLabel(album.artist)} &middot; {album.trackIds.length} track
+            {album.trackIds.length !== 1 ? "s" : ""}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (active.type === "track" && track) {
+    return (
+      <div className="flex w-64 max-w-[calc(100vw-2rem)] items-center gap-2 rounded-md border bg-card px-4 py-3 text-left shadow-lg">
+        <FileMusic className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate text-sm">{track.filename}</span>
+      </div>
+    );
+  }
+
+  return null;
 }

--- a/components/audio/AlbumSidebarEmptyState.tsx
+++ b/components/audio/AlbumSidebarEmptyState.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function AlbumSidebarEmptyState({
+  onAddAlbum,
+  onClearSelection,
+}: {
+  onAddAlbum: () => void;
+  onClearSelection: () => void;
+}) {
+  return (
+    <div
+      className="w-full flex-1 min-h-0 flex flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground px-4"
+      onClick={onClearSelection}
+    >
+      <p>no tracks yet</p>
+      <p className="text-xs">create an empty album or upload tracks</p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={(event) => {
+          event.stopPropagation();
+          onAddAlbum();
+        }}
+      >
+        <Plus className="h-4 w-4" />
+        add album
+      </Button>
+    </div>
+  );
+}

--- a/components/audio/albumOps.test.ts
+++ b/components/audio/albumOps.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
-import { mergeUploadedTracksIntoAlbums } from "./albumOps";
+import { mergeUploadedTracksIntoAlbums, moveTrackInSidebar, reorderAlbums } from "./albumOps";
 import type { UploadedTrack } from "./mp3Utils";
-import type { AudioMetadata } from "./types";
+import type { AlbumGroup, AudioMetadata } from "./types";
 
 const metadata = (trackNumber?: number): AudioMetadata => ({
   filename: "track",
@@ -33,6 +33,14 @@ const upload = (
     metadata: metadata(trackNumber),
   },
   albumSeed,
+});
+
+const album = (id: string, trackIds: string[]): AlbumGroup => ({
+  id,
+  title: id,
+  artist: "",
+  genre: "",
+  trackIds,
 });
 
 describe("albumOps", () => {
@@ -67,5 +75,53 @@ describe("albumOps", () => {
     );
 
     expect(result.albumsToSync).toEqual([]);
+  });
+
+  it("moves tracks between album and loose sidebar lists", () => {
+    const result = moveTrackInSidebar(
+      [album("album-1", ["a", "b"]), album("album-2", ["c"])],
+      ["loose-1"],
+      "b",
+      {
+        type: "album",
+        albumId: "album-2",
+        placement: "before",
+        referenceTrackId: "c",
+      },
+      { syncTrackNumbers: true },
+    );
+
+    expect(result.albums.map((entry) => entry.trackIds)).toEqual([["a"], ["b", "c"]]);
+    expect(result.looseTrackIds).toEqual(["loose-1"]);
+    expect(result.albumsToSync).toEqual(["album-1", "album-2"]);
+  });
+
+  it("keeps track moves single-track and preserves empty albums", () => {
+    const result = moveTrackInSidebar(
+      [album("album-1", ["a"])],
+      ["loose-1", "loose-2"],
+      "a",
+      {
+        type: "loose",
+        placement: "after",
+        referenceTrackId: "loose-1",
+      },
+      { syncTrackNumbers: false },
+    );
+
+    expect(result.albums).toEqual([album("album-1", [])]);
+    expect(result.looseTrackIds).toEqual(["loose-1", "a", "loose-2"]);
+    expect(result.albumsToSync).toEqual([]);
+  });
+
+  it("reorders albums by target index", () => {
+    const albums = [album("album-1", []), album("album-2", []), album("album-3", [])];
+
+    expect(reorderAlbums(albums, "album-1", 2).map((entry) => entry.id)).toEqual([
+      "album-2",
+      "album-3",
+      "album-1",
+    ]);
+    expect(reorderAlbums(albums, "missing", 1)).toEqual(albums);
   });
 });

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "prepare": "vp config"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@imput/libav.js-encode-cli": "6.8.7",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",


### PR DESCRIPTION
## Summary
- replace AlbumSidebar internal HTML5 drag/drop with dnd-kit sortable contexts and touch/keyboard sensors
- keep native file drop handling for loose/sidebar and album uploads
- split sidebar DnD row/card helpers and add pure move/reorder coverage

## Verification
- vp fmt --check
- vp lint .
- vp check
- vp test run
- vp build

## Review loop
- antagonistic review loop completed until no actionable feedback