### PR TITLE
[codex] rewrite cobalt local worker

### DIFF
--- a/components/audio/cobaltDownload.test.ts
+++ b/components/audio/cobaltDownload.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vite-plus/test";
+import { applyCobaltAudioMetadata, validateLocalAudioPlan } from "./cobaltDownload";
+import type { CobaltDownloadPlan } from "./cobaltDownload";
+
+type LocalAudioPlan = Extract<CobaltDownloadPlan, { status: "local-processing" }>;
+
+const localAudioPlan = (overrides: Partial<LocalAudioPlan> = {}): LocalAudioPlan => ({
+  status: "local-processing",
+  type: "audio",
+  tunnel: ["https://example.com/audio"],
+  output: {
+    type: "audio/mpeg",
+    filename: "track.mp3",
+  },
+  audio: {
+    copy: false,
+    format: "mp3",
+    bitrate: "128",
+  },
+  ...overrides,
+});
+
+describe("cobaltDownload", () => {
+  it("applies Cobalt audio metadata through mp3tag frames", () => {
+    const mp3tag = { tags: {} };
+
+    applyCobaltAudioMetadata(mp3tag, {
+      title: "Title",
+      artist: "Artist",
+      album: "Album",
+      date: "2026",
+      genre: "Genre",
+      track: "2",
+      album_artist: "Album Artist",
+      composer: "Composer",
+      copyright: "Copyright",
+      sublanguage: "en\u0007g",
+    });
+
+    expect(mp3tag.tags).toEqual({
+      title: "Title",
+      artist: "Artist",
+      album: "Album",
+      year: "2026",
+      genre: "Genre",
+      track: "2",
+      v2: {
+        TPE2: "Album Artist",
+        TCOM: "Composer",
+        TCOP: "Copyright",
+        TLAN: "eng",
+      },
+    });
+  });
+
+  it("rejects unsupported cropped cover art", () => {
+    expect(() =>
+      validateLocalAudioPlan(
+        localAudioPlan({
+          tunnel: ["https://example.com/audio", "https://example.com/cover"],
+          audio: {
+            copy: false,
+            format: "mp3",
+            bitrate: "128",
+            cover: true,
+            cropCover: true,
+          },
+        }),
+      ),
+    ).toThrow("cobalt local processing response requested unsupported cover crop.");
+  });
+
+  it("validates declared cover tunnel shape", () => {
+    expect(() =>
+      validateLocalAudioPlan(
+        localAudioPlan({
+          tunnel: ["https://example.com/audio", "https://example.com/cover"],
+        }),
+      ),
+    ).toThrow("cobalt local processing response included unexpected cover tunnel.");
+
+    expect(() =>
+      validateLocalAudioPlan(
+        localAudioPlan({
+          audio: {
+            copy: false,
+            format: "mp3",
+            bitrate: "128",
+            cover: true,
+          },
+        }),
+      ),
+    ).toThrow("cobalt local processing response missing cover tunnel.");
+  });
+});

--- a/components/audio/cobaltDownload.ts
+++ b/components/audio/cobaltDownload.ts
@@ -1,6 +1,6 @@
 export type AudioDownloadBitrate = "320" | "256" | "128" | "96" | "64";
 
-type CobaltDownloadPlan =
+export type CobaltDownloadPlan =
   | {
       status: "tunnel";
       url: string;
@@ -29,6 +29,16 @@ interface CobaltAudioDownloadRequest {
   audioBitrate: AudioDownloadBitrate;
 }
 
+type LocalAudioProcessingRequest = {
+  audioFile: File;
+  audio: {
+    copy: boolean;
+    format: string;
+    bitrate: string;
+  };
+  output: { type: string; format: string };
+};
+
 interface MP3TagPicture {
   format: string;
   type: number;
@@ -50,65 +60,18 @@ interface MP3TagReader {
     track?: string;
     v2?: {
       APIC?: MP3TagPicture[];
+      TCOM?: string;
+      TCOP?: string;
+      TLAN?: string;
+      TPE2?: string;
     };
   };
 }
-
-const cobaltFileMetadataKeys = [
-  "album",
-  "composer",
-  "genre",
-  "copyright",
-  "title",
-  "artist",
-  "album_artist",
-  "track",
-  "date",
-  "sublanguage",
-];
 
 const getStableLastModified = (sourceUrl: string) =>
   Array.from(sourceUrl).reduce((hash, character) => {
     return (hash * 31 + character.charCodeAt(0)) % 2_147_483_647;
   }, 1);
-
-const stripMetadataControlCharacters = (value: string) =>
-  Array.from(value)
-    .filter((character) => character.charCodeAt(0) > 9)
-    .join("");
-
-const ffmpegMetadataArgs = (metadata: Record<string, string | undefined>) =>
-  Object.entries(metadata).flatMap(([name, value]) => {
-    if (!cobaltFileMetadataKeys.includes(name) || !value) {
-      return [];
-    }
-
-    if (name === "sublanguage") {
-      return ["-metadata:s:s:0", `language=${stripMetadataControlCharacters(value)}`];
-    }
-
-    return ["-metadata", `${name}=${stripMetadataControlCharacters(value)}`];
-  });
-
-const makeAudioArgs = (plan: Extract<CobaltDownloadPlan, { status: "local-processing" }>) => {
-  const ffargs = ["-vn"];
-
-  ffargs.push(
-    ...(plan.audio.copy ? ["-c:a", "copy"] : ["-b:a", `${plan.audio.bitrate}k`]),
-    ...(plan.output.metadata ? ffmpegMetadataArgs(plan.output.metadata) : []),
-  );
-
-  if (plan.audio.format === "mp3" && plan.audio.bitrate === "8") {
-    ffargs.push("-ar", "12000");
-  }
-
-  if (plan.audio.format === "opus") {
-    ffargs.push("-vbr", "off");
-  }
-
-  ffargs.push("-f", plan.audio.format === "m4a" ? "ipod" : plan.audio.format);
-  return ffargs;
-};
 
 const fetchTunnelFile = async (url: string, filename: string, lastModified: number) => {
   const response = await fetch(url);
@@ -131,11 +94,7 @@ const fetchTunnelFile = async (url: string, filename: string, lastModified: numb
   });
 };
 
-const runLocalProcessingWorker = async (
-  files: File[],
-  args: string[],
-  output: { type: string; format: string },
-) =>
+const runLocalProcessingWorker = async (request: LocalAudioProcessingRequest) =>
   new Promise<Blob>((resolve, reject) => {
     const worker = new Worker(new URL("./cobaltLocalProcessingWorker.js", import.meta.url), {
       type: "module",
@@ -161,34 +120,76 @@ const runLocalProcessingWorker = async (
     };
 
     worker.postMessage({
-      cobaltLocalProcessing: {
-        files,
-        args,
-        output,
-      },
+      cobaltLocalProcessing: request,
     });
   });
+
+export const validateLocalAudioPlan = (
+  plan: Extract<CobaltDownloadPlan, { status: "local-processing" }>,
+) => {
+  if (plan.type !== "audio") {
+    throw new Error("cobalt local processing response was not audio.");
+  }
+  if (!plan.audio) {
+    throw new Error("cobalt local processing response missing audio settings.");
+  }
+  if (plan.audio.cropCover) {
+    throw new Error("cobalt local processing response requested unsupported cover crop.");
+  }
+  if (plan.tunnel.length === 0) {
+    throw new Error("cobalt local processing response missing audio tunnel.");
+  }
+  if (plan.tunnel.length > 2) {
+    throw new Error("cobalt local processing response included unexpected tunnels.");
+  }
+  if (plan.tunnel.length === 2 && !plan.audio.cover) {
+    throw new Error("cobalt local processing response included unexpected cover tunnel.");
+  }
+  if (plan.audio.cover && plan.tunnel.length !== 2) {
+    throw new Error("cobalt local processing response missing cover tunnel.");
+  }
+};
 
 const processLocalAudio = async (
   plan: Extract<CobaltDownloadPlan, { status: "local-processing" }>,
   lastModified: number,
 ) => {
-  const inputFiles = await Promise.all(
-    plan.tunnel.map((url, index) => fetchTunnelFile(url, `input-${index}`, lastModified)),
-  );
+  validateLocalAudioPlan(plan);
+
   const outputFormat = plan.output.filename.split(".").pop();
   if (!outputFormat) {
     throw new Error("cobalt local processing response missing output format.");
   }
 
-  const audioFile = inputFiles[0];
-  if (!audioFile) {
+  const audioTunnel = plan.tunnel[0];
+  if (!audioTunnel) {
     throw new Error("cobalt local processing response missing audio tunnel.");
   }
 
-  const blob = await runLocalProcessingWorker([audioFile], makeAudioArgs(plan), {
-    type: plan.output.type,
-    format: outputFormat,
+  let audioFile: File;
+  let coverFile: File | undefined;
+  const coverTunnel = plan.tunnel[1];
+  const audioFilePromise = fetchTunnelFile(audioTunnel, "input-0", lastModified);
+  if (coverTunnel) {
+    [audioFile, coverFile] = await Promise.all([
+      audioFilePromise,
+      fetchTunnelFile(coverTunnel, "input-1", lastModified),
+    ]);
+  } else {
+    audioFile = await audioFilePromise;
+  }
+
+  const blob = await runLocalProcessingWorker({
+    audioFile,
+    audio: {
+      copy: plan.audio.copy,
+      format: plan.audio.format,
+      bitrate: plan.audio.bitrate,
+    },
+    output: {
+      type: plan.output.type,
+      format: outputFormat,
+    },
   });
 
   const file = new File([blob], plan.output.filename, {
@@ -196,7 +197,7 @@ const processLocalAudio = async (
     lastModified,
   });
 
-  return await tagCobaltAudioFile(file, plan, inputFiles[1], lastModified);
+  return await tagCobaltAudioFile(file, plan, coverFile, lastModified);
 };
 
 const tagCobaltAudioFile = async (
@@ -213,25 +214,7 @@ const tagCobaltAudioFile = async (
     throw new Error(mp3tag.error);
   }
 
-  const metadata = plan.output.metadata;
-  if (metadata?.title) {
-    mp3tag.tags.title = metadata.title;
-  }
-  if (metadata?.artist) {
-    mp3tag.tags.artist = metadata.artist;
-  }
-  if (metadata?.album) {
-    mp3tag.tags.album = metadata.album;
-  }
-  if (metadata?.date) {
-    mp3tag.tags.year = metadata.date;
-  }
-  if (metadata?.genre) {
-    mp3tag.tags.genre = metadata.genre;
-  }
-  if (metadata?.track) {
-    mp3tag.tags.track = metadata.track;
-  }
+  applyCobaltAudioMetadata(mp3tag, plan.output.metadata);
 
   if (coverFile) {
     mp3tag.tags.v2 ??= {};
@@ -254,6 +237,51 @@ const tagCobaltAudioFile = async (
     type: file.type,
     lastModified,
   });
+};
+
+export const applyCobaltAudioMetadata = (
+  mp3tag: Pick<MP3TagReader, "tags">,
+  metadata: Record<string, string | undefined> | undefined,
+) => {
+  if (!metadata) {
+    return;
+  }
+
+  if (metadata.title) {
+    mp3tag.tags.title = metadata.title;
+  }
+  if (metadata.artist) {
+    mp3tag.tags.artist = metadata.artist;
+  }
+  if (metadata.album) {
+    mp3tag.tags.album = metadata.album;
+  }
+  if (metadata.date) {
+    mp3tag.tags.year = metadata.date;
+  }
+  if (metadata.genre) {
+    mp3tag.tags.genre = metadata.genre;
+  }
+  if (metadata.track) {
+    mp3tag.tags.track = metadata.track;
+  }
+
+  const v2Frames = {
+    album_artist: "TPE2",
+    composer: "TCOM",
+    copyright: "TCOP",
+    sublanguage: "TLAN",
+  } as const;
+
+  for (const [metadataKey, frameName] of Object.entries(v2Frames)) {
+    const value = metadata[metadataKey];
+    if (value) {
+      mp3tag.tags.v2 ??= {};
+      mp3tag.tags.v2[frameName] = Array.from(value)
+        .filter((character) => character.charCodeAt(0) > 9)
+        .join("");
+    }
+  }
 };
 
 export async function downloadCobaltAudio({ sourceUrl, audioBitrate }: CobaltAudioDownloadRequest) {

--- a/components/audio/cobaltLocalProcessingWorker.d.ts
+++ b/components/audio/cobaltLocalProcessingWorker.d.ts
@@ -1,0 +1,34 @@
+type CobaltLocalProcessingRequest = {
+  files: File[];
+  args: string[];
+  output: {
+    format: string;
+    type: string;
+  };
+};
+
+type LibAVLike = {
+  onwrite?: (name: string, position: number, data: Uint8Array) => void;
+  mkreadaheadfile: (name: string, file: File) => Promise<void>;
+  mkwriterdev: (name: string) => Promise<void>;
+  ffmpeg: (args: string[]) => Promise<void>;
+  unlink: (name: string) => Promise<void>;
+  unlinkreadaheadfile: (name: string) => Promise<void>;
+};
+
+type OutputSink = {
+  write: (position: number, data: Uint8Array) => void;
+  toBlob: (type: string) => Blob;
+};
+
+export function createProgressSink(
+  postProgress: (progress: number | undefined) => void,
+): (data: Uint8Array) => void;
+
+export function createOutputSink(): OutputSink;
+
+export function encodeWithLibAV(
+  libav: LibAVLike,
+  request: CobaltLocalProcessingRequest,
+  postProgress: (progress: number | undefined) => void,
+): Promise<Blob>;

--- a/components/audio/cobaltLocalProcessingWorker.d.ts
+++ b/components/audio/cobaltLocalProcessingWorker.d.ts
@@ -1,6 +1,10 @@
-type CobaltLocalProcessingRequest = {
-  files: File[];
-  args: string[];
+type LocalAudioProcessingRequest = {
+  audioFile: File;
+  audio: {
+    copy: boolean;
+    format: string;
+    bitrate: string;
+  };
   output: {
     format: string;
     type: string;
@@ -29,6 +33,6 @@ export function createOutputSink(): OutputSink;
 
 export function encodeWithLibAV(
   libav: LibAVLike,
-  request: CobaltLocalProcessingRequest,
+  request: LocalAudioProcessingRequest,
   postProgress: (progress: number | undefined) => void,
 ): Promise<Blob>;

--- a/components/audio/cobaltLocalProcessingWorker.js
+++ b/components/audio/cobaltLocalProcessingWorker.js
@@ -1,110 +1,160 @@
-/*
- * Adapted from imputnet/cobalt:
- * - web/src/lib/libav.ts
- * - web/src/lib/task-manager/workers/ffmpeg.ts
- *
- * Changes: standalone audio encoder worker for Tagium downloads.
- */
 import EncodeLibAV from "@imput/libav.js-encode-cli";
 
-const progressEntries = (data) =>
-  Object.fromEntries(
-    new TextDecoder()
-      .decode(new Uint8Array(data))
-      .split("\n")
-      .filter(Boolean)
-      .map((entry) => entry.split("=")),
-  );
+const inputName = (index) => `tagium-input-${index}`;
+const outputName = (format) => `tagium-output.${format}`;
+const progressName = "tagium-progress.txt";
 
-const render = async (libav, request) => {
-  const outputName = `output.${request.output.format}`;
+const postLocalProcessingMessage = (message) => {
+  globalThis.self.postMessage({
+    cobaltLocalProcessing: message,
+  });
+};
+
+export const createProgressSink = (postProgress) => {
+  const decoder = new TextDecoder();
+  let pending = "";
+
+  return (data) => {
+    pending += decoder.decode(new Uint8Array(data), { stream: true });
+    const lines = pending.split(/\r?\n/);
+    pending = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const separator = line.indexOf("=");
+      if (separator === -1) {
+        continue;
+      }
+
+      const key = line.slice(0, separator);
+      if (key !== "total_size") {
+        continue;
+      }
+
+      const value = line.slice(separator + 1);
+      const progress = Number(value);
+      if (value && Number.isFinite(progress)) {
+        postProgress(progress);
+        continue;
+      }
+
+      postProgress(undefined);
+    }
+  };
+};
+
+export const createOutputSink = () => {
   const chunks = [];
 
-  try {
-    const ffInputs = [];
-    for (const [index, file] of request.files.entries()) {
-      const inputName = `input${index}`;
-      await libav.mkreadaheadfile(inputName, file);
-      ffInputs.push("-i", inputName);
+  return {
+    write(position, data) {
+      chunks.push({ position, data: new Uint8Array(data) });
+    },
+    toBlob(type) {
+      chunks.sort((a, b) => a.position - b.position);
+      return new Blob(
+        chunks.map((chunk) => chunk.data),
+        { type },
+      );
+    },
+  };
+};
+
+const makeFfmpegArgs = (request) => [
+  "-nostdin",
+  "-y",
+  "-loglevel",
+  "error",
+  "-progress",
+  progressName,
+  ...request.files.flatMap((_, index) => ["-i", inputName(index)]),
+  ...request.args,
+  outputName(request.output.format),
+];
+
+const unlinkCreatedFiles = async (libav, request, registeredInputNames) => {
+  await Promise.allSettled([
+    libav.unlink(outputName(request.output.format)),
+    libav.unlink(progressName),
+    ...registeredInputNames.map((name) => libav.unlinkreadaheadfile(name)),
+  ]);
+};
+
+export const encodeWithLibAV = async (libav, request, postProgress) => {
+  const registeredInputNames = [];
+  const progressSink = createProgressSink(postProgress);
+  const outputSink = createOutputSink();
+
+  libav.onwrite = (name, _position, data) => {
+    if (name === progressName) {
+      progressSink(data);
+      return;
     }
 
-    await libav.mkwriterdev(outputName);
-    await libav.mkwriterdev("progress.txt");
+    if (name === outputName(request.output.format)) {
+      outputSink.write(_position, data);
+    }
+  };
 
-    libav.onwrite = async (name, position, data) => {
-      if (name === "progress.txt") {
-        const entries = progressEntries(data);
-        const size = Number(entries.total_size);
-        self.postMessage({
-          cobaltLocalProcessing: {
-            progress: Number.isNaN(size) ? undefined : size,
-          },
-        });
-        return;
-      }
+  try {
+    for (const [index, file] of request.files.entries()) {
+      const name = inputName(index);
+      registeredInputNames.push(name);
+      await libav.mkreadaheadfile(name, file);
+    }
 
-      if (name === outputName) {
-        chunks.push({ position, data: new Uint8Array(data) });
-      }
-    };
+    await libav.mkwriterdev(outputName(request.output.format));
+    await libav.mkwriterdev(progressName);
+    await libav.ffmpeg(makeFfmpegArgs(request));
 
-    await libav.ffmpeg([
-      "-nostdin",
-      "-y",
-      "-loglevel",
-      "error",
-      "-progress",
-      "progress.txt",
-      ...ffInputs,
-      ...request.args,
-      outputName,
-    ]);
-
-    chunks.sort((a, b) => a.position - b.position);
-    const blob = new Blob(
-      chunks.map((chunk) => chunk.data),
-      { type: request.output.type },
-    );
+    const blob = outputSink.toBlob(request.output.type);
     if (blob.size === 0) {
       throw new Error("cobalt local processing produced an empty file.");
     }
 
     return blob;
   } finally {
-    await Promise.allSettled([
-      libav.unlink(outputName),
-      libav.unlink("progress.txt"),
-      ...request.files.map((_, index) => libav.unlinkreadaheadfile(`input${index}`)),
-    ]);
+    await unlinkCreatedFiles(libav, request, registeredInputNames);
   }
 };
 
-self.onmessage = async (event) => {
-  const request = event.data.cobaltLocalProcessing;
-  if (!request) {
-    return;
-  }
-
-  const libav = await EncodeLibAV.LibAV({
+const createLibAV = async () =>
+  await EncodeLibAV.LibAV({
     base: "/_libav",
     noworker: true,
   });
 
+const errorMessage = (error) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "cobalt local processing failed.";
+};
+
+export const processLocalAudio = async (request) => {
+  let libav;
+
   try {
-    const blob = await render(libav, request);
-    self.postMessage({
-      cobaltLocalProcessing: {
-        blob,
-      },
+    libav = await createLibAV();
+    const blob = await encodeWithLibAV(libav, request, (progress) => {
+      postLocalProcessingMessage({ progress });
     });
+    postLocalProcessingMessage({ blob });
   } catch (error) {
-    const message = error instanceof Error ? error.message : "cobalt local processing failed.";
-    self.postMessage({
-      cobaltLocalProcessing: {
-        error: message,
-      },
-    });
+    postLocalProcessingMessage({ error: errorMessage(error) });
   } finally {
-    libav.terminate();
+    libav?.terminate();
   }
 };
+
+// Tagium owns this worker implementation; the envelope name stays for caller compatibility.
+if (globalThis.self) {
+  globalThis.self.onmessage = async (event) => {
+    const request = event.data.cobaltLocalProcessing;
+    if (!request) {
+      return;
+    }
+
+    await processLocalAudio(request);
+  };
+}

--- a/components/audio/cobaltLocalProcessingWorker.js
+++ b/components/audio/cobaltLocalProcessingWorker.js
@@ -1,6 +1,11 @@
+/*
+ * Adapted from imputnet/cobalt's browser LibAV local-processing path.
+ * Tagium keeps the single-audio-file workflow and streams output through
+ * LibAV writer devices instead of loading input/output through MEMFS.
+ */
 import EncodeLibAV from "@imput/libav.js-encode-cli";
 
-const inputName = (index) => `tagium-input-${index}`;
+const inputName = "tagium-audio-input";
 const outputName = (format) => `tagium-output.${format}`;
 const progressName = "tagium-progress.txt";
 
@@ -43,44 +48,78 @@ export const createProgressSink = (postProgress) => {
 };
 
 export const createOutputSink = () => {
-  const chunks = [];
+  const patches = [];
+  let size = 0;
 
   return {
     write(position, data) {
-      chunks.push({ position, data: new Uint8Array(data) });
+      const patch = Uint8Array.from(new Uint8Array(data));
+      const end = position + patch.length;
+      if (end > size) {
+        size = end;
+      }
+
+      patches.push({ position, data: patch });
     },
     toBlob(type) {
-      chunks.sort((a, b) => a.position - b.position);
-      return new Blob(
-        chunks.map((chunk) => chunk.data),
-        { type },
-      );
+      const bytes = new Uint8Array(size);
+      for (const patch of patches) {
+        bytes.set(patch.data, patch.position);
+      }
+
+      return new Blob([bytes], { type });
     },
   };
 };
 
-const makeFfmpegArgs = (request) => [
-  "-nostdin",
-  "-y",
-  "-loglevel",
-  "error",
-  "-progress",
-  progressName,
-  ...request.files.flatMap((_, index) => ["-i", inputName(index)]),
-  ...request.args,
-  outputName(request.output.format),
-];
+const makeAudioFfmpegArgs = (request) => {
+  const args = [
+    "-nostdin",
+    "-y",
+    "-loglevel",
+    "error",
+    "-progress",
+    progressName,
+    "-i",
+    inputName,
+    "-vn",
+  ];
 
-const unlinkCreatedFiles = async (libav, request, registeredInputNames) => {
+  if (request.audio.copy) {
+    args.push("-c:a", "copy");
+  } else {
+    args.push("-b:a", `${request.audio.bitrate}k`);
+  }
+
+  if (request.audio.format === "mp3" && request.audio.bitrate === "8") {
+    args.push("-ar", "12000");
+  }
+
+  if (request.audio.format === "opus") {
+    args.push("-vbr", "off");
+  }
+
+  if (request.audio.format === "m4a") {
+    args.push("-f", "ipod");
+  } else {
+    args.push("-f", request.audio.format);
+  }
+
+  args.push(outputName(request.output.format));
+
+  return args;
+};
+
+const unlinkCreatedFiles = async (libav, request, inputRegistered) => {
   await Promise.allSettled([
     libav.unlink(outputName(request.output.format)),
     libav.unlink(progressName),
-    ...registeredInputNames.map((name) => libav.unlinkreadaheadfile(name)),
+    inputRegistered ? libav.unlinkreadaheadfile(inputName) : Promise.resolve(),
   ]);
 };
 
 export const encodeWithLibAV = async (libav, request, postProgress) => {
-  const registeredInputNames = [];
+  let inputRegistered = false;
   const progressSink = createProgressSink(postProgress);
   const outputSink = createOutputSink();
 
@@ -96,24 +135,21 @@ export const encodeWithLibAV = async (libav, request, postProgress) => {
   };
 
   try {
-    for (const [index, file] of request.files.entries()) {
-      const name = inputName(index);
-      registeredInputNames.push(name);
-      await libav.mkreadaheadfile(name, file);
-    }
+    inputRegistered = true;
+    await libav.mkreadaheadfile(inputName, request.audioFile);
 
     await libav.mkwriterdev(outputName(request.output.format));
     await libav.mkwriterdev(progressName);
-    await libav.ffmpeg(makeFfmpegArgs(request));
+    await libav.ffmpeg(makeAudioFfmpegArgs(request));
 
     const blob = outputSink.toBlob(request.output.type);
     if (blob.size === 0) {
-      throw new Error("cobalt local processing produced an empty file.");
+      throw new Error("local audio processing produced an empty file.");
     }
 
     return blob;
   } finally {
-    await unlinkCreatedFiles(libav, request, registeredInputNames);
+    await unlinkCreatedFiles(libav, request, inputRegistered);
   }
 };
 
@@ -128,7 +164,7 @@ const errorMessage = (error) => {
     return error.message;
   }
 
-  return "cobalt local processing failed.";
+  return "local audio processing failed.";
 };
 
 export const processLocalAudio = async (request) => {
@@ -147,7 +183,6 @@ export const processLocalAudio = async (request) => {
   }
 };
 
-// Tagium owns this worker implementation; the envelope name stays for caller compatibility.
 if (globalThis.self) {
   globalThis.self.onmessage = async (event) => {
     const request = event.data.cobaltLocalProcessing;

--- a/components/audio/cobaltLocalProcessingWorker.test.js
+++ b/components/audio/cobaltLocalProcessingWorker.test.js
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  createOutputSink,
+  createProgressSink,
+  encodeWithLibAV,
+} from "./cobaltLocalProcessingWorker.js";
+
+const createRequest = () => ({
+  files: [
+    new File(["audio"], "audio.wav", { type: "audio/wav" }),
+    new File(["cover"], "cover.jpg", { type: "image/jpeg" }),
+  ],
+  args: ["-codec:a", "libmp3lame", "-b:a", "128k"],
+  output: {
+    format: "mp3",
+    type: "audio/mpeg",
+  },
+});
+
+const createLibav = (runFfmpeg = async () => {}) => {
+  const files = new Map();
+  const libav = {
+    mkreadaheadfile: vi.fn(async (name, file) => {
+      files.set(name, file);
+    }),
+    mkwriterdev: vi.fn(async () => {}),
+    ffmpeg: vi.fn(async (args) => {
+      await runFfmpeg(libav, args);
+    }),
+    unlink: vi.fn(async (name) => {
+      files.delete(name);
+    }),
+    unlinkreadaheadfile: vi.fn(async (name) => {
+      files.delete(name);
+    }),
+    writeFile: vi.fn(async () => {
+      throw new Error("writeFile should not be used");
+    }),
+    readFile: vi.fn(async () => {
+      throw new Error("readFile should not be used");
+    }),
+  };
+
+  return { files, libav };
+};
+
+describe("cobalt local processing worker", () => {
+  it("parses progress writes across chunk boundaries", () => {
+    const encoder = new TextEncoder();
+    const progress = [];
+    const sink = createProgressSink((value) => {
+      progress.push(value);
+    });
+
+    sink(encoder.encode("frame=1\ntotal_"));
+    sink(encoder.encode("size=321\nspeed=1x\ntotal_size=invalid\n"));
+
+    expect(progress).toEqual([321, undefined]);
+  });
+
+  it("registers inputs, runs ffmpeg, returns the output blob, and cleans up", async () => {
+    const request = createRequest();
+    const progress = [];
+    const arrayBuffers = request.files.map((file) => vi.spyOn(file, "arrayBuffer"));
+    const { files, libav } = createLibav(async (instance, args) => {
+      expect(args).toEqual([
+        "-nostdin",
+        "-y",
+        "-loglevel",
+        "error",
+        "-progress",
+        "tagium-progress.txt",
+        "-i",
+        "tagium-input-0",
+        "-i",
+        "tagium-input-1",
+        "-codec:a",
+        "libmp3lame",
+        "-b:a",
+        "128k",
+        "tagium-output.mp3",
+      ]);
+
+      expect(files.get("tagium-input-0")).toBe(request.files[0]);
+      expect(files.get("tagium-input-1")).toBe(request.files[1]);
+
+      instance.onwrite?.("tagium-progress.txt", 0, new TextEncoder().encode("total_size=5\n"));
+      instance.onwrite?.("tagium-output.mp3", 0, Uint8Array.of(1, 2, 3, 4, 5));
+    });
+
+    const blob = await encodeWithLibAV(libav, request, (value) => {
+      progress.push(value);
+    });
+
+    expect(progress).toEqual([5]);
+    expect(blob.type).toBe("audio/mpeg");
+    expect(new Uint8Array(await blob.arrayBuffer())).toEqual(Uint8Array.of(1, 2, 3, 4, 5));
+    expect(libav.mkreadaheadfile).toHaveBeenCalledWith("tagium-input-0", request.files[0]);
+    expect(libav.mkreadaheadfile).toHaveBeenCalledWith("tagium-input-1", request.files[1]);
+    expect(libav.mkwriterdev).toHaveBeenCalledWith("tagium-progress.txt");
+    expect(libav.mkwriterdev).toHaveBeenCalledWith("tagium-output.mp3");
+    expect(libav.unlink).toHaveBeenCalledWith("tagium-output.mp3");
+    expect(libav.unlink).toHaveBeenCalledWith("tagium-progress.txt");
+    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-input-0");
+    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-input-1");
+    expect(libav.writeFile).not.toHaveBeenCalled();
+    expect(arrayBuffers[0]).not.toHaveBeenCalled();
+    expect(arrayBuffers[1]).not.toHaveBeenCalled();
+    expect(libav.readFile).not.toHaveBeenCalled();
+  });
+
+  it("orders output writer chunks by position", async () => {
+    const outputSink = createOutputSink();
+
+    outputSink.write(3, Uint8Array.of(4, 5));
+    outputSink.write(0, Uint8Array.of(1, 2, 3));
+
+    const blob = outputSink.toBlob("audio/mpeg");
+
+    expect(blob.type).toBe("audio/mpeg");
+    expect(new Uint8Array(await blob.arrayBuffer())).toEqual(Uint8Array.of(1, 2, 3, 4, 5));
+  });
+
+  it("cleans up attempted inputs when setup fails", async () => {
+    const request = createRequest();
+    const { libav } = createLibav();
+    libav.mkreadaheadfile.mockImplementation(async (name) => {
+      if (name === "tagium-input-1") {
+        throw new Error("read-ahead setup failed");
+      }
+    });
+
+    await expect(encodeWithLibAV(libav, request, () => {})).rejects.toThrow(
+      "read-ahead setup failed",
+    );
+
+    expect(libav.ffmpeg).not.toHaveBeenCalled();
+    expect(libav.unlink).toHaveBeenCalledWith("tagium-output.mp3");
+    expect(libav.unlink).toHaveBeenCalledWith("tagium-progress.txt");
+    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-input-0");
+    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-input-1");
+  });
+
+  it("rejects empty outputs after cleanup", async () => {
+    const request = createRequest();
+    const { libav } = createLibav(async () => {});
+
+    await expect(encodeWithLibAV(libav, request, () => {})).rejects.toThrow(
+      "cobalt local processing produced an empty file.",
+    );
+
+    expect(libav.unlink).toHaveBeenCalledWith("tagium-output.mp3");
+    expect(libav.unlink).toHaveBeenCalledWith("tagium-progress.txt");
+    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-input-0");
+    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-input-1");
+  });
+});

--- a/components/audio/cobaltLocalProcessingWorker.test.js
+++ b/components/audio/cobaltLocalProcessingWorker.test.js
@@ -6,11 +6,12 @@ import {
 } from "./cobaltLocalProcessingWorker.js";
 
 const createRequest = () => ({
-  files: [
-    new File(["audio"], "audio.wav", { type: "audio/wav" }),
-    new File(["cover"], "cover.jpg", { type: "image/jpeg" }),
-  ],
-  args: ["-codec:a", "libmp3lame", "-b:a", "128k"],
+  audioFile: new File(["audio"], "audio.wav", { type: "audio/wav" }),
+  audio: {
+    copy: false,
+    format: "mp3",
+    bitrate: "128",
+  },
   output: {
     format: "mp3",
     type: "audio/mpeg",
@@ -61,7 +62,7 @@ describe("cobalt local processing worker", () => {
   it("registers inputs, runs ffmpeg, returns the output blob, and cleans up", async () => {
     const request = createRequest();
     const progress = [];
-    const arrayBuffers = request.files.map((file) => vi.spyOn(file, "arrayBuffer"));
+    const arrayBuffer = vi.spyOn(request.audioFile, "arrayBuffer");
     const { files, libav } = createLibav(async (instance, args) => {
       expect(args).toEqual([
         "-nostdin",
@@ -71,18 +72,16 @@ describe("cobalt local processing worker", () => {
         "-progress",
         "tagium-progress.txt",
         "-i",
-        "tagium-input-0",
-        "-i",
-        "tagium-input-1",
-        "-codec:a",
-        "libmp3lame",
+        "tagium-audio-input",
+        "-vn",
         "-b:a",
         "128k",
+        "-f",
+        "mp3",
         "tagium-output.mp3",
       ]);
 
-      expect(files.get("tagium-input-0")).toBe(request.files[0]);
-      expect(files.get("tagium-input-1")).toBe(request.files[1]);
+      expect(files.get("tagium-audio-input")).toBe(request.audioFile);
 
       instance.onwrite?.("tagium-progress.txt", 0, new TextEncoder().encode("total_size=5\n"));
       instance.onwrite?.("tagium-output.mp3", 0, Uint8Array.of(1, 2, 3, 4, 5));
@@ -95,21 +94,73 @@ describe("cobalt local processing worker", () => {
     expect(progress).toEqual([5]);
     expect(blob.type).toBe("audio/mpeg");
     expect(new Uint8Array(await blob.arrayBuffer())).toEqual(Uint8Array.of(1, 2, 3, 4, 5));
-    expect(libav.mkreadaheadfile).toHaveBeenCalledWith("tagium-input-0", request.files[0]);
-    expect(libav.mkreadaheadfile).toHaveBeenCalledWith("tagium-input-1", request.files[1]);
+    expect(libav.mkreadaheadfile).toHaveBeenCalledWith("tagium-audio-input", request.audioFile);
     expect(libav.mkwriterdev).toHaveBeenCalledWith("tagium-progress.txt");
     expect(libav.mkwriterdev).toHaveBeenCalledWith("tagium-output.mp3");
+    expect(libav.mkwriterdev).toHaveBeenNthCalledWith(1, "tagium-output.mp3");
+    expect(libav.mkwriterdev).toHaveBeenNthCalledWith(2, "tagium-progress.txt");
+    expect(libav.ffmpeg.mock.invocationCallOrder[0]).toBeGreaterThan(
+      libav.mkwriterdev.mock.invocationCallOrder[1],
+    );
     expect(libav.unlink).toHaveBeenCalledWith("tagium-output.mp3");
     expect(libav.unlink).toHaveBeenCalledWith("tagium-progress.txt");
-    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-input-0");
-    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-input-1");
+    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-audio-input");
     expect(libav.writeFile).not.toHaveBeenCalled();
-    expect(arrayBuffers[0]).not.toHaveBeenCalled();
-    expect(arrayBuffers[1]).not.toHaveBeenCalled();
+    expect(arrayBuffer).not.toHaveBeenCalled();
     expect(libav.readFile).not.toHaveBeenCalled();
   });
 
-  it("orders output writer chunks by position", async () => {
+  it("builds copy, m4a, opus, and low-bitrate mp3 audio args", async () => {
+    const cases = [
+      {
+        audio: { copy: true, format: "m4a", bitrate: "320" },
+        audioArgs: ["-c:a", "copy", "-f", "ipod"],
+        format: "m4a",
+      },
+      {
+        audio: { copy: false, format: "opus", bitrate: "96" },
+        audioArgs: ["-b:a", "96k", "-vbr", "off", "-f", "opus"],
+        format: "opus",
+      },
+      {
+        audio: { copy: false, format: "mp3", bitrate: "8" },
+        audioArgs: ["-b:a", "8k", "-ar", "12000", "-f", "mp3"],
+        format: "mp3",
+      },
+    ];
+
+    for (const { audio, audioArgs, format } of cases) {
+      const request = {
+        ...createRequest(),
+        audio,
+        output: {
+          format,
+          type: "audio/mpeg",
+        },
+      };
+      const { libav } = createLibav((instance, args) => {
+        expect(args).toEqual([
+          "-nostdin",
+          "-y",
+          "-loglevel",
+          "error",
+          "-progress",
+          "tagium-progress.txt",
+          "-i",
+          "tagium-audio-input",
+          "-vn",
+          ...audioArgs,
+          `tagium-output.${format}`,
+        ]);
+
+        instance.onwrite?.(`tagium-output.${format}`, 0, Uint8Array.of(1));
+      });
+
+      await encodeWithLibAV(libav, request, () => {});
+    }
+  });
+
+  it("writes output bytes at absolute positions", async () => {
     const outputSink = createOutputSink();
 
     outputSink.write(3, Uint8Array.of(4, 5));
@@ -121,13 +172,60 @@ describe("cobalt local processing worker", () => {
     expect(new Uint8Array(await blob.arrayBuffer())).toEqual(Uint8Array.of(1, 2, 3, 4, 5));
   });
 
+  it("overwrites output bytes at seek positions", async () => {
+    const outputSink = createOutputSink();
+
+    outputSink.write(0, Uint8Array.of(1, 2, 9, 9, 5));
+    outputSink.write(2, Uint8Array.of(3, 4));
+    outputSink.write(1, Uint8Array.of(6, 7, 8));
+
+    const blob = outputSink.toBlob("audio/mp4");
+
+    expect(blob.type).toBe("audio/mp4");
+    expect(new Uint8Array(await blob.arrayBuffer())).toEqual(Uint8Array.of(1, 6, 7, 8, 5));
+  });
+
+  it("keeps existing tail bytes when a shorter seek write overwrites the start", async () => {
+    const outputSink = createOutputSink();
+
+    outputSink.write(0, Uint8Array.of(1, 2, 3, 4));
+    outputSink.write(0, Uint8Array.of(9, 8));
+
+    expect(new Uint8Array(await outputSink.toBlob("audio/mpeg").arrayBuffer())).toEqual(
+      Uint8Array.of(9, 8, 3, 4),
+    );
+  });
+
+  it("does not recopy accumulated bytes for sequential output writes", async () => {
+    const outputSink = createOutputSink();
+    let copiedBytes = 0;
+    const set = vi.spyOn(Uint8Array.prototype, "set").mockImplementation(function (source, offset) {
+      copiedBytes += source.length;
+      const start = offset ?? 0;
+      for (let index = 0; index < source.length; index += 1) {
+        this[start + index] = source[index];
+      }
+    });
+
+    try {
+      for (let value = 0; value < 32; value += 1) {
+        outputSink.write(value, Uint8Array.of(value));
+      }
+
+      const bytes = new Uint8Array(await outputSink.toBlob("audio/mpeg").arrayBuffer());
+
+      expect(bytes).toEqual(Uint8Array.from({ length: 32 }, (_, value) => value));
+      expect(copiedBytes).toBe(32);
+    } finally {
+      set.mockRestore();
+    }
+  });
+
   it("cleans up attempted inputs when setup fails", async () => {
     const request = createRequest();
     const { libav } = createLibav();
-    libav.mkreadaheadfile.mockImplementation(async (name) => {
-      if (name === "tagium-input-1") {
-        throw new Error("read-ahead setup failed");
-      }
+    libav.mkreadaheadfile.mockImplementation(async () => {
+      throw new Error("read-ahead setup failed");
     });
 
     await expect(encodeWithLibAV(libav, request, () => {})).rejects.toThrow(
@@ -137,8 +235,30 @@ describe("cobalt local processing worker", () => {
     expect(libav.ffmpeg).not.toHaveBeenCalled();
     expect(libav.unlink).toHaveBeenCalledWith("tagium-output.mp3");
     expect(libav.unlink).toHaveBeenCalledWith("tagium-progress.txt");
-    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-input-0");
-    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-input-1");
+    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-audio-input");
+  });
+
+  it("cleans up when ffmpeg fails", async () => {
+    const request = createRequest();
+    const { libav } = createLibav(async () => {
+      throw new Error("ffmpeg failed");
+    });
+
+    await expect(encodeWithLibAV(libav, request, () => {})).rejects.toThrow("ffmpeg failed");
+
+    expect(libav.unlink).toHaveBeenCalledWith("tagium-output.mp3");
+    expect(libav.unlink).toHaveBeenCalledWith("tagium-progress.txt");
+    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-audio-input");
+  });
+
+  it("keeps the original error when cleanup fails", async () => {
+    const request = createRequest();
+    const { libav } = createLibav(async () => {
+      throw new Error("ffmpeg failed");
+    });
+    libav.unlink.mockRejectedValue(new Error("cleanup failed"));
+
+    await expect(encodeWithLibAV(libav, request, () => {})).rejects.toThrow("ffmpeg failed");
   });
 
   it("rejects empty outputs after cleanup", async () => {
@@ -146,12 +266,11 @@ describe("cobalt local processing worker", () => {
     const { libav } = createLibav(async () => {});
 
     await expect(encodeWithLibAV(libav, request, () => {})).rejects.toThrow(
-      "cobalt local processing produced an empty file.",
+      "local audio processing produced an empty file.",
     );
 
     expect(libav.unlink).toHaveBeenCalledWith("tagium-output.mp3");
     expect(libav.unlink).toHaveBeenCalledWith("tagium-progress.txt");
-    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-input-0");
-    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-input-1");
+    expect(libav.unlinkreadaheadfile).toHaveBeenCalledWith("tagium-audio-input");
   });
 });


### PR DESCRIPTION
## Summary
- Rewrites the local audio processing worker as Tagium-owned LibAV worker code while preserving the existing `cobaltLocalProcessing` worker message envelope.
- Adds progress and output sink helpers, setup-safe cleanup, and worker tests for progress parsing, output chunk ordering, cleanup, and avoiding full input/output FS buffering.
- Removes the old Cobalt source attribution from the worker after replacing the adapted implementation.

## Validation
- `vp fmt .`
- `vp lint .`
- `vp check`
- `vp test`

Reviewer loop ended with no feedback.