### PR TITLE
[codex] add download progress indicators

### DIFF
--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -43,6 +43,7 @@ import {
 import type { AlbumGroup, TagiumFile } from "./types";
 
 interface AlbumSidebarProps {
+  downloadDisabled: boolean;
   albums: AlbumGroup[];
   looseTrackIds: string[];
   files: TagiumFile[];
@@ -78,6 +79,7 @@ interface AlbumSidebarProps {
 const isFileDrag = (event: React.DragEvent) => event.dataTransfer.types.includes("Files");
 
 export default function AlbumSidebar({
+  downloadDisabled,
   albums,
   looseTrackIds,
   files,
@@ -323,7 +325,7 @@ export default function AlbumSidebar({
                   key={album.id}
                   album={album}
                   selected={selectedAlbumId === album.id}
-                  canDownload={canDownloadAlbum}
+                  canDownload={canDownloadAlbum && !downloadDisabled}
                   onSelect={(event) => onSelectAlbum(album.id, event)}
                   onEdit={() => onEditAlbum(album.id)}
                   onDownload={() => onDownloadAlbum(album.id)}

--- a/components/audio/AlbumSidebarDnd.tsx
+++ b/components/audio/AlbumSidebarDnd.tsx
@@ -139,6 +139,30 @@ export function SortableTrackRow({
   onRemove,
   onRetry,
 }: TrackRowProps) {
+  const downloadProgress = track.downloadProgress;
+  let downloadProgressPercent: number | null = null;
+  let downloadProgressBarWidth = "100%";
+  if (
+    downloadProgress &&
+    downloadProgress.value !== undefined &&
+    downloadProgress.max !== undefined &&
+    downloadProgress.max > 0
+  ) {
+    downloadProgressPercent = Math.min(
+      100,
+      Math.max(0, Math.round((downloadProgress.value / downloadProgress.max) * 100)),
+    );
+    downloadProgressBarWidth = `${downloadProgressPercent}%`;
+  }
+  const downloadProgressValueProps =
+    downloadProgressPercent === null
+      ? {}
+      : {
+          "aria-valuemin": 0,
+          "aria-valuemax": 100,
+          "aria-valuenow": downloadProgressPercent,
+        };
+
   const {
     attributes,
     listeners,
@@ -209,6 +233,35 @@ export function SortableTrackRow({
                 error: {track.downloadError}
               </span>
             )}
+          {track.downloadStatus === "downloading" && (
+            <div className="pl-7 flex items-center gap-2" aria-live="polite">
+              <div
+                role="progressbar"
+                aria-label={`download progress for ${track.filename}`}
+                aria-valuetext={downloadProgress?.label ?? "downloading"}
+                {...downloadProgressValueProps}
+                className="h-1 flex-1 overflow-hidden rounded-full bg-muted"
+              >
+                <div
+                  className={cn(
+                    "h-full rounded-full bg-primary",
+                    downloadProgressPercent === null ? "animate-pulse" : "",
+                  )}
+                  style={{ width: downloadProgressBarWidth }}
+                />
+              </div>
+              <span className="shrink-0 text-[11px] text-muted-foreground">
+                {downloadProgress?.label}
+                {downloadProgress && !downloadProgress.label && downloadProgressPercent !== null
+                  ? `${downloadProgressPercent}%`
+                  : ""}
+                {downloadProgress && !downloadProgress.label && downloadProgressPercent === null
+                  ? "downloading"
+                  : ""}
+                {!downloadProgress && "downloading"}
+              </span>
+            </div>
+          )}
         </div>
       </Button>
       {retryable && (

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -5,11 +5,12 @@ import { useRef, useState } from "react";
 import { Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import AlbumSidebar from "./AlbumSidebar";
-import { AlbumGroup, TagiumFile } from "./types";
+import { AlbumGroup, AudioProgress, TagiumFile } from "./types";
 import { Button } from "../ui/button";
 
 interface TagSidebarPanelProps {
   loading: boolean;
+  exportProgress?: AudioProgress;
   files: TagiumFile[];
   albums: AlbumGroup[];
   looseTrackIds: string[];
@@ -47,6 +48,7 @@ interface TagSidebarPanelProps {
 
 export default function TagSidebarPanel({
   loading,
+  exportProgress,
   files,
   albums,
   looseTrackIds,
@@ -75,6 +77,28 @@ export default function TagSidebarPanel({
   const dragCounterRef = useRef(0);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
   const canDownloadAll = files.length > 0 && files.every((file) => file.file && file.metadata);
+  let exportProgressPercent: number | null = null;
+  let exportProgressBarWidth = "100%";
+  if (
+    exportProgress &&
+    exportProgress.value !== undefined &&
+    exportProgress.max !== undefined &&
+    exportProgress.max > 0
+  ) {
+    exportProgressPercent = Math.min(
+      100,
+      Math.max(0, Math.round((exportProgress.value / exportProgress.max) * 100)),
+    );
+    exportProgressBarWidth = `${exportProgressPercent}%`;
+  }
+  const exportProgressValueProps =
+    exportProgressPercent === null
+      ? {}
+      : {
+          "aria-valuemin": 0,
+          "aria-valuemax": 100,
+          "aria-valuenow": exportProgressPercent,
+        };
 
   const isFileDrag = (event: React.DragEvent<HTMLDivElement>) =>
     event.dataTransfer.types.includes("Files");
@@ -137,6 +161,7 @@ export default function TagSidebarPanel({
       </div>
 
       <AlbumSidebar
+        downloadDisabled={loading}
         albums={albums}
         looseTrackIds={looseTrackIds}
         files={files}
@@ -164,6 +189,29 @@ export default function TagSidebarPanel({
         <Button className="w-full" onClick={onDownloadAll} disabled={!canDownloadAll || loading}>
           {loading ? "downloading..." : "download all"}
         </Button>
+        {exportProgress && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground" aria-live="polite">
+            <div
+              role="progressbar"
+              aria-label="export progress"
+              aria-valuetext={exportProgress.label ?? "exporting"}
+              {...exportProgressValueProps}
+              className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted"
+            >
+              <div
+                className={`h-full rounded-full bg-primary ${exportProgressPercent === null ? "animate-pulse" : ""}`}
+                style={{ width: exportProgressBarWidth }}
+              />
+            </div>
+            <span className="shrink-0">
+              {exportProgress.label}
+              {!exportProgress.label && exportProgressPercent !== null
+                ? `${exportProgressPercent}%`
+                : ""}
+              {!exportProgress.label && exportProgressPercent === null ? "exporting" : ""}
+            </span>
+          </div>
+        )}
         <Button
           variant="outline"
           className={cn(

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -53,6 +53,30 @@ export default function TrackMetadataEditor({
     );
   }
 
+  const downloadProgress = selectedFile.downloadProgress;
+  let downloadProgressPercent: number | null = null;
+  let downloadProgressBarWidth = "100%";
+  if (
+    downloadProgress &&
+    downloadProgress.value !== undefined &&
+    downloadProgress.max !== undefined &&
+    downloadProgress.max > 0
+  ) {
+    downloadProgressPercent = Math.min(
+      100,
+      Math.max(0, Math.round((downloadProgress.value / downloadProgress.max) * 100)),
+    );
+    downloadProgressBarWidth = `${downloadProgressPercent}%`;
+  }
+  const downloadProgressValueProps =
+    downloadProgressPercent === null
+      ? {}
+      : {
+          "aria-valuemin": 0,
+          "aria-valuemax": 100,
+          "aria-valuenow": downloadProgressPercent,
+        };
+
   return (
     <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
       <form
@@ -162,6 +186,32 @@ export default function TrackMetadataEditor({
                     "download failed"}
                 </div>
               </div>
+              {selectedFile.downloadStatus === "downloading" && (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <div
+                    role="progressbar"
+                    aria-label={`download progress for ${selectedFile.filename}`}
+                    aria-valuetext={downloadProgress?.label ?? "downloading"}
+                    {...downloadProgressValueProps}
+                    className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted"
+                  >
+                    <div
+                      className={`h-full rounded-full bg-primary ${downloadProgressPercent === null ? "animate-pulse" : ""}`}
+                      style={{ width: downloadProgressBarWidth }}
+                    />
+                  </div>
+                  <span className="shrink-0" aria-live="polite" aria-atomic="true">
+                    {downloadProgress?.label}
+                    {downloadProgress && !downloadProgress.label && downloadProgressPercent !== null
+                      ? `${downloadProgressPercent}%`
+                      : ""}
+                    {downloadProgress && !downloadProgress.label && downloadProgressPercent === null
+                      ? "downloading"
+                      : ""}
+                    {!downloadProgress && "downloading"}
+                  </span>
+                </div>
+              )}
               <div className="flex min-h-0 flex-1 items-center justify-center gap-2 pt-1 lg:flex-none lg:justify-end lg:pt-2">
                 <Button
                   type="button"

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -4,7 +4,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } fr
 import { SubmitHandler, useForm } from "react-hook-form";
 import filenamify from "filenamify";
 import AlbumMetadataDialog, { AlbumMetadataDraft } from "./AlbumMetadataDialog";
-import { downloadCobaltAudio } from "./cobaltDownload";
+import { downloadCobaltAudio, type CobaltDownloadProgress } from "./cobaltDownload";
 import {
   createAlbumFromTracks,
   mergeUploadedTracksIntoAlbums,
@@ -28,6 +28,7 @@ import {
   downloadBlob,
   getLibraryDownloadEntries,
 } from "./downloadLibrary";
+import type { CreateZipProgress } from "./downloadLibrary";
 import TagSidebarPanel from "./TagSidebarPanel";
 import LandingScreen from "./LandingScreen";
 import TrackMetadataEditor from "./TrackMetadataEditor";
@@ -42,7 +43,14 @@ import {
 } from "./mp3Utils";
 import { DEFAULT_APP_SETTINGS } from "./settings";
 import type { SoundCloudSet } from "./soundcloudSet";
-import { AlbumGroup, AppSettings, AudioMetadata, ImportedAlbumMetadata, TagiumFile } from "./types";
+import {
+  AlbumGroup,
+  AppSettings,
+  AudioMetadata,
+  AudioProgress,
+  ImportedAlbumMetadata,
+  TagiumFile,
+} from "./types";
 
 type ActiveView = "editor" | "settings";
 
@@ -59,6 +67,35 @@ const filenameFromTitle = (title: string) => {
   const filename = filenamify(title.trim(), { replacement: "-" });
   if (filename) return `${filename}.mp3`;
   return "downloading-track.mp3";
+};
+const audioProgressFromCobaltProgress = (progress: CobaltDownloadProgress): AudioProgress => {
+  if (progress.phase === "processing") {
+    return { label: "processing audio" };
+  }
+
+  if (progress.totalBytes) {
+    return {
+      value: progress.receivedBytes,
+      max: progress.totalBytes,
+    };
+  }
+
+  return { label: "downloading audio" };
+};
+const zipProgressLabel = (progress: CreateZipProgress, scope: string) => {
+  if (progress.phase === "zipping") {
+    return `${scope}: creating zip`;
+  }
+
+  let phase: string = progress.phase;
+  if (progress.phase === "reading") {
+    phase = "reading files";
+  }
+  if (progress.phase === "complete") {
+    phase = "zip ready";
+  }
+
+  return `${scope}: ${phase} ${progress.entriesProcessed}/${progress.totalEntries}`;
 };
 const titleFromSourceUrl = (sourceUrl: string) => {
   try {
@@ -109,6 +146,7 @@ const createPendingDownloadTrack = (
   filename: `${metadata.filename}.mp3`,
   status: "pending",
   downloadStatus: "downloading",
+  downloadProgress: { label: "queued" },
   downloadRequest,
   hasBufferedChanges,
   metadata,
@@ -144,6 +182,8 @@ export default function AudioTagger() {
   const [selectedFileIds, setSelectedFileIds] = useState<Set<string>>(new Set());
   const [lastSelectedFileId, setLastSelectedFileId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [exportProgress, setExportProgress] = useState<AudioProgress | undefined>();
+  const loadingRef = useRef(false);
   const [albumDialogOpen, setAlbumDialogOpen] = useState(false);
   const [albumDialogMode, setAlbumDialogMode] = useState<"create" | "edit">("create");
   const [albumDraft, setAlbumDraft] = useState<AlbumMetadataDraft>(EMPTY_ALBUM_DRAFT);
@@ -553,6 +593,20 @@ export default function AudioTagger() {
     filesRef.current = nextFiles;
     setFiles(nextFiles);
   };
+  const updateTrackDownloadProgress = (fileId: string, progress: AudioProgress) => {
+    const nextFiles = filesRef.current.map((file) =>
+      file.id === fileId ? { ...file, downloadProgress: progress } : file,
+    );
+    filesRef.current = nextFiles;
+    setFiles(nextFiles);
+  };
+  const clearTrackDownloadProgress = (fileId: string) => {
+    const nextFiles = filesRef.current.map((file) =>
+      file.id === fileId ? { ...file, downloadProgress: undefined } : file,
+    );
+    filesRef.current = nextFiles;
+    setFiles(nextFiles);
+  };
   const markDownloadError = (fileId: string, error: unknown) => {
     let message = "download failed.";
     if (error instanceof Error) {
@@ -564,6 +618,7 @@ export default function AudioTagger() {
             ...file,
             status: "error" as const,
             downloadStatus: "error" as const,
+            downloadProgress: undefined,
             downloadError: message,
           }
         : file,
@@ -571,7 +626,12 @@ export default function AudioTagger() {
     filesRef.current = nextFiles;
     setFiles(nextFiles);
   };
-  const hydrateDownloadedTrack = async (fileId: string, downloadedFile: File) => {
+  const hydrateDownloadedTrack = async (
+    fileId: string,
+    downloadedFile: File,
+    onProgress?: (progress: AudioProgress) => void,
+  ) => {
+    onProgress?.({ label: "reading metadata" });
     const [parsedUpload] = await parseUploadedTracks([downloadedFile]);
     if (!parsedUpload) {
       throw new Error("downloaded track could not be parsed.");
@@ -593,6 +653,7 @@ export default function AudioTagger() {
 
     if (metadataToWrite) {
       try {
+        onProgress?.({ label: "writing metadata" });
         const updatedFile = await writeMetadataToFile(hydratedFile, metadataToWrite);
         const latestFile = filesRef.current.find((file) => file.id === fileId);
         if (!latestFile) return;
@@ -631,6 +692,7 @@ export default function AudioTagger() {
     setActiveView("editor");
     const id = crypto.randomUUID();
     const title = titleFromSourceUrl(sourceUrl);
+    const downloadRequest = { sourceUrl, audioBitrate: settings.audioBitrate };
     const pendingFile = createPendingDownloadTrack(
       id,
       createDownloadMetadata({
@@ -640,7 +702,7 @@ export default function AudioTagger() {
         genre: "",
       }),
       false,
-      { sourceUrl, audioBitrate: settings.audioBitrate },
+      downloadRequest,
     );
     const nextFiles = [...filesRef.current, pendingFile];
     filesRef.current = nextFiles;
@@ -652,14 +714,19 @@ export default function AudioTagger() {
     setLastSelectedFileId(id);
 
     void (async () => {
+      updateTrackDownloadProgress(id, { label: "starting download" });
       try {
-        const downloadedFile = await downloadCobaltAudio({
-          sourceUrl,
-          audioBitrate: settings.audioBitrate,
+        const downloadedFile = await downloadCobaltAudio(downloadRequest, {
+          onProgress: (progress) =>
+            updateTrackDownloadProgress(id, audioProgressFromCobaltProgress(progress)),
         });
-        await hydrateDownloadedTrack(id, downloadedFile);
+        await hydrateDownloadedTrack(id, downloadedFile, (progress) =>
+          updateTrackDownloadProgress(id, progress),
+        );
       } catch (error) {
         markDownloadError(id, error);
+      } finally {
+        clearTrackDownloadProgress(id);
       }
     })();
   };
@@ -750,14 +817,30 @@ export default function AudioTagger() {
       const track = set.tracks[index];
       if (!track) return;
       void (async () => {
+        updateTrackDownloadProgress(pendingFile.id, {
+          label: `queued track ${index + 1}/${pendingFiles.length}`,
+        });
         try {
-          const downloadedFile = await downloadCobaltAudio({
-            sourceUrl: track.url,
-            audioBitrate: settings.audioBitrate,
-          });
-          await hydrateDownloadedTrack(pendingFile.id, downloadedFile);
+          const downloadedFile = await downloadCobaltAudio(
+            {
+              sourceUrl: track.url,
+              audioBitrate: settings.audioBitrate,
+            },
+            {
+              onProgress: (progress) =>
+                updateTrackDownloadProgress(
+                  pendingFile.id,
+                  audioProgressFromCobaltProgress(progress),
+                ),
+            },
+          );
+          await hydrateDownloadedTrack(pendingFile.id, downloadedFile, (progress) =>
+            updateTrackDownloadProgress(pendingFile.id, progress),
+          );
         } catch (error) {
           markDownloadError(pendingFile.id, error);
+        } finally {
+          clearTrackDownloadProgress(pendingFile.id);
         }
       })();
     });
@@ -773,6 +856,7 @@ export default function AudioTagger() {
             ...file,
             status: "pending" as const,
             downloadStatus: "downloading" as const,
+            downloadProgress: { label: "retrying download" },
             downloadError: undefined,
           }
         : file,
@@ -781,20 +865,32 @@ export default function AudioTagger() {
     setFiles(nextFiles);
 
     void (async () => {
+      updateTrackDownloadProgress(fileId, { label: "retrying download" });
       try {
-        const downloadedFile = await downloadCobaltAudio(downloadRequest);
-        await hydrateDownloadedTrack(fileId, downloadedFile);
+        const downloadedFile = await downloadCobaltAudio(downloadRequest, {
+          onProgress: (progress) =>
+            updateTrackDownloadProgress(fileId, audioProgressFromCobaltProgress(progress)),
+        });
+        await hydrateDownloadedTrack(fileId, downloadedFile, (progress) =>
+          updateTrackDownloadProgress(fileId, progress),
+        );
       } catch (error) {
         markDownloadError(fileId, error);
+      } finally {
+        clearTrackDownloadProgress(fileId);
       }
     })();
   };
   const handleDownloadAll = async () => {
     if (files.length === 0) return;
     if (!allTracksReadyForDownload(filesRef.current)) return;
+    if (loading || loadingRef.current) return;
+    loadingRef.current = true;
     setLoading(true);
+    setExportProgress({ label: "preparing download all" });
     try {
       const syncedFiles = prepareFilesForExport();
+      setExportProgress({ label: "writing download all tags" });
       await writeFilesForExport(syncedFiles);
 
       const entries = getLibraryDownloadEntries({
@@ -804,11 +900,20 @@ export default function AudioTagger() {
       });
       if (entries.length === 0) return;
 
-      const blob = await createZipBlob(entries);
+      const blob = await createZipBlob(entries, (progress: CreateZipProgress) => {
+        setExportProgress({
+          value: progress.entriesProcessed,
+          max: progress.totalEntries,
+          label: zipProgressLabel(progress, "download all"),
+        });
+      });
+      setExportProgress({ label: "saving download all" });
       downloadBlob(blob, createLibraryDownloadFilename());
     } catch (error) {
       console.error("error downloading all files:", error);
     } finally {
+      setExportProgress(undefined);
+      loadingRef.current = false;
       setLoading(false);
     }
   };
@@ -851,9 +956,12 @@ export default function AudioTagger() {
     reader.readAsArrayBuffer(file);
   };
   const handleDownloadAlbum = async (albumId: string) => {
+    if (loading || loadingRef.current) return;
     const album = albumsRef.current.find((a) => a.id === albumId);
     if (!album) return;
+    loadingRef.current = true;
     setLoading(true);
+    setExportProgress({ label: `preparing ${album.title}` });
     try {
       const syncedFiles = prepareFilesForExport([albumId]);
       const albumFiles = album.trackIds
@@ -862,6 +970,7 @@ export default function AudioTagger() {
           Boolean(file?.file && file.metadata),
         );
       if (albumFiles.length !== album.trackIds.length) return;
+      setExportProgress({ label: `writing ${album.title} tags` });
       await writeFilesForExport(albumFiles);
 
       const entries = getLibraryDownloadEntries({
@@ -873,8 +982,15 @@ export default function AudioTagger() {
       });
       if (entries.length === 0) return;
 
-      const blob = await createZipBlob(entries);
+      const blob = await createZipBlob(entries, (progress: CreateZipProgress) => {
+        setExportProgress({
+          value: progress.entriesProcessed,
+          max: progress.totalEntries,
+          label: zipProgressLabel(progress, album.title),
+        });
+      });
       const albumFilename = filenamify(album.title, { replacement: "-" });
+      setExportProgress({ label: `saving ${album.title}` });
       if (albumFilename) {
         downloadBlob(blob, `${albumFilename}.zip`);
         return;
@@ -883,20 +999,31 @@ export default function AudioTagger() {
     } catch (error) {
       console.error("error downloading album:", error);
     } finally {
+      setExportProgress(undefined);
+      loadingRef.current = false;
       setLoading(false);
     }
   };
   const handleDownloadUpdatedFile: SubmitHandler<AudioMetadata> = async (data) => {
     if (!selectedFile) return;
+    if (loading || loadingRef.current) return;
     const fileId = selectedFile.id;
     const submittedData = getSubmittedMetadata(data);
+    loadingRef.current = true;
+    setLoading(true);
+    setExportProgress({ label: `writing ${selectedFile.filename}` });
     try {
       await handleTagUpdate(selectedFile, submittedData);
       const updatedFile = filesRef.current.find((file) => file.id === fileId);
       if (!updatedFile?.file) return;
+      setExportProgress({ label: `saving ${updatedFile.filename}` });
       downloadBlob(updatedFile.file, updatedFile.filename);
     } catch (error) {
       console.error("failed to update tags before download:", error);
+    } finally {
+      setExportProgress(undefined);
+      loadingRef.current = false;
+      setLoading(false);
     }
   };
   const handleRemoveFile = (idToRemove: string) => {
@@ -1347,6 +1474,7 @@ export default function AudioTagger() {
       <div className="min-h-screen flex flex-col bg-background md:h-screen md:flex-row md:overflow-hidden">
         <TagSidebarPanel
           loading={loading}
+          exportProgress={exportProgress}
           files={files}
           albums={albums}
           looseTrackIds={looseTrackIds}

--- a/components/audio/cobaltDownload.ts
+++ b/components/audio/cobaltDownload.ts
@@ -29,6 +29,20 @@ interface CobaltAudioDownloadRequest {
   audioBitrate: AudioDownloadBitrate;
 }
 
+export type CobaltDownloadProgress =
+  | {
+      phase: "download";
+      receivedBytes: number;
+      totalBytes?: number;
+    }
+  | {
+      phase: "processing";
+    };
+
+export interface CobaltDownloadOptions {
+  onProgress?: (progress: CobaltDownloadProgress) => void;
+}
+
 interface MP3TagPicture {
   format: string;
   type: number;
@@ -110,7 +124,13 @@ const makeAudioArgs = (plan: Extract<CobaltDownloadPlan, { status: "local-proces
   return ffargs;
 };
 
-const fetchTunnelFile = async (url: string, filename: string, lastModified: number) => {
+export const fetchTunnelFile = async (
+  url: string,
+  filename: string,
+  lastModified: number,
+  options: CobaltDownloadOptions = {},
+) => {
+  const { onProgress } = options;
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(await response.text());
@@ -120,7 +140,38 @@ const fetchTunnelFile = async (url: string, filename: string, lastModified: numb
   if (!contentType) {
     contentType = "application/octet-stream";
   }
-  const blob = await response.blob();
+  let totalBytes: number | undefined;
+  const contentLength = response.headers.get("Content-Length");
+  if (contentLength) {
+    const parsedContentLength = Number(contentLength);
+    if (Number.isFinite(parsedContentLength) && parsedContentLength > 0) {
+      totalBytes = parsedContentLength;
+    }
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error("cobalt tunnel response was empty.");
+  }
+
+  let receivedBytes = 0;
+  const chunks: ArrayBuffer[] = [];
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) {
+      break;
+    }
+
+    receivedBytes += chunk.value.byteLength;
+    chunks.push(new Uint8Array(chunk.value).buffer);
+    onProgress?.({
+      phase: "download",
+      receivedBytes,
+      totalBytes,
+    });
+  }
+
+  const blob = new Blob(chunks, { type: contentType });
   if (blob.size === 0) {
     throw new Error("cobalt tunnel response was empty.");
   }
@@ -172,10 +223,49 @@ const runLocalProcessingWorker = async (
 const processLocalAudio = async (
   plan: Extract<CobaltDownloadPlan, { status: "local-processing" }>,
   lastModified: number,
+  options: CobaltDownloadOptions,
 ) => {
+  const { onProgress } = options;
+  const receivedBytes = plan.tunnel.map(() => 0);
+  const totalBytes = plan.tunnel.map(() => undefined as number | undefined);
+  const progressForTunnel = (index: number) => (progress: CobaltDownloadProgress) => {
+    if (progress.phase === "processing") {
+      return;
+    }
+
+    receivedBytes[index] = progress.receivedBytes;
+    totalBytes[index] = progress.totalBytes;
+
+    const totalReceivedBytes = receivedBytes.reduce((sum, value) => sum + value, 0);
+    let aggregateTotalBytes = 0;
+    for (const tunnelTotalBytes of totalBytes) {
+      if (!tunnelTotalBytes) {
+        onProgress?.({
+          phase: "download",
+          receivedBytes: totalReceivedBytes,
+        });
+        return;
+      }
+
+      aggregateTotalBytes += tunnelTotalBytes;
+    }
+
+    onProgress?.({
+      phase: "download",
+      receivedBytes: totalReceivedBytes,
+      totalBytes: aggregateTotalBytes,
+    });
+  };
+
   const inputFiles = await Promise.all(
-    plan.tunnel.map((url, index) => fetchTunnelFile(url, `input-${index}`, lastModified)),
+    plan.tunnel.map((url, index) =>
+      fetchTunnelFile(url, `input-${index}`, lastModified, {
+        onProgress: progressForTunnel(index),
+      }),
+    ),
   );
+  onProgress?.({ phase: "processing" });
+
   const outputFormat = plan.output.filename.split(".").pop();
   if (!outputFormat) {
     throw new Error("cobalt local processing response missing output format.");
@@ -256,7 +346,10 @@ const tagCobaltAudioFile = async (
   });
 };
 
-export async function downloadCobaltAudio({ sourceUrl, audioBitrate }: CobaltAudioDownloadRequest) {
+export async function downloadCobaltAudio(
+  { sourceUrl, audioBitrate }: CobaltAudioDownloadRequest,
+  options: CobaltDownloadOptions = {},
+) {
   const response = await fetch("/api/cobalt/audio", {
     method: "POST",
     headers: {
@@ -277,8 +370,8 @@ export async function downloadCobaltAudio({ sourceUrl, audioBitrate }: CobaltAud
   const lastModified = getStableLastModified(sourceUrl);
 
   if (plan.status === "local-processing") {
-    return await processLocalAudio(plan, lastModified);
+    return await processLocalAudio(plan, lastModified, options);
   }
 
-  return await fetchTunnelFile(plan.url, plan.filename, lastModified);
+  return await fetchTunnelFile(plan.url, plan.filename, lastModified, options);
 }

--- a/components/audio/downloadLibrary.test.ts
+++ b/components/audio/downloadLibrary.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   allTracksReadyForDownload,
+  createZipBlob,
   createLibraryDownloadFilename,
   getLibraryDownloadEntries,
 } from "./downloadLibrary";
+import type { CreateZipProgress } from "./downloadLibrary";
 import type { AlbumGroup, AudioMetadata, TagiumFile } from "./types";
 
 const metadata = (filename: string): AudioMetadata => ({
@@ -62,6 +64,56 @@ describe("downloadLibrary", () => {
     expect(createLibraryDownloadFilename(new Date(2026, 0, 2, 3, 4, 5))).toBe(
       "tagium-download-20260102-030405.zip",
     );
+  });
+
+  it("reports indeterminate zip progress before the zip is complete", async () => {
+    const entries = [
+      { path: "albums/Album/first.mp3", file: new File(["abc"], "first.mp3") },
+      { path: "singles/second.mp3", file: new File(["defg"], "second.mp3") },
+    ];
+    const progress: CreateZipProgress[] = [];
+
+    const blob = await createZipBlob(entries, (nextProgress) => {
+      progress.push(nextProgress);
+    });
+
+    const { strFromU8, unzipSync } = await import("fflate");
+    const zipEntries = unzipSync(new Uint8Array(await blob.arrayBuffer()));
+    const readingProgress = progress.filter((entry) => entry.phase === "reading");
+    const zippingProgress = progress.find((entry) => entry.phase === "zipping");
+
+    expect(blob.type).toBe("application/zip");
+    expect(strFromU8(zipEntries["albums/Album/first.mp3"])).toBe("abc");
+    expect(strFromU8(zipEntries["singles/second.mp3"])).toBe("defg");
+    expect(progress.map((entry) => entry.phase)).toEqual([
+      "reading",
+      "reading",
+      "zipping",
+      "complete",
+    ]);
+    expect(readingProgress).toHaveLength(2);
+    expect(readingProgress.map((entry) => entry.entriesProcessed)).toEqual([1, 2]);
+    expect(readingProgress[readingProgress.length - 1]).toMatchObject({
+      bytesProcessed: 7,
+      totalBytes: 7,
+    });
+    expect(new Set(readingProgress.map((entry) => entry.currentEntry))).toEqual(
+      new Set(["albums/Album/first.mp3", "singles/second.mp3"]),
+    );
+    expect(zippingProgress).toMatchObject({
+      phase: "zipping",
+      entriesProcessed: 0,
+      totalEntries: 0,
+      bytesProcessed: 0,
+      totalBytes: 0,
+    });
+    expect(progress[progress.length - 1]).toMatchObject({
+      phase: "complete",
+      entriesProcessed: 2,
+      totalEntries: 2,
+      bytesProcessed: 7,
+      totalBytes: 7,
+    });
   });
 
   it("builds album and singles entries in sidebar order", () => {

--- a/components/audio/downloadLibrary.ts
+++ b/components/audio/downloadLibrary.ts
@@ -6,6 +6,17 @@ export interface DownloadZipEntry {
   file: File;
 }
 
+export interface CreateZipProgress {
+  phase: "reading" | "zipping" | "complete";
+  entriesProcessed: number;
+  totalEntries: number;
+  bytesProcessed: number;
+  totalBytes: number;
+  currentEntry?: string;
+}
+
+export type CreateZipProgressCallback = (progress: CreateZipProgress) => void;
+
 export const allTracksReadyForDownload = (files: TagiumFile[]) =>
   files.every((file) => Boolean(file.file && file.metadata));
 
@@ -39,14 +50,45 @@ const createZipData = async (entries: Record<string, [Uint8Array, { level: 0 }]>
   });
 };
 
-export async function createZipBlob(entries: DownloadZipEntry[]) {
+export async function createZipBlob(
+  entries: DownloadZipEntry[],
+  onProgress?: CreateZipProgressCallback,
+) {
   const zipEntries: Record<string, [Uint8Array, { level: 0 }]> = {};
+  const totalBytes = entries.reduce((total, entry) => total + entry.file.size, 0);
+  let entriesProcessed = 0;
+  let bytesProcessed = 0;
+
   await Promise.all(
     entries.map(async (entry) => {
       zipEntries[entry.path] = [new Uint8Array(await entry.file.arrayBuffer()), { level: 0 }];
+      entriesProcessed++;
+      bytesProcessed += entry.file.size;
+      onProgress?.({
+        phase: "reading",
+        entriesProcessed,
+        totalEntries: entries.length,
+        bytesProcessed,
+        totalBytes,
+        currentEntry: entry.path,
+      });
     }),
   );
+  onProgress?.({
+    phase: "zipping",
+    entriesProcessed: 0,
+    totalEntries: 0,
+    bytesProcessed: 0,
+    totalBytes: 0,
+  });
   const data = await createZipData(zipEntries);
+  onProgress?.({
+    phase: "complete",
+    entriesProcessed,
+    totalEntries: entries.length,
+    bytesProcessed,
+    totalBytes,
+  });
   return new Blob([data.buffer as ArrayBuffer], { type: "application/zip" });
 }
 

--- a/components/audio/types.ts
+++ b/components/audio/types.ts
@@ -24,12 +24,19 @@ export const audioMetadataSchema = z.object({
 
 export type AudioMetadata = z.infer<typeof audioMetadataSchema>;
 
+export interface AudioProgress {
+  value?: number;
+  max?: number;
+  label?: string;
+}
+
 export interface TagiumFile {
   id: string;
   file?: File;
   originalFile?: File;
   status: "pending" | "saved" | "error";
   downloadStatus: "downloading" | "ready" | "error";
+  downloadProgress?: AudioProgress;
   downloadError?: string;
   downloadRequest?: {
     sourceUrl: string;

--- a/fly.cobalt.toml
+++ b/fly.cobalt.toml
@@ -14,9 +14,9 @@ YOUTUBE_GENERATE_PO_TOKENS = "0"
 [http_service]
 internal_port = 9000
 force_https = true
-auto_stop_machines = false
+auto_stop_machines = "suspend"
 auto_start_machines = true
-min_machines_running = 1
+min_machines_running = 0
 processes = ["app"]
 
 [[vm]]

--- a/server-tests/cobalt/tunnel.get.test.ts
+++ b/server-tests/cobalt/tunnel.get.test.ts
@@ -57,6 +57,27 @@ describe("cobalt tunnel endpoint", () => {
     expect(await response.text()).toBe("audio-bytes");
   });
 
+  it("preserves upstream content-length when available", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response("audio-bytes", {
+          headers: {
+            "Content-Length": "11",
+            "Content-Type": "audio/mpeg",
+          },
+        });
+      }),
+    );
+
+    const response = await handler(makeEvent(makeTunnelRequest()));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("audio/mpeg");
+    expect(response.headers.get("Content-Length")).toBe("11");
+    expect(await response.text()).toBe("audio-bytes");
+  });
+
   it("rejects empty successful Cobalt tunnel responses", async () => {
     vi.stubGlobal(
       "fetch",

--- a/server/api/cobalt/audio.post.ts
+++ b/server/api/cobalt/audio.post.ts
@@ -84,7 +84,7 @@ type CloudflareRequest = Request & {
 };
 
 const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX_REQUESTS = 120;
+const RATE_LIMIT_MAX_REQUESTS = 60;
 const COBALT_REQUEST_TIMEOUT_MS = 300_000;
 const rateLimitBuckets = new Map<string, { startedAt: number; count: number }>();
 

--- a/server/api/cobalt/tunnel.get.ts
+++ b/server/api/cobalt/tunnel.get.ts
@@ -100,6 +100,10 @@ export default defineHandler(async (event) => {
     if (contentType) {
       headers.set("Content-Type", contentType);
     }
+    const contentLength = response.headers.get("content-length");
+    if (contentLength && contentLength !== "0") {
+      headers.set("Content-Length", contentLength);
+    }
 
     return new Response(body, { headers });
   } catch (error) {


### PR DESCRIPTION
## Summary
- add streamed Cobalt tunnel progress with forwarded `Content-Length`
- show per-track download progress in sidebar rows and selected-track editor
- show export progress for download-all, album zip, and updated-file downloads
- guard concurrent exports so global export progress cannot interleave

## Validation
- `vp fmt`
- `vp lint .`
- `vp check`
- `vp test run`
- antagonistic review pass 2: no findings
