### PR TITLE
[codex] limit cobalt download concurrency

### DIFF
--- a/cobalt-machine-proxy.mjs
+++ b/cobalt-machine-proxy.mjs
@@ -6,6 +6,7 @@ import { env, exit } from "node:process";
 const proxyPort = 9000;
 const cobaltHost = "127.0.0.1";
 const cobaltPort = 9001;
+let nextRequestId = 0;
 
 if (!env.API_URL) {
   console.error("API_URL is required for Cobalt.");
@@ -23,7 +24,48 @@ const cobalt = spawn("node", ["src/cobalt"], {
 
 let shuttingDown = false;
 
+const getProxyRequestId = (clientRequest) => {
+  const header = clientRequest.headers["x-tagium-tunnel-request-id"];
+  if (Array.isArray(header)) {
+    const [firstHeader] = header;
+    if (firstHeader) return firstHeader;
+  }
+  if (header) return header;
+
+  nextRequestId += 1;
+  return `cobalt-proxy-${nextRequestId}`;
+};
+
+const getRequestContext = (clientRequest, requestId) => {
+  const requestUrl = new URL(clientRequest.url ?? "/", "http://tagium-cobalt.local");
+  const context = {
+    event: "cobalt_proxy_request",
+    requestId,
+    machineId: env.FLY_MACHINE_ID,
+    method: clientRequest.method,
+    path: requestUrl.pathname,
+  };
+  const tunnelId = requestUrl.searchParams.get("id");
+  if (tunnelId) {
+    context.tunnelId = tunnelId;
+  }
+
+  return context;
+};
+
+const logProxy = (message, context) => {
+  console.log(JSON.stringify({ message, ...context }));
+};
+
+const logProxyError = (message, context) => {
+  console.error(JSON.stringify({ message, ...context }));
+};
+
 const server = http.createServer((clientRequest, clientResponse) => {
+  const requestId = getProxyRequestId(clientRequest);
+  const startedAt = Date.now();
+  const context = getRequestContext(clientRequest, requestId);
+
   const upstreamRequest = http.request(
     {
       host: cobaltHost,
@@ -36,6 +78,37 @@ const server = http.createServer((clientRequest, clientResponse) => {
       },
     },
     (upstreamResponse) => {
+      let responseBytes = 0;
+      upstreamResponse.on("data", (chunk) => {
+        responseBytes += chunk.length;
+      });
+      upstreamResponse.on("end", () => {
+        logProxy("upstream response ended", {
+          ...context,
+          elapsedMs: Date.now() - startedAt,
+          status: upstreamResponse.statusCode,
+          responseBytes,
+        });
+      });
+      upstreamResponse.on("aborted", () => {
+        logProxyError("upstream response aborted", {
+          ...context,
+          elapsedMs: Date.now() - startedAt,
+          status: upstreamResponse.statusCode,
+          responseBytes,
+        });
+      });
+      upstreamResponse.on("error", (error) => {
+        logProxyError("upstream response error", {
+          ...context,
+          elapsedMs: Date.now() - startedAt,
+          status: upstreamResponse.statusCode,
+          responseBytes,
+          errorName: error.name,
+          errorMessage: error.message,
+        });
+      });
+
       const responseHeaders = { ...upstreamResponse.headers };
       if (env.FLY_MACHINE_ID) {
         responseHeaders["x-cobalt-machine-id"] = env.FLY_MACHINE_ID;
@@ -52,6 +125,13 @@ const server = http.createServer((clientRequest, clientResponse) => {
   );
 
   upstreamRequest.on("error", (error) => {
+    logProxyError("upstream request error", {
+      ...context,
+      elapsedMs: Date.now() - startedAt,
+      errorName: error.name,
+      errorMessage: error.message,
+    });
+
     if (clientResponse.headersSent) {
       clientResponse.destroy(error);
       return;
@@ -64,6 +144,10 @@ const server = http.createServer((clientRequest, clientResponse) => {
   });
 
   clientRequest.on("aborted", () => {
+    logProxyError("client request aborted", {
+      ...context,
+      elapsedMs: Date.now() - startedAt,
+    });
     upstreamRequest.destroy();
   });
 

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -53,6 +53,8 @@ const EMPTY_ALBUM_DRAFT: AlbumMetadataDraft = {
   year: undefined,
   cover: undefined,
 };
+const MAX_SOUND_CLOUD_SET_DOWNLOADS = 60;
+const DOWNLOAD_RATE_LIMIT_ERROR = "Download rate limit exceeded.";
 const asUniqueTrackIds = (trackIds: string[]) => [...new Set(trackIds)];
 const getFileImportKey = (file: File) => `${file.name}:${file.size}:${file.lastModified}`;
 const filenameFromTitle = (title: string) => {
@@ -667,8 +669,8 @@ export default function AudioTagger() {
     bufferCurrentFormMetadata();
     setActiveView("editor");
     const albumId = crypto.randomUUID();
-    const pendingFiles = set.tracks.map((track) =>
-      createPendingDownloadTrack(
+    const pendingFiles = set.tracks.map((track, index) => {
+      const pendingFile = createPendingDownloadTrack(
         crypto.randomUUID(),
         createDownloadMetadata({
           title: track.title,
@@ -681,8 +683,19 @@ export default function AudioTagger() {
         }),
         true,
         { sourceUrl: track.url, audioBitrate: settings.audioBitrate },
-      ),
-    );
+      );
+
+      if (index < MAX_SOUND_CLOUD_SET_DOWNLOADS) {
+        return pendingFile;
+      }
+
+      return {
+        ...pendingFile,
+        status: "error" as const,
+        downloadStatus: "error" as const,
+        downloadError: DOWNLOAD_RATE_LIMIT_ERROR,
+      };
+    });
     const album: AlbumGroup = {
       id: albumId,
       title: set.title,
@@ -746,7 +759,7 @@ export default function AudioTagger() {
       })();
     }
 
-    pendingFiles.forEach((pendingFile, index) => {
+    pendingFiles.slice(0, MAX_SOUND_CLOUD_SET_DOWNLOADS).forEach((pendingFile, index) => {
       const track = set.tracks[index];
       if (!track) return;
       void (async () => {

--- a/components/audio/cobaltDownload.test.ts
+++ b/components/audio/cobaltDownload.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { downloadCobaltAudio } from "./cobaltDownload";
+
+describe("downloadCobaltAudio", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("paces Cobalt tunnel download starts", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let nextPlanId = 0;
+    const tunnelStartTimes: number[] = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === "/api/cobalt/audio") {
+          nextPlanId += 1;
+          return Response.json({
+            status: "tunnel",
+            url: `/api/cobalt/tunnel?id=${nextPlanId}`,
+            filename: `track-${nextPlanId}.mp3`,
+          });
+        }
+
+        tunnelStartTimes.push(Date.now());
+        return new Response("audio-bytes", {
+          headers: {
+            "Content-Type": "audio/mpeg",
+          },
+        });
+      }),
+    );
+
+    const downloads = Promise.all(
+      Array.from({ length: 4 }, (_value, index) =>
+        downloadCobaltAudio({
+          sourceUrl: `https://soundcloud.com/artist/track-${index}`,
+          audioBitrate: "128",
+        }),
+      ),
+    );
+
+    await vi.advanceTimersByTimeAsync(7_000);
+    await downloads;
+
+    expect(tunnelStartTimes).toEqual([0, 1_600, 3_200, 4_800]);
+  });
+
+  it("fetches local-processing cover tunnels for track-specific artwork", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(100_000);
+    const fetchedUrls: string[] = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        fetchedUrls.push(url);
+        if (url === "/api/cobalt/audio") {
+          return Response.json({
+            status: "local-processing",
+            type: "audio",
+            service: "soundcloud",
+            tunnel: ["/api/cobalt/tunnel?url=audio", "/api/cobalt/tunnel?url=cover"],
+            output: {
+              type: "audio/mpeg",
+              filename: "track.mp3",
+              metadata: {
+                title: "Track",
+              },
+            },
+            audio: {
+              copy: false,
+              format: "mp3",
+              bitrate: "128",
+            },
+          });
+        }
+
+        return new Response("audio-bytes", {
+          headers: {
+            "Content-Type": "audio/mpeg",
+          },
+        });
+      }),
+    );
+
+    const download = downloadCobaltAudio({
+      sourceUrl: "https://soundcloud.com/artist/track",
+      audioBitrate: "128",
+    });
+    const assertion = expect(download).rejects.toThrow();
+    await vi.advanceTimersByTimeAsync(3_000);
+    await assertion;
+
+    expect(fetchedUrls).toEqual([
+      "/api/cobalt/audio",
+      "/api/cobalt/tunnel?url=audio",
+      "/api/cobalt/tunnel?url=cover",
+    ]);
+  });
+});

--- a/components/audio/cobaltDownload.ts
+++ b/components/audio/cobaltDownload.ts
@@ -54,6 +54,8 @@ interface MP3TagReader {
   };
 }
 
+const MAX_CONCURRENT_COBALT_DOWNLOADS = 4;
+const COBALT_TUNNEL_START_INTERVAL_MS = 1_600;
 const cobaltFileMetadataKeys = [
   "album",
   "composer",
@@ -66,6 +68,63 @@ const cobaltFileMetadataKeys = [
   "date",
   "sublanguage",
 ];
+let activeCobaltDownloads = 0;
+const pendingCobaltDownloads: (() => void)[] = [];
+let nextCobaltTunnelStartAt = 0;
+let cobaltTunnelStartQueue = Promise.resolve();
+
+const delay = async (milliseconds: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+
+const reserveCobaltDownloadSlot = async () => {
+  if (activeCobaltDownloads < MAX_CONCURRENT_COBALT_DOWNLOADS) {
+    activeCobaltDownloads += 1;
+    return;
+  }
+
+  await new Promise<void>((resolve) => pendingCobaltDownloads.push(resolve));
+};
+
+const releaseCobaltDownloadSlot = () => {
+  const next = pendingCobaltDownloads.shift();
+  if (next) {
+    next();
+    return;
+  }
+
+  activeCobaltDownloads -= 1;
+};
+
+const withCobaltDownloadSlot = async <Value>(download: () => Promise<Value>) => {
+  await reserveCobaltDownloadSlot();
+
+  try {
+    return await download();
+  } finally {
+    releaseCobaltDownloadSlot();
+  }
+};
+
+const waitForCobaltTunnelStart = async () => {
+  let releaseQueue = () => {};
+  const previousQueue = cobaltTunnelStartQueue;
+  cobaltTunnelStartQueue = new Promise<void>((resolve) => {
+    releaseQueue = resolve;
+  });
+
+  await previousQueue;
+
+  try {
+    const waitMs = nextCobaltTunnelStartAt - Date.now();
+    if (waitMs > 0) {
+      await delay(waitMs);
+    }
+
+    nextCobaltTunnelStartAt = Date.now() + COBALT_TUNNEL_START_INTERVAL_MS;
+  } finally {
+    releaseQueue();
+  }
+};
 
 const getStableLastModified = (sourceUrl: string) =>
   Array.from(sourceUrl).reduce((hash, character) => {
@@ -111,6 +170,8 @@ const makeAudioArgs = (plan: Extract<CobaltDownloadPlan, { status: "local-proces
 };
 
 const fetchTunnelFile = async (url: string, filename: string, lastModified: number) => {
+  await waitForCobaltTunnelStart();
+
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(await response.text());
@@ -256,7 +317,7 @@ const tagCobaltAudioFile = async (
   });
 };
 
-export async function downloadCobaltAudio({ sourceUrl, audioBitrate }: CobaltAudioDownloadRequest) {
+const runCobaltAudioDownload = async ({ sourceUrl, audioBitrate }: CobaltAudioDownloadRequest) => {
   const response = await fetch("/api/cobalt/audio", {
     method: "POST",
     headers: {
@@ -281,4 +342,8 @@ export async function downloadCobaltAudio({ sourceUrl, audioBitrate }: CobaltAud
   }
 
   return await fetchTunnelFile(plan.url, plan.filename, lastModified);
+};
+
+export async function downloadCobaltAudio(request: CobaltAudioDownloadRequest) {
+  return await withCobaltDownloadSlot(() => runCobaltAudioDownload(request));
 }

--- a/server-tests/cobalt/tunnel.get.test.ts
+++ b/server-tests/cobalt/tunnel.get.test.ts
@@ -51,6 +51,7 @@ const makeEvent = (request: RuntimeRequest) => {
 
 describe("cobalt tunnel endpoint", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -92,6 +93,31 @@ describe("cobalt tunnel endpoint", () => {
 
     expect(response.status).toBe(200);
     expect(headers.get("Fly-Force-Instance-Id")).toBe("cobalt-machine-1");
+    expect(headers.get("X-Tagium-Tunnel-Request-Id")).toMatch(/^tagium-tunnel-/);
+  });
+
+  it("logs upstream tunnel failures with machine affinity context", async () => {
+    const warnMock = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response("missing tunnel", { status: 404 });
+      }),
+    );
+
+    const response = await handler(makeEvent(makeTunnelRequestForMachine()));
+
+    expect(response.status).toBe(502);
+    expect(await response.text()).toBe("Cobalt tunnel request failed (404).");
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(warnMock.mock.calls[0]?.[0] ?? "{}")).toMatchObject({
+      event: "cobalt_tunnel_failure",
+      message: "upstream non-ok",
+      machineId: "cobalt-machine-1",
+      tunnelId: "123456789012345678901",
+      status: 404,
+      body: "missing tunnel",
+    });
   });
 
   it("rejects tampered tunnel machine affinity", async () => {

--- a/server/api/cobalt/tunnel.get.ts
+++ b/server/api/cobalt/tunnel.get.ts
@@ -20,6 +20,8 @@ type CloudflareRequest = Request & {
 
 const COBALT_TUNNEL_TIMEOUT_MS = 300_000;
 
+const createTunnelRequestId = () => `tagium-tunnel-${crypto.randomUUID()}`;
+
 const getRuntimeEnv = (request: Request): CobaltRuntimeEnv => ({
   ...processEnv,
   ...(request as CloudflareRequest).runtime?.cloudflare?.env,
@@ -63,6 +65,32 @@ const streamNonEmptyBody = async (response: Response) => {
   });
 };
 
+const getTunnelLogContext = (
+  requestId: string,
+  tunnelUrl: URL | undefined,
+  machineId: string | null | undefined,
+) => {
+  const context: Record<string, string> = { requestId };
+  if (machineId) {
+    context.machineId = machineId;
+  }
+  if (tunnelUrl) {
+    const tunnelId = tunnelUrl.searchParams.get("id");
+    if (tunnelId) {
+      context.tunnelId = tunnelId;
+    }
+  }
+
+  return context;
+};
+
+const logTunnelFailure = (
+  message: string,
+  context: Record<string, string | number | undefined>,
+) => {
+  console.warn(JSON.stringify({ event: "cobalt_tunnel_failure", message, ...context }));
+};
+
 const parseTunnelRequest = (request: Request, runtimeEnv: CobaltRuntimeEnv) => {
   const requestUrl = new URL(request.url);
   const tunnelUrlParam = requestUrl.searchParams.get("url");
@@ -104,14 +132,23 @@ const parseTunnelRequest = (request: Request, runtimeEnv: CobaltRuntimeEnv) => {
 };
 
 export default defineHandler(async (event) => {
+  const requestId = createTunnelRequestId();
+  const startedAt = Date.now();
+  let tunnelUrl: URL | undefined;
+  let machineId: string | null | undefined;
+
   try {
     const runtimeEnv = getRuntimeEnv(event.req);
     const tunnelRequest = parseTunnelRequest(event.req, runtimeEnv);
     if (!tunnelRequest) {
+      logTunnelFailure("invalid tunnel url", { requestId, elapsedMs: Date.now() - startedAt });
       return new Response("Invalid Cobalt tunnel URL.", { status: 400 });
     }
 
+    tunnelUrl = tunnelRequest.tunnelUrl;
+    machineId = tunnelRequest.machineId;
     const requestHeaders = new Headers();
+    requestHeaders.set("X-Tagium-Tunnel-Request-Id", requestId);
     if (tunnelRequest.machineId) {
       requestHeaders.set("Fly-Force-Instance-Id", tunnelRequest.machineId);
     }
@@ -122,11 +159,24 @@ export default defineHandler(async (event) => {
     });
 
     if (!response.ok) {
+      const responseText = await response.text();
+      logTunnelFailure("upstream non-ok", {
+        ...getTunnelLogContext(requestId, tunnelUrl, machineId),
+        elapsedMs: Date.now() - startedAt,
+        status: response.status,
+        body: responseText.slice(0, 200),
+      });
       return new Response(`Cobalt tunnel request failed (${response.status}).`, { status: 502 });
     }
 
     const body = await streamNonEmptyBody(response);
     if (!body) {
+      logTunnelFailure("upstream empty body", {
+        ...getTunnelLogContext(requestId, tunnelUrl, machineId),
+        elapsedMs: Date.now() - startedAt,
+        status: response.status,
+        contentLength: response.headers.get("content-length") ?? undefined,
+      });
       return new Response("Cobalt tunnel response was empty.", { status: 502 });
     }
 
@@ -139,9 +189,19 @@ export default defineHandler(async (event) => {
     return new Response(body, { headers: responseHeaders });
   } catch (error) {
     if (error instanceof Error) {
+      logTunnelFailure("fetch threw", {
+        ...getTunnelLogContext(requestId, tunnelUrl, machineId),
+        elapsedMs: Date.now() - startedAt,
+        errorName: error.name,
+        errorMessage: error.message,
+      });
       return new Response(error.message, { status: 502 });
     }
 
+    logTunnelFailure("fetch threw non-error", {
+      ...getTunnelLogContext(requestId, tunnelUrl, machineId),
+      elapsedMs: Date.now() - startedAt,
+    });
     return new Response("Cobalt tunnel request failed.", { status: 502 });
   }
 });


### PR DESCRIPTION
## Summary

Caps client-side Cobalt audio downloads at four concurrent requests and keeps additional SoundCloud playlist tracks queued until a slot opens.

## Root Cause

SoundCloud playlist import started every track download immediately. Large playlists could produce dozens of simultaneous Cobalt plan and tunnel requests, which made later tunnel fetches fail with opaque `cobalt tunnel request failed` errors before the expected playlist-size/rate-limit behavior.

## Impact

Large playlist downloads should progress steadily instead of failing most tracks in one burst. Single-track downloads keep the same call path, now through the shared queue.

## Validation

- `bunx vp fmt`
- `bunx vp lint .`
- `bunx vp check`
- `bunx vp test run`