### PR TITLE
feat: auto-apply SoundCloud cover

### DIFF
--- a/components/audio/SettingsPage.tsx
+++ b/components/audio/SettingsPage.tsx
@@ -97,6 +97,21 @@ export default function SettingsPage({ settings, onChange }: SettingsPageProps) 
                 </PopoverContent>
               </Popover>
             </div>
+            <label className="flex cursor-pointer items-start gap-3 py-1">
+              <Checkbox
+                checked={settings.applySoundCloudAlbumCoverToTracks}
+                onCheckedChange={(checked) =>
+                  onChange({
+                    ...settings,
+                    applySoundCloudAlbumCoverToTracks: checked === true,
+                  })
+                }
+                className="mt-0.5"
+              />
+              <span className="text-sm font-medium">
+                automatically apply SoundCloud album cover to all tracks
+              </span>
+            </label>
           </section>
 
           <section className="flex flex-col gap-5">

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -18,6 +18,7 @@ import {
   applyAlbumSharedTagsToFiles,
   applySyncedFilenamesToFiles,
   applyTrackOrderNumbersToFiles,
+  applySoundCloudSetImportedCover,
   prepareDownloadedTrackHydration,
   resolveDownloadedTrackHydrationWrite,
   resolveDownloadedTrackHydrationWriteError,

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -16,6 +16,7 @@ import {
 import {
   applyAlbumCoverToFilesWithSelectedMetadata,
   applyAlbumSharedTagsToFiles,
+  applySoundCloudSetImportedCover,
   applySyncedFilenamesToFiles,
   applyTrackOrderNumbersToFiles,
   prepareDownloadedTrackHydration,
@@ -61,7 +62,7 @@ import {
   writeMetadataToFile,
 } from "./mp3Utils";
 import { loadAppSettings, saveAppSettings } from "./settings";
-import { shouldApplySoundCloudSetCoverToTracks, type SoundCloudSet } from "./soundcloudSet";
+import type { SoundCloudSet } from "./soundcloudSet";
 import { AlbumGroup, AppSettings, AudioMetadata, ImportedAlbumMetadata, TagiumFile } from "./types";
 
 type ActiveView = "editor" | "settings";
@@ -988,29 +989,32 @@ export default function AudioTagger() {
     setLastSelectedFileId(pendingFiles[0]?.id ?? null);
 
     const coverUrl = set.coverUrl;
-    const applyCoverToTracks = shouldApplySoundCloudSetCoverToTracks(set, settings);
     if (coverUrl) {
       void (async () => {
         try {
           const cover = await fetchImportedCover(coverUrl);
-          const coveredAlbums = albumsRef.current.map((currentAlbum) =>
-            currentAlbum.id === albumId ? { ...currentAlbum, cover } : currentAlbum,
-          );
-          albumsRef.current = coveredAlbums;
-          setAlbums(coveredAlbums);
-          if (!applyCoverToTracks) return;
-
-          const covered = applyAlbumCoverToFilesWithSelectedMetadata(
+          const {
+            albums: coveredAlbums,
+            files: coveredFiles,
+            selectedMetadata,
+          } = applySoundCloudSetImportedCover(
             filesRef.current,
+            albumsRef.current,
+            albumId,
             album.trackIds,
+            set,
+            settings,
             cover,
             selectedFileIdRef.current,
           );
-          const coveredFiles = covered.files;
+          albumsRef.current = coveredAlbums;
+          setAlbums(coveredAlbums);
+          if (coveredFiles === filesRef.current) return;
+
           filesRef.current = coveredFiles;
           setFiles(coveredFiles);
-          if (covered.selectedMetadata) {
-            reset(covered.selectedMetadata);
+          if (selectedMetadata) {
+            reset(selectedMetadata);
           }
           const trackIdSet = new Set(album.trackIds);
           await Promise.all(

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -61,7 +61,7 @@ import {
   writeMetadataToFile,
 } from "./mp3Utils";
 import { loadAppSettings, saveAppSettings } from "./settings";
-import type { SoundCloudSet } from "./soundcloudSet";
+import { shouldApplySoundCloudSetCoverToTracks, type SoundCloudSet } from "./soundcloudSet";
 import { AlbumGroup, AppSettings, AudioMetadata, ImportedAlbumMetadata, TagiumFile } from "./types";
 
 type ActiveView = "editor" | "settings";
@@ -988,6 +988,7 @@ export default function AudioTagger() {
     setLastSelectedFileId(pendingFiles[0]?.id ?? null);
 
     const coverUrl = set.coverUrl;
+    const applyCoverToTracks = shouldApplySoundCloudSetCoverToTracks(set, settings);
     if (coverUrl) {
       void (async () => {
         try {
@@ -997,22 +998,21 @@ export default function AudioTagger() {
           );
           albumsRef.current = coveredAlbums;
           setAlbums(coveredAlbums);
-          const trackIdSet = new Set(album.trackIds);
-          const coveredFiles = filesRef.current.map((file) =>
-            trackIdSet.has(file.id) && file.file && file.metadata
-              ? {
-                  ...file,
-                  metadata: {
-                    ...file.metadata,
-                    picture: cover,
-                  },
-                  status: file.status === "saved" ? "pending" : file.status,
-                  hasBufferedChanges: true,
-                }
-              : file,
+          if (!applyCoverToTracks) return;
+
+          const covered = applyAlbumCoverToFilesWithSelectedMetadata(
+            filesRef.current,
+            album.trackIds,
+            cover,
+            selectedFileIdRef.current,
           );
+          const coveredFiles = covered.files;
           filesRef.current = coveredFiles;
           setFiles(coveredFiles);
+          if (covered.selectedMetadata) {
+            reset(covered.selectedMetadata);
+          }
+          const trackIdSet = new Set(album.trackIds);
           await Promise.all(
             coveredFiles
               .filter((file) => trackIdSet.has(file.id) && Boolean(file.file) && file.metadata)

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -16,7 +16,6 @@ import {
 import {
   applyAlbumCoverToFilesWithSelectedMetadata,
   applyAlbumSharedTagsToFiles,
-  applySoundCloudSetImportedCover,
   applySyncedFilenamesToFiles,
   applyTrackOrderNumbersToFiles,
   prepareDownloadedTrackHydration,
@@ -62,6 +61,11 @@ import {
   writeMetadataToFile,
 } from "./mp3Utils";
 import { loadAppSettings, saveAppSettings } from "./settings";
+import {
+  createDownloadMetadata,
+  createPendingDownloadTrack,
+  fetchImportedCover,
+} from "./soundcloudSetImport";
 import type { SoundCloudSet } from "./soundcloudSet";
 import { AlbumGroup, AppSettings, AudioMetadata, ImportedAlbumMetadata, TagiumFile } from "./types";
 
@@ -95,11 +99,6 @@ const isPlaylistDownloadAbort = (error: unknown) => {
 };
 const asUniqueTrackIds = (trackIds: string[]) => [...new Set(trackIds)];
 const getFileImportKey = (file: File) => `${file.name}:${file.size}:${file.lastModified}`;
-const filenameFromTitle = (title: string) => {
-  const filename = filenamify(title.trim(), { replacement: "-" });
-  if (filename) return `${filename}.mp3`;
-  return "downloading-track.mp3";
-};
 const titleFromSourceUrl = (sourceUrl: string) => {
   try {
     const url = new URL(sourceUrl);
@@ -109,70 +108,6 @@ const titleFromSourceUrl = (sourceUrl: string) => {
   } catch {
     return "downloading audio";
   }
-};
-const createDownloadMetadata = ({
-  title,
-  artist,
-  album,
-  genre,
-  year,
-  duration,
-  trackNumber,
-}: {
-  title: string;
-  artist: string;
-  album: string;
-  genre: string;
-  year?: number;
-  duration?: number;
-  trackNumber?: number;
-}): AudioMetadata => ({
-  filename: filenameFromTitle(title).replace(/\.mp3$/i, ""),
-  title,
-  artist,
-  album,
-  year,
-  genre,
-  duration: duration ?? 0,
-  bitrate: 0,
-  sampleRate: 0,
-  picture: [],
-  trackNumber,
-});
-const createPendingDownloadTrack = (
-  id: string,
-  metadata: AudioMetadata,
-  hasBufferedChanges: boolean,
-  downloadRequest: TagiumFile["downloadRequest"],
-): TagiumFile => ({
-  id,
-  filename: `${metadata.filename}.mp3`,
-  status: "pending",
-  downloadStatus: "downloading",
-  downloadRequest,
-  hasBufferedChanges,
-  metadata,
-});
-const fetchImportedCover = async (coverUrl: string): Promise<AudioMetadata["picture"]> => {
-  const response = await fetch(coverUrl);
-
-  if (!response.ok) {
-    throw new Error(`album cover request failed (${response.status})`);
-  }
-
-  const contentType = response.headers.get("content-type");
-  if (!contentType) {
-    throw new Error("album cover response missing content type.");
-  }
-
-  return [
-    {
-      format: contentType,
-      type: 3,
-      data: new Uint8Array(await response.arrayBuffer()),
-      description: "album cover",
-    },
-  ];
 };
 const getManagedDownloadTrackTitle = (file: TagiumFile) => {
   if (file.metadata?.title) return file.metadata.title;

--- a/components/audio/downloadLibrary.test.ts
+++ b/components/audio/downloadLibrary.test.ts
@@ -57,6 +57,15 @@ const album = (id: string, title: string, trackIds: string[]): AlbumGroup => ({
   trackIds,
 });
 
+const cover: AudioMetadata["picture"] = [
+  {
+    format: "image/jpeg",
+    type: 3,
+    description: "album cover",
+    data: new Uint8Array([1, 2, 3]),
+  },
+];
+
 describe("downloadLibrary", () => {
   it("creates timestamped library download filenames", () => {
     expect(createLibraryDownloadFilename(new Date(2026, 0, 2, 3, 4, 5))).toBe(
@@ -85,14 +94,79 @@ describe("downloadLibrary", () => {
   });
 
   it("can nest a single album export at the zip root", () => {
+    const singleAlbum = {
+      ...album("album", "Single Track Album", ["track"]),
+      cover,
+    };
     const entries = getLibraryDownloadEntries({
-      albums: [album("album", "Single Track Album", ["track"])],
+      albums: [singleAlbum],
       looseTrackIds: [],
       files: [file("track", "song.mp3")],
       albumRoot: "",
     });
 
-    expect(entries.map((entry) => entry.path)).toEqual(["Single Track Album/song.mp3"]);
+    expect(entries.map((entry) => entry.path)).toEqual([
+      "Single Track Album/song.mp3",
+      "Single Track Album/cover.jpg",
+    ]);
+    expect(entries[1]?.file.type).toBe("image/jpeg");
+  });
+
+  it("bundles png album cover files with album folders", () => {
+    const pngCover: AudioMetadata["picture"] = [
+      {
+        format: "image/png",
+        type: 3,
+        description: "album cover",
+        data: new Uint8Array([4, 5, 6]),
+      },
+    ];
+    const entries = getLibraryDownloadEntries({
+      albums: [{ ...album("album", "Album One", ["track"]), cover: pngCover }],
+      looseTrackIds: [],
+      files: [file("track", "song.mp3")],
+    });
+
+    expect(entries.map((entry) => entry.path)).toEqual([
+      "albums/Album One/song.mp3",
+      "albums/Album One/cover.png",
+    ]);
+    expect(entries[1]?.file.type).toBe("image/png");
+  });
+
+  it("preserves cover-like track filenames when adding album cover files", () => {
+    const entries = getLibraryDownloadEntries({
+      albums: [{ ...album("album", "Album", ["track"]), cover }],
+      looseTrackIds: [],
+      files: [file("track", "cover.jpg")],
+    });
+
+    expect(entries.map((entry) => entry.path)).toEqual([
+      "albums/Album/cover.jpg",
+      "albums/Album/cover-2.jpg",
+    ]);
+  });
+
+  it("uses cover file extensions for image content types with parameters", () => {
+    const parameterizedCover: AudioMetadata["picture"] = [
+      {
+        format: "image/jpeg; charset=utf-8",
+        type: 3,
+        description: "album cover",
+        data: new Uint8Array([7, 8, 9]),
+      },
+    ];
+    const entries = getLibraryDownloadEntries({
+      albums: [{ ...album("album", "Album", ["track"]), cover: parameterizedCover }],
+      looseTrackIds: [],
+      files: [file("track", "song.mp3")],
+    });
+
+    expect(entries.map((entry) => entry.path)).toEqual([
+      "albums/Album/song.mp3",
+      "albums/Album/cover.jpg",
+    ]);
+    expect(entries[1]?.file.type).toBe("image/jpeg");
   });
 
   it("can scope a single album export without unrelated tracks", () => {

--- a/components/audio/downloadLibrary.ts
+++ b/components/audio/downloadLibrary.ts
@@ -131,6 +131,24 @@ export function getLibraryDownloadEntries({
     for (const track of albumTracks) {
       addTrackEntry(entries, usedPaths, albumFolder, track);
     }
+
+    const albumCover = album.cover?.[0];
+    if (albumCover) {
+      const coverFormat = albumCover.format.split(";")[0]?.trim().toLowerCase();
+      let coverFilename = "";
+      if (coverFormat === "image/jpeg" || coverFormat === "image/jpg") {
+        coverFilename = "cover.jpg";
+      }
+      if (coverFormat === "image/png") {
+        coverFilename = "cover.png";
+      }
+      if (coverFilename) {
+        entries.push({
+          path: uniquePath(`${albumFolder}/${coverFilename}`, usedPaths),
+          file: new File([albumCover.data], coverFilename, { type: coverFormat }),
+        });
+      }
+    }
   }
 
   for (const trackId of looseTrackIds) {

--- a/components/audio/fileMetadataOps.ts
+++ b/components/audio/fileMetadataOps.ts
@@ -1,4 +1,5 @@
 import filenamify from "filenamify";
+import type { SoundCloudSet } from "./soundcloudSet";
 import { AlbumGroup, AudioMetadata, TagiumFile } from "./types";
 
 export interface DownloadedTrackHydration {
@@ -149,6 +150,30 @@ export function applyAlbumCoverToFilesWithSelectedMetadata(
   return {
     files: coveredFiles,
     selectedMetadata: selectedFile?.metadata,
+  };
+}
+
+export function applySoundCloudSetImportedCover(
+  files: TagiumFile[],
+  albums: AlbumGroup[],
+  albumId: string,
+  trackIds: string[],
+  set: Pick<SoundCloudSet, "isAlbum">,
+  settings: { applySoundCloudAlbumCoverToTracks: boolean },
+  cover: AudioMetadata["picture"],
+  selectedFileId: string | null,
+) {
+  const coveredAlbums = albums.map((currentAlbum) =>
+    currentAlbum.id === albumId ? { ...currentAlbum, cover } : currentAlbum,
+  );
+
+  if (!set.isAlbum || !settings.applySoundCloudAlbumCoverToTracks) {
+    return { albums: coveredAlbums, files };
+  }
+
+  return {
+    albums: coveredAlbums,
+    ...applyAlbumCoverToFilesWithSelectedMetadata(files, trackIds, cover, selectedFileId),
   };
 }
 

--- a/components/audio/settings.test.ts
+++ b/components/audio/settings.test.ts
@@ -85,6 +85,7 @@ describe("settings", () => {
       syncTrackNumbers: false,
       syncFilenames: false,
       audioBitrate: "256",
+      applySoundCloudAlbumCoverToTracks: false,
     };
 
     expect(() => saveAppSettings(settings, storage)).not.toThrow();

--- a/components/audio/settings.test.ts
+++ b/components/audio/settings.test.ts
@@ -51,6 +51,7 @@ describe("settings", () => {
         syncTrackNumbers: false,
         syncFilenames: "no",
         audioBitrate: "999",
+        applySoundCloudAlbumCoverToTracks: "yes",
       }),
     );
 
@@ -66,6 +67,7 @@ describe("settings", () => {
       syncTrackNumbers: false,
       syncFilenames: false,
       audioBitrate: "256",
+      applySoundCloudAlbumCoverToTracks: false,
     };
 
     saveAppSettings(settings, storage);

--- a/components/audio/settings.ts
+++ b/components/audio/settings.ts
@@ -14,6 +14,7 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   syncTrackNumbers: true,
   syncFilenames: true,
   audioBitrate: "320",
+  applySoundCloudAlbumCoverToTracks: true,
 };
 
 export const APP_SETTINGS_STORAGE_KEY = "tagium:app-settings";
@@ -23,6 +24,9 @@ const storedAppSettingsSchema = z
     syncTrackNumbers: z.boolean().catch(DEFAULT_APP_SETTINGS.syncTrackNumbers),
     syncFilenames: z.boolean().catch(DEFAULT_APP_SETTINGS.syncFilenames),
     audioBitrate: z.enum(AUDIO_BITRATE_OPTIONS).catch(DEFAULT_APP_SETTINGS.audioBitrate),
+    applySoundCloudAlbumCoverToTracks: z
+      .boolean()
+      .catch(DEFAULT_APP_SETTINGS.applySoundCloudAlbumCoverToTracks),
   })
   .catch(DEFAULT_APP_SETTINGS);
 

--- a/components/audio/soundcloudSet.test.ts
+++ b/components/audio/soundcloudSet.test.ts
@@ -1,31 +1,88 @@
 import { describe, expect, it } from "vite-plus/test";
-import { shouldApplySoundCloudSetCoverToTracks } from "./soundcloudSet";
+import { applySoundCloudSetImportedCover } from "./fileMetadataOps";
+import type { AlbumGroup, AudioMetadata, TagiumFile } from "./types";
+
+const cover: AudioMetadata["picture"] = [
+  {
+    format: "image/jpeg",
+    type: 3,
+    description: "soundcloud cover",
+    data: new Uint8Array([1, 2, 3]),
+  },
+];
+
+const metadata = (): AudioMetadata => ({
+  filename: "track",
+  title: "Track",
+  artist: "Artist",
+  album: "Set",
+  year: 2024,
+  genre: "",
+  duration: 0,
+  bitrate: 0,
+  sampleRate: 0,
+  picture: [],
+  trackNumber: undefined,
+});
+
+const readyFile = (id: string): TagiumFile => ({
+  id,
+  file: new File(["a"], `${id}.mp3`, { type: "audio/mpeg" }),
+  originalFile: new File(["a"], `${id}.mp3`, { type: "audio/mpeg" }),
+  filename: `${id}.mp3`,
+  status: "saved",
+  downloadStatus: "ready",
+  hasBufferedChanges: false,
+  metadata: metadata(),
+});
+
+const album = (trackIds: string[]): AlbumGroup => ({
+  id: "album-1",
+  title: "Set",
+  artist: "Artist",
+  genre: "",
+  trackIds,
+});
 
 describe("soundcloud set cover writes", () => {
-  it("applies covers to tracks for SoundCloud albums when enabled", () => {
-    expect(
-      shouldApplySoundCloudSetCoverToTracks(
-        { isAlbum: true },
-        { applySoundCloudAlbumCoverToTracks: true },
-      ),
-    ).toBe(true);
+  it("applies SoundCloud album cover to album tracks when enabled", () => {
+    const files = [readyFile("track-1"), readyFile("track-2"), readyFile("loose")];
+
+    const result = applySoundCloudSetImportedCover(
+      files,
+      [album(["track-1", "track-2"])],
+      "album-1",
+      ["track-1", "track-2"],
+      { isAlbum: true },
+      { applySoundCloudAlbumCoverToTracks: true },
+      cover,
+      null,
+    );
+
+    expect(result.albums[0].cover).toEqual(cover);
+    expect(result.files[0].metadata?.picture).toEqual(cover);
+    expect(result.files[0].hasBufferedChanges).toBe(true);
+    expect(result.files[1].metadata?.picture).toEqual(cover);
+    expect(result.files[2]).toBe(files[2]);
   });
 
-  it("does not apply covers to tracks for SoundCloud playlists", () => {
-    expect(
-      shouldApplySoundCloudSetCoverToTracks(
+  it("keeps SoundCloud playlist cover off tracks regardless of setting", () => {
+    const files = [readyFile("track-1")];
+
+    for (const applySoundCloudAlbumCoverToTracks of [true, false]) {
+      const result = applySoundCloudSetImportedCover(
+        files,
+        [album(["track-1"])],
+        "album-1",
+        ["track-1"],
         { isAlbum: false },
-        { applySoundCloudAlbumCoverToTracks: true },
-      ),
-    ).toBe(false);
-  });
+        { applySoundCloudAlbumCoverToTracks },
+        cover,
+        null,
+      );
 
-  it("does not apply covers to tracks when the album setting is off", () => {
-    expect(
-      shouldApplySoundCloudSetCoverToTracks(
-        { isAlbum: true },
-        { applySoundCloudAlbumCoverToTracks: false },
-      ),
-    ).toBe(false);
+      expect(result.albums[0].cover).toEqual(cover);
+      expect(result.files[0]).toBe(files[0]);
+    }
   });
 });

--- a/components/audio/soundcloudSet.test.ts
+++ b/components/audio/soundcloudSet.test.ts
@@ -1,6 +1,29 @@
 import { describe, expect, it } from "vite-plus/test";
-import { applySoundCloudSetImportedCover } from "./fileMetadataOps";
-import type { AlbumGroup, AudioMetadata, TagiumFile } from "./types";
+import { startSoundCloudSetImport } from "./soundcloudSetImport";
+import type { SoundCloudSet } from "./soundcloudSet";
+import type { AlbumGroup, AppSettings, AudioMetadata, TagiumFile } from "./types";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+}
+
+const deferred = <T>(): Deferred<T> => {
+  let resolve: Deferred<T>["resolve"] = () => {};
+  let reject: Deferred<T>["reject"] = () => {};
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+};
+
+const settle = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
 
 const cover: AudioMetadata["picture"] = [
   {
@@ -11,78 +34,241 @@ const cover: AudioMetadata["picture"] = [
   },
 ];
 
-const metadata = (): AudioMetadata => ({
-  filename: "track",
-  title: "Track",
-  artist: "Artist",
-  album: "Set",
+const defaultSettings: AppSettings = {
+  audioBitrate: "320",
+  syncFilenames: false,
+  syncTrackNumbers: false,
+  applySoundCloudAlbumCoverToTracks: true,
+};
+
+const soundCloudSet = (overrides: Partial<SoundCloudSet> = {}): SoundCloudSet => ({
+  title: "Imported Set",
+  artist: "Set Artist",
+  genre: "Electronic",
   year: 2024,
-  genre: "",
-  duration: 0,
-  bitrate: 0,
-  sampleRate: 0,
-  picture: [],
-  trackNumber: undefined,
+  isAlbum: true,
+  coverUrl: "https://img.example/cover.jpg",
+  tracks: [
+    {
+      title: "First Track",
+      url: "https://soundcloud.com/artist/first-track",
+      duration: 101,
+      trackNumber: 1,
+    },
+    {
+      title: "Second Track",
+      url: "https://soundcloud.com/artist/second-track",
+      duration: 102,
+      trackNumber: 2,
+    },
+  ],
+  ...overrides,
 });
 
-const readyFile = (id: string): TagiumFile => ({
-  id,
-  file: new File(["a"], `${id}.mp3`, { type: "audio/mpeg" }),
-  originalFile: new File(["a"], `${id}.mp3`, { type: "audio/mpeg" }),
-  filename: `${id}.mp3`,
-  status: "saved",
-  downloadStatus: "ready",
-  hasBufferedChanges: false,
-  metadata: metadata(),
-});
+const createHarness = (settings: AppSettings = defaultSettings) => {
+  let files: TagiumFile[] = [];
+  let albums: AlbumGroup[] = [];
+  let activeView = "";
+  let selectedAlbumId: string | null = null;
+  let selectedFileId: string | null = null;
+  let selectedFileIds = new Set<string>();
+  let lastSelectedFileId: string | null = null;
+  let bufferCount = 0;
+  const events: string[] = [];
+  const hydratedPictures: Array<AudioMetadata["picture"] | undefined> = [];
+  const updateTagsCalls: string[] = [];
+  const coverRequest = deferred<AudioMetadata["picture"]>();
+  const downloads = new Map<string, Deferred<File>>();
+  const ids = ["album-1", "track-1", "track-2"];
 
-const album = (trackIds: string[]): AlbumGroup => ({
-  id: "album-1",
-  title: "Set",
-  artist: "Artist",
-  genre: "",
-  trackIds,
-});
+  const start = (set: SoundCloudSet) =>
+    startSoundCloudSetImport(set, {
+      settings,
+      bufferCurrentFormMetadata: () => {
+        bufferCount++;
+      },
+      setActiveView: (view) => {
+        activeView = view;
+      },
+      getFiles: () => files,
+      setFiles: (nextFiles) => {
+        files = nextFiles;
+      },
+      getAlbums: () => albums,
+      setAlbums: (nextAlbums) => {
+        albums = nextAlbums;
+      },
+      setSelectedAlbumId: (albumId) => {
+        selectedAlbumId = albumId;
+      },
+      setSelectedFileId: (fileId) => {
+        selectedFileId = fileId;
+      },
+      setSelectedFileIds: (fileIds) => {
+        selectedFileIds = fileIds;
+      },
+      setLastSelectedFileId: (fileId) => {
+        lastSelectedFileId = fileId;
+      },
+      createId: () => {
+        const id = ids.shift();
+        if (!id) throw new Error("missing test id");
+        return id;
+      },
+      fetchImportedCover: (coverUrl) => {
+        events.push(`cover:${coverUrl}`);
+        return coverRequest.promise;
+      },
+      downloadCobaltAudio: (request) => {
+        events.push(`download:${request.sourceUrl}:${request.audioBitrate}`);
+        const download = deferred<File>();
+        downloads.set(request.sourceUrl, download);
+        return download.promise;
+      },
+      hydrateDownloadedTrack: async (fileId, downloadedFile) => {
+        const currentFile = files.find((file) => file.id === fileId);
+        hydratedPictures.push(currentFile?.metadata?.picture);
+        files = files.map((file) =>
+          file.id === fileId
+            ? {
+                ...file,
+                file: downloadedFile,
+                originalFile: downloadedFile,
+                status: file.hasBufferedChanges ? "pending" : "saved",
+                downloadStatus: "ready",
+              }
+            : file,
+        );
+      },
+      markDownloadError: () => {},
+      updateTags: async (file) => {
+        updateTagsCalls.push(file.id);
+      },
+      warn: () => {},
+    });
 
-describe("soundcloud set cover writes", () => {
-  it("applies SoundCloud album cover to album tracks when enabled", () => {
-    const files = [readyFile("track-1"), readyFile("track-2"), readyFile("loose")];
+  return {
+    get activeView() {
+      return activeView;
+    },
+    get albums() {
+      return albums;
+    },
+    get bufferCount() {
+      return bufferCount;
+    },
+    coverRequest,
+    downloads,
+    events,
+    get files() {
+      return files;
+    },
+    get hydratedPictures() {
+      return hydratedPictures;
+    },
+    get lastSelectedFileId() {
+      return lastSelectedFileId;
+    },
+    get selectedAlbumId() {
+      return selectedAlbumId;
+    },
+    get selectedFileId() {
+      return selectedFileId;
+    },
+    get selectedFileIds() {
+      return selectedFileIds;
+    },
+    start,
+    updateTagsCalls,
+  };
+};
 
-    const result = applySoundCloudSetImportedCover(
-      files,
-      [album(["track-1", "track-2"])],
-      "album-1",
-      ["track-1", "track-2"],
-      { isAlbum: true },
-      { applySoundCloudAlbumCoverToTracks: true },
-      cover,
-      null,
-    );
+describe("soundcloud set import", () => {
+  it("imports an album through the shipped operation across cover and hydration ordering", async () => {
+    const harness = createHarness();
 
-    expect(result.albums[0].cover).toEqual(cover);
-    expect(result.files[0].metadata?.picture).toEqual(cover);
-    expect(result.files[0].hasBufferedChanges).toBe(true);
-    expect(result.files[1].metadata?.picture).toEqual(cover);
-    expect(result.files[2]).toBe(files[2]);
+    harness.start(soundCloudSet());
+
+    expect(harness.bufferCount).toBe(1);
+    expect(harness.activeView).toBe("editor");
+    expect(harness.selectedAlbumId).toBe("album-1");
+    expect(harness.selectedFileId).toBe("track-1");
+    expect([...harness.selectedFileIds]).toEqual(["track-1"]);
+    expect(harness.lastSelectedFileId).toBe("track-1");
+    expect(harness.albums).toEqual([
+      {
+        id: "album-1",
+        title: "Imported Set",
+        artist: "Set Artist",
+        genre: "Electronic",
+        trackIds: ["track-1", "track-2"],
+        year: 2024,
+      },
+    ]);
+    expect(harness.files.map((file) => file.downloadRequest)).toEqual([
+      { sourceUrl: "https://soundcloud.com/artist/first-track", audioBitrate: "320" },
+      { sourceUrl: "https://soundcloud.com/artist/second-track", audioBitrate: "320" },
+    ]);
+    expect(harness.events).toEqual([
+      "cover:https://img.example/cover.jpg",
+      "download:https://soundcloud.com/artist/first-track:320",
+      "download:https://soundcloud.com/artist/second-track:320",
+    ]);
+
+    harness.downloads
+      .get("https://soundcloud.com/artist/first-track")
+      ?.resolve(new File(["first"], "first.mp3", { type: "audio/mpeg" }));
+    await settle();
+
+    expect(harness.hydratedPictures).toEqual([[]]);
+
+    harness.coverRequest.resolve(cover);
+    await settle();
+
+    expect(harness.albums[0].cover).toEqual(cover);
+    expect(harness.files.map((file) => file.metadata?.picture)).toEqual([cover, cover]);
+    expect(harness.files.map((file) => file.hasBufferedChanges)).toEqual([true, true]);
+    expect(harness.updateTagsCalls).toEqual(["track-1"]);
+
+    harness.downloads
+      .get("https://soundcloud.com/artist/second-track")
+      ?.resolve(new File(["second"], "second.mp3", { type: "audio/mpeg" }));
+    await settle();
+
+    expect(harness.hydratedPictures).toEqual([[], cover]);
   });
 
-  it("keeps SoundCloud playlist cover off tracks regardless of setting", () => {
-    const files = [readyFile("track-1")];
+  it("keeps SoundCloud playlist cover off track metadata even when setting is enabled", async () => {
+    const harness = createHarness();
 
-    for (const applySoundCloudAlbumCoverToTracks of [true, false]) {
-      const result = applySoundCloudSetImportedCover(
-        files,
-        [album(["track-1"])],
-        "album-1",
-        ["track-1"],
-        { isAlbum: false },
-        { applySoundCloudAlbumCoverToTracks },
-        cover,
-        null,
-      );
+    harness.start(soundCloudSet({ isAlbum: false }));
+    harness.coverRequest.resolve(cover);
+    await settle();
 
-      expect(result.albums[0].cover).toEqual(cover);
-      expect(result.files[0]).toBe(files[0]);
-    }
+    expect(harness.albums[0].cover).toEqual(cover);
+    expect(harness.files.map((file) => file.metadata?.picture)).toEqual([[], []]);
+    expect(harness.updateTagsCalls).toEqual([]);
+
+    harness.downloads
+      .get("https://soundcloud.com/artist/first-track")
+      ?.resolve(new File(["first"], "first.mp3", { type: "audio/mpeg" }));
+    await settle();
+
+    expect(harness.hydratedPictures).toEqual([[]]);
+  });
+
+  it("keeps SoundCloud album cover off track metadata when the setting is disabled", async () => {
+    const harness = createHarness({
+      ...defaultSettings,
+      applySoundCloudAlbumCoverToTracks: false,
+    });
+
+    harness.start(soundCloudSet());
+    harness.coverRequest.resolve(cover);
+    await settle();
+
+    expect(harness.albums[0].cover).toEqual(cover);
+    expect(harness.files.map((file) => file.metadata?.picture)).toEqual([[], []]);
+    expect(harness.updateTagsCalls).toEqual([]);
   });
 });

--- a/components/audio/soundcloudSet.test.ts
+++ b/components/audio/soundcloudSet.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+import { shouldApplySoundCloudSetCoverToTracks } from "./soundcloudSet";
+
+describe("soundcloud set cover writes", () => {
+  it("applies covers to tracks for SoundCloud albums when enabled", () => {
+    expect(
+      shouldApplySoundCloudSetCoverToTracks(
+        { isAlbum: true },
+        { applySoundCloudAlbumCoverToTracks: true },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not apply covers to tracks for SoundCloud playlists", () => {
+    expect(
+      shouldApplySoundCloudSetCoverToTracks(
+        { isAlbum: false },
+        { applySoundCloudAlbumCoverToTracks: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not apply covers to tracks when the album setting is off", () => {
+    expect(
+      shouldApplySoundCloudSetCoverToTracks(
+        { isAlbum: true },
+        { applySoundCloudAlbumCoverToTracks: false },
+      ),
+    ).toBe(false);
+  });
+});

--- a/components/audio/soundcloudSet.ts
+++ b/components/audio/soundcloudSet.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { AppSettings, ImportedAlbumMetadata } from "./types";
+import type { ImportedAlbumMetadata } from "./types";
 
 const soundCloudSetSchema = z.object({
   title: z.string(),
@@ -55,8 +55,3 @@ export const toImportedAlbumMetadata = (set: SoundCloudSet): ImportedAlbumMetada
   year: set.year,
   coverUrl: set.coverUrl,
 });
-
-export const shouldApplySoundCloudSetCoverToTracks = (
-  set: Pick<SoundCloudSet, "isAlbum">,
-  settings: Pick<AppSettings, "applySoundCloudAlbumCoverToTracks">,
-) => set.isAlbum && settings.applySoundCloudAlbumCoverToTracks;

--- a/components/audio/soundcloudSet.ts
+++ b/components/audio/soundcloudSet.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ImportedAlbumMetadata } from "./types";
+import type { AppSettings, ImportedAlbumMetadata } from "./types";
 
 const soundCloudSetSchema = z.object({
   title: z.string(),
@@ -55,3 +55,8 @@ export const toImportedAlbumMetadata = (set: SoundCloudSet): ImportedAlbumMetada
   year: set.year,
   coverUrl: set.coverUrl,
 });
+
+export const shouldApplySoundCloudSetCoverToTracks = (
+  set: Pick<SoundCloudSet, "isAlbum">,
+  settings: Pick<AppSettings, "applySoundCloudAlbumCoverToTracks">,
+) => set.isAlbum && settings.applySoundCloudAlbumCoverToTracks;

--- a/components/audio/soundcloudSetImport.ts
+++ b/components/audio/soundcloudSetImport.ts
@@ -1,0 +1,201 @@
+import filenamify from "filenamify";
+import { applySoundCloudSetImportedCover } from "./fileMetadataOps";
+import type { SoundCloudSet } from "./soundcloudSet";
+import type { AlbumGroup, AppSettings, AudioMetadata, TagiumFile } from "./types";
+
+const filenameFromTitle = (title: string) => {
+  const filename = filenamify(title.trim(), { replacement: "-" });
+  if (filename) return `${filename}.mp3`;
+  return "downloading-track.mp3";
+};
+
+export const createDownloadMetadata = ({
+  title,
+  artist,
+  album,
+  genre,
+  year,
+  duration,
+  trackNumber,
+}: {
+  title: string;
+  artist: string;
+  album: string;
+  genre: string;
+  year?: number;
+  duration?: number;
+  trackNumber?: number;
+}): AudioMetadata => ({
+  filename: filenameFromTitle(title).replace(/\.mp3$/i, ""),
+  title,
+  artist,
+  album,
+  year,
+  genre,
+  duration: duration ?? 0,
+  bitrate: 0,
+  sampleRate: 0,
+  picture: [],
+  trackNumber,
+});
+
+export const createPendingDownloadTrack = (
+  id: string,
+  metadata: AudioMetadata,
+  hasBufferedChanges: boolean,
+  downloadRequest: NonNullable<TagiumFile["downloadRequest"]>,
+): TagiumFile => ({
+  id,
+  filename: `${metadata.filename}.mp3`,
+  status: "pending",
+  downloadStatus: "downloading",
+  downloadRequest,
+  hasBufferedChanges,
+  metadata,
+});
+
+export const fetchImportedCover = async (coverUrl: string): Promise<AudioMetadata["picture"]> => {
+  const response = await fetch(coverUrl);
+
+  if (!response.ok) {
+    throw new Error(`album cover request failed (${response.status})`);
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (!contentType) {
+    throw new Error("album cover response missing content type.");
+  }
+
+  return [
+    {
+      format: contentType,
+      type: 3,
+      data: new Uint8Array(await response.arrayBuffer()),
+      description: "album cover",
+    },
+  ];
+};
+
+interface SoundCloudSetImportDeps {
+  settings: Pick<AppSettings, "audioBitrate" | "applySoundCloudAlbumCoverToTracks">;
+  bufferCurrentFormMetadata: () => void;
+  setActiveView: (view: "editor") => void;
+  getFiles: () => TagiumFile[];
+  setFiles: (files: TagiumFile[]) => void;
+  getAlbums: () => AlbumGroup[];
+  setAlbums: (albums: AlbumGroup[]) => void;
+  setSelectedAlbumId: (albumId: string | null) => void;
+  setSelectedFileId: (fileId: string | null) => void;
+  setSelectedFileIds: (fileIds: Set<string>) => void;
+  setLastSelectedFileId: (fileId: string | null) => void;
+  createId: () => string;
+  fetchImportedCover: (coverUrl: string) => Promise<AudioMetadata["picture"]>;
+  downloadCobaltAudio: (request: NonNullable<TagiumFile["downloadRequest"]>) => Promise<File>;
+  hydrateDownloadedTrack: (fileId: string, downloadedFile: File) => Promise<void>;
+  markDownloadError: (fileId: string, error: unknown) => void;
+  updateTags: (file: TagiumFile, metadata: AudioMetadata) => Promise<void>;
+  warn: (message: string, error: unknown) => void;
+}
+
+export const startSoundCloudSetImport = (set: SoundCloudSet, deps: SoundCloudSetImportDeps) => {
+  deps.bufferCurrentFormMetadata();
+  deps.setActiveView("editor");
+
+  const albumId = deps.createId();
+  const pendingFiles = set.tracks.map((track) =>
+    createPendingDownloadTrack(
+      deps.createId(),
+      createDownloadMetadata({
+        title: track.title,
+        artist: set.artist,
+        album: set.title,
+        genre: set.genre,
+        year: set.year,
+        duration: track.duration,
+        trackNumber: track.trackNumber,
+      }),
+      true,
+      { sourceUrl: track.url, audioBitrate: deps.settings.audioBitrate },
+    ),
+  );
+  const album: AlbumGroup = {
+    id: albumId,
+    title: set.title,
+    artist: set.artist,
+    genre: set.genre,
+    trackIds: pendingFiles.map((file) => file.id),
+    year: set.year,
+  };
+  const nextFiles = [...deps.getFiles(), ...pendingFiles];
+  const nextAlbums = [...deps.getAlbums(), album];
+  deps.setFiles(nextFiles);
+  deps.setAlbums(nextAlbums);
+  deps.setSelectedAlbumId(albumId);
+
+  let firstPendingFileId: string | null = null;
+  const firstPendingFile = pendingFiles[0];
+  if (firstPendingFile) {
+    firstPendingFileId = firstPendingFile.id;
+  }
+  deps.setSelectedFileId(firstPendingFileId);
+  const selectedFileIds = new Set<string>();
+  if (firstPendingFileId) {
+    selectedFileIds.add(firstPendingFileId);
+  }
+  deps.setSelectedFileIds(selectedFileIds);
+  deps.setLastSelectedFileId(firstPendingFileId);
+
+  const coverUrl = set.coverUrl;
+  if (coverUrl) {
+    void (async () => {
+      try {
+        const cover = await deps.fetchImportedCover(coverUrl);
+        const { albums: coveredAlbums, files: coveredFiles } = applySoundCloudSetImportedCover(
+          deps.getFiles(),
+          deps.getAlbums(),
+          albumId,
+          album.trackIds,
+          set,
+          deps.settings,
+          cover,
+          null,
+        );
+        deps.setAlbums(coveredAlbums);
+        if (coveredFiles === deps.getFiles()) return;
+
+        deps.setFiles(coveredFiles);
+        const trackIdSet = new Set(album.trackIds);
+        await Promise.all(
+          coveredFiles
+            .filter((file) => trackIdSet.has(file.id) && Boolean(file.file) && file.metadata)
+            .map(async (file) => {
+              if (!file.metadata) return;
+              try {
+                await deps.updateTags(file, file.metadata);
+              } catch {
+                // updateTags records the per-track error state.
+              }
+            }),
+        );
+      } catch (error) {
+        deps.warn("failed to import album cover:", error);
+      }
+    })();
+  }
+
+  pendingFiles.forEach((pendingFile, index) => {
+    const track = set.tracks[index];
+    if (!track) return;
+    void (async () => {
+      try {
+        const downloadedFile = await deps.downloadCobaltAudio({
+          sourceUrl: track.url,
+          audioBitrate: deps.settings.audioBitrate,
+        });
+        await deps.hydrateDownloadedTrack(pendingFile.id, downloadedFile);
+      } catch (error) {
+        deps.markDownloadError(pendingFile.id, error);
+      }
+    })();
+  });
+};

--- a/components/audio/types.ts
+++ b/components/audio/types.ts
@@ -54,6 +54,7 @@ export interface AppSettings {
   syncTrackNumbers: boolean;
   syncFilenames: boolean;
   audioBitrate: AudioDownloadBitrate;
+  applySoundCloudAlbumCoverToTracks: boolean;
 }
 
 export interface ImportedAlbumMetadata {


### PR DESCRIPTION
## Scope
- Auto-applies SoundCloud cover art when importing SoundCloud metadata.
- Builds on the explicit album cover apply behavior from the prior branch.

## Verification
- Current stack was handed off as verified before submit.
- Required checks from the verified stack: `vp fmt`, `vp lint`, `vp check`; `vp test` for logic coverage.
- Submit pass only checked branch/working-tree state and pushed without rewriting commits.

## Review-loop summary
- Submitted as PR 4 of 4.
- Base branch is `codex/pr3-explicit-album-cover-apply-stack` to preserve the reviewed stack order.
- Draft because GitHub `main` has advanced past the verified local base commit `b5072cb`, and this submit pass intentionally did not rebase or rewrite code.
