### PR TITLE
[codex] scope mobile mp3 upload picker

### DIFF
--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -101,7 +101,7 @@ export default function LandingScreen({
       <input
         ref={fileInputRef}
         type="file"
-        accept="audio/*"
+        accept=".mp3,audio/mpeg"
         multiple
         className="hidden"
         onChange={handleFileChange}

--- a/components/audio/audioUpload.tsx
+++ b/components/audio/audioUpload.tsx
@@ -15,7 +15,7 @@ export default function AudioUpload({ onAudioUpload }: AudioUploadProps) {
 
   const handleAudioUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
-    // The accept="audio/*" attribute on the Input component already filters for audio files.
+    // The accept=".mp3,audio/mpeg" attribute on the Input component already filters for MP3 files.
     // No need for explicit filtering here unless more specific audio types are required.
 
     if (files.length > 0) {
@@ -37,7 +37,7 @@ export default function AudioUpload({ onAudioUpload }: AudioUploadProps) {
         type="file"
         id={inputId}
         className="hidden"
-        accept="audio/*"
+        accept=".mp3,audio/mpeg"
         onChange={handleAudioUpload}
         multiple
         ref={fileInputRef}

--- a/components/audio/uploadInputAttributes.test.tsx
+++ b/components/audio/uploadInputAttributes.test.tsx
@@ -1,0 +1,33 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+import AudioUpload from "./audioUpload";
+import LandingScreen from "./LandingScreen";
+
+const fileInput = (markup: string) => {
+  const inputs = Array.from(markup.matchAll(/<input\b[^>]*type="file"[^>]*>/g), ([input]) => input);
+  expect(inputs).toHaveLength(1);
+  return inputs[0];
+};
+
+describe("upload input attributes", () => {
+  it("keeps mobile MP3 uploads scoped to files instead of capture", () => {
+    const inputs = [
+      fileInput(renderToStaticMarkup(<AudioUpload onAudioUpload={() => {}} />)),
+      fileInput(
+        renderToStaticMarkup(
+          <LandingScreen
+            onAudioUpload={() => {}}
+            onAudioDownload={() => {}}
+            onSoundCloudSetDownload={() => {}}
+          />,
+        ),
+      ),
+    ];
+
+    for (const input of inputs) {
+      expect(input).toContain('accept=".mp3,audio/mpeg"');
+      expect(input).toContain("multiple");
+      expect(input).not.toContain("capture");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Scope MP3 upload inputs to `.mp3,audio/mpeg` instead of broad `audio/*`.
- Add a regression test for upload input attributes across both upload entry points.

## Root Cause
Mobile browsers can route broad media wildcard accepts such as `audio/*` through media/photo-style pickers. Tagium only imports MP3s, so the upload hint should be explicit.

## Validation
- `bun x vp fmt`
- `bun x vp lint .`
- `bun x vp check`
- `bun x vp test run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File upload fields now limit selection to MP3-compatible audio files, helping prevent unsupported uploads.
  * Improved consistency across audio upload screens so both places use the same file selection rules.

* **Tests**
  * Added coverage to verify the audio upload file picker shows the expected MP3-only options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->