### PR TITLE
[codex] fix sidebar track overlap

### DIFF
--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -289,7 +289,11 @@ export default function AlbumSidebar({
             <DroppableTrackContainer
               id={LOOSE_CONTAINER_ID}
               data={{ type: "container", container: "loose" }}
-              className={looseTracks.length === 0 && activeDrag?.type === "track" ? "min-h-12" : ""}
+              className={
+                looseTracks.length === 0 && activeDrag?.type === "track"
+                  ? "min-h-12 shrink-0"
+                  : "shrink-0"
+              }
             >
               {looseTracks.map((track) => (
                 <SortableTrackRow

--- a/components/audio/AlbumSidebarDnd.tsx
+++ b/components/audio/AlbumSidebarDnd.tsx
@@ -280,7 +280,7 @@ export function SortableAlbumCard({
     <div
       ref={setNodeRef}
       className={cn(
-        "border-b transition-all",
+        "border-b transition-all shrink-0",
         selected ? "bg-primary/5" : "",
         isDragging ? "z-10 opacity-60" : "",
       )}


### PR DESCRIPTION
## Summary

- Prevent loose-track groups from shrinking inside the sidebar scroll flex column.
- Prevent album cards from shrinking below their rendered track contents.
- Keep the bottom loose-track append drop zone flexible.

## Root cause

The sidebar scroll area is a flex column. Loose-track containers and album cards were allowed to flex-shrink, so long loose-track lists could reserve less height than their painted rows and visually overlap the following album.

## Validation

- `vp fmt`
- `vp lint`
- `vp check`
- `vp test`
- Browser layout fixture in Chrome: `overlap: false`, loose container bottom equals album top, scroll content exceeds viewport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved album sidebar drag-and-drop layout so empty track lists maintain a stable minimum height while dragging.
  * Prevented album cards from shrinking unexpectedly, helping the interface stay consistent during reordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->