### PR TITLE
feat: persist settings

### DIFF
--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -59,7 +59,7 @@ import {
   toGenreString,
   writeMetadataToFile,
 } from "./mp3Utils";
-import { DEFAULT_APP_SETTINGS } from "./settings";
+import { loadAppSettings, saveAppSettings } from "./settings";
 import type { SoundCloudSet } from "./soundcloudSet";
 import { AlbumGroup, AppSettings, AudioMetadata, ImportedAlbumMetadata, TagiumFile } from "./types";
 
@@ -209,7 +209,7 @@ export default function AudioTagger() {
   const [editingAlbumId, setEditingAlbumId] = useState<string | null>(null);
   const [createSeedTrackIds, setCreateSeedTrackIds] = useState<string[]>([]);
   const [activeView, setActiveView] = useState<ActiveView>("editor");
-  const [settings, setSettings] = useState<AppSettings>(DEFAULT_APP_SETTINGS);
+  const [settings, setSettings] = useState<AppSettings>(loadAppSettings);
   const [playlistDownloadQueue, setPlaylistDownloadQueue] =
     useState<PlaylistDownloadQueueState | null>(null);
   const filesRef = useRef<TagiumFile[]>(files);
@@ -1090,6 +1090,7 @@ export default function AudioTagger() {
     }
   };
   const handleSettingsChange = (nextSettings: AppSettings) => {
+    saveAppSettings(nextSettings);
     setSettings(nextSettings);
     let syncedFiles = filesRef.current;
     if (!settings.syncTrackNumbers && nextSettings.syncTrackNumbers) {

--- a/components/audio/settings.test.ts
+++ b/components/audio/settings.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  APP_SETTINGS_STORAGE_KEY,
+  DEFAULT_APP_SETTINGS,
+  loadAppSettings,
+  saveAppSettings,
+} from "./settings";
+import type { AppSettings } from "./types";
+
+const storageWith = (initialValue: string | null) => {
+  let savedValue: string | null = initialValue;
+
+  return {
+    getItem: (key: string) => (key === APP_SETTINGS_STORAGE_KEY ? savedValue : null),
+    setItem: (key: string, value: string) => {
+      if (key === APP_SETTINGS_STORAGE_KEY) {
+        savedValue = value;
+      }
+    },
+    savedValue: () => savedValue,
+  };
+};
+
+describe("settings", () => {
+  it("uses defaults when no settings are stored", () => {
+    expect(loadAppSettings(storageWith(null))).toEqual(DEFAULT_APP_SETTINGS);
+  });
+
+  it("fills new default keys when stored settings are incomplete", () => {
+    const storage = storageWith(JSON.stringify({ syncTrackNumbers: false }));
+
+    expect(loadAppSettings(storage)).toEqual({
+      ...DEFAULT_APP_SETTINGS,
+      syncTrackNumbers: false,
+    });
+  });
+
+  it("ignores invalid stored setting values", () => {
+    const storage = storageWith(
+      JSON.stringify({
+        syncTrackNumbers: false,
+        syncFilenames: "no",
+        audioBitrate: "999",
+      }),
+    );
+
+    expect(loadAppSettings(storage)).toEqual({
+      ...DEFAULT_APP_SETTINGS,
+      syncTrackNumbers: false,
+    });
+  });
+
+  it("saves app settings", () => {
+    const storage = storageWith(null);
+    const settings: AppSettings = {
+      syncTrackNumbers: false,
+      syncFilenames: false,
+      audioBitrate: "256",
+    };
+
+    saveAppSettings(settings, storage);
+
+    expect(storage.savedValue()).toBe(JSON.stringify(settings));
+  });
+});

--- a/components/audio/settings.test.ts
+++ b/components/audio/settings.test.ts
@@ -26,6 +26,16 @@ describe("settings", () => {
     expect(loadAppSettings(storageWith(null))).toEqual(DEFAULT_APP_SETTINGS);
   });
 
+  it("uses defaults when stored settings cannot be read", () => {
+    const storage = {
+      getItem: () => {
+        throw new Error("storage unavailable");
+      },
+    };
+
+    expect(loadAppSettings(storage)).toEqual(DEFAULT_APP_SETTINGS);
+  });
+
   it("fills new default keys when stored settings are incomplete", () => {
     const storage = storageWith(JSON.stringify({ syncTrackNumbers: false }));
 
@@ -61,5 +71,20 @@ describe("settings", () => {
     saveAppSettings(settings, storage);
 
     expect(storage.savedValue()).toBe(JSON.stringify(settings));
+  });
+
+  it("ignores app settings save failures", () => {
+    const storage = {
+      setItem: () => {
+        throw new Error("storage unavailable");
+      },
+    };
+    const settings: AppSettings = {
+      syncTrackNumbers: false,
+      syncFilenames: false,
+      audioBitrate: "256",
+    };
+
+    expect(() => saveAppSettings(settings, storage)).not.toThrow();
   });
 });

--- a/components/audio/settings.ts
+++ b/components/audio/settings.ts
@@ -26,11 +26,12 @@ const storedAppSettingsSchema = z
   })
   .catch(DEFAULT_APP_SETTINGS);
 
-export const loadAppSettings = (storage: Pick<Storage, "getItem"> = localStorage): AppSettings => {
-  const storedSettings = storage.getItem(APP_SETTINGS_STORAGE_KEY);
-  if (storedSettings === null) return DEFAULT_APP_SETTINGS;
-
+export const loadAppSettings = (storage?: Pick<Storage, "getItem">): AppSettings => {
   try {
+    const targetStorage = storage ?? localStorage;
+    const storedSettings = targetStorage.getItem(APP_SETTINGS_STORAGE_KEY);
+    if (storedSettings === null) return DEFAULT_APP_SETTINGS;
+
     return {
       ...DEFAULT_APP_SETTINGS,
       ...storedAppSettingsSchema.parse(JSON.parse(storedSettings)),
@@ -40,9 +41,11 @@ export const loadAppSettings = (storage: Pick<Storage, "getItem"> = localStorage
   }
 };
 
-export const saveAppSettings = (
-  settings: AppSettings,
-  storage: Pick<Storage, "setItem"> = localStorage,
-) => {
-  storage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+export const saveAppSettings = (settings: AppSettings, storage?: Pick<Storage, "setItem">) => {
+  try {
+    const targetStorage = storage ?? localStorage;
+    targetStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    return;
+  }
 };

--- a/components/audio/settings.ts
+++ b/components/audio/settings.ts
@@ -1,10 +1,48 @@
+import { z } from "zod";
 import type { AudioDownloadBitrate } from "./cobaltDownload";
 import type { AppSettings } from "./types";
 
-export const AUDIO_BITRATE_OPTIONS: AudioDownloadBitrate[] = ["320", "256", "128", "96", "64"];
+export const AUDIO_BITRATE_OPTIONS = [
+  "320",
+  "256",
+  "128",
+  "96",
+  "64",
+] as const satisfies readonly AudioDownloadBitrate[];
 
 export const DEFAULT_APP_SETTINGS: AppSettings = {
   syncTrackNumbers: true,
   syncFilenames: true,
   audioBitrate: "320",
+};
+
+export const APP_SETTINGS_STORAGE_KEY = "tagium:app-settings";
+
+const storedAppSettingsSchema = z
+  .object({
+    syncTrackNumbers: z.boolean().catch(DEFAULT_APP_SETTINGS.syncTrackNumbers),
+    syncFilenames: z.boolean().catch(DEFAULT_APP_SETTINGS.syncFilenames),
+    audioBitrate: z.enum(AUDIO_BITRATE_OPTIONS).catch(DEFAULT_APP_SETTINGS.audioBitrate),
+  })
+  .catch(DEFAULT_APP_SETTINGS);
+
+export const loadAppSettings = (storage: Pick<Storage, "getItem"> = localStorage): AppSettings => {
+  const storedSettings = storage.getItem(APP_SETTINGS_STORAGE_KEY);
+  if (storedSettings === null) return DEFAULT_APP_SETTINGS;
+
+  try {
+    return {
+      ...DEFAULT_APP_SETTINGS,
+      ...storedAppSettingsSchema.parse(JSON.parse(storedSettings)),
+    };
+  } catch {
+    return DEFAULT_APP_SETTINGS;
+  }
+};
+
+export const saveAppSettings = (
+  settings: AppSettings,
+  storage: Pick<Storage, "setItem"> = localStorage,
+) => {
+  storage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
 };


### PR DESCRIPTION
## Scope
- Persist settings across app sessions.
- Establishes the base settings persistence behavior for the stack.

## Verification
- Current stack was handed off as verified before submit.
- Required checks from the verified stack: `vp fmt`, `vp lint`, `vp check`; `vp test` for logic coverage.
- Submit pass only checked branch/working-tree state and pushed without rewriting commits.

## Review-loop summary
- Submitted as PR 1 of 4.
- Draft because GitHub `main` has advanced past the verified local base commit `b5072cb`, and this submit pass intentionally did not rebase or rewrite code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio settings now load from and save to persisted app preferences, so bitrate and related choices are remembered between sessions.

* **Bug Fixes**
  * Added stronger validation for saved audio settings to safely fall back to defaults when stored data is missing, invalid, or corrupted.
  * Improved resilience when saving settings so storage failures won’t break the app.

* **Chores**
  * Adjusted service scaling behavior to better handle idle periods.
  * Reduced audio request limits to help prevent overuse and improve stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->