### PR TITLE
feat: add managed playlist download queue

### DIFF
--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -120,7 +120,9 @@ export default function AlbumSidebar({
 
   const isRetryableError = (track: TagiumFile) =>
     Boolean(track.downloadRequest) &&
-    (track.downloadStatus === "error" || track.status === "error");
+    (track.downloadStatus === "error" ||
+      track.downloadStatus === "canceled" ||
+      track.status === "error");
   const selectedTone = (trackId: string) => {
     if (selectedFileIds.has(trackId)) return "primary";
     if (selectedFileId === trackId) return "secondary";

--- a/components/audio/AlbumSidebarDnd.tsx
+++ b/components/audio/AlbumSidebarDnd.tsx
@@ -12,6 +12,7 @@ import {
 import { useSortable } from "@dnd-kit/sortable";
 import {
   AlertCircle,
+  Ban,
   Check,
   Download,
   FileMusic,
@@ -202,7 +203,15 @@ export function SortableTrackRow({
                 )}
               />
             )}
+            {track.downloadStatus === "canceled" && (
+              <Ban className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+            )}
           </div>
+          {track.downloadStatus === "canceled" && (
+            <span className="pl-7 text-xs text-muted-foreground truncate" aria-live="polite">
+              canceled
+            </span>
+          )}
           {(track.downloadStatus === "error" || track.status === "error") &&
             track.downloadError && (
               <span className="pl-7 text-xs text-destructive truncate" aria-live="polite">

--- a/components/audio/PlaylistDownloadQueuePanel.tsx
+++ b/components/audio/PlaylistDownloadQueuePanel.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { RefreshCw, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export type PlaylistDownloadQueueStatus = "downloading" | "waiting" | "error" | "canceled";
+
+export interface PlaylistDownloadQueueTrack {
+  id: string;
+  title: string;
+}
+
+export interface PlaylistDownloadQueuePanelState {
+  status: PlaylistDownloadQueueStatus;
+  downloadedCount: number;
+  totalCount: number;
+  failedCount: number;
+  canceledCount: number;
+  currentTracks: PlaylistDownloadQueueTrack[];
+  progress: number;
+  eta?: string;
+  canCancel?: boolean;
+  canRetry?: boolean;
+}
+
+interface PlaylistDownloadQueuePanelProps {
+  queue: PlaylistDownloadQueuePanelState | null;
+  onCancel?: () => void;
+  onRetry?: () => void;
+}
+
+export default function PlaylistDownloadQueuePanel({
+  queue,
+  onCancel,
+  onRetry,
+}: PlaylistDownloadQueuePanelProps) {
+  if (!queue) return null;
+
+  const progress = Math.min(100, Math.max(0, queue.progress));
+  const shownTracks = queue.currentTracks.slice(0, 2);
+  const hiddenTrackCount = queue.currentTracks.length - shownTracks.length;
+  const showCancel = Boolean(onCancel && queue.canCancel !== false);
+  const showRetry = Boolean(onRetry && queue.canRetry !== false);
+  let label = `downloading ${queue.downloadedCount}/${queue.totalCount}`;
+  if (queue.status === "error") {
+    label = `failed ${queue.failedCount}/${queue.totalCount}`;
+  }
+  if (queue.status === "canceled") {
+    label = `canceled ${queue.canceledCount}/${queue.totalCount}`;
+  }
+
+  return (
+    <section className="shrink-0 border-t bg-muted/20 px-3 py-3" aria-live="polite">
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <p className="truncate text-xs font-medium">{label}</p>
+            {queue.eta && (
+              <span className="shrink-0 text-[11px] text-muted-foreground">{queue.eta}</span>
+            )}
+          </div>
+          {queue.status === "waiting" && (
+            <p className="mt-1 truncate text-[11px] text-muted-foreground">
+              waiting for cobalt tunnel budget...
+            </p>
+          )}
+          {queue.status === "canceled" && (
+            <p className="mt-1 truncate text-[11px] text-muted-foreground">
+              remaining tracks canceled
+            </p>
+          )}
+        </div>
+
+        {(showCancel || showRetry) && (
+          <div className="flex shrink-0 items-center gap-1">
+            {showRetry && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                onClick={onRetry}
+                aria-label="retry playlist downloads"
+              >
+                <RefreshCw className="size-3.5" />
+              </Button>
+            )}
+            {showCancel && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                onClick={onCancel}
+                aria-label="cancel playlist downloads"
+              >
+                <X className="size-3.5" />
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {shownTracks.length > 0 && (
+        <div className="mt-2 space-y-1">
+          {shownTracks.map((track) => (
+            <p key={track.id} className="truncate text-xs text-muted-foreground">
+              {track.title}
+            </p>
+          ))}
+          {hiddenTrackCount > 0 && (
+            <p className="text-[11px] text-muted-foreground">+{hiddenTrackCount} more</p>
+          )}
+        </div>
+      )}
+
+      <div
+        className="mt-2 h-1.5 overflow-hidden rounded-full bg-background"
+        role="progressbar"
+        aria-label="playlist download progress"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(progress)}
+      >
+        <div className="h-full bg-primary transition-[width]" style={{ width: `${progress}%` }} />
+      </div>
+
+      {queue.status === "error" && (
+        <p className="mt-2 text-[11px] text-destructive">downloads failed</p>
+      )}
+    </section>
+  );
+}

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -5,6 +5,9 @@ import { useRef, useState } from "react";
 import { Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import AlbumSidebar from "./AlbumSidebar";
+import PlaylistDownloadQueuePanel, {
+  type PlaylistDownloadQueuePanelState,
+} from "./PlaylistDownloadQueuePanel";
 import { AlbumGroup, TagiumFile } from "./types";
 import { Button } from "../ui/button";
 
@@ -41,8 +44,11 @@ interface TagSidebarPanelProps {
   ) => void;
   onPromptCreateAlbumFromLooseTracks: (sourceTrackId: string, targetTrackId: string) => void;
   onReorderAlbums: (albumId: string, targetIndex: number) => void;
+  playlistDownloadQueue?: PlaylistDownloadQueuePanelState | null;
   onDownloadAll: () => void;
   onOpenSettings: () => void;
+  onCancelPlaylistDownloadQueue?: () => void;
+  onRetryPlaylistDownloadQueue?: () => void;
 }
 
 export default function TagSidebarPanel({
@@ -69,8 +75,11 @@ export default function TagSidebarPanel({
   onMoveTrackToLoose,
   onPromptCreateAlbumFromLooseTracks,
   onReorderAlbums,
+  playlistDownloadQueue = null,
   onDownloadAll,
   onOpenSettings,
+  onCancelPlaylistDownloadQueue,
+  onRetryPlaylistDownloadQueue,
 }: TagSidebarPanelProps) {
   const dragCounterRef = useRef(0);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
@@ -158,6 +167,12 @@ export default function TagSidebarPanel({
         onPromptCreateAlbumFromLooseTracks={onPromptCreateAlbumFromLooseTracks}
         onReorderAlbums={onReorderAlbums}
         onAudioUpload={onAudioUpload}
+      />
+
+      <PlaylistDownloadQueuePanel
+        queue={playlistDownloadQueue}
+        onCancel={onCancelPlaylistDownloadQueue}
+        onRetry={onRetryPlaylistDownloadQueue}
       />
 
       <div className="px-3 py-3 border-t flex-shrink-0 flex flex-col gap-2">

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -162,6 +162,9 @@ export default function TrackMetadataEditor({
                   {!selectedFile.file &&
                     selectedFile.downloadStatus === "error" &&
                     "download failed"}
+                  {!selectedFile.file &&
+                    selectedFile.downloadStatus === "canceled" &&
+                    "download canceled"}
                 </div>
               </div>
               <div className="flex min-h-0 flex-1 items-center justify-center gap-2 pt-1 max-lg:[@media(max-height:700px)]:flex-none max-lg:[@media(max-height:700px)]:pt-0 lg:flex-none lg:justify-end lg:pt-2">

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -29,6 +29,25 @@ import {
   getLibraryDownloadEntries,
 } from "./downloadLibrary";
 import TagSidebarPanel from "./TagSidebarPanel";
+import type { PlaylistDownloadQueuePanelState } from "./PlaylistDownloadQueuePanel";
+import {
+  cancelActivePlaylistDownloadTracks,
+  cancelPendingPlaylistDownloadTracks,
+  createPlaylistDownloadQueueRun,
+  derivePlaylistDownloadQueueState,
+  enqueuePlaylistDownloadQueueTracks,
+  finishPlaylistDownloadQueueRunIfIdle,
+  markPlaylistDownloadTrackActive,
+  markPlaylistDownloadTrackCanceled,
+  markPlaylistDownloadTrackCompleted,
+  markPlaylistDownloadTrackFailed,
+  removeActivePlaylistDownloadTrack,
+  reserveNextPlaylistDownloadTrack,
+} from "./playlistDownloadQueueRuntime";
+import type {
+  PlaylistDownloadQueueRun as PlaylistDownloadQueueRuntimeRun,
+  PlaylistDownloadQueueRuntimeSnapshot,
+} from "./playlistDownloadQueueRuntime";
 import LandingScreen from "./LandingScreen";
 import TrackMetadataEditor from "./TrackMetadataEditor";
 import SettingsPage from "./SettingsPage";
@@ -45,6 +64,17 @@ import type { SoundCloudSet } from "./soundcloudSet";
 import { AlbumGroup, AppSettings, AudioMetadata, ImportedAlbumMetadata, TagiumFile } from "./types";
 
 type ActiveView = "editor" | "settings";
+type DownloadRequest = NonNullable<TagiumFile["downloadRequest"]>;
+type ManagedDownloadTrack = {
+  fileId: string;
+  title: string;
+  downloadRequest: DownloadRequest;
+};
+type PlaylistDownloadQueueState = PlaylistDownloadQueueRuntimeSnapshot;
+type PlaylistDownloadQueueRun = PlaylistDownloadQueueRuntimeRun<ManagedDownloadTrack> & {
+  budgetWakeTimeout?: ReturnType<typeof setTimeout>;
+  abortControllers: Map<string, AbortController>;
+};
 
 const EMPTY_ALBUM_DRAFT: AlbumMetadataDraft = {
   title: "",
@@ -53,8 +83,14 @@ const EMPTY_ALBUM_DRAFT: AlbumMetadataDraft = {
   year: undefined,
   cover: undefined,
 };
-const MAX_SOUND_CLOUD_SET_DOWNLOADS = 60;
-const DOWNLOAD_RATE_LIMIT_ERROR = "Download rate limit exceeded.";
+const PLAYLIST_DOWNLOAD_CONCURRENCY = 3;
+const createPlaylistDownloadAbortReason = () =>
+  new DOMException("playlist download canceled.", "AbortError");
+const isPlaylistDownloadAbort = (error: unknown) => {
+  if (error instanceof DOMException && error.name === "AbortError") return true;
+  if (error instanceof Error && error.name === "AbortError") return true;
+  return false;
+};
 const asUniqueTrackIds = (trackIds: string[]) => [...new Set(trackIds)];
 const getFileImportKey = (file: File) => `${file.name}:${file.size}:${file.lastModified}`;
 const filenameFromTitle = (title: string) => {
@@ -136,6 +172,27 @@ const fetchImportedCover = async (coverUrl: string): Promise<AudioMetadata["pict
     },
   ];
 };
+const getManagedDownloadTrackTitle = (file: TagiumFile) => {
+  if (file.metadata?.title) return file.metadata.title;
+  return file.filename;
+};
+const formatPlaylistQueueEta = (etaMs?: number) => {
+  if (etaMs === undefined) return null;
+
+  const minutes = Math.ceil(etaMs / 60_000);
+  if (minutes <= 1) return "<1 min";
+  if (minutes < 60) return `${minutes} min`;
+
+  const hours = Math.floor(minutes / 60);
+  const leftoverMinutes = minutes % 60;
+  if (leftoverMinutes === 0) return `${hours} hr`;
+  return `${hours} hr ${leftoverMinutes} min`;
+};
+const createPlaylistDownloadModelTrack = (track: ManagedDownloadTrack) => ({
+  id: track.fileId,
+  title: track.title,
+  sourceUrl: track.downloadRequest.sourceUrl,
+});
 
 export default function AudioTagger() {
   const [files, setFiles] = useState<TagiumFile[]>([]);
@@ -153,6 +210,8 @@ export default function AudioTagger() {
   const [createSeedTrackIds, setCreateSeedTrackIds] = useState<string[]>([]);
   const [activeView, setActiveView] = useState<ActiveView>("editor");
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_APP_SETTINGS);
+  const [playlistDownloadQueue, setPlaylistDownloadQueue] =
+    useState<PlaylistDownloadQueueState | null>(null);
   const filesRef = useRef<TagiumFile[]>(files);
   const albumsRef = useRef<AlbumGroup[]>(albums);
   const selectedFileIdRef = useRef<string | null>(selectedFileId);
@@ -160,6 +219,9 @@ export default function AudioTagger() {
   const formDirtyRef = useRef(false);
   const importQueueRef = useRef(Promise.resolve());
   const pendingImportKeysRef = useRef(new Set<string>());
+  const playlistDownloadQueueRef = useRef<PlaylistDownloadQueueState | null>(null);
+  const playlistDownloadQueueRunRef = useRef<PlaylistDownloadQueueRun | null>(null);
+  const playlistDownloadQueueIdRef = useRef(0);
   filesRef.current = files;
   albumsRef.current = albums;
   selectedFileIdRef.current = selectedFileId;
@@ -573,8 +635,14 @@ export default function AudioTagger() {
     filesRef.current = nextFiles;
     setFiles(nextFiles);
   };
-  const hydrateDownloadedTrack = async (fileId: string, downloadedFile: File) => {
+  const hydrateDownloadedTrack = async (
+    fileId: string,
+    downloadedFile: File,
+    signal?: AbortSignal,
+  ) => {
+    signal?.throwIfAborted();
     const [parsedUpload] = await parseUploadedTracks([downloadedFile]);
+    signal?.throwIfAborted();
     if (!parsedUpload) {
       throw new Error("downloaded track could not be parsed.");
     }
@@ -595,7 +663,9 @@ export default function AudioTagger() {
 
     if (metadataToWrite) {
       try {
+        signal?.throwIfAborted();
         const updatedFile = await writeMetadataToFile(hydratedFile, metadataToWrite);
+        signal?.throwIfAborted();
         const latestFile = filesRef.current.find((file) => file.id === fileId);
         if (!latestFile) return;
         const latestFormMetadata =
@@ -626,7 +696,224 @@ export default function AudioTagger() {
       }
     }
 
+    signal?.throwIfAborted();
     replaceFileById(fileId, hydratedFile);
+  };
+  const replacePlaylistQueueState = (nextQueue: PlaylistDownloadQueueState) => {
+    playlistDownloadQueueRef.current = nextQueue;
+    setPlaylistDownloadQueue(nextQueue);
+  };
+  const updatePlaylistQueueState = (
+    queueId: number,
+    update: (queue: PlaylistDownloadQueueState) => PlaylistDownloadQueueState,
+  ) => {
+    setPlaylistDownloadQueue((currentQueue) => {
+      if (!currentQueue) return currentQueue;
+      if (currentQueue.id !== queueId) return currentQueue;
+
+      const nextQueue = update(currentQueue);
+      playlistDownloadQueueRef.current = nextQueue;
+      return nextQueue;
+    });
+  };
+  const createPlaylistQueueState = (run: PlaylistDownloadQueueRun): PlaylistDownloadQueueState => {
+    return derivePlaylistDownloadQueueState(run, Date.now());
+  };
+  const publishPlaylistQueueRun = (run: PlaylistDownloadQueueRun) => {
+    updatePlaylistQueueState(run.id, () => createPlaylistQueueState(run));
+  };
+  const clearPlaylistBudgetWake = (run: PlaylistDownloadQueueRun) => {
+    if (run.budgetWakeTimeout === undefined) return;
+
+    clearTimeout(run.budgetWakeTimeout);
+    run.budgetWakeTimeout = undefined;
+  };
+  const schedulePlaylistBudgetWake = (run: PlaylistDownloadQueueRun, waitMs: number) => {
+    clearPlaylistBudgetWake(run);
+    run.budgetWakeTimeout = setTimeout(() => {
+      run.budgetWakeTimeout = undefined;
+      pumpPlaylistDownloadQueue(run);
+    }, waitMs);
+  };
+  const markDownloadsQueued = (tracks: ManagedDownloadTrack[]) => {
+    const trackIds = new Set(tracks.map((track) => track.fileId));
+    const nextFiles = filesRef.current.map((file) =>
+      trackIds.has(file.id)
+        ? {
+            ...file,
+            status: "pending" as const,
+            downloadStatus: "downloading" as const,
+            downloadError: undefined,
+          }
+        : file,
+    );
+    filesRef.current = nextFiles;
+    setFiles(nextFiles);
+  };
+  const markDownloadsCanceled = (trackIds: string[]) => {
+    const trackIdSet = new Set(trackIds);
+    const nextFiles = filesRef.current.map((file) =>
+      trackIdSet.has(file.id) && file.downloadStatus === "downloading"
+        ? {
+            ...file,
+            downloadStatus: "canceled" as const,
+            downloadError: undefined,
+          }
+        : file,
+    );
+    filesRef.current = nextFiles;
+    setFiles(nextFiles);
+  };
+  const cancelPendingPlaylistDownloads = (run: PlaylistDownloadQueueRun) => {
+    if (run.pending.length === 0) return;
+
+    const canceledTrackIds = cancelPendingPlaylistDownloadTracks(run, Date.now());
+    markDownloadsCanceled(canceledTrackIds);
+  };
+  const cancelActivePlaylistDownloads = (run: PlaylistDownloadQueueRun) => {
+    if (run.active.length === 0) return;
+
+    const canceledTrackIds = cancelActivePlaylistDownloadTracks(run, Date.now());
+    for (const trackId of canceledTrackIds) {
+      run.abortControllers.get(trackId)?.abort(createPlaylistDownloadAbortReason());
+    }
+    markDownloadsCanceled(canceledTrackIds);
+  };
+  const finishPlaylistQueueRunIfIdle = (run: PlaylistDownloadQueueRun) => {
+    if (!finishPlaylistDownloadQueueRunIfIdle(run)) return false;
+
+    clearPlaylistBudgetWake(run);
+    publishPlaylistQueueRun(run);
+    return true;
+  };
+  const startManagedDownload = (run: PlaylistDownloadQueueRun, track: ManagedDownloadTrack) => {
+    const startedAt = Date.now();
+    const abortController = new AbortController();
+    run.abortControllers.set(track.fileId, abortController);
+    markPlaylistDownloadTrackActive(run, track, startedAt);
+    publishPlaylistQueueRun(run);
+
+    void (async () => {
+      try {
+        const currentFile = filesRef.current.find((file) => file.id === track.fileId);
+        if (!currentFile) {
+          markPlaylistDownloadTrackCompleted(run, track.fileId, Date.now());
+          return;
+        }
+
+        const downloadedFile = await downloadCobaltAudio({
+          ...track.downloadRequest,
+          signal: abortController.signal,
+        });
+        abortController.signal.throwIfAborted();
+        if (playlistDownloadQueueRunRef.current !== run) return;
+
+        await hydrateDownloadedTrack(track.fileId, downloadedFile, abortController.signal);
+        abortController.signal.throwIfAborted();
+        if (playlistDownloadQueueRunRef.current !== run) return;
+
+        markPlaylistDownloadTrackCompleted(run, track.fileId, Date.now());
+      } catch (error) {
+        if (isPlaylistDownloadAbort(error)) {
+          markPlaylistDownloadTrackCanceled(run, track.fileId, Date.now());
+          if (playlistDownloadQueueRunRef.current === run) {
+            markDownloadsCanceled([track.fileId]);
+          }
+          return;
+        }
+
+        let message = "download failed.";
+        if (error instanceof Error) {
+          message = error.message;
+        }
+        markPlaylistDownloadTrackFailed(run, track.fileId, message, Date.now());
+        if (playlistDownloadQueueRunRef.current === run) {
+          markDownloadError(track.fileId, error);
+        }
+      } finally {
+        run.abortControllers.delete(track.fileId);
+        removeActivePlaylistDownloadTrack(run, track.fileId);
+        publishPlaylistQueueRun(run);
+        pumpPlaylistDownloadQueue(run);
+      }
+    })();
+  };
+  const pumpPlaylistDownloadQueue = (run: PlaylistDownloadQueueRun) => {
+    if (playlistDownloadQueueRunRef.current !== run) return;
+    if (run.done) return;
+
+    if (run.canceled) {
+      clearPlaylistBudgetWake(run);
+      cancelPendingPlaylistDownloads(run);
+      cancelActivePlaylistDownloads(run);
+      publishPlaylistQueueRun(run);
+      finishPlaylistQueueRunIfIdle(run);
+      return;
+    }
+
+    clearPlaylistBudgetWake(run);
+    while (run.active.length < PLAYLIST_DOWNLOAD_CONCURRENCY && run.pending.length > 0) {
+      const budget = reserveNextPlaylistDownloadTrack(run, Date.now());
+
+      if (budget.status === "waiting-for-tunnel-budget") {
+        schedulePlaylistBudgetWake(run, budget.waitMs);
+        publishPlaylistQueueRun(run);
+        return;
+      }
+
+      if (budget.status === "reserved") {
+        startManagedDownload(run, budget.track);
+      }
+    }
+
+    finishPlaylistQueueRunIfIdle(run);
+  };
+  const queueDownloadTracks = (tracks: ManagedDownloadTrack[]) => {
+    if (tracks.length === 0) return;
+
+    const currentRun = playlistDownloadQueueRunRef.current;
+    if (currentRun && !currentRun.done && !currentRun.canceled) {
+      const fileErrorTrackIds = new Set(
+        filesRef.current.filter((file) => file.status === "error").map((file) => file.id),
+      );
+      const queuedTracks = enqueuePlaylistDownloadQueueTracks(
+        currentRun,
+        tracks,
+        Date.now(),
+        fileErrorTrackIds,
+        createPlaylistDownloadModelTrack,
+      );
+      if (queuedTracks.length === 0) return;
+
+      markDownloadsQueued(queuedTracks);
+      publishPlaylistQueueRun(currentRun);
+      pumpPlaylistDownloadQueue(currentRun);
+      return;
+    }
+
+    const run: PlaylistDownloadQueueRun = {
+      ...createPlaylistDownloadQueueRun(
+        playlistDownloadQueueIdRef.current + 1,
+        tracks,
+        Date.now(),
+        createPlaylistDownloadModelTrack,
+      ),
+      abortControllers: new Map(),
+    };
+    playlistDownloadQueueIdRef.current = run.id;
+    playlistDownloadQueueRunRef.current = run;
+    markDownloadsQueued(tracks);
+    replacePlaylistQueueState(createPlaylistQueueState(run));
+    pumpPlaylistDownloadQueue(run);
+  };
+  const managedDownloadTrackFromFile = (file: TagiumFile): ManagedDownloadTrack | null => {
+    if (!file.downloadRequest) return null;
+
+    return {
+      fileId: file.id,
+      title: getManagedDownloadTrackTitle(file),
+      downloadRequest: file.downloadRequest,
+    };
   };
   const handleAudioDownload = (sourceUrl: string) => {
     bufferCurrentFormMetadata();
@@ -652,25 +939,20 @@ export default function AudioTagger() {
     setSelectedFileId(id);
     setSelectedFileIds(new Set([id]));
     setLastSelectedFileId(id);
-
-    void (async () => {
-      try {
-        const downloadedFile = await downloadCobaltAudio({
-          sourceUrl,
-          audioBitrate: settings.audioBitrate,
-        });
-        await hydrateDownloadedTrack(id, downloadedFile);
-      } catch (error) {
-        markDownloadError(id, error);
-      }
-    })();
+    queueDownloadTracks([
+      {
+        fileId: id,
+        title,
+        downloadRequest: { sourceUrl, audioBitrate: settings.audioBitrate },
+      },
+    ]);
   };
   const handleSoundCloudSetDownload = (set: SoundCloudSet) => {
     bufferCurrentFormMetadata();
     setActiveView("editor");
     const albumId = crypto.randomUUID();
-    const pendingFiles = set.tracks.map((track, index) => {
-      const pendingFile = createPendingDownloadTrack(
+    const pendingFiles = set.tracks.map((track) =>
+      createPendingDownloadTrack(
         crypto.randomUUID(),
         createDownloadMetadata({
           title: track.title,
@@ -683,19 +965,8 @@ export default function AudioTagger() {
         }),
         true,
         { sourceUrl: track.url, audioBitrate: settings.audioBitrate },
-      );
-
-      if (index < MAX_SOUND_CLOUD_SET_DOWNLOADS) {
-        return pendingFile;
-      }
-
-      return {
-        ...pendingFile,
-        status: "error" as const,
-        downloadStatus: "error" as const,
-        downloadError: DOWNLOAD_RATE_LIMIT_ERROR,
-      };
-    });
+      ),
+    );
     const album: AlbumGroup = {
       id: albumId,
       title: set.title,
@@ -727,7 +998,7 @@ export default function AudioTagger() {
           setAlbums(coveredAlbums);
           const trackIdSet = new Set(album.trackIds);
           const coveredFiles = filesRef.current.map((file) =>
-            trackIdSet.has(file.id) && file.metadata
+            trackIdSet.has(file.id) && file.file && file.metadata
               ? {
                   ...file,
                   metadata: {
@@ -759,48 +1030,41 @@ export default function AudioTagger() {
       })();
     }
 
-    pendingFiles.slice(0, MAX_SOUND_CLOUD_SET_DOWNLOADS).forEach((pendingFile, index) => {
-      const track = set.tracks[index];
-      if (!track) return;
-      void (async () => {
-        try {
-          const downloadedFile = await downloadCobaltAudio({
-            sourceUrl: track.url,
-            audioBitrate: settings.audioBitrate,
-          });
-          await hydrateDownloadedTrack(pendingFile.id, downloadedFile);
-        } catch (error) {
-          markDownloadError(pendingFile.id, error);
-        }
-      })();
-    });
+    const tracksToDownload = pendingFiles
+      .map((pendingFile) => managedDownloadTrackFromFile(pendingFile))
+      .filter((track): track is ManagedDownloadTrack => Boolean(track));
+    queueDownloadTracks(tracksToDownload);
   };
   const handleRetryDownload = (fileId: string) => {
     const fileToRetry = filesRef.current.find((file) => file.id === fileId);
-    const downloadRequest = fileToRetry?.downloadRequest;
-    if (!fileToRetry || !downloadRequest) return;
+    if (!fileToRetry) return;
 
-    const nextFiles = filesRef.current.map((file) =>
-      file.id === fileId
-        ? {
-            ...file,
-            status: "pending" as const,
-            downloadStatus: "downloading" as const,
-            downloadError: undefined,
-          }
-        : file,
-    );
-    filesRef.current = nextFiles;
-    setFiles(nextFiles);
+    const trackToRetry = managedDownloadTrackFromFile(fileToRetry);
+    if (!trackToRetry) return;
 
-    void (async () => {
-      try {
-        const downloadedFile = await downloadCobaltAudio(downloadRequest);
-        await hydrateDownloadedTrack(fileId, downloadedFile);
-      } catch (error) {
-        markDownloadError(fileId, error);
-      }
-    })();
+    queueDownloadTracks([trackToRetry]);
+  };
+  const handleCancelPlaylistDownloads = () => {
+    const currentRun = playlistDownloadQueueRunRef.current;
+    if (!currentRun) return;
+    if (currentRun.done) return;
+
+    currentRun.canceled = true;
+    cancelActivePlaylistDownloads(currentRun);
+    publishPlaylistQueueRun(currentRun);
+    pumpPlaylistDownloadQueue(currentRun);
+  };
+  const handleRetryPlaylistDownloads = () => {
+    const currentQueue = playlistDownloadQueueRef.current;
+    if (!currentQueue) return;
+    if (currentQueue.active.length > 0) return;
+
+    const trackIdSet = new Set(currentQueue.trackIds);
+    const tracksToRetry = filesRef.current
+      .filter((file) => trackIdSet.has(file.id) && !file.file)
+      .map((file) => managedDownloadTrackFromFile(file))
+      .filter((track): track is ManagedDownloadTrack => Boolean(track));
+    queueDownloadTracks(tracksToRetry);
   };
   const handleDownloadAll = async () => {
     if (files.length === 0) return;
@@ -1333,6 +1597,60 @@ export default function AudioTagger() {
   };
 
   const libraryIsEmpty = files.length === 0 && albums.length === 0 && looseTrackIds.length === 0;
+  const playlistQueueDownloaded = playlistDownloadQueue ? playlistDownloadQueue.completed : 0;
+  const playlistQueueEta = playlistDownloadQueue
+    ? formatPlaylistQueueEta(playlistDownloadQueue.etaMs)
+    : null;
+  let playlistQueueRetryCount = 0;
+  if (playlistDownloadQueue) {
+    const playlistTrackIds = new Set(playlistDownloadQueue.trackIds);
+    playlistQueueRetryCount = files.filter(
+      (file) => playlistTrackIds.has(file.id) && !file.file && file.downloadRequest,
+    ).length;
+  }
+  const canRetryPlaylistQueue = Boolean(
+    playlistDownloadQueue &&
+    playlistDownloadQueue.active.length === 0 &&
+    playlistQueueRetryCount > 0 &&
+    (playlistDownloadQueue.canceled || playlistDownloadQueue.failed > 0),
+  );
+  let playlistSidebarQueue: PlaylistDownloadQueuePanelState | null = null;
+  if (playlistDownloadQueue && playlistDownloadQueue.total > 1) {
+    let status: PlaylistDownloadQueuePanelState["status"] = "downloading";
+    if (playlistDownloadQueue.waitingForTunnelBudget) {
+      status = "waiting";
+    }
+    if (playlistDownloadQueue.done && playlistDownloadQueue.failed > 0) {
+      status = "error";
+    }
+    if (playlistDownloadQueue.canceled && playlistDownloadQueue.failed === 0) {
+      status = "canceled";
+    }
+
+    const playlistQueueSettled =
+      playlistDownloadQueue.completed +
+      playlistDownloadQueue.failed +
+      playlistDownloadQueue.canceledCount;
+
+    const nextPlaylistSidebarQueue: PlaylistDownloadQueuePanelState = {
+      status,
+      downloadedCount: playlistQueueDownloaded,
+      totalCount: playlistDownloadQueue.total,
+      failedCount: playlistDownloadQueue.failed,
+      canceledCount: playlistDownloadQueue.canceledCount,
+      currentTracks: playlistDownloadQueue.active.map((track) => ({
+        id: track.fileId,
+        title: track.title,
+      })),
+      progress: (playlistQueueSettled / playlistDownloadQueue.total) * 100,
+      canCancel: !playlistDownloadQueue.done && !playlistDownloadQueue.canceled,
+      canRetry: canRetryPlaylistQueue,
+    };
+    if (playlistQueueEta) {
+      nextPlaylistSidebarQueue.eta = `eta ${playlistQueueEta}`;
+    }
+    playlistSidebarQueue = nextPlaylistSidebarQueue;
+  }
 
   return (
     <>
@@ -1382,8 +1700,11 @@ export default function AudioTagger() {
           onMoveTrackToLoose={handleMoveTrackToLoose}
           onPromptCreateAlbumFromLooseTracks={handlePromptCreateAlbumFromLooseTracks}
           onReorderAlbums={handleReorderAlbums}
+          playlistDownloadQueue={playlistSidebarQueue}
           onDownloadAll={handleDownloadAll}
           onOpenSettings={() => setActiveView("settings")}
+          onCancelPlaylistDownloadQueue={handleCancelPlaylistDownloads}
+          onRetryPlaylistDownloadQueue={handleRetryPlaylistDownloads}
         />
         <div className="relative order-1 flex-shrink-0 flex flex-col md:order-none md:min-h-0 md:flex-1">
           <div className="h-svh min-h-0 flex flex-col overflow-hidden md:h-auto md:min-h-0 md:flex-1">
@@ -1412,7 +1733,7 @@ export default function AudioTagger() {
           </div>
           {!libraryIsEmpty && activeView === "editor" && (
             <div className="flex-shrink-0 border-t bg-background/95 p-3 lg:pointer-events-none lg:absolute lg:inset-x-0 lg:bottom-4 lg:z-10 lg:flex lg:justify-center lg:border-t-0 lg:bg-transparent lg:px-4 lg:p-0">
-              <div className="pointer-events-auto w-full max-w-3xl">
+              <div className="pointer-events-auto flex w-full max-w-3xl flex-col gap-2">
                 <AudioDownloader
                   onAudioDownload={handleAudioDownload}
                   onSoundCloudSetDownload={handleSoundCloudSetDownload}

--- a/components/audio/cobaltDownload.test.ts
+++ b/components/audio/cobaltDownload.test.ts
@@ -49,6 +49,65 @@ describe("downloadCobaltAudio", () => {
     expect(tunnelStartTimes).toEqual([0, 1_600, 3_200, 4_800]);
   });
 
+  it("reports Cobalt tunnel budget waits", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    let nextPlanId = 0;
+    const lifecycleEvents: Array<{ downloadIndex: number; time: number; type: string }> = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === "/api/cobalt/audio") {
+          nextPlanId += 1;
+          return Response.json({
+            status: "tunnel",
+            url: `/api/cobalt/tunnel?id=${nextPlanId}`,
+            filename: `track-${nextPlanId}.mp3`,
+          });
+        }
+
+        return new Response("audio-bytes", {
+          headers: {
+            "Content-Type": "audio/mpeg",
+          },
+        });
+      }),
+    );
+
+    const downloads = Promise.all(
+      Array.from({ length: 2 }, (_value, downloadIndex) =>
+        downloadCobaltAudio({
+          sourceUrl: `https://soundcloud.com/artist/wait-${downloadIndex}`,
+          audioBitrate: "128",
+          onLifecycle: (event) => {
+            lifecycleEvents.push({
+              downloadIndex,
+              time: Date.now(),
+              type: event.type,
+            });
+          },
+        }),
+      ),
+    );
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await downloads;
+
+    expect(lifecycleEvents).toEqual([
+      {
+        downloadIndex: 1,
+        time: 10_000,
+        type: "tunnel-budget-wait-started",
+      },
+      {
+        downloadIndex: 1,
+        time: 11_600,
+        type: "tunnel-budget-wait-ended",
+      },
+    ]);
+  });
+
   it("fetches local-processing cover tunnels for track-specific artwork", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(100_000);

--- a/components/audio/cobaltDownload.ts
+++ b/components/audio/cobaltDownload.ts
@@ -24,9 +24,23 @@ type CobaltDownloadPlan =
       };
     };
 
-interface CobaltAudioDownloadRequest {
+export type CobaltAudioDownloadLifecycleEvent =
+  | {
+      type: "tunnel-budget-wait-started";
+    }
+  | {
+      type: "tunnel-budget-wait-ended";
+    };
+
+export type CobaltAudioDownloadLifecycleCallback = (
+  event: CobaltAudioDownloadLifecycleEvent,
+) => void;
+
+export interface CobaltAudioDownloadRequest {
   sourceUrl: string;
   audioBitrate: AudioDownloadBitrate;
+  onLifecycle?: CobaltAudioDownloadLifecycleCallback;
+  signal?: AbortSignal;
 }
 
 interface MP3TagPicture {
@@ -72,17 +86,55 @@ let activeCobaltDownloads = 0;
 const pendingCobaltDownloads: (() => void)[] = [];
 let nextCobaltTunnelStartAt = 0;
 let cobaltTunnelStartQueue = Promise.resolve();
+let waitingCobaltTunnelStarts = 0;
 
-const delay = async (milliseconds: number) =>
-  new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+const delay = async (milliseconds: number, signal?: AbortSignal) => {
+  signal?.throwIfAborted();
 
-const reserveCobaltDownloadSlot = async () => {
+  await new Promise<void>((resolve, reject) => {
+    let timeout: ReturnType<typeof setTimeout>;
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(signal?.reason);
+    };
+
+    timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, milliseconds);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+};
+
+const reserveCobaltDownloadSlot = async (signal?: AbortSignal) => {
+  signal?.throwIfAborted();
+
   if (activeCobaltDownloads < MAX_CONCURRENT_COBALT_DOWNLOADS) {
     activeCobaltDownloads += 1;
     return;
   }
 
-  await new Promise<void>((resolve) => pendingCobaltDownloads.push(resolve));
+  await new Promise<void>((resolve, reject) => {
+    const resolveSlot = () => {
+      signal?.removeEventListener("abort", onAbort);
+      if (signal?.aborted) {
+        releaseCobaltDownloadSlot();
+        reject(signal.reason);
+        return;
+      }
+      resolve();
+    };
+    const onAbort = () => {
+      const pendingIndex = pendingCobaltDownloads.indexOf(resolveSlot);
+      if (pendingIndex >= 0) {
+        pendingCobaltDownloads.splice(pendingIndex, 1);
+      }
+      reject(signal?.reason);
+    };
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+    pendingCobaltDownloads.push(resolveSlot);
+  });
 };
 
 const releaseCobaltDownloadSlot = () => {
@@ -95,8 +147,11 @@ const releaseCobaltDownloadSlot = () => {
   activeCobaltDownloads -= 1;
 };
 
-const withCobaltDownloadSlot = async <Value>(download: () => Promise<Value>) => {
-  await reserveCobaltDownloadSlot();
+const withCobaltDownloadSlot = async <Value>(
+  download: () => Promise<Value>,
+  signal?: AbortSignal,
+) => {
+  await reserveCobaltDownloadSlot(signal);
 
   try {
     return await download();
@@ -105,24 +160,46 @@ const withCobaltDownloadSlot = async <Value>(download: () => Promise<Value>) => 
   }
 };
 
-const waitForCobaltTunnelStart = async () => {
+const waitForCobaltTunnelStart = async (
+  onLifecycle?: CobaltAudioDownloadLifecycleCallback,
+  signal?: AbortSignal,
+) => {
   let releaseQueue = () => {};
   const previousQueue = cobaltTunnelStartQueue;
   cobaltTunnelStartQueue = new Promise<void>((resolve) => {
     releaseQueue = resolve;
   });
-
-  await previousQueue;
+  let isWaitingForBudget = false;
+  waitingCobaltTunnelStarts += 1;
 
   try {
-    const waitMs = nextCobaltTunnelStartAt - Date.now();
-    if (waitMs > 0) {
-      await delay(waitMs);
+    if (waitingCobaltTunnelStarts > 1 || nextCobaltTunnelStartAt > Date.now()) {
+      isWaitingForBudget = true;
+      onLifecycle?.({ type: "tunnel-budget-wait-started" });
     }
 
+    await previousQueue;
+
+    signal?.throwIfAborted();
+
+    const waitMs = nextCobaltTunnelStartAt - Date.now();
+    if (waitMs > 0) {
+      if (!isWaitingForBudget) {
+        onLifecycle?.({ type: "tunnel-budget-wait-started" });
+        isWaitingForBudget = true;
+      }
+
+      await delay(waitMs, signal);
+    }
+
+    signal?.throwIfAborted();
     nextCobaltTunnelStartAt = Date.now() + COBALT_TUNNEL_START_INTERVAL_MS;
   } finally {
+    waitingCobaltTunnelStarts -= 1;
     releaseQueue();
+    if (isWaitingForBudget) {
+      onLifecycle?.({ type: "tunnel-budget-wait-ended" });
+    }
   }
 };
 
@@ -169,10 +246,16 @@ const makeAudioArgs = (plan: Extract<CobaltDownloadPlan, { status: "local-proces
   return ffargs;
 };
 
-const fetchTunnelFile = async (url: string, filename: string, lastModified: number) => {
-  await waitForCobaltTunnelStart();
+const fetchTunnelFile = async (
+  url: string,
+  filename: string,
+  lastModified: number,
+  onLifecycle?: CobaltAudioDownloadLifecycleCallback,
+  signal?: AbortSignal,
+) => {
+  await waitForCobaltTunnelStart(onLifecycle, signal);
 
-  const response = await fetch(url);
+  const response = await fetch(url, { signal });
   if (!response.ok) {
     throw new Error(await response.text());
   }
@@ -196,28 +279,43 @@ const runLocalProcessingWorker = async (
   files: File[],
   args: string[],
   output: { type: string; format: string },
+  signal?: AbortSignal,
 ) =>
   new Promise<Blob>((resolve, reject) => {
+    signal?.throwIfAborted();
+
     const worker = new Worker(new URL("./cobaltLocalProcessingWorker.js", import.meta.url), {
       type: "module",
     });
+    const cleanup = () => {
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      worker.terminate();
+      cleanup();
+      reject(signal?.reason);
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
 
     worker.onmessage = (event: MessageEvent) => {
       const message = event.data.cobaltLocalProcessing;
       if (message?.blob) {
         worker.terminate();
+        cleanup();
         resolve(message.blob);
         return;
       }
 
       if (message?.error) {
         worker.terminate();
+        cleanup();
         reject(new Error(message.error));
       }
     };
 
     worker.onerror = (error) => {
       worker.terminate();
+      cleanup();
       reject(new Error(error.message));
     };
 
@@ -233,9 +331,13 @@ const runLocalProcessingWorker = async (
 const processLocalAudio = async (
   plan: Extract<CobaltDownloadPlan, { status: "local-processing" }>,
   lastModified: number,
+  onLifecycle?: CobaltAudioDownloadLifecycleCallback,
+  signal?: AbortSignal,
 ) => {
   const inputFiles = await Promise.all(
-    plan.tunnel.map((url, index) => fetchTunnelFile(url, `input-${index}`, lastModified)),
+    plan.tunnel.map((url, index) =>
+      fetchTunnelFile(url, `input-${index}`, lastModified, onLifecycle, signal),
+    ),
   );
   const outputFormat = plan.output.filename.split(".").pop();
   if (!outputFormat) {
@@ -247,16 +349,23 @@ const processLocalAudio = async (
     throw new Error("cobalt local processing response missing audio tunnel.");
   }
 
-  const blob = await runLocalProcessingWorker([audioFile], makeAudioArgs(plan), {
-    type: plan.output.type,
-    format: outputFormat,
-  });
+  const blob = await runLocalProcessingWorker(
+    [audioFile],
+    makeAudioArgs(plan),
+    {
+      type: plan.output.type,
+      format: outputFormat,
+    },
+    signal,
+  );
+  signal?.throwIfAborted();
 
   const file = new File([blob], plan.output.filename, {
     type: plan.output.type,
     lastModified,
   });
 
+  signal?.throwIfAborted();
   return await tagCobaltAudioFile(file, plan, inputFiles[1], lastModified);
 };
 
@@ -317,13 +426,19 @@ const tagCobaltAudioFile = async (
   });
 };
 
-const runCobaltAudioDownload = async ({ sourceUrl, audioBitrate }: CobaltAudioDownloadRequest) => {
+const runCobaltAudioDownload = async ({
+  sourceUrl,
+  audioBitrate,
+  onLifecycle,
+  signal,
+}: CobaltAudioDownloadRequest) => {
   const response = await fetch("/api/cobalt/audio", {
     method: "POST",
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json",
     },
+    signal,
     body: JSON.stringify({
       url: sourceUrl,
       audioBitrate,
@@ -338,12 +453,12 @@ const runCobaltAudioDownload = async ({ sourceUrl, audioBitrate }: CobaltAudioDo
   const lastModified = getStableLastModified(sourceUrl);
 
   if (plan.status === "local-processing") {
-    return await processLocalAudio(plan, lastModified);
+    return await processLocalAudio(plan, lastModified, onLifecycle, signal);
   }
 
-  return await fetchTunnelFile(plan.url, plan.filename, lastModified);
+  return await fetchTunnelFile(plan.url, plan.filename, lastModified, onLifecycle, signal);
 };
 
 export async function downloadCobaltAudio(request: CobaltAudioDownloadRequest) {
-  return await withCobaltDownloadSlot(() => runCobaltAudioDownload(request));
+  return await withCobaltDownloadSlot(() => runCobaltAudioDownload(request), request.signal);
 }

--- a/components/audio/playlistDownloadQueue.test.ts
+++ b/components/audio/playlistDownloadQueue.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  createPlaylistDownloadQueue,
+  derivePlaylistDownloadQueueSummary,
+  getNextPlaylistDownloadBudgetWaitMs,
+  markPlaylistDownloadActive,
+  markPlaylistDownloadCanceled,
+  markPlaylistDownloadCompleted,
+  markPlaylistDownloadFailed,
+  reservePlaylistDownloadBudget,
+  retryPlaylistDownloadItem,
+} from "./playlistDownloadQueue";
+import type {
+  PlaylistDownloadQueueState,
+  PlaylistDownloadQueueTrack,
+} from "./playlistDownloadQueue";
+
+const tracks = (count: number): PlaylistDownloadQueueTrack[] =>
+  Array.from({ length: count }, (_value, index) => ({
+    id: `track-${index + 1}`,
+    title: `Track ${index + 1}`,
+    sourceUrl: `https://soundcloud.com/artist/track-${index + 1}`,
+  }));
+
+const reserve = (
+  queue: PlaylistDownloadQueueState,
+  itemId: string,
+  nowMs: number,
+): PlaylistDownloadQueueState => {
+  const result = reservePlaylistDownloadBudget(queue, itemId, nowMs);
+  expect(result.status).toBe("reserved");
+  return result.queue;
+};
+
+describe("playlistDownloadQueue", () => {
+  it("creates every playlist item pending immediately", () => {
+    const queue = createPlaylistDownloadQueue(tracks(3));
+
+    expect(queue.items.map((item) => item.status)).toEqual(["pending", "pending", "pending"]);
+    expect(queue.items.map((item) => item.tunnelCost)).toEqual([2, 2, 2]);
+  });
+
+  it("fits 20 two-tunnel SoundCloud tracks and makes the 21st wait", () => {
+    let queue = createPlaylistDownloadQueue(tracks(21));
+
+    for (const item of queue.items.slice(0, 20)) {
+      queue = reserve(queue, item.id, 0);
+    }
+
+    const wait = reservePlaylistDownloadBudget(queue, "track-21", 0);
+
+    expect(queue.budgetReservations).toHaveLength(20);
+    expect(getNextPlaylistDownloadBudgetWaitMs(queue, 2, 0)).toBe(60_000);
+    expect(wait).toEqual({
+      status: "waiting-for-tunnel-budget",
+      queue,
+      waitMs: 60_000,
+    });
+  });
+
+  it("keeps the 21st track pending when active tracks hold the Cobalt budget", () => {
+    let queue = createPlaylistDownloadQueue(tracks(21));
+
+    for (const item of queue.items.slice(0, 20)) {
+      queue = reserve(queue, item.id, 0);
+      queue = markPlaylistDownloadActive(queue, item.id, 0);
+    }
+
+    const wait = reservePlaylistDownloadBudget(queue, "track-21", 0);
+    const summary = derivePlaylistDownloadQueueSummary(wait.queue, 0);
+
+    expect(wait.status).toBe("waiting-for-tunnel-budget");
+    expect(wait.queue.items[20].status).toBe("pending");
+    expect(summary.activeCount).toBe(20);
+    expect(summary.pendingCount).toBe(1);
+    expect(summary.waitingForTunnelBudget).toBe(true);
+    expect(getNextPlaylistDownloadBudgetWaitMs(wait.queue, 2, 60_000)).toBe(0);
+  });
+
+  it("keeps tunnel-budget waits out of failed state", () => {
+    let queue = createPlaylistDownloadQueue(tracks(21));
+
+    for (const item of queue.items.slice(0, 20)) {
+      queue = reserve(queue, item.id, 0);
+    }
+
+    const wait = reservePlaylistDownloadBudget(queue, "track-21", 0);
+    const summary = derivePlaylistDownloadQueueSummary(wait.queue, 0);
+
+    expect(wait.status).toBe("waiting-for-tunnel-budget");
+    expect(wait.queue.items[20].status).toBe("pending");
+    expect(summary.failedCount).toBe(0);
+    expect(summary.waitingForTunnelBudget).toBe(true);
+    expect(summary.nextBudgetWaitMs).toBe(60_000);
+  });
+
+  it("derives progress counts and active titles", () => {
+    let queue = createPlaylistDownloadQueue(tracks(3));
+    queue = markPlaylistDownloadActive(queue, "track-1", 0);
+    queue = markPlaylistDownloadActive(queue, "track-2", 1_000);
+    queue = markPlaylistDownloadCompleted(queue, "track-1", 10_000);
+
+    const summary = derivePlaylistDownloadQueueSummary(queue, 12_000);
+
+    expect(summary.label).toBe("Downloading 1/3");
+    expect(summary.completedCount).toBe(1);
+    expect(summary.activeCount).toBe(1);
+    expect(summary.pendingCount).toBe(1);
+    expect(summary.activeTitles).toEqual(["Track 2"]);
+  });
+
+  it("retries failed and canceled items as pending", () => {
+    let queue = createPlaylistDownloadQueue(tracks(2));
+    queue = markPlaylistDownloadActive(queue, "track-1", 0);
+    queue = markPlaylistDownloadFailed(queue, "track-1", "network failed", 1_000);
+    queue = markPlaylistDownloadActive(queue, "track-2", 0);
+    queue = markPlaylistDownloadCanceled(queue, "track-2", 1_000);
+
+    queue = retryPlaylistDownloadItem(queue, "track-1");
+    queue = retryPlaylistDownloadItem(queue, "track-2");
+
+    expect(queue.items[0]).toMatchObject({
+      status: "pending",
+      attempts: 1,
+      error: undefined,
+      startedAtMs: undefined,
+      failedAtMs: undefined,
+    });
+    expect(queue.items[1]).toMatchObject({
+      status: "pending",
+      attempts: 1,
+      canceledAtMs: undefined,
+    });
+  });
+
+  it("only derives ETA when completed durations exist", () => {
+    let queue = createPlaylistDownloadQueue(tracks(3));
+    queue = markPlaylistDownloadActive(queue, "track-1", 0);
+
+    expect(derivePlaylistDownloadQueueSummary(queue, 5_000).etaMs).toBeUndefined();
+
+    queue = markPlaylistDownloadCompleted(queue, "track-1", 10_000);
+    queue = markPlaylistDownloadActive(queue, "track-2", 10_000);
+
+    expect(derivePlaylistDownloadQueueSummary(queue, 15_000).etaMs).toBe(15_000);
+  });
+});

--- a/components/audio/playlistDownloadQueue.ts
+++ b/components/audio/playlistDownloadQueue.ts
@@ -1,0 +1,362 @@
+export type PlaylistDownloadQueueItemStatus =
+  | "pending"
+  | "active"
+  | "completed"
+  | "failed"
+  | "canceled";
+
+export interface PlaylistDownloadQueueTrack {
+  id: string;
+  title: string;
+  sourceUrl: string;
+  tunnelCost?: number;
+}
+
+export interface PlaylistDownloadQueueItem {
+  id: string;
+  title: string;
+  sourceUrl: string;
+  tunnelCost: number;
+  status: PlaylistDownloadQueueItemStatus;
+  attempts: number;
+  startedAtMs?: number;
+  completedAtMs?: number;
+  failedAtMs?: number;
+  canceledAtMs?: number;
+  error?: string;
+}
+
+export interface PlaylistDownloadQueueBudgetReservation {
+  itemId: string;
+  tunnelCost: number;
+  reservedAtMs: number;
+}
+
+export interface PlaylistDownloadQueueState {
+  items: PlaylistDownloadQueueItem[];
+  budgetReservations: PlaylistDownloadQueueBudgetReservation[];
+}
+
+export interface PlaylistDownloadQueueSummary {
+  label: string;
+  totalCount: number;
+  completedCount: number;
+  activeCount: number;
+  pendingCount: number;
+  failedCount: number;
+  canceledCount: number;
+  activeTitles: string[];
+  waitingForTunnelBudget: boolean;
+  nextBudgetWaitMs?: number;
+  etaMs?: number;
+}
+
+export type PlaylistDownloadQueueBudgetResult =
+  | {
+      status: "reserved";
+      queue: PlaylistDownloadQueueState;
+    }
+  | {
+      status: "waiting-for-tunnel-budget";
+      queue: PlaylistDownloadQueueState;
+      waitMs: number;
+    };
+
+export const PLAYLIST_DOWNLOAD_TUNNEL_BUDGET = 40;
+export const PLAYLIST_DOWNLOAD_TUNNEL_BUDGET_WINDOW_MS = 60_000;
+export const SOUND_CLOUD_TRACK_TUNNEL_COST = 2;
+
+export const createPlaylistDownloadQueueItem = (
+  track: PlaylistDownloadQueueTrack,
+): PlaylistDownloadQueueItem => {
+  let tunnelCost = SOUND_CLOUD_TRACK_TUNNEL_COST;
+  if (track.tunnelCost !== undefined) {
+    tunnelCost = track.tunnelCost;
+  }
+
+  return {
+    id: track.id,
+    title: track.title,
+    sourceUrl: track.sourceUrl,
+    tunnelCost,
+    status: "pending",
+    attempts: 0,
+  };
+};
+
+export const createPlaylistDownloadQueue = (
+  tracks: PlaylistDownloadQueueTrack[],
+): PlaylistDownloadQueueState => ({
+  items: tracks.map(createPlaylistDownloadQueueItem),
+  budgetReservations: [],
+});
+
+export const getNextPlaylistDownloadBudgetWaitMs = (
+  queue: PlaylistDownloadQueueState,
+  tunnelCost: number,
+  nowMs: number,
+) => {
+  if (tunnelCost > PLAYLIST_DOWNLOAD_TUNNEL_BUDGET) {
+    throw new Error("playlist download item exceeds Cobalt tunnel budget.");
+  }
+
+  const reservations = getActiveBudgetReservations(queue, nowMs);
+  let usedTunnelCount = 0;
+  for (const reservation of reservations) {
+    usedTunnelCount += reservation.tunnelCost;
+  }
+
+  if (usedTunnelCount + tunnelCost <= PLAYLIST_DOWNLOAD_TUNNEL_BUDGET) {
+    return 0;
+  }
+
+  let releasedTunnelCount = 0;
+  const sortedReservations = [...reservations].sort((left, right) => {
+    return left.reservedAtMs - right.reservedAtMs;
+  });
+
+  for (const reservation of sortedReservations) {
+    releasedTunnelCount += reservation.tunnelCost;
+    if (usedTunnelCount - releasedTunnelCount + tunnelCost <= PLAYLIST_DOWNLOAD_TUNNEL_BUDGET) {
+      const availableAtMs = reservation.reservedAtMs + PLAYLIST_DOWNLOAD_TUNNEL_BUDGET_WINDOW_MS;
+      return Math.max(0, availableAtMs - nowMs);
+    }
+  }
+
+  throw new Error("playlist download budget wait could not be calculated.");
+};
+
+export const reservePlaylistDownloadBudget = (
+  queue: PlaylistDownloadQueueState,
+  itemId: string,
+  nowMs: number,
+): PlaylistDownloadQueueBudgetResult => {
+  const item = findPlaylistDownloadQueueItem(queue, itemId);
+  if (item.status !== "pending") {
+    throw new Error("playlist download budget can only be reserved for pending items.");
+  }
+
+  const budgetReservations = getActiveBudgetReservations(queue, nowMs);
+  const waitMs = getNextPlaylistDownloadBudgetWaitMs(queue, item.tunnelCost, nowMs);
+  const nextQueue = {
+    ...queue,
+    budgetReservations,
+  };
+
+  if (waitMs > 0) {
+    return {
+      status: "waiting-for-tunnel-budget",
+      queue: nextQueue,
+      waitMs,
+    };
+  }
+
+  return {
+    status: "reserved",
+    queue: {
+      ...nextQueue,
+      budgetReservations: [
+        ...budgetReservations,
+        {
+          itemId,
+          tunnelCost: item.tunnelCost,
+          reservedAtMs: nowMs,
+        },
+      ],
+    },
+  };
+};
+
+export const markPlaylistDownloadActive = (
+  queue: PlaylistDownloadQueueState,
+  itemId: string,
+  nowMs: number,
+) =>
+  updatePlaylistDownloadQueueItem(queue, itemId, (item) => ({
+    ...item,
+    status: "active",
+    attempts: item.attempts + 1,
+    startedAtMs: nowMs,
+    completedAtMs: undefined,
+    failedAtMs: undefined,
+    canceledAtMs: undefined,
+    error: undefined,
+  }));
+
+export const markPlaylistDownloadCompleted = (
+  queue: PlaylistDownloadQueueState,
+  itemId: string,
+  nowMs: number,
+) =>
+  updatePlaylistDownloadQueueItem(queue, itemId, (item) => ({
+    ...item,
+    status: "completed",
+    completedAtMs: nowMs,
+    failedAtMs: undefined,
+    canceledAtMs: undefined,
+    error: undefined,
+  }));
+
+export const markPlaylistDownloadFailed = (
+  queue: PlaylistDownloadQueueState,
+  itemId: string,
+  error: string,
+  nowMs: number,
+) =>
+  updatePlaylistDownloadQueueItem(queue, itemId, (item) => ({
+    ...item,
+    status: "failed",
+    failedAtMs: nowMs,
+    canceledAtMs: undefined,
+    error,
+  }));
+
+export const markPlaylistDownloadCanceled = (
+  queue: PlaylistDownloadQueueState,
+  itemId: string,
+  nowMs: number,
+) =>
+  updatePlaylistDownloadQueueItem(queue, itemId, (item) => ({
+    ...item,
+    status: "canceled",
+    failedAtMs: undefined,
+    canceledAtMs: nowMs,
+    error: undefined,
+  }));
+
+export const retryPlaylistDownloadItem = (queue: PlaylistDownloadQueueState, itemId: string) =>
+  updatePlaylistDownloadQueueItem(queue, itemId, (item) => {
+    if (item.status !== "failed" && item.status !== "canceled") {
+      return item;
+    }
+
+    return {
+      ...item,
+      status: "pending",
+      startedAtMs: undefined,
+      completedAtMs: undefined,
+      failedAtMs: undefined,
+      canceledAtMs: undefined,
+      error: undefined,
+    };
+  });
+
+export const derivePlaylistDownloadQueueSummary = (
+  queue: PlaylistDownloadQueueState,
+  nowMs: number,
+): PlaylistDownloadQueueSummary => {
+  const activeItems = queue.items.filter((item) => item.status === "active");
+  const pendingItems = queue.items.filter((item) => item.status === "pending");
+  const completedCount = queue.items.filter((item) => item.status === "completed").length;
+  const failedCount = queue.items.filter((item) => item.status === "failed").length;
+  const canceledCount = queue.items.filter((item) => item.status === "canceled").length;
+  let nextBudgetWaitMs: number | undefined;
+
+  const firstPendingItem = pendingItems[0];
+  if (firstPendingItem) {
+    const waitMs = getNextPlaylistDownloadBudgetWaitMs(queue, firstPendingItem.tunnelCost, nowMs);
+    if (waitMs > 0) {
+      nextBudgetWaitMs = waitMs;
+    }
+  }
+
+  return {
+    label: `Downloading ${completedCount}/${queue.items.length}`,
+    totalCount: queue.items.length,
+    completedCount,
+    activeCount: activeItems.length,
+    pendingCount: pendingItems.length,
+    failedCount,
+    canceledCount,
+    activeTitles: activeItems.map((item) => item.title),
+    waitingForTunnelBudget: nextBudgetWaitMs !== undefined,
+    nextBudgetWaitMs,
+    etaMs: estimatePlaylistDownloadQueueEtaMs(queue, nowMs),
+  };
+};
+
+const getActiveBudgetReservations = (queue: PlaylistDownloadQueueState, nowMs: number) =>
+  queue.budgetReservations.filter((reservation) => {
+    return reservation.reservedAtMs + PLAYLIST_DOWNLOAD_TUNNEL_BUDGET_WINDOW_MS > nowMs;
+  });
+
+const findPlaylistDownloadQueueItem = (queue: PlaylistDownloadQueueState, itemId: string) => {
+  const item = queue.items.find((entry) => entry.id === itemId);
+  if (!item) {
+    throw new Error("playlist download item not found.");
+  }
+
+  return item;
+};
+
+const updatePlaylistDownloadQueueItem = (
+  queue: PlaylistDownloadQueueState,
+  itemId: string,
+  updateItem: (item: PlaylistDownloadQueueItem) => PlaylistDownloadQueueItem,
+) => {
+  let foundItem = false;
+  const items = queue.items.map((item) => {
+    if (item.id !== itemId) {
+      return item;
+    }
+
+    foundItem = true;
+    return updateItem(item);
+  });
+
+  if (!foundItem) {
+    throw new Error("playlist download item not found.");
+  }
+
+  return {
+    ...queue,
+    items,
+  };
+};
+
+const estimatePlaylistDownloadQueueEtaMs = (queue: PlaylistDownloadQueueState, nowMs: number) => {
+  const completedDurations: number[] = [];
+  for (const item of queue.items) {
+    if (item.status !== "completed") {
+      continue;
+    }
+
+    if (item.startedAtMs === undefined || item.completedAtMs === undefined) {
+      continue;
+    }
+
+    const durationMs = item.completedAtMs - item.startedAtMs;
+    if (durationMs > 0) {
+      completedDurations.push(durationMs);
+    }
+  }
+
+  if (completedDurations.length === 0) {
+    return undefined;
+  }
+
+  const unfinishedItems = queue.items.filter((item) => {
+    return item.status === "active" || item.status === "pending";
+  });
+  if (unfinishedItems.length === 0) {
+    return undefined;
+  }
+
+  let totalCompletedDurationMs = 0;
+  for (const durationMs of completedDurations) {
+    totalCompletedDurationMs += durationMs;
+  }
+
+  const averageDurationMs = totalCompletedDurationMs / completedDurations.length;
+  let etaMs = 0;
+  for (const item of unfinishedItems) {
+    if (item.status === "active" && item.startedAtMs !== undefined) {
+      etaMs += Math.max(0, averageDurationMs - (nowMs - item.startedAtMs));
+      continue;
+    }
+
+    etaMs += averageDurationMs;
+  }
+
+  return Math.round(etaMs);
+};

--- a/components/audio/playlistDownloadQueueRuntime.test.ts
+++ b/components/audio/playlistDownloadQueueRuntime.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  cancelActivePlaylistDownloadTracks,
+  cancelPendingPlaylistDownloadTracks,
+  createPlaylistDownloadQueueRun,
+  derivePlaylistDownloadQueueState,
+  enqueuePlaylistDownloadQueueTracks,
+  markPlaylistDownloadTrackActive,
+  markPlaylistDownloadTrackCanceled,
+  markPlaylistDownloadTrackCompleted,
+  markPlaylistDownloadTrackFailed,
+  removeActivePlaylistDownloadTrack,
+  reserveNextPlaylistDownloadTrack,
+} from "./playlistDownloadQueueRuntime";
+import type { PlaylistDownloadRuntimeTrack } from "./playlistDownloadQueueRuntime";
+
+type Track = PlaylistDownloadRuntimeTrack & {
+  sourceUrl: string;
+};
+
+const tracks = (count: number): Track[] =>
+  Array.from({ length: count }, (_value, index) => ({
+    fileId: `track-${index + 1}`,
+    title: `Track ${index + 1}`,
+    sourceUrl: `https://soundcloud.com/artist/track-${index + 1}`,
+  }));
+
+const createRun = (count: number) =>
+  createPlaylistDownloadQueueRun(1, tracks(count), 0, (track) => ({
+    id: track.fileId,
+    title: track.title,
+    sourceUrl: track.sourceUrl,
+  }));
+
+const reserve = (run: ReturnType<typeof createRun>, nowMs: number) => {
+  const result = reserveNextPlaylistDownloadTrack(run, nowMs);
+  expect(result.status).toBe("reserved");
+  if (result.status !== "reserved") {
+    throw new Error("expected reserved playlist track.");
+  }
+  return result.track;
+};
+
+describe("playlistDownloadQueueRuntime", () => {
+  it("waits on the 21st track before marking it active", () => {
+    const run = createRun(21);
+
+    for (let index = 0; index < 20; index += 1) {
+      reserve(run, 0);
+    }
+
+    const result = reserveNextPlaylistDownloadTrack(run, 0);
+    const state = derivePlaylistDownloadQueueState(run, 0);
+
+    expect(result).toEqual({
+      status: "waiting-for-tunnel-budget",
+      waitMs: 60_000,
+    });
+    expect(run.active).toEqual([]);
+    expect(run.pending.map((track) => track.fileId)).toEqual(["track-21"]);
+    expect(run.model.items[20].status).toBe("pending");
+    expect(state.waitingForTunnelBudget).toBe(true);
+  });
+
+  it("exposes the budget wake result when tunnel capacity opens later", () => {
+    const run = createRun(21);
+
+    for (let index = 0; index < 20; index += 1) {
+      reserve(run, 0);
+    }
+
+    expect(reserveNextPlaylistDownloadTrack(run, 59_999)).toEqual({
+      status: "waiting-for-tunnel-budget",
+      waitMs: 1,
+    });
+    expect(reserveNextPlaylistDownloadTrack(run, 60_000)).toMatchObject({
+      status: "reserved",
+      track: { fileId: "track-21" },
+    });
+  });
+
+  it("retries failed, canceled, and completed file-error items without duplicating queue items", () => {
+    const retryTracks = tracks(3);
+    const run = createRun(3);
+    const firstTrack = reserve(run, 0);
+    markPlaylistDownloadTrackActive(run, firstTrack, 0);
+    markPlaylistDownloadTrackFailed(run, firstTrack.fileId, "network failed", 1_000);
+    removeActivePlaylistDownloadTrack(run, firstTrack.fileId);
+
+    const secondTrack = reserve(run, 0);
+    markPlaylistDownloadTrackActive(run, secondTrack, 0);
+    markPlaylistDownloadTrackCanceled(run, secondTrack.fileId, 1_000);
+    removeActivePlaylistDownloadTrack(run, secondTrack.fileId);
+
+    const thirdTrack = reserve(run, 0);
+    markPlaylistDownloadTrackActive(run, thirdTrack, 0);
+    markPlaylistDownloadTrackCompleted(run, thirdTrack.fileId, 1_000);
+    removeActivePlaylistDownloadTrack(run, thirdTrack.fileId);
+
+    const queuedTracks = enqueuePlaylistDownloadQueueTracks(
+      run,
+      retryTracks,
+      2_000,
+      new Set(["track-3"]),
+      (track) => ({
+        id: track.fileId,
+        title: track.title,
+        sourceUrl: track.sourceUrl,
+      }),
+    );
+
+    expect(queuedTracks.map((track) => track.fileId)).toEqual(["track-1", "track-2", "track-3"]);
+    expect(run.pending.map((track) => track.fileId)).toEqual(["track-1", "track-2", "track-3"]);
+    expect(run.total).toBe(3);
+    expect(run.completed).toBe(0);
+    expect(run.failed).toBe(0);
+    expect(run.model.items).toHaveLength(3);
+    expect(run.model.items.map((item) => item.status)).toEqual(["pending", "pending", "pending"]);
+    expect(derivePlaylistDownloadQueueState(run, 2_000)).toMatchObject({
+      total: 3,
+      completed: 0,
+      pending: 3,
+    });
+  });
+
+  it("marks pending and active queue items canceled", () => {
+    const run = createRun(3);
+    const activeTrack = reserve(run, 0);
+    markPlaylistDownloadTrackActive(run, activeTrack, 0);
+
+    const pendingCanceledTrackIds = cancelPendingPlaylistDownloadTracks(run, 1_000);
+    const activeCanceledTrackIds = cancelActivePlaylistDownloadTracks(run, 1_000);
+
+    expect(pendingCanceledTrackIds).toEqual(["track-2", "track-3"]);
+    expect(activeCanceledTrackIds).toEqual(["track-1"]);
+    expect(run.pending).toEqual([]);
+    expect(run.active.map((track) => track.fileId)).toEqual(["track-1"]);
+    expect(run.model.items.map((item) => item.status)).toEqual([
+      "canceled",
+      "canceled",
+      "canceled",
+    ]);
+    expect(derivePlaylistDownloadQueueState(run, 1_000).canceledCount).toBe(3);
+  });
+});

--- a/components/audio/playlistDownloadQueueRuntime.ts
+++ b/components/audio/playlistDownloadQueueRuntime.ts
@@ -1,0 +1,270 @@
+import {
+  createPlaylistDownloadQueue,
+  createPlaylistDownloadQueueItem,
+  derivePlaylistDownloadQueueSummary,
+  markPlaylistDownloadActive,
+  markPlaylistDownloadCanceled,
+  markPlaylistDownloadCompleted,
+  markPlaylistDownloadFailed,
+  reservePlaylistDownloadBudget,
+  retryPlaylistDownloadItem,
+} from "./playlistDownloadQueue";
+import type {
+  PlaylistDownloadQueueState as PlaylistDownloadQueueModel,
+  PlaylistDownloadQueueTrack as PlaylistDownloadQueueModelTrack,
+} from "./playlistDownloadQueue";
+
+export type PlaylistDownloadRuntimeTrack = {
+  fileId: string;
+  title: string;
+};
+
+export type ActivePlaylistDownload = {
+  fileId: string;
+  title: string;
+  startedAt: number;
+};
+
+export type PlaylistDownloadQueueRun<
+  Track extends PlaylistDownloadRuntimeTrack = PlaylistDownloadRuntimeTrack,
+> = {
+  id: number;
+  trackIds: string[];
+  pending: Track[];
+  active: ActivePlaylistDownload[];
+  total: number;
+  completed: number;
+  failed: number;
+  startedAt: number;
+  model: PlaylistDownloadQueueModel;
+  canceled: boolean;
+  done: boolean;
+};
+
+export type PlaylistDownloadQueueRuntimeSnapshot = {
+  id: number;
+  trackIds: string[];
+  total: number;
+  completed: number;
+  failed: number;
+  canceledCount: number;
+  pending: number;
+  active: ActivePlaylistDownload[];
+  startedAt: number;
+  etaMs?: number;
+  canceled: boolean;
+  done: boolean;
+  waitingForTunnelBudget: boolean;
+};
+
+export type ReserveNextPlaylistDownloadResult<Track extends PlaylistDownloadRuntimeTrack> =
+  | {
+      status: "empty";
+    }
+  | {
+      status: "reserved";
+      track: Track;
+    }
+  | {
+      status: "waiting-for-tunnel-budget";
+      waitMs: number;
+    };
+
+export const createPlaylistDownloadQueueRun = <Track extends PlaylistDownloadRuntimeTrack>(
+  id: number,
+  tracks: Track[],
+  startedAt: number,
+  createModelTrack: (track: Track) => PlaylistDownloadQueueModelTrack,
+): PlaylistDownloadQueueRun<Track> => ({
+  id,
+  trackIds: tracks.map((track) => track.fileId),
+  pending: [...tracks],
+  active: [],
+  total: tracks.length,
+  completed: 0,
+  failed: 0,
+  startedAt,
+  model: createPlaylistDownloadQueue(tracks.map(createModelTrack)),
+  canceled: false,
+  done: false,
+});
+
+export const derivePlaylistDownloadQueueState = (
+  run: PlaylistDownloadQueueRun,
+  nowMs: number,
+): PlaylistDownloadQueueRuntimeSnapshot => {
+  const summary = derivePlaylistDownloadQueueSummary(run.model, nowMs);
+
+  return {
+    id: run.id,
+    trackIds: run.trackIds,
+    total: run.total,
+    completed: summary.completedCount,
+    failed: summary.failedCount,
+    canceledCount: summary.canceledCount,
+    pending: summary.pendingCount,
+    active: run.active,
+    startedAt: run.startedAt,
+    etaMs: summary.etaMs,
+    canceled: run.canceled,
+    done: run.done,
+    waitingForTunnelBudget: !run.done && summary.waitingForTunnelBudget,
+  };
+};
+
+export const enqueuePlaylistDownloadQueueTracks = <Track extends PlaylistDownloadRuntimeTrack>(
+  run: PlaylistDownloadQueueRun<Track>,
+  tracks: Track[],
+  nowMs: number,
+  fileErrorTrackIds: Set<string>,
+  createModelTrack: (track: Track) => PlaylistDownloadQueueModelTrack,
+) => {
+  const retryTracks: Track[] = [];
+  const newTracks: Track[] = [];
+
+  for (const track of tracks) {
+    const queueItem = run.model.items.find((item) => item.id === track.fileId);
+    if (
+      queueItem?.status === "failed" ||
+      queueItem?.status === "canceled" ||
+      (queueItem?.status === "completed" && fileErrorTrackIds.has(track.fileId))
+    ) {
+      retryTracks.push(track);
+      if (queueItem.status === "failed") {
+        run.failed -= 1;
+      }
+      if (queueItem.status === "completed") {
+        run.completed -= 1;
+        run.model = markPlaylistDownloadCanceled(run.model, track.fileId, nowMs);
+      }
+      run.model = retryPlaylistDownloadItem(run.model, track.fileId);
+      continue;
+    }
+
+    if (!queueItem) {
+      newTracks.push(track);
+    }
+  }
+
+  const queuedTracks = [...retryTracks, ...newTracks];
+  if (queuedTracks.length === 0) return queuedTracks;
+
+  run.pending.push(...queuedTracks);
+  run.trackIds = asUniqueTrackIds([...run.trackIds, ...newTracks.map((track) => track.fileId)]);
+  run.total += newTracks.length;
+  run.model = {
+    ...run.model,
+    items: [
+      ...run.model.items,
+      ...newTracks.map((track) => createPlaylistDownloadQueueItem(createModelTrack(track))),
+    ],
+  };
+
+  return queuedTracks;
+};
+
+export const reserveNextPlaylistDownloadTrack = <Track extends PlaylistDownloadRuntimeTrack>(
+  run: PlaylistDownloadQueueRun<Track>,
+  nowMs: number,
+): ReserveNextPlaylistDownloadResult<Track> => {
+  const nextTrack = run.pending[0];
+  if (!nextTrack) return { status: "empty" };
+
+  const budget = reservePlaylistDownloadBudget(run.model, nextTrack.fileId, nowMs);
+  run.model = budget.queue;
+
+  if (budget.status === "waiting-for-tunnel-budget") {
+    return {
+      status: "waiting-for-tunnel-budget",
+      waitMs: budget.waitMs,
+    };
+  }
+
+  run.pending = run.pending.slice(1);
+  return {
+    status: "reserved",
+    track: nextTrack,
+  };
+};
+
+export const markPlaylistDownloadTrackActive = <Track extends PlaylistDownloadRuntimeTrack>(
+  run: PlaylistDownloadQueueRun<Track>,
+  track: Track,
+  startedAt: number,
+) => {
+  const activeTrack = {
+    fileId: track.fileId,
+    title: track.title,
+    startedAt,
+  };
+  run.model = markPlaylistDownloadActive(run.model, track.fileId, startedAt);
+  run.active = [...run.active, activeTrack];
+  return activeTrack;
+};
+
+export const markPlaylistDownloadTrackCompleted = (
+  run: PlaylistDownloadQueueRun,
+  trackId: string,
+  nowMs: number,
+) => {
+  run.completed += 1;
+  run.model = markPlaylistDownloadCompleted(run.model, trackId, nowMs);
+};
+
+export const markPlaylistDownloadTrackFailed = (
+  run: PlaylistDownloadQueueRun,
+  trackId: string,
+  error: string,
+  nowMs: number,
+) => {
+  run.failed += 1;
+  run.model = markPlaylistDownloadFailed(run.model, trackId, error, nowMs);
+};
+
+export const markPlaylistDownloadTrackCanceled = (
+  run: PlaylistDownloadQueueRun,
+  trackId: string,
+  nowMs: number,
+) => {
+  run.model = markPlaylistDownloadCanceled(run.model, trackId, nowMs);
+};
+
+export const removeActivePlaylistDownloadTrack = (
+  run: PlaylistDownloadQueueRun,
+  trackId: string,
+) => {
+  run.active = run.active.filter((track) => track.fileId !== trackId);
+};
+
+export const cancelPendingPlaylistDownloadTracks = (
+  run: PlaylistDownloadQueueRun,
+  nowMs: number,
+) => {
+  const canceledTrackIds = run.pending.map((track) => track.fileId);
+  for (const trackId of canceledTrackIds) {
+    run.model = markPlaylistDownloadCanceled(run.model, trackId, nowMs);
+  }
+  run.pending = [];
+  return canceledTrackIds;
+};
+
+export const cancelActivePlaylistDownloadTracks = (
+  run: PlaylistDownloadQueueRun,
+  nowMs: number,
+) => {
+  const canceledTrackIds = run.active.map((track) => track.fileId);
+  for (const trackId of canceledTrackIds) {
+    run.model = markPlaylistDownloadCanceled(run.model, trackId, nowMs);
+  }
+  return canceledTrackIds;
+};
+
+export const finishPlaylistDownloadQueueRunIfIdle = (run: PlaylistDownloadQueueRun) => {
+  if (run.active.length > 0) return false;
+  if (!run.canceled && run.pending.length > 0) return false;
+
+  run.done = true;
+  return true;
+};
+
+const asUniqueTrackIds = (trackIds: string[]) => [...new Set(trackIds)];

--- a/components/audio/types.ts
+++ b/components/audio/types.ts
@@ -29,7 +29,7 @@ export interface TagiumFile {
   file?: File;
   originalFile?: File;
   status: "pending" | "saved" | "error";
-  downloadStatus: "downloading" | "ready" | "error";
+  downloadStatus: "downloading" | "ready" | "error" | "canceled";
   downloadError?: string;
   downloadRequest?: {
     sourceUrl: string;


### PR DESCRIPTION
## Summary
- add a managed SoundCloud playlist download queue with real 40-tunnel / 60s Cobalt budget scheduling
- show sidebar queue progress, active tracks, budget waits, cancel, and retry controls
- keep Cobalt per-track cover tunnels/artwork and make canceled downloads a neutral retryable state

## Preview
https://codex-managed-playlist-download-queue-tagium.oliver-boorstein.workers.dev

## Validation
- vp fmt
- vp lint
- vp check
- vp test
- CI: Verify Build passed
- Cloudflare Workers build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added playlist download queue status UI with progress, ETA, current tracks, and cancel/retry actions.
  * Track downloads can now show a **canceled** state in sidebars and metadata views.
* **Bug Fixes**
  * Canceled downloads are now treated as retryable in the album sidebar.
  * Playlist downloads now handle cancellation and resumable queue behavior more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->