### PR TITLE
[codex] Add explicit loose-track album target

### DIFF
--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, type MouseEvent as ReactMouseEvent } from "react";
+import { type MouseEvent as ReactMouseEvent } from "react";
 import { useRef, useState } from "react";
 import {
   DndContext,
@@ -23,6 +23,7 @@ import {
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AlbumSidebarEmptyState } from "./AlbumSidebarEmptyState";
+import { sidebarCollisionDetection } from "./AlbumSidebarCollision";
 import {
   albumIdFromDrop,
   albumContainerId,
@@ -32,7 +33,6 @@ import {
   LOOSE_APPEND_CONTAINER_ID,
   LOOSE_CONTAINER_ID,
   rowPlacement,
-  sidebarCollisionDetection,
   SidebarDragPreview,
   SortableAlbumCard,
   SortableTrackRow,
@@ -288,21 +288,22 @@ export default function AlbumSidebar({
               className={looseTracks.length === 0 && activeDrag?.type === "track" ? "min-h-12" : ""}
             >
               {looseTracks.map((track) => (
-                <Fragment key={track.id}>
-                  <SortableTrackRow
-                    track={track}
-                    container="loose"
-                    selectedTone={selectedTone(track.id)}
-                    muted={track.downloadStatus === "downloading"}
-                    retryable={isRetryableError(track)}
-                    onSelect={(event) => onSelectLooseTrack(track.id, event)}
-                    onRetry={() => onRetryDownload(track.id)}
-                    onRemove={() => onRemoveFile(track.id)}
-                  />
-                  {looseCombineTarget.target?.targetTrackId === track.id ? (
-                    <LooseCombineDropTarget target={looseCombineTarget.target} />
-                  ) : null}
-                </Fragment>
+                <SortableTrackRow
+                  key={track.id}
+                  track={track}
+                  container="loose"
+                  selectedTone={selectedTone(track.id)}
+                  muted={track.downloadStatus === "downloading"}
+                  retryable={isRetryableError(track)}
+                  combineTarget={
+                    looseCombineTarget.target?.targetTrackId === track.id ? (
+                      <LooseCombineDropTarget target={looseCombineTarget.target} />
+                    ) : undefined
+                  }
+                  onSelect={(event) => onSelectLooseTrack(track.id, event)}
+                  onRetry={() => onRetryDownload(track.id)}
+                  onRemove={() => onRemoveFile(track.id)}
+                />
               ))}
             </DroppableTrackContainer>
           </SortableContext>

--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { MouseEvent as ReactMouseEvent } from "react";
+import { Fragment, type MouseEvent as ReactMouseEvent } from "react";
 import { useRef, useState } from "react";
 import {
   DndContext,
@@ -9,6 +9,7 @@ import {
   type DragOverEvent,
   type DragStartEvent,
   KeyboardSensor,
+  MeasuringStrategy,
   MouseSensor,
   useSensor,
   useSensors,
@@ -28,7 +29,6 @@ import {
   albumItemId,
   dragStartY,
   DroppableTrackContainer,
-  isCenteredLooseDrop,
   LOOSE_APPEND_CONTAINER_ID,
   LOOSE_CONTAINER_ID,
   rowPlacement,
@@ -40,6 +40,11 @@ import {
   type SidebarDragData,
   type SidebarDropData,
 } from "./AlbumSidebarDnd";
+import {
+  LooseCombineDropTarget,
+  looseCombineTargetFromDrag,
+  useLooseCombineTarget,
+} from "./AlbumSidebarLooseCombine";
 import type { AlbumGroup, TagiumFile } from "./types";
 
 interface AlbumSidebarProps {
@@ -102,7 +107,7 @@ export default function AlbumSidebar({
 }: AlbumSidebarProps) {
   const [activeDrag, setActiveDrag] = useState<SidebarDragData | null>(null);
   const dragStartYRef = useRef<number | null>(null);
-  const recentLooseTargetRef = useRef<{ trackId: string; expiresAt: number } | null>(null);
+  const looseCombineTarget = useLooseCombineTarget();
   const sensors = useSensors(
     useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 6 } }),
@@ -129,19 +134,18 @@ export default function AlbumSidebar({
 
   const handleDragStart = (event: DragStartEvent) => {
     setActiveDrag((event.active.data.current as SidebarDragData | undefined) ?? null);
-    recentLooseTargetRef.current = null;
+    looseCombineTarget.clear();
     dragStartYRef.current = dragStartY(event.activatorEvent);
   };
 
   const handleDragOver = (event: DragOverEvent) => {
     const active = event.active.data.current as SidebarDragData | undefined;
     const over = event.over?.data.current as SidebarDropData | undefined;
-    if (active?.type !== "track") return;
-    if (active.container !== "loose") return;
-    if (over?.type !== "track") return;
-    if (over.container !== "loose") return;
-    if (over.trackId === active.trackId) return;
-    recentLooseTargetRef.current = { trackId: over.trackId, expiresAt: Date.now() + 700 };
+    if (over?.type === "combine") return;
+    if (looseCombineTarget.target && over?.type === "container" && over.container === "loose") {
+      return;
+    }
+    looseCombineTarget.queue(looseCombineTargetFromDrag(active, over));
   };
 
   const trackIdsForDrop = (drop: Extract<SidebarDropData, { type: "track" }>) => {
@@ -172,6 +176,11 @@ export default function AlbumSidebar({
   ) => {
     if (active.type !== "track") return;
 
+    if (over.type === "combine") {
+      onPromptCreateAlbumFromLooseTracks(over.sourceTrackId, over.targetTrackId);
+      return;
+    }
+
     if (over.type === "track") {
       if (over.trackId === active.trackId) return;
 
@@ -183,10 +192,6 @@ export default function AlbumSidebar({
         dragStartYRef.current,
       );
       if (over.container === "loose") {
-        if (active.container === "loose" && isCenteredLooseDrop(event, dragStartYRef.current)) {
-          onPromptCreateAlbumFromLooseTracks(active.trackId, over.trackId);
-          return;
-        }
         onMoveTrackToLoose(active.trackId, placement, over.trackId);
         return;
       }
@@ -206,16 +211,6 @@ export default function AlbumSidebar({
     }
 
     if (over.type === "container" && over.container === "loose") {
-      const recentLooseTarget = recentLooseTargetRef.current;
-      if (
-        active.container === "loose" &&
-        event.over?.id !== LOOSE_APPEND_CONTAINER_ID &&
-        recentLooseTarget &&
-        recentLooseTarget.expiresAt > Date.now()
-      ) {
-        onPromptCreateAlbumFromLooseTracks(active.trackId, recentLooseTarget.trackId);
-        return;
-      }
       onMoveTrackToLoose(active.trackId, "append");
     }
   };
@@ -229,7 +224,7 @@ export default function AlbumSidebar({
       handleTrackDragEnd(event, active, over);
     }
     dragStartYRef.current = null;
-    recentLooseTargetRef.current = null;
+    looseCombineTarget.clear();
     setActiveDrag(null);
   };
 
@@ -261,11 +256,12 @@ export default function AlbumSidebar({
       <DndContext
         sensors={sensors}
         collisionDetection={sidebarCollisionDetection}
+        measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}
         onDragCancel={() => {
           dragStartYRef.current = null;
-          recentLooseTargetRef.current = null;
+          looseCombineTarget.clear();
           setActiveDrag(null);
         }}
         onDragEnd={handleDragEnd}
@@ -292,17 +288,21 @@ export default function AlbumSidebar({
               className={looseTracks.length === 0 && activeDrag?.type === "track" ? "min-h-12" : ""}
             >
               {looseTracks.map((track) => (
-                <SortableTrackRow
-                  key={track.id}
-                  track={track}
-                  container="loose"
-                  selectedTone={selectedTone(track.id)}
-                  muted={track.downloadStatus === "downloading"}
-                  retryable={isRetryableError(track)}
-                  onSelect={(event) => onSelectLooseTrack(track.id, event)}
-                  onRetry={() => onRetryDownload(track.id)}
-                  onRemove={() => onRemoveFile(track.id)}
-                />
+                <Fragment key={track.id}>
+                  <SortableTrackRow
+                    track={track}
+                    container="loose"
+                    selectedTone={selectedTone(track.id)}
+                    muted={track.downloadStatus === "downloading"}
+                    retryable={isRetryableError(track)}
+                    onSelect={(event) => onSelectLooseTrack(track.id, event)}
+                    onRetry={() => onRetryDownload(track.id)}
+                    onRemove={() => onRemoveFile(track.id)}
+                  />
+                  {looseCombineTarget.target?.targetTrackId === track.id ? (
+                    <LooseCombineDropTarget target={looseCombineTarget.target} />
+                  ) : null}
+                </Fragment>
               ))}
             </DroppableTrackContainer>
           </SortableContext>

--- a/components/audio/AlbumSidebarCollision.ts
+++ b/components/audio/AlbumSidebarCollision.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import {
+  closestCorners,
+  type Collision,
+  type CollisionDetection,
+  type DroppableContainer,
+  pointerWithin,
+  rectIntersection,
+} from "@dnd-kit/core";
+import type { SidebarDragData, SidebarDropData } from "./AlbumSidebarDnd";
+
+type CollisionArgs = Parameters<CollisionDetection>[0];
+
+const sidebarDropData = (container: DroppableContainer) =>
+  container.data.current as SidebarDropData | undefined;
+
+const collisionPriority = (collision: Collision, prioritizeCombine: boolean) => {
+  const container = collision.data?.droppableContainer as DroppableContainer | undefined;
+  const data = container ? sidebarDropData(container) : undefined;
+  if (data?.type === "combine") return prioritizeCombine ? 0 : 4;
+  if (data?.type === "track") return 1;
+  if (data?.type === "album") return 2;
+  if (data?.type === "container") return 3;
+  return 3;
+};
+
+const collisionsForSidebar = (collisions: Collision[], prioritizeCombine: boolean) =>
+  [...collisions].sort(
+    (left, right) =>
+      collisionPriority(left, prioritizeCombine) - collisionPriority(right, prioritizeCombine),
+  );
+
+const collisionArgsForSidebar = (args: CollisionArgs): CollisionArgs => {
+  const active = args.active.data.current as SidebarDragData | undefined;
+  if (active?.type !== "album") return args;
+
+  return {
+    ...args,
+    droppableContainers: args.droppableContainers.filter(
+      (container) => sidebarDropData(container)?.type === "album",
+    ),
+  };
+};
+
+export const sidebarCollisionDetection: CollisionDetection = (args) => {
+  const sidebarArgs = collisionArgsForSidebar(args);
+  const pointerCollisions = pointerWithin(sidebarArgs);
+  if (pointerCollisions.length > 0) return collisionsForSidebar(pointerCollisions, true);
+
+  const intersections = rectIntersection(sidebarArgs);
+  if (intersections.length > 0) return collisionsForSidebar(intersections, false);
+
+  return collisionsForSidebar(closestCorners(sidebarArgs), false);
+};

--- a/components/audio/AlbumSidebarDnd.tsx
+++ b/components/audio/AlbumSidebarDnd.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
-import {
-  closestCorners,
-  type CollisionDetection,
-  type DragEndEvent,
-  pointerWithin,
-  rectIntersection,
-  useDroppable,
-} from "@dnd-kit/core";
+import { type DragEndEvent, useDroppable } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import {
   AlertCircle,
@@ -42,16 +35,6 @@ export type SidebarDropData =
 export const albumItemId = (albumId: string) => `album:${albumId}`;
 export const albumContainerId = (albumId: string) => `container:album:${albumId}`;
 export const trackItemId = (trackId: string) => `track:${trackId}`;
-
-export const sidebarCollisionDetection: CollisionDetection = (args) => {
-  const pointerCollisions = pointerWithin(args);
-  if (pointerCollisions.length > 0) return pointerCollisions;
-
-  const intersections = rectIntersection(args);
-  if (intersections.length > 0) return intersections;
-
-  return closestCorners(args);
-};
 
 export const dragStartY = (event: Event) => {
   const sourceEvent = event as Event & {
@@ -100,6 +83,7 @@ type TrackRowBaseProps = {
   selectedTone: "primary" | "secondary" | null;
   muted: boolean;
   retryable: boolean;
+  combineTarget?: ReactNode;
   onSelect: (event: ReactMouseEvent) => void;
   onRemove: () => void;
   onRetry: () => void;
@@ -127,6 +111,7 @@ export function SortableTrackRow({
   selectedTone,
   muted,
   retryable,
+  combineTarget,
   onSelect,
   onRemove,
   onRetry,
@@ -149,85 +134,87 @@ export function SortableTrackRow({
 
   return (
     <div
-      ref={setNodeRef}
       className={cn(
-        "relative group border-t first:border-t-0",
+        "border-t first:border-t-0",
         container === "loose" ? "border-b border-t-0 first:border-t-0" : "",
         isDragging ? "z-10 opacity-60" : "",
       )}
       style={sortableStyle(transform, transition)}
     >
-      <Button
-        type="button"
-        ref={setActivatorNodeRef}
-        variant="ghost"
-        className={cn(
-          "justify-start h-auto py-2.5 px-4 pr-8 w-full text-left font-normal rounded-none hover:bg-accent/30",
-          container === "loose" ? "py-3" : "",
-          muted ? "opacity-65" : "",
-          selectedTone === "primary" ? "bg-accent text-accent-foreground" : "",
-          selectedTone === "secondary" ? "bg-accent/50 text-accent-foreground" : "",
-        )}
-        onClick={onSelect}
-        {...attributes}
-        {...listeners}
-      >
-        <div className="flex flex-col gap-1 w-full min-w-0">
-          <div className="flex items-center gap-1.5 w-full overflow-hidden">
-            {container === "loose" ? (
-              <FileMusic className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
-            ) : (
-              <span className="min-w-3 text-[11px] text-muted-foreground">{index}</span>
-            )}
-            <span className="truncate text-sm flex-1">{track.filename}</span>
-            {track.downloadStatus === "downloading" && (
-              <Loader2 className="h-3 w-3 text-muted-foreground flex-shrink-0 animate-spin" />
-            )}
-            {track.downloadStatus !== "downloading" && track.status === "saved" && (
-              <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
-            )}
-            {(track.downloadStatus === "error" || track.status === "error") && (
-              <AlertCircle
-                className={cn(
-                  "h-3 w-3 text-red-500 flex-shrink-0",
-                  retryable ? "group-hover:opacity-0" : "",
-                )}
-              />
-            )}
+      <div ref={setNodeRef} className="relative group">
+        <Button
+          type="button"
+          ref={setActivatorNodeRef}
+          variant="ghost"
+          className={cn(
+            "justify-start h-auto py-2.5 px-4 pr-8 w-full text-left font-normal rounded-none hover:bg-accent/30",
+            container === "loose" ? "py-3" : "",
+            muted ? "opacity-65" : "",
+            selectedTone === "primary" ? "bg-accent text-accent-foreground" : "",
+            selectedTone === "secondary" ? "bg-accent/50 text-accent-foreground" : "",
+          )}
+          onClick={onSelect}
+          {...attributes}
+          {...listeners}
+        >
+          <div className="flex flex-col gap-1 w-full min-w-0">
+            <div className="flex items-center gap-1.5 w-full overflow-hidden">
+              {container === "loose" ? (
+                <FileMusic className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+              ) : (
+                <span className="min-w-3 text-[11px] text-muted-foreground">{index}</span>
+              )}
+              <span className="truncate text-sm flex-1">{track.filename}</span>
+              {track.downloadStatus === "downloading" && (
+                <Loader2 className="h-3 w-3 text-muted-foreground flex-shrink-0 animate-spin" />
+              )}
+              {track.downloadStatus !== "downloading" && track.status === "saved" && (
+                <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
+              )}
+              {(track.downloadStatus === "error" || track.status === "error") && (
+                <AlertCircle
+                  className={cn(
+                    "h-3 w-3 text-red-500 flex-shrink-0",
+                    retryable ? "group-hover:opacity-0" : "",
+                  )}
+                />
+              )}
+            </div>
+            {(track.downloadStatus === "error" || track.status === "error") &&
+              track.downloadError && (
+                <span className="pl-7 text-xs text-destructive truncate" aria-live="polite">
+                  error: {track.downloadError}
+                </span>
+              )}
           </div>
-          {(track.downloadStatus === "error" || track.status === "error") &&
-            track.downloadError && (
-              <span className="pl-7 text-xs text-destructive truncate" aria-live="polite">
-                error: {track.downloadError}
-              </span>
-            )}
-        </div>
-      </Button>
-      {retryable && (
+        </Button>
+        {retryable && (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onRetry();
+            }}
+            className="absolute right-7 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded-full cursor-pointer"
+            title="retry download"
+            aria-label={`retry download for ${track.filename}`}
+          >
+            <RefreshCw className="h-3 w-3 text-muted-foreground hover:text-primary" />
+          </button>
+        )}
         <button
           type="button"
           onClick={(event) => {
             event.stopPropagation();
-            onRetry();
+            onRemove();
           }}
-          className="absolute right-7 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded-full cursor-pointer"
-          title="retry download"
-          aria-label={`retry download for ${track.filename}`}
+          className="absolute right-3 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
+          title="remove track"
         >
-          <RefreshCw className="h-3 w-3 text-muted-foreground hover:text-primary" />
+          <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
         </button>
-      )}
-      <button
-        type="button"
-        onClick={(event) => {
-          event.stopPropagation();
-          onRemove();
-        }}
-        className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
-        title="remove track"
-      >
-        <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
-      </button>
+      </div>
+      {combineTarget}
     </div>
   );
 }

--- a/components/audio/AlbumSidebarDnd.tsx
+++ b/components/audio/AlbumSidebarDnd.tsx
@@ -36,7 +36,8 @@ export type SidebarDragData =
 export type SidebarDropData =
   | SidebarDragData
   | { type: "container"; container: "loose" }
-  | { type: "container"; container: "album"; albumId: string };
+  | { type: "container"; container: "album"; albumId: string }
+  | { type: "combine"; sourceTrackId: string; targetTrackId: string };
 
 export const albumItemId = (albumId: string) => `album:${albumId}`;
 export const albumContainerId = (albumId: string) => `container:album:${albumId}`;
@@ -90,15 +91,6 @@ export const rowPlacement = (
 
   const y = initialY + event.delta.y;
   return y > rect.top + rect.height / 2 ? "after" : "before";
-};
-
-export const isCenteredLooseDrop = (event: DragEndEvent, initialY: number | null) => {
-  const rect = event.over?.rect;
-  if (!rect) return false;
-  if (initialY === null) return false;
-  const y = initialY + event.delta.y;
-  const position = (y - rect.top) / rect.height;
-  return position > 0.3 && position < 0.7;
 };
 
 const artistLabel = (artist: string) => (artist ? artist : "unknown");

--- a/components/audio/AlbumSidebarLooseCombine.tsx
+++ b/components/audio/AlbumSidebarLooseCombine.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useDroppable } from "@dnd-kit/core";
+import { cn } from "@/lib/utils";
+import type { SidebarDragData, SidebarDropData } from "./AlbumSidebarDnd";
+
+export interface LooseCombineTarget {
+  sourceTrackId: string;
+  targetTrackId: string;
+}
+
+const COMBINE_DELAY_MS = 300;
+
+export const looseCombineTargetId = (targetTrackId: string) => `combine:loose:${targetTrackId}`;
+
+const isSameTarget = (left: LooseCombineTarget | null, right: LooseCombineTarget | null) =>
+  Boolean(left) &&
+  Boolean(right) &&
+  left?.sourceTrackId === right?.sourceTrackId &&
+  left?.targetTrackId === right?.targetTrackId;
+
+export function looseCombineTargetFromDrag(
+  active: SidebarDragData | undefined,
+  over: SidebarDropData | undefined,
+) {
+  if (active?.type !== "track") return null;
+  if (active.container !== "loose") return null;
+  if (over?.type !== "track") return null;
+  if (over.container !== "loose") return null;
+  if (over.trackId === active.trackId) return null;
+  return { sourceTrackId: active.trackId, targetTrackId: over.trackId };
+}
+
+export function useLooseCombineTarget() {
+  const [target, setTarget] = useState<LooseCombineTarget | null>(null);
+  const pendingTargetRef = useRef<LooseCombineTarget | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clear = () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = null;
+    pendingTargetRef.current = null;
+    setTarget(null);
+  };
+
+  const queue = (nextTarget: LooseCombineTarget | null) => {
+    if (!nextTarget) {
+      clear();
+      return;
+    }
+    if (isSameTarget(target, nextTarget)) return;
+    if (isSameTarget(pendingTargetRef.current, nextTarget)) return;
+
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    pendingTargetRef.current = nextTarget;
+    setTarget(null);
+    timeoutRef.current = setTimeout(() => {
+      setTarget(nextTarget);
+      pendingTargetRef.current = null;
+      timeoutRef.current = null;
+    }, COMBINE_DELAY_MS);
+  };
+
+  return { clear, queue, target };
+}
+
+export function LooseCombineDropTarget({ target }: { target: LooseCombineTarget }) {
+  const { isOver, setNodeRef } = useDroppable({
+    id: looseCombineTargetId(target.targetTrackId),
+    data: {
+      type: "combine",
+      sourceTrackId: target.sourceTrackId,
+      targetTrackId: target.targetTrackId,
+    } satisfies SidebarDropData,
+  });
+
+  return (
+    <div className="px-2 py-1" ref={setNodeRef}>
+      <div
+        className={cn(
+          "flex min-h-10 items-center justify-center rounded-md border border-dashed border-primary/60 bg-primary/5 px-3 text-xs font-medium text-primary transition-shadow",
+          isOver ? "shadow-[inset_0_0_0_2px_var(--primary)]" : "",
+        )}
+      >
+        create album with these 2 tracks
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace implicit center-drop album creation with a delayed inline combine target
- keep normal loose-track row drops as reorder/move behavior
- measure droppables during drag so the target is active as soon as it appears

## Verification
- vp fmt --check
- vp lint .
- vp check
- vp test run
- vp build