### PR TITLE
feat: require explicit album cover apply

### DIFF
--- a/components/audio/AlbumMetadataDialog.tsx
+++ b/components/audio/AlbumMetadataDialog.tsx
@@ -31,6 +31,7 @@ interface AlbumMetadataDialogProps {
   onClose: () => void;
   onSave: () => void;
   onDelete?: () => void;
+  onApplyCover?: () => void;
 }
 
 export default function AlbumMetadataDialog({
@@ -42,9 +43,11 @@ export default function AlbumMetadataDialog({
   onClose,
   onSave,
   onDelete,
+  onApplyCover,
 }: AlbumMetadataDialogProps) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showErrors, setShowErrors] = useState(false);
+  const canApplyCover = mode === "edit" && draft.cover && draft.cover.length > 0 && onApplyCover;
 
   const handleCoverUpload = (file: File) => {
     const reader = new FileReader();
@@ -196,6 +199,11 @@ export default function AlbumMetadataDialog({
                     onClick={() => setShowDeleteConfirm(true)}
                   >
                     delete album
+                  </Button>
+                )}
+                {canApplyCover && (
+                  <Button type="button" variant="outline" onClick={onApplyCover}>
+                    apply cover to tracks
                   </Button>
                 )}
                 <Button type="button" variant="outline" onClick={onClose}>

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -14,6 +14,7 @@ import {
   reorderAlbums,
 } from "./albumOps";
 import {
+  applyAlbumCoverToFiles,
   applyAlbumSharedTagsToFiles,
   applySyncedFilenamesToFiles,
   applyTrackOrderNumbersToFiles,
@@ -1468,6 +1469,18 @@ export default function AudioTagger() {
   const closeAlbumDialog = () => {
     setAlbumDialogOpen(false);
   };
+  const applyAlbumDraftCoverToTracks = () => {
+    if (albumDialogMode !== "edit" || !editingAlbumId || !albumDraft.cover) return;
+    if (albumDraft.cover.length === 0) return;
+
+    const album = albumsRef.current.find((entry) => entry.id === editingAlbumId);
+    if (!album) return;
+
+    const bufferedFiles = applyCurrentFormMetadataToFiles(filesRef.current, album.trackIds);
+    const coveredFiles = applyAlbumCoverToFiles(bufferedFiles, album.trackIds, albumDraft.cover);
+    filesRef.current = coveredFiles;
+    setFiles(coveredFiles);
+  };
   const saveAlbumDialog = () => {
     const title = albumDraft.title.trim() || "untitled album";
     const artist = albumDraft.artist.trim();
@@ -1667,6 +1680,7 @@ export default function AudioTagger() {
         onChange={setAlbumDraft}
         onClose={closeAlbumDialog}
         onSave={saveAlbumDialog}
+        onApplyCover={applyAlbumDraftCoverToTracks}
         onDelete={
           albumDialogMode === "edit" && editingAlbumId
             ? () => {

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -14,7 +14,7 @@ import {
   reorderAlbums,
 } from "./albumOps";
 import {
-  applyAlbumCoverToFiles,
+  applyAlbumCoverToFilesWithSelectedMetadata,
   applyAlbumSharedTagsToFiles,
   applySyncedFilenamesToFiles,
   applyTrackOrderNumbersToFiles,
@@ -1477,9 +1477,18 @@ export default function AudioTagger() {
     if (!album) return;
 
     const bufferedFiles = applyCurrentFormMetadataToFiles(filesRef.current, album.trackIds);
-    const coveredFiles = applyAlbumCoverToFiles(bufferedFiles, album.trackIds, albumDraft.cover);
+    const covered = applyAlbumCoverToFilesWithSelectedMetadata(
+      bufferedFiles,
+      album.trackIds,
+      albumDraft.cover,
+      selectedFileIdRef.current,
+    );
+    const coveredFiles = covered.files;
     filesRef.current = coveredFiles;
     setFiles(coveredFiles);
+    if (covered.selectedMetadata) {
+      reset(covered.selectedMetadata);
+    }
   };
   const saveAlbumDialog = () => {
     const title = albumDraft.title.trim() || "untitled album";

--- a/components/audio/fileMetadataOps.test.ts
+++ b/components/audio/fileMetadataOps.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   applyAlbumCoverToFiles,
+  applyAlbumCoverToFilesWithSelectedMetadata,
   applyAlbumSharedTagsToFiles,
   applySyncedFilenamesToFiles,
   applyTrackOrderNumbersToFiles,
@@ -208,6 +209,55 @@ describe("fileMetadataOps", () => {
     expect(result[1].metadata?.picture).toEqual(albumCover);
     expect(result[1].hasBufferedChanges).toBe(true);
     expect(result[2]).toBe(files[2]);
+  });
+
+  it("returns selected metadata with applied cover after buffering dirty form metadata", () => {
+    const oldFormCover = [
+      {
+        format: "image/png",
+        type: 3,
+        description: "old dirty form cover",
+        data: new Uint8Array([9]),
+      },
+    ];
+    const albumCover = [
+      {
+        format: "image/jpeg",
+        type: 3,
+        description: "album cover",
+        data: new Uint8Array([1, 2, 3]),
+      },
+    ];
+    const dirtySelectedMetadata = metadata({
+      filename: "dirty-title",
+      title: "Dirty Title",
+      picture: oldFormCover,
+    });
+    const files = [
+      readyFile({
+        id: "track-1",
+        filename: "dirty-title.mp3",
+        metadata: dirtySelectedMetadata,
+        hasBufferedChanges: true,
+      }),
+      readyFile({
+        id: "track-2",
+        metadata: metadata({ picture: [] }),
+      }),
+    ];
+
+    const result = applyAlbumCoverToFilesWithSelectedMetadata(
+      files,
+      ["track-1", "track-2"],
+      albumCover,
+      "track-1",
+    );
+
+    expect(result.files[0].metadata?.title).toBe("Dirty Title");
+    expect(result.files[0].metadata?.picture).toEqual(albumCover);
+    expect(result.selectedMetadata?.title).toBe("Dirty Title");
+    expect(result.selectedMetadata?.picture).toEqual(albumCover);
+    expect(result.files[1].metadata?.picture).toEqual(albumCover);
   });
 
   it("syncs filenames from titles across any tracks", () => {

--- a/components/audio/fileMetadataOps.test.ts
+++ b/components/audio/fileMetadataOps.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
+  applyAlbumCoverToFiles,
   applyAlbumSharedTagsToFiles,
   applySyncedFilenamesToFiles,
   applyTrackOrderNumbersToFiles,
@@ -103,7 +104,7 @@ describe("fileMetadataOps", () => {
     expect(result[1].metadata?.trackNumber).toBe(1);
   });
 
-  it("applies shared album metadata and preserves existing cover when none is provided", () => {
+  it("applies shared album metadata without applying album cover", () => {
     const originalCover = [
       {
         format: "image/jpeg",
@@ -143,6 +144,14 @@ describe("fileMetadataOps", () => {
       title: "New Album",
       artist: "New Artist",
       genre: "Ambient",
+      cover: [
+        {
+          format: "image/png",
+          type: 3,
+          description: "album cover",
+          data: new Uint8Array([4, 5, 6]),
+        },
+      ],
       trackIds: ["track-1"],
     };
 
@@ -155,6 +164,50 @@ describe("fileMetadataOps", () => {
     expect(updatedFile.metadata?.genre).toBe("Ambient");
     expect(updatedFile.metadata?.trackNumber).toBe(9);
     expect(updatedFile.metadata?.picture).toEqual(originalCover);
+  });
+
+  it("explicitly applies album cover to album tracks", () => {
+    const albumCover = [
+      {
+        format: "image/jpeg",
+        type: 3,
+        description: "album cover",
+        data: new Uint8Array([1, 2, 3]),
+      },
+    ];
+    const files = [
+      readyFile({
+        id: "track-1",
+        status: "saved",
+        metadata: metadata({ picture: [] }),
+      }),
+      readyFile({
+        id: "track-2",
+        metadata: metadata({
+          picture: [
+            {
+              format: "image/png",
+              type: 3,
+              description: "old cover",
+              data: new Uint8Array([9]),
+            },
+          ],
+        }),
+      }),
+      readyFile({
+        id: "track-3",
+        metadata: metadata({ picture: [] }),
+      }),
+    ];
+
+    const result = applyAlbumCoverToFiles(files, ["track-1", "track-2"], albumCover);
+
+    expect(result[0].metadata?.picture).toEqual(albumCover);
+    expect(result[0].status).toBe("pending");
+    expect(result[0].hasBufferedChanges).toBe(true);
+    expect(result[1].metadata?.picture).toEqual(albumCover);
+    expect(result[1].hasBufferedChanges).toBe(true);
+    expect(result[2]).toBe(files[2]);
   });
 
   it("syncs filenames from titles across any tracks", () => {

--- a/components/audio/fileMetadataOps.ts
+++ b/components/audio/fileMetadataOps.ts
@@ -102,7 +102,30 @@ export function applyAlbumSharedTagsToFiles(files: TagiumFile[], album: AlbumGro
         album: album.title,
         genre: album.genre,
         year: album.year !== undefined ? album.year : file.metadata.year,
-        picture: album.cover && album.cover.length > 0 ? album.cover : file.metadata.picture,
+      },
+    };
+  });
+}
+
+export function applyAlbumCoverToFiles(
+  files: TagiumFile[],
+  trackIds: string[],
+  cover: AudioMetadata["picture"],
+) {
+  if (trackIds.length === 0 || cover.length === 0) return files;
+
+  const trackSet = new Set(trackIds);
+
+  return files.map((file) => {
+    if (!trackSet.has(file.id) || !file.metadata) return file;
+
+    return {
+      ...file,
+      status: file.status === "saved" ? "pending" : file.status,
+      hasBufferedChanges: true,
+      metadata: {
+        ...file.metadata,
+        picture: cover,
       },
     };
   });

--- a/components/audio/fileMetadataOps.ts
+++ b/components/audio/fileMetadataOps.ts
@@ -131,6 +131,27 @@ export function applyAlbumCoverToFiles(
   });
 }
 
+export function applyAlbumCoverToFilesWithSelectedMetadata(
+  files: TagiumFile[],
+  trackIds: string[],
+  cover: AudioMetadata["picture"],
+  selectedFileId: string | null,
+) {
+  const coveredFiles = applyAlbumCoverToFiles(files, trackIds, cover);
+  if (!selectedFileId) {
+    return { files: coveredFiles };
+  }
+  if (!trackIds.includes(selectedFileId)) {
+    return { files: coveredFiles };
+  }
+
+  const selectedFile = coveredFiles.find((file) => file.id === selectedFileId);
+  return {
+    files: coveredFiles,
+    selectedMetadata: selectedFile?.metadata,
+  };
+}
+
 export function prepareDownloadedTrackHydration(
   currentFile: TagiumFile,
   parsedFile: TagiumFile,

--- a/components/audio/fileMetadataOps.ts
+++ b/components/audio/fileMetadataOps.ts
@@ -136,7 +136,7 @@ export function applyAlbumCoverToFilesWithSelectedMetadata(
   trackIds: string[],
   cover: AudioMetadata["picture"],
   selectedFileId: string | null,
-) {
+): { files: TagiumFile[]; selectedMetadata?: AudioMetadata } {
   const coveredFiles = applyAlbumCoverToFiles(files, trackIds, cover);
   if (!selectedFileId) {
     return { files: coveredFiles };


### PR DESCRIPTION
## Scope
- Requires an explicit apply action for album cover updates.
- Keeps album art application intentional before the final SoundCloud auto-apply behavior.

## Verification
- Current stack was handed off as verified before submit.
- Required checks from the verified stack: `vp fmt`, `vp lint`, `vp check`; `vp test` for logic coverage.
- Submit pass only checked branch/working-tree state and pushed without rewriting commits.

## Review-loop summary
- Submitted as PR 3 of 4.
- Base branch is `codex/pr2-soundcloud-set-kind-stack` to preserve the reviewed stack order.
- Draft because GitHub `main` has advanced past the verified local base commit `b5072cb`, and this submit pass intentionally did not rebase or rewrite code.
