### PR TITLE
fix: handle mobile safari viewport height

### DIFF
--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -90,7 +90,7 @@ export default function LandingScreen({
   return (
     <div
       className={cn(
-        "min-h-screen flex flex-col items-center justify-center p-8 transition-colors duration-200",
+        "h-full min-h-0 overflow-y-auto flex flex-col items-center justify-center p-8 transition-colors duration-200",
         isDragging && "bg-primary/5",
       )}
       onDragEnter={handleDragEnter}
@@ -107,7 +107,7 @@ export default function LandingScreen({
         onChange={handleFileChange}
       />
 
-      <div className="flex flex-col items-center gap-10 w-full max-w-md">
+      <div className="flex flex-col items-center gap-10 w-full max-w-md max-lg:[@media(max-height:700px)]:gap-6">
         <div className="text-center select-none">
           <h1 className="text-7xl font-bold tracking-tighter text-foreground">tagium</h1>
           <p className="text-muted-foreground mt-3 text-base">tag your music</p>
@@ -118,7 +118,7 @@ export default function LandingScreen({
           onClick={() => fileInputRef.current?.click()}
           className={cn(
             "w-full rounded-3xl border-2 border-dashed transition-all duration-200 cursor-pointer",
-            "flex flex-col items-center justify-center gap-5 py-16 px-8 outline-none",
+            "flex flex-col items-center justify-center gap-5 py-16 px-8 outline-none max-lg:[@media(max-height:700px)]:gap-3 max-lg:[@media(max-height:700px)]:py-8",
             isDragging
               ? "border-primary bg-primary/10 scale-[1.015] shadow-xl shadow-primary/10"
               : "border-border hover:border-primary/50 hover:bg-accent/20 focus-visible:border-primary/50",

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -113,7 +113,7 @@ export default function TagSidebarPanel({
   return (
     <div
       className={cn(
-        "order-2 min-h-screen w-full flex-shrink-0 flex flex-col border-t bg-card overflow-hidden transition-colors duration-200 md:order-none md:min-h-0 md:w-72 md:border-t-0 md:border-r",
+        "order-2 h-svh w-full flex-shrink-0 flex flex-col border-t bg-card overflow-hidden transition-colors duration-200 md:order-none md:h-auto md:min-h-0 md:w-72 md:border-t-0 md:border-r",
         isDraggingFile && "bg-primary/5 shadow-[inset_0_0_0_2px_var(--primary)]",
       )}
       onDragEnter={handleSidebarDragEnter}

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -61,8 +61,10 @@ export default function TrackMetadataEditor({
         }}
         className="flex min-h-0 flex-col h-full"
       >
-        <div className="h-16 border-b flex-shrink-0 flex flex-col justify-center gap-1 px-4 lg:h-[104px] lg:p-6">
-          <h2 className="truncate text-base font-semibold lg:text-lg">{selectedFile.filename}</h2>
+        <div className="h-16 border-b flex-shrink-0 flex flex-col justify-center gap-1 px-4 max-lg:[@media(max-height:700px)]:h-12 max-lg:[@media(max-height:700px)]:px-3 lg:h-[104px] lg:p-6">
+          <h2 className="truncate text-base font-semibold max-lg:[@media(max-height:700px)]:text-sm lg:text-lg">
+            {selectedFile.filename}
+          </h2>
           {(selectedFile.downloadStatus === "error" || selectedFile.status === "error") &&
             selectedFile.downloadError && (
               <p className="text-xs text-destructive truncate" aria-live="polite">
@@ -70,8 +72,8 @@ export default function TrackMetadataEditor({
               </p>
             )}
         </div>
-        <div className="flex-1 min-h-0 overflow-y-auto p-3 pb-3 lg:p-6 lg:pb-28">
-          <div className="flex min-h-full flex-col gap-3 lg:min-h-0 lg:flex-row lg:gap-4">
+        <div className="flex-1 min-h-0 overflow-y-auto p-3 pb-3 max-lg:[@media(max-height:700px)]:p-2 lg:p-6 lg:pb-28">
+          <div className="flex min-h-full flex-col gap-3 max-lg:[@media(max-height:700px)]:gap-2 lg:min-h-0 lg:flex-row lg:gap-4">
             <Controller
               name="picture"
               control={control}
@@ -83,7 +85,7 @@ export default function TrackMetadataEditor({
                 />
               )}
             />
-            <div className="flex flex-1 flex-col gap-2 lg:gap-3">
+            <div className="flex flex-1 flex-col gap-2 max-lg:[@media(max-height:700px)]:gap-1.5 lg:gap-3">
               <div>
                 <label className="mb-1 block text-xs font-medium md:text-sm">filename:</label>
                 <div
@@ -162,12 +164,12 @@ export default function TrackMetadataEditor({
                     "download failed"}
                 </div>
               </div>
-              <div className="flex min-h-0 flex-1 items-center justify-center gap-2 pt-1 lg:flex-none lg:justify-end lg:pt-2">
+              <div className="flex min-h-0 flex-1 items-center justify-center gap-2 pt-1 max-lg:[@media(max-height:700px)]:flex-none max-lg:[@media(max-height:700px)]:pt-0 lg:flex-none lg:justify-end lg:pt-2">
                 <Button
                   type="button"
                   onClick={handleSubmit(onDownloadUpdatedFile)}
                   disabled={!audioReady}
-                  className="min-w-36"
+                  className="min-w-36 max-lg:[@media(max-height:700px)]:h-10 max-lg:[@media(max-height:700px)]:text-xs"
                 >
                   download track
                 </Button>

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -1344,7 +1344,7 @@ export default function AudioTagger() {
             : undefined
         }
       />
-      <div className="min-h-screen flex flex-col bg-background md:h-screen md:flex-row md:overflow-hidden">
+      <div className="min-h-svh flex flex-col bg-background md:h-svh md:flex-row md:overflow-hidden">
         <TagSidebarPanel
           loading={loading}
           files={files}
@@ -1372,29 +1372,31 @@ export default function AudioTagger() {
           onDownloadAll={handleDownloadAll}
           onOpenSettings={() => setActiveView("settings")}
         />
-        <div className="relative order-1 h-svh flex flex-col overflow-hidden md:order-none md:h-auto md:min-h-0 md:flex-1">
-          {activeView === "settings" ? (
-            <SettingsPage settings={settings} onChange={handleSettingsChange} />
-          ) : libraryIsEmpty ? (
-            <LandingScreen
-              onAudioUpload={handleAudioUpload}
-              onAudioDownload={handleAudioDownload}
-              onSoundCloudSetDownload={handleSoundCloudSetDownload}
-            />
-          ) : (
-            <TrackMetadataEditor
-              selectedFile={selectedFile}
-              selectedFileId={selectedFileId}
-              register={register}
-              control={control}
-              handleSubmit={handleSubmit}
-              onTrackCoverUpload={handleTrackCoverUpload}
-              onDownloadUpdatedFile={handleDownloadUpdatedFile}
-              selectedFileAlbum={selectedFileAlbum}
-              syncFilenames={settings.syncFilenames}
-              syncTrackNumbers={settings.syncTrackNumbers}
-            />
-          )}
+        <div className="relative order-1 flex-shrink-0 flex flex-col md:order-none md:min-h-0 md:flex-1">
+          <div className="h-svh min-h-0 flex flex-col overflow-hidden md:h-auto md:min-h-0 md:flex-1">
+            {activeView === "settings" ? (
+              <SettingsPage settings={settings} onChange={handleSettingsChange} />
+            ) : libraryIsEmpty ? (
+              <LandingScreen
+                onAudioUpload={handleAudioUpload}
+                onAudioDownload={handleAudioDownload}
+                onSoundCloudSetDownload={handleSoundCloudSetDownload}
+              />
+            ) : (
+              <TrackMetadataEditor
+                selectedFile={selectedFile}
+                selectedFileId={selectedFileId}
+                register={register}
+                control={control}
+                handleSubmit={handleSubmit}
+                onTrackCoverUpload={handleTrackCoverUpload}
+                onDownloadUpdatedFile={handleDownloadUpdatedFile}
+                selectedFileAlbum={selectedFileAlbum}
+                syncFilenames={settings.syncFilenames}
+                syncTrackNumbers={settings.syncTrackNumbers}
+              />
+            )}
+          </div>
           {!libraryIsEmpty && activeView === "editor" && (
             <div className="flex-shrink-0 border-t bg-background/95 p-3 lg:pointer-events-none lg:absolute lg:inset-x-0 lg:bottom-4 lg:z-10 lg:flex lg:justify-center lg:border-t-0 lg:bg-transparent lg:px-4 lg:p-0">
               <div className="pointer-events-auto w-full max-w-3xl">

--- a/components/audio/coverArt.tsx
+++ b/components/audio/coverArt.tsx
@@ -105,7 +105,7 @@ export default function CoverArt({
         className={
           isCompact
             ? "relative w-24 md:w-44"
-            : "relative size-[min(80vw,clamp(7.5rem,calc(75svh-25.3125rem),19.25rem))] lg:size-auto"
+            : "relative size-[min(80vw,clamp(7.5rem,calc(75svh-25.3125rem),19.25rem))] max-lg:[@media(max-height:700px)]:size-24 lg:size-auto"
         }
       >
         {coverSrc ? (
@@ -137,7 +137,7 @@ export default function CoverArt({
                 size="sm"
                 variant="secondary"
                 aria-label="crop cover art"
-                className="absolute top-2 right-2 size-10 p-0 md:size-8"
+                className="absolute top-2 right-2 size-10 p-0 max-lg:[@media(max-height:700px)]:top-1.5 max-lg:[@media(max-height:700px)]:right-1.5"
                 onClick={() => {
                   if (tempImageForCropping) {
                     URL.revokeObjectURL(tempImageForCropping);
@@ -170,7 +170,7 @@ export default function CoverArt({
         className={
           isCompact
             ? "flex min-w-0 flex-1 md:mt-auto md:block md:flex-none md:pt-2"
-            : "flex w-[min(80vw,clamp(7.5rem,calc(75svh-25.3125rem),19.25rem))] lg:w-auto lg:flex-none lg:flex-col lg:gap-2"
+            : "flex w-[min(80vw,clamp(7.5rem,calc(75svh-25.3125rem),19.25rem))] max-lg:[@media(max-height:700px)]:w-24 lg:w-auto lg:flex-none lg:flex-col lg:gap-2"
         }
       >
         <Input
@@ -186,16 +186,18 @@ export default function CoverArt({
           className={
             isCompact
               ? "h-24 w-full border-dashed border-2 flex flex-col items-center gap-1 px-2 hover:bg-accent/50 cursor-pointer md:h-10 md:w-44 md:flex-row md:gap-2 md:px-3"
-              : "h-8 w-full border-dashed border-2 flex gap-2 px-3 hover:bg-accent/50 cursor-pointer lg:h-24 lg:w-64 lg:flex-col"
+              : "h-10 w-full border-dashed border-2 flex gap-2 px-3 hover:bg-accent/50 cursor-pointer max-lg:[@media(max-height:700px)]:gap-1 lg:h-24 lg:w-64 lg:flex-col"
           }
           onClick={() => fileInputRef.current?.click()}
         >
           <Upload
             className={
-              isCompact ? "h-4 w-4 text-muted-foreground" : "h-6 w-6 text-muted-foreground"
+              isCompact
+                ? "h-4 w-4 text-muted-foreground"
+                : "h-6 w-6 text-muted-foreground max-lg:[@media(max-height:700px)]:h-4 max-lg:[@media(max-height:700px)]:w-4"
             }
           />
-          <span className="text-muted-foreground whitespace-nowrap text-[11px] md:text-xs">
+          <span className="text-muted-foreground whitespace-nowrap text-[10px] md:text-xs">
             upload cover
           </span>
         </Button>

--- a/src/index.css
+++ b/src/index.css
@@ -199,6 +199,12 @@
     @apply border-border outline-ring/50;
   }
 
+  html,
+  body,
+  #root {
+    min-height: 100svh;
+  }
+
   body {
     @apply bg-background text-foreground;
     letter-spacing: var(--tracking-normal);


### PR DESCRIPTION
## Summary
- switch the mobile app shell/editor/sidebar panes to dynamic viewport height with stable svh minimums
- make the landing/editor/cover layouts more compact on short mobile viewports
- preserve tablet dialog cover sizing and keep touch targets at least 40px

## Verification
- vp fmt
- vp lint .
- vp check
- mobile viewport smoke at 390x620 in local browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the audio tagging screens’ responsiveness on shorter and mobile viewports.
  * Adjusted page and panel sizing so scrolling, spacing, and layout fit more consistently across screen heights.
  * Refined upload, metadata, and cover-art UI spacing to reduce clipping and crowding on smaller displays.
  * Updated the app’s base height behavior to better support full-screen layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->