### PR TITLE
[codex] Pin Cobalt tunnels to Fly Machines

### DIFF
--- a/Dockerfile.cobalt
+++ b/Dockerfile.cobalt
@@ -1,0 +1,5 @@
+FROM registry.fly.io/tagium-cobalt@sha256:ed27935513f69bb6ed754daa7296a14dff85490f6c9623f11e197e40106101a0
+
+COPY --chown=node:node cobalt-machine-proxy.mjs /app/cobalt-machine-proxy.mjs
+
+CMD ["node", "/app/cobalt-machine-proxy.mjs"]

--- a/cobalt-machine-proxy.mjs
+++ b/cobalt-machine-proxy.mjs
@@ -1,0 +1,135 @@
+import { spawn } from "node:child_process";
+import http from "node:http";
+import net from "node:net";
+import { env, exit } from "node:process";
+
+const proxyPort = 9000;
+const cobaltHost = "127.0.0.1";
+const cobaltPort = 9001;
+
+if (!env.API_URL) {
+  console.error("API_URL is required for Cobalt.");
+  exit(1);
+}
+
+const cobalt = spawn("node", ["src/cobalt"], {
+  stdio: "inherit",
+  env: {
+    ...env,
+    API_LISTEN_ADDRESS: cobaltHost,
+    API_PORT: String(cobaltPort),
+  },
+});
+
+let shuttingDown = false;
+
+const server = http.createServer((clientRequest, clientResponse) => {
+  const upstreamRequest = http.request(
+    {
+      host: cobaltHost,
+      port: cobaltPort,
+      method: clientRequest.method,
+      path: clientRequest.url,
+      headers: {
+        ...clientRequest.headers,
+        host: `${cobaltHost}:${cobaltPort}`,
+      },
+    },
+    (upstreamResponse) => {
+      const responseHeaders = { ...upstreamResponse.headers };
+      if (env.FLY_MACHINE_ID) {
+        responseHeaders["x-cobalt-machine-id"] = env.FLY_MACHINE_ID;
+      }
+
+      let statusCode = upstreamResponse.statusCode;
+      if (statusCode === undefined) {
+        statusCode = 502;
+      }
+
+      clientResponse.writeHead(statusCode, responseHeaders);
+      upstreamResponse.pipe(clientResponse);
+    },
+  );
+
+  upstreamRequest.on("error", (error) => {
+    if (clientResponse.headersSent) {
+      clientResponse.destroy(error);
+      return;
+    }
+
+    clientResponse.writeHead(502, {
+      "content-type": "text/plain;charset=UTF-8",
+    });
+    clientResponse.end(`Cobalt upstream request failed: ${error.message}`);
+  });
+
+  clientRequest.on("aborted", () => {
+    upstreamRequest.destroy();
+  });
+
+  clientRequest.pipe(upstreamRequest);
+});
+
+const shutdown = (signal) => {
+  shuttingDown = true;
+  if (server.listening) {
+    server.close();
+  }
+  cobalt.kill(signal);
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+cobalt.on("exit", (code) => {
+  if (shuttingDown) {
+    return;
+  }
+
+  let exitCode = code;
+  if (exitCode === null) {
+    exitCode = 1;
+  }
+
+  console.error(`Cobalt exited with status ${exitCode}.`);
+  exit(exitCode);
+});
+
+const waitForCobalt = () => {
+  if (shuttingDown) {
+    return;
+  }
+
+  const socket = net.createConnection({
+    host: cobaltHost,
+    port: cobaltPort,
+  });
+
+  socket.once("connect", () => {
+    socket.end();
+
+    if (shuttingDown) {
+      return;
+    }
+
+    server.listen(proxyPort, "0.0.0.0", () => {
+      console.log(`Cobalt proxy listening on 0.0.0.0:${proxyPort}.`);
+    });
+  });
+
+  socket.once("error", (error) => {
+    socket.destroy();
+
+    if (shuttingDown) {
+      return;
+    }
+
+    if (error.code !== "ECONNREFUSED" && error.code !== "ECONNRESET") {
+      throw error;
+    }
+
+    setTimeout(waitForCobalt, 100);
+  });
+};
+
+waitForCobalt();

--- a/docs/cobalt-audio-downloads.md
+++ b/docs/cobalt-audio-downloads.md
@@ -14,7 +14,21 @@ SoundCloud set URLs are resolved by Tagium, downloaded track-by-track through Co
 For production, deploy Cobalt from upstream source and point Tagium at it with `COBALT_API_URL`.
 If the Cobalt instance is private, set `COBALT_API_KEY` on Tagium and configure Cobalt API auth for the same key source.
 Set `COBALT_ALLOWED_ORIGIN` to the public Tagium origin when the request URL origin differs from the browser origin behind your host.
-The Tagium proxy enforces same-origin browser requests and limits each client to 120 download requests per minute.
+The Tagium proxy enforces same-origin browser requests and limits each client to 60 download requests per minute.
+
+## Fly deploy
+
+`fly.cobalt.toml` builds `Dockerfile.cobalt`, which layers `cobalt-machine-proxy.mjs` over the pinned Cobalt image.
+The wrapper listens on Fly's public internal port `9000`, starts upstream Cobalt on `127.0.0.1:9001`, proxies requests to it, and adds `X-Cobalt-Machine-Id` from `FLY_MACHINE_ID` when Fly provides it.
+
+Deploy Cobalt with:
+
+```sh
+flyctl deploy --config fly.cobalt.toml
+```
+
+Keep `API_URL` set to the public Cobalt URL in `fly.cobalt.toml`.
+Cobalt uses it when generating tunnel URLs, while the wrapper keeps the upstream process on the private secondary port.
 
 ## Cloudflare deploy env
 
@@ -30,5 +44,25 @@ Set the API key as a Cloudflare secret, not in git:
 wrangler secret put COBALT_API_KEY
 ```
 
+If Cobalt emits `X-Cobalt-Machine-Id`, Tagium signs machine-bound tunnel URLs. Set the signing key as a Cloudflare secret:
+
+```sh
+wrangler secret put COBALT_MACHINE_AFFINITY_SECRET
+```
+
 Preview deployments should leave `COBALT_ALLOWED_ORIGIN` unset so each preview URL can use the same-origin fallback.
 Production can set `COBALT_ALLOWED_ORIGIN` to the final public Tagium origin once the domain is fixed.
+
+## Fly scaling
+
+Cobalt tunnel URLs are process-local. On Fly, a Cobalt API response from one Machine can point at a tunnel served only by that same Machine.
+
+The Fly wrapper makes machine affinity deployable by emitting `X-Cobalt-Machine-Id` on Cobalt API responses.
+Tagium can use that value to send follow-up tunnel requests with `Fly-Force-Instance-Id`.
+
+Do not scale Cobalt past one Machine unless one of these is true:
+
+- A Cobalt wrapper or middleware emits `X-Cobalt-Machine-Id` on Cobalt API responses, sourced from Fly's `FLY_MACHINE_ID`, so Tagium can route follow-up tunnel requests back to that Machine.
+- Durable artifact storage exists, so tunnel URLs no longer depend on the originating process.
+
+If the wrapper is absent, keep `tagium-cobalt` to a single Machine.

--- a/fly.cobalt.toml
+++ b/fly.cobalt.toml
@@ -14,9 +14,9 @@ YOUTUBE_GENERATE_PO_TOKENS = "0"
 [http_service]
 internal_port = 9000
 force_https = true
-auto_stop_machines = false
+auto_stop_machines = "suspend"
 auto_start_machines = true
-min_machines_running = 1
+min_machines_running = 0
 processes = ["app"]
 
 [[vm]]

--- a/fly.cobalt.toml
+++ b/fly.cobalt.toml
@@ -2,18 +2,20 @@ app = "tagium-cobalt"
 primary_region = "lax"
 
 [build]
-image = "registry.fly.io/tagium-cobalt@sha256:ed27935513f69bb6ed754daa7296a14dff85490f6c9623f11e197e40106101a0"
+dockerfile = "Dockerfile.cobalt"
 
 [processes]
-app = "node src/cobalt"
+app = "node /app/cobalt-machine-proxy.mjs"
 
 [env]
+API_URL = "https://tagium-cobalt.fly.dev/"
 CUSTOM_INNERTUBE_CLIENT = "WEB_EMBEDDED"
 YOUTUBE_GENERATE_PO_TOKENS = "0"
 
 [http_service]
 internal_port = 9000
 force_https = true
+# Wrapper emits X-Cobalt-Machine-Id so tunnel requests can target the same Machine.
 auto_stop_machines = "suspend"
 auto_start_machines = true
 min_machines_running = 0

--- a/server-tests/cobalt/audio.post.test.ts
+++ b/server-tests/cobalt/audio.post.test.ts
@@ -6,10 +6,13 @@ type RuntimeRequest = Request & {
     cloudflare: {
       env: {
         COBALT_API_URL: string;
+        COBALT_MACHINE_AFFINITY_SECRET: string;
       };
     };
   };
 };
+
+const machineAffinitySecret = "test-machine-affinity-secret";
 
 const makeAudioRequest = () => {
   const request = new Request("https://tagium.test/api/cobalt/audio", {
@@ -28,6 +31,7 @@ const makeAudioRequest = () => {
     cloudflare: {
       env: {
         COBALT_API_URL: "https://cobalt.test/",
+        COBALT_MACHINE_AFFINITY_SECRET: machineAffinitySecret,
       },
     },
   };
@@ -91,6 +95,102 @@ describe("cobalt audio endpoint", () => {
         filename: "download.mp3",
       },
     });
+  });
+
+  it("appends Cobalt machine ids to proxied tunnel URLs", async () => {
+    const audioTunnel =
+      "https://cobalt.test/tunnel?id=123456789012345678901&exp=1234567890123&sig=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&sec=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb&iv=cccccccccccccccccccccc";
+    const coverTunnel =
+      "https://cobalt.test/tunnel?id=223456789012345678901&exp=1234567890123&sig=ddddddddddddddddddddddddddddddddddddddddddd&sec=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee&iv=ffffffffffffffffffffff";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return Response.json(
+          {
+            status: "local-processing",
+            type: "audio",
+            service: "youtube",
+            tunnel: [audioTunnel, coverTunnel],
+            output: {
+              type: "audio/mpeg",
+              filename: "download.mp3",
+            },
+            audio: {
+              copy: false,
+              format: "mp3",
+              bitrate: "128",
+            },
+          },
+          {
+            headers: {
+              "X-Cobalt-Machine-Id": "cobalt-machine-1",
+            },
+          },
+        );
+      }),
+    );
+
+    const response = await handler(makeEvent(makeAudioRequest()));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      status: "local-processing",
+      tunnel: [
+        `/api/cobalt/tunnel?url=${encodeURIComponent(audioTunnel)}&machine=cobalt-machine-1&signature=2302919c93e4a4b8486de4ab75fff6f2030499d2c6e85b65a3195de735782113`,
+        `/api/cobalt/tunnel?url=${encodeURIComponent(coverTunnel)}&machine=cobalt-machine-1&signature=93217531746bfde711a0169d7ecc2f1598eb8cf2b43521bad3e476194706a1b7`,
+      ],
+    });
+  });
+
+  it("rejects malformed Cobalt machine ids at ingestion", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return Response.json(
+          {
+            status: "tunnel",
+            url: "https://cobalt.test/tunnel?id=123456789012345678901",
+            filename: "download.mp3",
+          },
+          {
+            headers: {
+              "X-Cobalt-Machine-Id": "bad machine",
+            },
+          },
+        );
+      }),
+    );
+
+    const response = await handler(makeEvent(makeAudioRequest()));
+
+    expect(response.status).toBe(502);
+    expect(await response.text()).toBe("Cobalt returned invalid machine id.");
+  });
+
+  it("rejects blank Cobalt machine ids at ingestion", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return Response.json(
+          {
+            status: "tunnel",
+            url: "https://cobalt.test/tunnel?id=123456789012345678901",
+            filename: "download.mp3",
+          },
+          {
+            headers: {
+              "X-Cobalt-Machine-Id": "",
+            },
+          },
+        );
+      }),
+    );
+
+    const response = await handler(makeEvent(makeAudioRequest()));
+
+    expect(response.status).toBe(502);
+    expect(await response.text()).toBe("Cobalt returned invalid machine id.");
   });
 
   it("does not retry non-HLS Cobalt errors", async () => {

--- a/server-tests/cobalt/machine-affinity.test.ts
+++ b/server-tests/cobalt/machine-affinity.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vite-plus/test";
+import { signCobaltMachine } from "../../server/utils/cobalt-machine-affinity";
+
+describe("cobalt machine affinity", () => {
+  it("signs machine-bound tunnel URLs with a fixed payload vector", () => {
+    expect(
+      signCobaltMachine(
+        { COBALT_MACHINE_AFFINITY_SECRET: "test-machine-affinity-secret" },
+        "https://example.test/tunnel?b=2&a=1",
+        "cobalt-machine-1",
+      ),
+    ).toBe("4dc08b444310acb7001482a821983ee754d4ad960f1dd3f2b6f4c22f5f68c105");
+  });
+});

--- a/server-tests/cobalt/tunnel.get.test.ts
+++ b/server-tests/cobalt/tunnel.get.test.ts
@@ -6,25 +6,43 @@ type RuntimeRequest = Request & {
     cloudflare: {
       env: {
         COBALT_API_URL: string;
+        COBALT_MACHINE_AFFINITY_SECRET: string;
       };
     };
   };
 };
 
+const machineAffinitySecret = "test-machine-affinity-secret";
+const tunnelUrl =
+  "https://cobalt.test/tunnel?id=123456789012345678901&exp=1234567890123&sig=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&sec=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb&iv=cccccccccccccccccccccc";
+const tunnelSignature = "2302919c93e4a4b8486de4ab75fff6f2030499d2c6e85b65a3195de735782113";
+
 const makeTunnelRequest = () => {
   const request = new Request(
-    "https://tagium.test/api/cobalt/tunnel?url=https%3A%2F%2Fcobalt.test%2Ftunnel%3Fid%3D123456789012345678901%26exp%3D1234567890123%26sig%3Daaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa%26sec%3Dbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb%26iv%3Dcccccccccccccccccccccc",
+    `https://tagium.test/api/cobalt/tunnel?url=${encodeURIComponent(tunnelUrl)}`,
   ) as RuntimeRequest;
 
   request.runtime = {
     cloudflare: {
       env: {
         COBALT_API_URL: "https://cobalt.test/",
+        COBALT_MACHINE_AFFINITY_SECRET: machineAffinitySecret,
       },
     },
   };
 
   return request;
+};
+
+const makeTunnelRequestForMachine = () => {
+  const request = makeTunnelRequest();
+  const url = new URL(request.url);
+  url.searchParams.set("machine", "cobalt-machine-1");
+  url.searchParams.set("signature", tunnelSignature);
+  const machineRequest = new Request(url, request) as RuntimeRequest;
+  machineRequest.runtime = request.runtime;
+
+  return machineRequest;
 };
 
 const makeEvent = (request: RuntimeRequest) => {
@@ -55,6 +73,57 @@ describe("cobalt tunnel endpoint", () => {
     expect(response.headers.get("Content-Type")).toBe("audio/mpeg");
     expect(response.headers.get("Content-Length")).toBeNull();
     expect(await response.text()).toBe("audio-bytes");
+  });
+
+  it("forwards Fly machine affinity when machine param is present", async () => {
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => {
+      return new Response("audio-bytes", {
+        headers: {
+          "Content-Type": "audio/mpeg",
+        },
+      });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handler(makeEvent(makeTunnelRequestForMachine()));
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = new Headers(init?.headers);
+
+    expect(response.status).toBe(200);
+    expect(headers.get("Fly-Force-Instance-Id")).toBe("cobalt-machine-1");
+  });
+
+  it("rejects tampered tunnel machine affinity", async () => {
+    const request = makeTunnelRequestForMachine();
+    const url = new URL(request.url);
+    url.searchParams.set("machine", "cobalt-machine-2");
+    const tamperedRequest = new Request(url, request) as RuntimeRequest;
+    tamperedRequest.runtime = request.runtime;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handler(makeEvent(tamperedRequest));
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("Invalid Cobalt tunnel URL.");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects tampered tunnel machine signatures", async () => {
+    const request = makeTunnelRequestForMachine();
+    const url = new URL(request.url);
+    url.searchParams.set("signature", "a".repeat(64));
+    const tamperedRequest = new Request(url, request) as RuntimeRequest;
+    tamperedRequest.runtime = request.runtime;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handler(makeEvent(tamperedRequest));
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("Invalid Cobalt tunnel URL.");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("rejects empty successful Cobalt tunnel responses", async () => {

--- a/server/api/cobalt/audio.post.ts
+++ b/server/api/cobalt/audio.post.ts
@@ -9,6 +9,7 @@
 import { defineHandler } from "nitro";
 import { env as processEnv } from "node:process";
 import { z } from "zod";
+import { parseCobaltMachineId, signCobaltMachine } from "../../utils/cobalt-machine-affinity";
 
 enum CobaltResponseType {
   Error = "error",
@@ -70,10 +71,15 @@ const cobaltResponseSchema = z.discriminatedUnion("status", [
 ]);
 
 type CobaltResponse = z.infer<typeof cobaltResponseSchema>;
+type CobaltAudioResult = {
+  response: CobaltResponse;
+  machineId: string | undefined;
+};
 type CobaltRuntimeEnv = {
   COBALT_ALLOWED_ORIGIN?: string;
   COBALT_API_KEY?: string;
   COBALT_API_URL?: string;
+  COBALT_MACHINE_AFFINITY_SECRET?: string;
 };
 type CloudflareRequest = Request & {
   runtime?: {
@@ -191,7 +197,7 @@ const requestCobaltAudio = async (
   runtimeEnv: CobaltRuntimeEnv,
   url: string,
   audioBitrate: string,
-) => {
+): Promise<CobaltAudioResult> => {
   let response: Response;
 
   try {
@@ -219,13 +225,19 @@ const requestCobaltAudio = async (
     }
 
     return {
-      status: CobaltResponseType.Error,
-      error: { code },
-    } satisfies CobaltResponse;
+      response: {
+        status: CobaltResponseType.Error,
+        error: { code },
+      },
+      machineId: undefined,
+    };
   }
 
   try {
-    return await parseCobaltJson(response);
+    return {
+      response: await parseCobaltJson(response),
+      machineId: parseCobaltMachineId(response.headers.get("X-Cobalt-Machine-Id")),
+    };
   } catch (error) {
     let code = "error.api.invalid_response";
     if (error instanceof Error) {
@@ -233,9 +245,12 @@ const requestCobaltAudio = async (
     }
 
     return {
-      status: CobaltResponseType.Error,
-      error: { code },
-    } satisfies CobaltResponse;
+      response: {
+        status: CobaltResponseType.Error,
+        error: { code },
+      },
+      machineId: undefined,
+    };
   }
 };
 
@@ -247,29 +262,44 @@ const cobaltErrorResponse = (message: string) =>
     },
   });
 
-const toTunnelProxyUrl = (request: Request, tunnelUrl: string) => {
+const toTunnelProxyUrl = (
+  request: Request,
+  runtimeEnv: CobaltRuntimeEnv,
+  tunnelUrl: string,
+  machineId: string | undefined,
+) => {
   const proxyUrl = new URL("/api/cobalt/tunnel", request.url);
   proxyUrl.searchParams.set("url", tunnelUrl);
+  if (machineId) {
+    proxyUrl.searchParams.set("machine", machineId);
+    proxyUrl.searchParams.set("signature", signCobaltMachine(runtimeEnv, tunnelUrl, machineId));
+  }
   return `${proxyUrl.pathname}${proxyUrl.search}`;
 };
 
 const proxiedTunnelResponse = (
   request: Request,
+  runtimeEnv: CobaltRuntimeEnv,
   response: Extract<CobaltResponse, { url: string }>,
+  machineId: string | undefined,
 ) =>
   Response.json({
     status: CobaltResponseType.Tunnel,
-    url: toTunnelProxyUrl(request, response.url),
+    url: toTunnelProxyUrl(request, runtimeEnv, response.url, machineId),
     filename: response.filename,
   });
 
 const localProcessingResponse = (
   request: Request,
+  runtimeEnv: CobaltRuntimeEnv,
   response: Extract<CobaltResponse, { status: CobaltResponseType.LocalProcessing }>,
+  machineId: string | undefined,
 ) =>
   Response.json({
     ...response,
-    tunnel: response.tunnel.map((tunnelUrl) => toTunnelProxyUrl(request, tunnelUrl)),
+    tunnel: response.tunnel.map((tunnelUrl) =>
+      toTunnelProxyUrl(request, runtimeEnv, tunnelUrl, machineId),
+    ),
   });
 
 const parseAudioRequest = async (request: Request) => {
@@ -298,14 +328,15 @@ export default defineHandler(async (event) => {
       return new Response("Invalid audio download request.", { status: 400 });
     }
 
-    const cobaltResponse = await requestCobaltAudio(runtimeEnv, body.url, body.audioBitrate);
+    const cobaltResult = await requestCobaltAudio(runtimeEnv, body.url, body.audioBitrate);
+    const cobaltResponse = cobaltResult.response;
 
     if (cobaltResponse.status === CobaltResponseType.Error) {
       return cobaltErrorResponse(cobaltResponse.error.code);
     }
 
     if (cobaltResponse.status === CobaltResponseType.LocalProcessing) {
-      return localProcessingResponse(event.req, cobaltResponse);
+      return localProcessingResponse(event.req, runtimeEnv, cobaltResponse, cobaltResult.machineId);
     }
 
     if (cobaltResponse.status === CobaltResponseType.Picker) {
@@ -313,14 +344,19 @@ export default defineHandler(async (event) => {
         return cobaltErrorResponse("Cobalt returned multiple items without a single audio file.");
       }
 
-      return proxiedTunnelResponse(event.req, {
-        status: CobaltResponseType.Tunnel,
-        url: cobaltResponse.audio,
-        filename: cobaltResponse.audioFilename,
-      });
+      return proxiedTunnelResponse(
+        event.req,
+        runtimeEnv,
+        {
+          status: CobaltResponseType.Tunnel,
+          url: cobaltResponse.audio,
+          filename: cobaltResponse.audioFilename,
+        },
+        cobaltResult.machineId,
+      );
     }
 
-    return proxiedTunnelResponse(event.req, cobaltResponse);
+    return proxiedTunnelResponse(event.req, runtimeEnv, cobaltResponse, cobaltResult.machineId);
   } catch (error) {
     if (error instanceof Error) {
       return cobaltErrorResponse(error.message);

--- a/server/api/cobalt/audio.post.ts
+++ b/server/api/cobalt/audio.post.ts
@@ -84,7 +84,7 @@ type CloudflareRequest = Request & {
 };
 
 const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX_REQUESTS = 120;
+const RATE_LIMIT_MAX_REQUESTS = 60;
 const COBALT_REQUEST_TIMEOUT_MS = 300_000;
 const rateLimitBuckets = new Map<string, { startedAt: number; count: number }>();
 

--- a/server/api/cobalt/tunnel.get.ts
+++ b/server/api/cobalt/tunnel.get.ts
@@ -1,8 +1,13 @@
 import { defineHandler } from "nitro";
 import { env as processEnv } from "node:process";
+import {
+  isCobaltMachineId,
+  isValidCobaltMachineSignature,
+} from "../../utils/cobalt-machine-affinity";
 
 type CobaltRuntimeEnv = {
   COBALT_API_URL?: string;
+  COBALT_MACHINE_AFFINITY_SECRET?: string;
 };
 
 type CloudflareRequest = Request & {
@@ -58,31 +63,61 @@ const streamNonEmptyBody = async (response: Response) => {
   });
 };
 
-const parseTunnelUrl = (request: Request, runtimeEnv: CobaltRuntimeEnv) => {
+const parseTunnelRequest = (request: Request, runtimeEnv: CobaltRuntimeEnv) => {
   const requestUrl = new URL(request.url);
   const tunnelUrlParam = requestUrl.searchParams.get("url");
   if (!tunnelUrlParam) {
     return undefined;
   }
 
-  const tunnelUrl = new URL(tunnelUrlParam);
+  let tunnelUrl: URL;
+  try {
+    tunnelUrl = new URL(tunnelUrlParam);
+  } catch {
+    return undefined;
+  }
+
   const cobaltUrl = new URL(getCobaltApiUrl(runtimeEnv));
   if (tunnelUrl.origin !== cobaltUrl.origin || tunnelUrl.pathname !== "/tunnel") {
     return undefined;
   }
 
-  return tunnelUrl;
+  const machineId = requestUrl.searchParams.get("machine");
+  const signature = requestUrl.searchParams.get("signature");
+  if (machineId === null) {
+    if (signature !== null) {
+      return undefined;
+    }
+
+    return { tunnelUrl, machineId };
+  }
+
+  if (!isCobaltMachineId(machineId) || signature === null) {
+    return undefined;
+  }
+
+  if (!isValidCobaltMachineSignature(runtimeEnv, tunnelUrlParam, machineId, signature)) {
+    return undefined;
+  }
+
+  return { tunnelUrl, machineId };
 };
 
 export default defineHandler(async (event) => {
   try {
     const runtimeEnv = getRuntimeEnv(event.req);
-    const tunnelUrl = parseTunnelUrl(event.req, runtimeEnv);
-    if (!tunnelUrl) {
+    const tunnelRequest = parseTunnelRequest(event.req, runtimeEnv);
+    if (!tunnelRequest) {
       return new Response("Invalid Cobalt tunnel URL.", { status: 400 });
     }
 
-    const response = await fetch(tunnelUrl, {
+    const requestHeaders = new Headers();
+    if (tunnelRequest.machineId) {
+      requestHeaders.set("Fly-Force-Instance-Id", tunnelRequest.machineId);
+    }
+
+    const response = await fetch(tunnelRequest.tunnelUrl, {
+      headers: requestHeaders,
       signal: AbortSignal.timeout(COBALT_TUNNEL_TIMEOUT_MS),
     });
 
@@ -95,13 +130,13 @@ export default defineHandler(async (event) => {
       return new Response("Cobalt tunnel response was empty.", { status: 502 });
     }
 
-    const headers = new Headers();
+    const responseHeaders = new Headers();
     const contentType = response.headers.get("content-type");
     if (contentType) {
-      headers.set("Content-Type", contentType);
+      responseHeaders.set("Content-Type", contentType);
     }
 
-    return new Response(body, { headers });
+    return new Response(body, { headers: responseHeaders });
   } catch (error) {
     if (error instanceof Error) {
       return new Response(error.message, { status: 502 });

--- a/server/utils/cobalt-machine-affinity.ts
+++ b/server/utils/cobalt-machine-affinity.ts
@@ -1,0 +1,55 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+type CobaltMachineAffinityEnv = {
+  COBALT_MACHINE_AFFINITY_SECRET?: string;
+};
+
+const cobaltMachineIdPattern = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+export const isCobaltMachineId = (machineId: string) => cobaltMachineIdPattern.test(machineId);
+
+export const parseCobaltMachineId = (machineId: string | null) => {
+  if (machineId === null) {
+    return undefined;
+  }
+
+  if (!isCobaltMachineId(machineId)) {
+    throw new Error("Cobalt returned invalid machine id.");
+  }
+
+  return machineId;
+};
+
+export const getCobaltMachineAffinitySecret = (runtimeEnv: CobaltMachineAffinityEnv) => {
+  if (!runtimeEnv.COBALT_MACHINE_AFFINITY_SECRET) {
+    throw new Error("COBALT_MACHINE_AFFINITY_SECRET is not configured.");
+  }
+
+  return runtimeEnv.COBALT_MACHINE_AFFINITY_SECRET;
+};
+
+export const signCobaltMachine = (
+  runtimeEnv: CobaltMachineAffinityEnv,
+  tunnelUrl: string,
+  machineId: string,
+) =>
+  createHmac("sha256", getCobaltMachineAffinitySecret(runtimeEnv))
+    .update(machineId)
+    .update("\n")
+    .update(tunnelUrl)
+    .digest("hex");
+
+export const isValidCobaltMachineSignature = (
+  runtimeEnv: CobaltMachineAffinityEnv,
+  tunnelUrl: string,
+  machineId: string,
+  signature: string,
+) => {
+  const expected = signCobaltMachine(runtimeEnv, tunnelUrl, machineId);
+  const signatureBytes = new TextEncoder().encode(signature);
+  const expectedBytes = new TextEncoder().encode(expected);
+
+  return (
+    signatureBytes.length === expectedBytes.length && timingSafeEqual(signatureBytes, expectedBytes)
+  );
+};


### PR DESCRIPTION
## Summary

- add a Fly Cobalt wrapper image that starts upstream Cobalt behind a local proxy and emits `X-Cobalt-Machine-Id` from `FLY_MACHINE_ID`
- sign machine-bound tunnel proxy URLs in Tagium and forward verified tunnel fetches with `Fly-Force-Instance-Id`
- document the deploy requirements, required affinity secret, and one-Machine guard when durable artifacts are unavailable

## Root Cause

Cobalt tunnel URLs are process-local. With multiple Fly Machines, Tagium could ask Machine A for a download plan, then fetch the returned `/tunnel` URL through Machine B or C, where the tunnel handler did not exist.

## Validation

- `node --check cobalt-machine-proxy.mjs`
- `flyctl config validate --config fly.cobalt.toml`
- `bun run vp fmt`
- `bun run vp lint .`
- `bun run vp check`
- `bun run vp test run`
- `bun run vp build`
- antagonistic review loop completed; final review returned no findings

## Deployment Notes

Set `COBALT_MACHINE_AFFINITY_SECRET` anywhere Tagium handles Cobalt tunnel plans before scaling the Cobalt Fly app beyond one Machine. Deploy Cobalt with `flyctl deploy --config fly.cobalt.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for machine-affinity-aware Cobalt downloads and tunnel handling.
  * Updated deployment setup to run Cobalt through a proxy container and Fly.io build process.
* **Bug Fixes**
  * Improved validation for tunnel and machine-affinity parameters, with clearer error handling for invalid upstream responses.
  * Added safer proxy shutdown and request forwarding behavior.
* **Documentation**
  * Expanded deployment guidance for Fly.io, tunnel affinity, and scaling recommendations.
* **Tests**
  * Added coverage for signed tunnel URLs, machine-id validation, and invalid affinity rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->