### PR TITLE
feat: set SoundCloud import kind

### DIFF
--- a/components/audio/soundcloudSet.ts
+++ b/components/audio/soundcloudSet.ts
@@ -6,6 +6,7 @@ const soundCloudSetSchema = z.object({
   artist: z.string(),
   genre: z.string(),
   year: z.number().optional(),
+  isAlbum: z.boolean(),
   coverUrl: z.string().optional(),
   tracks: z.array(
     z.object({

--- a/server-tests/soundcloud-set.get.test.ts
+++ b/server-tests/soundcloud-set.get.test.ts
@@ -75,4 +75,65 @@ describe("soundcloud set endpoint", () => {
       ],
     });
   });
+
+  it("accepts null release date for playlist year", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        let url = "";
+        if (input instanceof Request) {
+          url = input.url;
+        } else {
+          url = new URL(input).toString();
+        }
+
+        if (url === "https://soundcloud.com/") {
+          return new Response(
+            '<script>window.__sc_version="1234567890"</script>{"hydratable":"apiClient","data":{"id":"client-id"}}',
+          );
+        }
+
+        expect(url).toContain("https://api-v2.soundcloud.com/resolve");
+
+        return Response.json({
+          kind: "playlist",
+          title: " Playlist ",
+          genre: " Electronic ",
+          display_date: "2024-05-01T00:00:00Z",
+          release_date: null,
+          is_album: false,
+          set_type: "playlist",
+          artwork_url: null,
+          user: {
+            username: " Artist ",
+          },
+          tracks: [
+            {
+              id: 1,
+              kind: "track",
+              title: " Track ",
+              permalink_url: "https://soundcloud.com/artist/track",
+              duration: 123,
+            },
+          ],
+        });
+      }),
+    );
+
+    await expect(handler(makeEvent())).resolves.toMatchObject({
+      title: "Playlist",
+      artist: "Artist",
+      genre: "Electronic",
+      year: 2024,
+      isAlbum: false,
+      tracks: [
+        {
+          title: "Track",
+          url: "https://soundcloud.com/artist/track",
+          duration: 123,
+          trackNumber: 1,
+        },
+      ],
+    });
+  });
 });

--- a/server-tests/soundcloud-set.get.test.ts
+++ b/server-tests/soundcloud-set.get.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import handler from "../server/api/soundcloud-set.get";
+
+const makeEvent = () => {
+  const request = new Request(
+    "https://tagium.test/api/soundcloud-set?url=https%3A%2F%2Fsoundcloud.com%2Fartist%2Fsets%2Falbum",
+  );
+
+  return { req: request } as unknown as Parameters<typeof handler>[0];
+};
+
+describe("soundcloud set endpoint", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns album kind and prefers release date for album year", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        let url = "";
+        if (input instanceof Request) {
+          url = input.url;
+        } else {
+          url = new URL(input).toString();
+        }
+
+        if (url === "https://soundcloud.com/") {
+          return new Response(
+            '<script>window.__sc_version="1234567890"</script>{"hydratable":"apiClient","data":{"id":"client-id"}}',
+          );
+        }
+
+        expect(url).toContain("https://api-v2.soundcloud.com/resolve");
+
+        return Response.json({
+          kind: "playlist",
+          title: " Album ",
+          genre: " Electronic ",
+          display_date: "2024-05-01T00:00:00Z",
+          release_date: "2023-09-15T00:00:00Z",
+          is_album: true,
+          set_type: "album",
+          artwork_url: "https://i1.sndcdn.com/artworks-large.jpg",
+          user: {
+            username: " Artist ",
+          },
+          tracks: [
+            {
+              id: 1,
+              kind: "track",
+              title: " Track ",
+              permalink_url: "https://soundcloud.com/artist/track",
+              duration: 123,
+            },
+          ],
+        });
+      }),
+    );
+
+    await expect(handler(makeEvent())).resolves.toMatchObject({
+      title: "Album",
+      artist: "Artist",
+      genre: "Electronic",
+      year: 2023,
+      isAlbum: true,
+      coverUrl: "https://i1.sndcdn.com/artworks-t1080x1080.jpg",
+      tracks: [
+        {
+          title: "Track",
+          url: "https://soundcloud.com/artist/track",
+          duration: 123,
+          trackNumber: 1,
+        },
+      ],
+    });
+  });
+});

--- a/server/api/soundcloud-set.get.ts
+++ b/server/api/soundcloud-set.get.ts
@@ -28,6 +28,9 @@ const soundCloudPlaylistSchema = z.object({
   title: z.string(),
   genre: z.string().optional(),
   display_date: z.string().optional(),
+  release_date: z.string().optional(),
+  is_album: z.boolean().optional(),
+  set_type: z.string().optional(),
   artwork_url: z.string().nullable().optional(),
   user: z
     .object({
@@ -145,12 +148,18 @@ export default defineHandler(async (event) => {
   );
   const trackEntries = playlist.tracks.filter((track) => track !== undefined);
   const tracks = await resolveTracks(clientId, trackEntries);
+  const isAlbum = [playlist.is_album, playlist.set_type === "album"].includes(true);
+  let yearDate = playlist.display_date;
+  if (isAlbum && playlist.release_date) {
+    yearDate = playlist.release_date;
+  }
 
   return {
     title: playlist.title.trim(),
     artist: playlist.user?.username?.trim() ?? "",
     genre: playlist.genre?.trim() ?? "",
-    year: getYear(playlist.display_date),
+    year: getYear(yearDate),
+    isAlbum,
     coverUrl: getCoverUrl(playlist.artwork_url),
     tracks: tracks.map((track, index) => ({
       title: track.title.trim(),

--- a/server/api/soundcloud-set.get.ts
+++ b/server/api/soundcloud-set.get.ts
@@ -28,7 +28,7 @@ const soundCloudPlaylistSchema = z.object({
   title: z.string(),
   genre: z.string().optional(),
   display_date: z.string().optional(),
-  release_date: z.string().optional(),
+  release_date: z.string().nullable().optional(),
   is_album: z.boolean().optional(),
   set_type: z.string().optional(),
   artwork_url: z.string().nullable().optional(),


### PR DESCRIPTION
## Scope
- Sets the imported SoundCloud metadata kind for SoundCloud set imports.
- Builds on the settings persistence branch.

## Verification
- Current stack was handed off as verified before submit.
- Required checks from the verified stack: `vp fmt`, `vp lint`, `vp check`; `vp test` for logic coverage.
- Submit pass only checked branch/working-tree state and pushed without rewriting commits.

## Review-loop summary
- Submitted as PR 2 of 4.
- Base branch is `codex/pr1-settings-persistence` to preserve the reviewed stack order.
- Draft because GitHub `main` has advanced past the verified local base commit `b5072cb`, and this submit pass intentionally did not rebase or rewrite code.
