### PR TITLE
[codex] fix ui critique issues

### DIFF
--- a/components/audio/AlbumMetadataDialog.tsx
+++ b/components/audio/AlbumMetadataDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,6 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import CoverArt from "./coverArt";
 import { AudioMetadata } from "./types";
 
@@ -31,7 +33,7 @@ interface AlbumMetadataDialogProps {
   onClose: () => void;
   onSave: () => void;
   onDelete?: () => void;
-  onApplyCover?: () => void;
+  onSyncCoverToTracks?: () => Promise<void> | void;
 }
 
 export default function AlbumMetadataDialog({
@@ -43,11 +45,31 @@ export default function AlbumMetadataDialog({
   onClose,
   onSave,
   onDelete,
-  onApplyCover,
+  onSyncCoverToTracks,
 }: AlbumMetadataDialogProps) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showErrors, setShowErrors] = useState(false);
-  const canApplyCover = mode === "edit" && draft.cover && draft.cover.length > 0 && onApplyCover;
+  const [isSyncingCover, setIsSyncingCover] = useState(false);
+  const [syncCoverRotation, setSyncCoverRotation] = useState(0);
+  const canSyncCoverToTracks =
+    mode === "edit" && draft.cover && draft.cover.length > 0 && onSyncCoverToTracks;
+  const syncCoverLabel = isSyncingCover ? "syncing cover to tracks" : "sync cover to tracks";
+
+  const handleSyncCoverToTracks = () => {
+    if (!onSyncCoverToTracks) return;
+    if (isSyncingCover) return;
+
+    const startedAt = performance.now();
+    setSyncCoverRotation((rotation) => rotation + 360);
+    setIsSyncingCover(true);
+    const result = onSyncCoverToTracks();
+
+    void Promise.resolve(result).finally(() => {
+      const elapsed = performance.now() - startedAt;
+      const remaining = Math.max(0, 650 - elapsed);
+      window.setTimeout(() => setIsSyncingCover(false), remaining);
+    });
+  };
 
   const handleCoverUpload = (file: File) => {
     const reader = new FileReader();
@@ -100,7 +122,38 @@ export default function AlbumMetadataDialog({
           </DialogHeader>
           <div className="p-5 overflow-y-auto">
             <div className="grid grid-cols-1 md:grid-cols-[11rem_minmax(0,1fr)] gap-4 md:min-h-[236px] items-stretch">
-              <CoverArt picture={draft.cover} onCoverUpload={handleCoverUpload} size="compact" />
+              <CoverArt
+                picture={draft.cover}
+                onCoverUpload={handleCoverUpload}
+                size="compact"
+                coverOverlay={
+                  canSyncCoverToTracks && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="secondary"
+                          aria-label={syncCoverLabel}
+                          aria-busy={isSyncingCover}
+                          className="absolute bottom-2 left-2 size-10 p-0 max-lg:[@media(max-height:700px)]:bottom-1.5 max-lg:[@media(max-height:700px)]:left-1.5"
+                          disabled={isSyncingCover}
+                          onClick={handleSyncCoverToTracks}
+                        >
+                          <RefreshCw
+                            data-icon="inline-start"
+                            style={{
+                              transform: `rotate(${syncCoverRotation}deg)`,
+                              transition: "transform 0.6s cubic-bezier(0.87, 0, 0.13, 1)",
+                            }}
+                          />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">{syncCoverLabel}</TooltipContent>
+                    </Tooltip>
+                  )
+                }
+              />
               <div className="min-w-0 h-full flex flex-col justify-between gap-3">
                 <div className="flex flex-col gap-3">
                   <div>
@@ -199,11 +252,6 @@ export default function AlbumMetadataDialog({
                     onClick={() => setShowDeleteConfirm(true)}
                   >
                     delete album
-                  </Button>
-                )}
-                {canApplyCover && (
-                  <Button type="button" variant="outline" onClick={onApplyCover}>
-                    apply cover to tracks
                   </Button>
                 )}
                 <Button type="button" variant="outline" onClick={onClose}>

--- a/components/audio/AudioDownloader.tsx
+++ b/components/audio/AudioDownloader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Download, Loader2, Link } from "lucide-react";
+import { ArrowRight, Loader2, Link } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { getDownloadErrorMessage } from "./downloadErrorMessage";
@@ -75,7 +75,7 @@ export default function AudioDownloader({
               }
             }}
             placeholder="paste media url"
-            className="pl-9"
+            className="pl-9 placeholder:text-muted-foreground/45"
             disabled={downloading}
           />
         </div>
@@ -83,11 +83,11 @@ export default function AudioDownloader({
           type="button"
           size="icon"
           disabled={!canDownload}
-          aria-label="download audio"
+          aria-label="start media import"
           onClick={() => void handleDownload()}
         >
           {downloading && <Loader2 className="animate-spin" />}
-          {!downloading && <Download />}
+          {!downloading && <ArrowRight />}
         </Button>
       </div>
       {progress && (

--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Music4, Link2, Download, Loader2, Upload } from "lucide-react";
+import { Music4, Link2, ArrowRight, Loader2, Upload } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getDownloadErrorMessage } from "./downloadErrorMessage";
 import { isSoundCloudSetUrl, resolveSoundCloudSet, type SoundCloudSet } from "./soundcloudSet";
@@ -161,19 +161,19 @@ export default function LandingScreen({
                 }}
                 placeholder="soundcloud or youtube url"
                 disabled={downloading}
-                className="w-full h-10 rounded-lg border border-input bg-transparent pl-9 pr-3 text-sm shadow-sm outline-none focus:ring-2 focus:ring-ring transition-shadow disabled:opacity-50 placeholder:text-muted-foreground"
+                className="w-full h-10 rounded-lg border border-input bg-transparent pl-9 pr-3 text-sm shadow-sm outline-none focus:ring-2 focus:ring-ring transition-shadow disabled:opacity-50 placeholder:text-muted-foreground/45"
               />
             </div>
             <button
               type="submit"
               disabled={!url.trim() || downloading}
-              aria-label="download audio"
-              className="h-10 w-10 rounded-lg bg-primary text-primary-foreground flex items-center justify-center flex-shrink-0 disabled:opacity-40 hover:bg-primary/90 transition-colors"
+              aria-label="start media import"
+              className="h-10 w-10 rounded-lg bg-primary text-primary-foreground flex items-center justify-center flex-shrink-0 cursor-pointer disabled:cursor-not-allowed disabled:opacity-40 hover:bg-primary/90 transition-colors"
             >
               {downloading ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
-                <Download className="h-4 w-4" />
+                <ArrowRight className="h-4 w-4" />
               )}
             </button>
           </div>

--- a/components/audio/SettingsPage.tsx
+++ b/components/audio/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ChevronsUpDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { AUDIO_BITRATE_OPTIONS } from "./settings";
 import type { AppSettings } from "./types";
@@ -24,9 +25,10 @@ export default function SettingsPage({ settings, onChange }: SettingsPageProps) 
       <div className="flex-1 overflow-y-auto p-6">
         <div className="max-w-xl flex flex-col gap-6">
           <section className="flex flex-col gap-3">
-            <h3 className="text-sm font-medium">metadata</h3>
-            <label className="flex cursor-pointer items-start gap-3 py-1">
+            <h3 className="text-base font-semibold">metadata</h3>
+            <div className="flex items-start gap-3 py-1">
               <Checkbox
+                id="sync-track-numbers"
                 checked={settings.syncTrackNumbers}
                 onCheckedChange={(checked) =>
                   onChange({
@@ -36,10 +38,11 @@ export default function SettingsPage({ settings, onChange }: SettingsPageProps) 
                 }
                 className="mt-0.5"
               />
-              <span className="text-sm font-medium">use album sidebar order as track number</span>
-            </label>
-            <label className="flex cursor-pointer items-start gap-3 py-1">
+              <Label htmlFor="sync-track-numbers">use album sidebar order as track number</Label>
+            </div>
+            <div className="flex items-start gap-3 py-1">
               <Checkbox
+                id="sync-filenames"
                 checked={settings.syncFilenames}
                 onCheckedChange={(checked) =>
                   onChange({
@@ -49,12 +52,11 @@ export default function SettingsPage({ settings, onChange }: SettingsPageProps) 
                 }
                 className="mt-0.5"
               />
-              <span className="text-sm font-medium">sync all filenames with track titles</span>
-            </label>
+              <Label htmlFor="sync-filenames">sync all filenames with track titles</Label>
+            </div>
           </section>
 
           <section className="flex flex-col gap-3">
-            <h3 className="text-sm font-medium">downloads</h3>
             <div className="flex flex-col gap-2">
               <span id="download-bitrate-label" className="text-sm font-medium">
                 download bitrate
@@ -116,21 +118,21 @@ export default function SettingsPage({ settings, onChange }: SettingsPageProps) 
 
           <section className="flex flex-col gap-5">
             <div className="flex flex-col gap-2">
-              <h3 className="text-sm font-medium">about</h3>
+              <h3 className="text-base font-semibold">about</h3>
               <p className="text-sm leading-6 text-muted-foreground">
                 tagium exists to make device-local music more accessible to everyone.
               </p>
             </div>
 
             <div className="flex flex-col gap-2">
-              <h3 className="text-sm font-medium">acknowledgements</h3>
+              <h3 className="text-base font-semibold">acknowledgements</h3>
               <div className="flex flex-col gap-2 text-sm leading-6 text-muted-foreground">
                 <p>
                   <a
                     href="https://cobalt.tools/"
                     target="_blank"
                     rel="noreferrer"
-                    className="text-primary underline-offset-4 hover:underline"
+                    className="cursor-pointer text-primary underline-offset-4 hover:underline"
                   >
                     cobalt
                   </a>{" "}
@@ -139,7 +141,7 @@ export default function SettingsPage({ settings, onChange }: SettingsPageProps) 
                     href="https://imput.net/"
                     target="_blank"
                     rel="noreferrer"
-                    className="text-primary underline-offset-4 hover:underline"
+                    className="cursor-pointer text-primary underline-offset-4 hover:underline"
                   >
                     imput
                   </a>
@@ -151,7 +153,7 @@ export default function SettingsPage({ settings, onChange }: SettingsPageProps) 
                     href="https://mp3tag.js.org/"
                     target="_blank"
                     rel="noreferrer"
-                    className="text-primary underline-offset-4 hover:underline"
+                    className="cursor-pointer text-primary underline-offset-4 hover:underline"
                   >
                     mp3tag.js
                   </a>
@@ -167,7 +169,7 @@ export default function SettingsPage({ settings, onChange }: SettingsPageProps) 
               target="_blank"
               rel="noreferrer"
               aria-label="GitHub"
-              className="inline-flex size-12 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none"
+              className="inline-flex size-12 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -189,7 +191,7 @@ export default function SettingsPage({ settings, onChange }: SettingsPageProps) 
               target="_blank"
               rel="noreferrer"
               aria-label="Twitter"
-              className="inline-flex size-12 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none"
+              className="inline-flex size-12 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -39,9 +39,14 @@ export default function TrackMetadataEditor({
   syncFilenames,
   syncTrackNumbers,
 }: TrackMetadataEditorProps) {
-  const watchedTitle = useWatch({ control, name: "title" });
+  const watchedTitle = useWatch({ control, name: "title", defaultValue: "" });
+  const watchedFilename = useWatch({ control, name: "filename", defaultValue: "" });
   const inAlbum = !!selectedFileAlbum;
   const audioReady = Boolean(selectedFile?.file);
+  const filenameInputSize = Math.max(watchedFilename.length, "bangarang".length);
+  const placeholderClassName = "placeholder:text-muted-foreground/45";
+  const syncedInputClassName =
+    "disabled:pointer-events-auto disabled:cursor-not-allowed disabled:border-dashed disabled:bg-muted/10 disabled:text-muted-foreground disabled:opacity-100 dark:disabled:bg-muted/10";
 
   if (!selectedFile || !selectedFile.metadata) {
     return (
@@ -88,34 +93,54 @@ export default function TrackMetadataEditor({
             <div className="flex flex-1 flex-col gap-2 max-lg:[@media(max-height:700px)]:gap-1.5 lg:gap-3">
               <div>
                 <label className="mb-1 block text-xs font-medium md:text-sm">filename:</label>
-                <div
-                  className={`flex items-center h-9 w-full rounded-md border border-input bg-transparent dark:bg-input/30 px-3 py-1 text-base shadow-sm transition-colors md:text-sm ${syncFilenames ? "opacity-50 cursor-not-allowed pointer-events-none" : "focus-within:ring-1 focus-within:ring-ring"}`}
+                <label
+                  className={`flex h-9 w-full items-center rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors dark:bg-input/30 md:text-sm ${syncFilenames ? "cursor-not-allowed border-dashed bg-muted/10 text-muted-foreground dark:bg-muted/10" : "focus-within:ring-1 focus-within:ring-ring"}`}
                 >
                   {syncFilenames ? (
-                    <span className="flex-1 min-w-0 truncate text-muted-foreground">
-                      {filenamify(watchedTitle || "", { replacement: "-" })}
+                    <span className="inline-flex min-w-0 max-w-full items-center">
+                      <span className="min-w-0 truncate">
+                        {filenamify(watchedTitle, { replacement: "-" })}
+                      </span>
+                      <span className="shrink-0 select-none text-muted-foreground/70">.mp3</span>
                     </span>
                   ) : (
-                    <input
-                      {...register("filename")}
-                      className="flex-1 bg-transparent outline-none placeholder:text-muted-foreground min-w-0"
-                      placeholder="bangarang"
-                    />
+                    <span className="inline-flex min-w-0 flex-1 items-center">
+                      <input
+                        {...register("filename")}
+                        size={filenameInputSize}
+                        className="min-w-[1ch] max-w-[calc(100%-2.25rem)] bg-transparent outline-none placeholder:text-muted-foreground/45"
+                        placeholder="bangarang"
+                      />
+                      <span className="shrink-0 select-none text-muted-foreground/70">.mp3</span>
+                    </span>
                   )}
-                  <span className="text-muted-foreground select-none">.mp3</span>
-                </div>
+                </label>
               </div>
               <div>
                 <label className="mb-1 block text-xs font-medium md:text-sm">title:</label>
-                <Input {...register("title")} placeholder="Bangarang" />
+                <Input
+                  {...register("title")}
+                  placeholder="Bangarang"
+                  className={placeholderClassName}
+                />
               </div>
               <div>
                 <label className="mb-1 block text-xs font-medium md:text-sm">artist:</label>
-                <Input {...register("artist")} placeholder="Skrillex" disabled={inAlbum} />
+                <Input
+                  {...register("artist")}
+                  placeholder="Skrillex"
+                  disabled={inAlbum}
+                  className={`${placeholderClassName} ${syncedInputClassName}`}
+                />
               </div>
               <div>
                 <label className="mb-1 block text-xs font-medium md:text-sm">album:</label>
-                <Input {...register("album")} placeholder="Bangarang EP" disabled={inAlbum} />
+                <Input
+                  {...register("album")}
+                  placeholder="Bangarang EP"
+                  disabled={inAlbum}
+                  className={`${placeholderClassName} ${syncedInputClassName}`}
+                />
               </div>
               <div className="grid grid-cols-[minmax(4.5rem,0.8fr)_minmax(0,1.4fr)_minmax(4.5rem,0.8fr)] gap-2">
                 <div>
@@ -125,12 +150,17 @@ export default function TrackMetadataEditor({
                     {...register("year", { valueAsNumber: true })}
                     placeholder="2011"
                     disabled={inAlbum}
-                    className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                    className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
                   />
                 </div>
                 <div>
                   <label className="mb-1 block text-xs font-medium md:text-sm">genre:</label>
-                  <Input {...register("genre")} placeholder="Dubstep" disabled={inAlbum} />
+                  <Input
+                    {...register("genre")}
+                    placeholder="Dubstep"
+                    disabled={inAlbum}
+                    className={`${placeholderClassName} ${syncedInputClassName}`}
+                  />
                 </div>
                 <div>
                   <label className="mb-1 block text-xs font-medium md:text-sm">track:</label>
@@ -139,7 +169,7 @@ export default function TrackMetadataEditor({
                     {...register("trackNumber", { valueAsNumber: true })}
                     placeholder="2"
                     disabled={inAlbum && syncTrackNumbers}
-                    className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                    className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
                   />
                 </div>
               </div>
@@ -167,7 +197,7 @@ export default function TrackMetadataEditor({
                     "download canceled"}
                 </div>
               </div>
-              <div className="flex min-h-0 flex-1 items-center justify-center gap-2 pt-1 max-lg:[@media(max-height:700px)]:flex-none max-lg:[@media(max-height:700px)]:pt-0 lg:flex-none lg:justify-end lg:pt-2">
+              <div className="flex min-h-0 flex-1 items-center justify-end gap-2 pt-1 max-lg:[@media(max-height:700px)]:flex-none max-lg:[@media(max-height:700px)]:pt-0 lg:flex-none lg:pt-2">
                 <Button
                   type="button"
                   onClick={handleSubmit(onDownloadUpdatedFile)}

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -19,6 +19,7 @@ import {
   applySyncedFilenamesToFiles,
   applyTrackOrderNumbersToFiles,
   applySoundCloudSetImportedCover,
+  areAlbumTrackCoversSynced,
   prepareDownloadedTrackHydration,
   resolveDownloadedTrackHydrationWrite,
   resolveDownloadedTrackHydrationWriteError,
@@ -1409,7 +1410,7 @@ export default function AudioTagger() {
   const closeAlbumDialog = () => {
     setAlbumDialogOpen(false);
   };
-  const applyAlbumDraftCoverToTracks = () => {
+  const syncAlbumDraftCoverToTracks = () => {
     if (albumDialogMode !== "edit" || !editingAlbumId || !albumDraft.cover) return;
     if (albumDraft.cover.length === 0) return;
 
@@ -1442,17 +1443,40 @@ export default function AudioTagger() {
       year: albumDraft.year,
     };
     if (albumDialogMode === "edit" && editingAlbumId) {
-      const updatedAlbums = updateAlbumMetadata(albums, editingAlbumId, metadata);
+      const currentAlbum = albumsRef.current.find((album) => album.id === editingAlbumId);
+      const updatedAlbums = updateAlbumMetadata(albumsRef.current, editingAlbumId, metadata);
+      albumsRef.current = updatedAlbums;
       setAlbums(updatedAlbums);
       const updatedAlbum = updatedAlbums.find((album) => album.id === editingAlbumId) ?? null;
       if (updatedAlbum) {
-        setFiles((prevFiles) => {
-          const taggedFiles = applyAlbumSharedTagsToFiles(prevFiles, updatedAlbum);
-          if (settings.syncFilenames) {
-            return applySyncedFilenamesToFiles(taggedFiles, updatedAlbum.trackIds);
+        const bufferedFiles = applyCurrentFormMetadataToFiles(
+          filesRef.current,
+          updatedAlbum.trackIds,
+        );
+        const shouldSyncCover =
+          Boolean(updatedAlbum.cover && updatedAlbum.cover.length > 0) &&
+          areAlbumTrackCoversSynced(bufferedFiles, updatedAlbum.trackIds, currentAlbum?.cover);
+        let taggedFiles = applyAlbumSharedTagsToFiles(bufferedFiles, updatedAlbum);
+
+        if (settings.syncFilenames) {
+          taggedFiles = applySyncedFilenamesToFiles(taggedFiles, updatedAlbum.trackIds);
+        }
+
+        if (shouldSyncCover && updatedAlbum.cover) {
+          const covered = applyAlbumCoverToFilesWithSelectedMetadata(
+            taggedFiles,
+            updatedAlbum.trackIds,
+            updatedAlbum.cover,
+            selectedFileIdRef.current,
+          );
+          taggedFiles = covered.files;
+          if (covered.selectedMetadata) {
+            reset(covered.selectedMetadata);
           }
-          return taggedFiles;
-        });
+        }
+
+        filesRef.current = taggedFiles;
+        setFiles(taggedFiles);
       }
       closeAlbumDialog();
       return;
@@ -1629,7 +1653,7 @@ export default function AudioTagger() {
         onChange={setAlbumDraft}
         onClose={closeAlbumDialog}
         onSave={saveAlbumDialog}
-        onApplyCover={applyAlbumDraftCoverToTracks}
+        onSyncCoverToTracks={syncAlbumDraftCoverToTracks}
         onDelete={
           albumDialogMode === "edit" && editingAlbumId
             ? () => {

--- a/components/audio/coverArt.tsx
+++ b/components/audio/coverArt.tsx
@@ -15,6 +15,7 @@ interface CoverArtProps {
     type?: number;
   }[];
   onCoverUpload?: (file: File) => void;
+  coverOverlay?: React.ReactNode;
   size?: "default" | "compact";
   resetKey?: string | null;
 }
@@ -22,6 +23,7 @@ interface CoverArtProps {
 export default function CoverArt({
   picture,
   onCoverUpload,
+  coverOverlay,
   size = "default",
   resetKey,
 }: CoverArtProps) {
@@ -165,11 +167,12 @@ export default function CoverArt({
             </PopoverContent>
           </Popover>
         )}
+        {coverSrc && coverOverlay}
       </div>
       <div
         className={
           isCompact
-            ? "flex min-w-0 flex-1 md:mt-auto md:block md:flex-none md:pt-2"
+            ? "flex min-w-0 flex-1"
             : "flex w-[min(80vw,clamp(7.5rem,calc(75svh-25.3125rem),19.25rem))] max-lg:[@media(max-height:700px)]:w-24 lg:w-auto lg:flex-none lg:flex-col lg:gap-2"
         }
       >
@@ -185,7 +188,7 @@ export default function CoverArt({
           variant="outline"
           className={
             isCompact
-              ? "h-24 w-full border-dashed border-2 flex flex-col items-center gap-1 px-2 hover:bg-accent/50 cursor-pointer md:h-10 md:w-44 md:flex-row md:gap-2 md:px-3"
+              ? "h-24 w-full border-dashed border-2 flex flex-col items-center gap-1 px-2 hover:bg-accent/50 cursor-pointer md:h-full md:min-h-12 md:w-44 md:px-3"
               : "h-10 w-full border-dashed border-2 flex gap-2 px-3 hover:bg-accent/50 cursor-pointer max-lg:[@media(max-height:700px)]:gap-1 lg:h-24 lg:w-64 lg:flex-col"
           }
           onClick={() => fileInputRef.current?.click()}

--- a/components/audio/fileMetadataOps.test.ts
+++ b/components/audio/fileMetadataOps.test.ts
@@ -5,6 +5,7 @@ import {
   applyAlbumSharedTagsToFiles,
   applySyncedFilenamesToFiles,
   applyTrackOrderNumbersToFiles,
+  areAlbumTrackCoversSynced,
   prepareDownloadedTrackHydration,
   resolveDownloadedTrackHydrationWrite,
   resolveDownloadedTrackHydrationWriteError,
@@ -209,6 +210,85 @@ describe("fileMetadataOps", () => {
     expect(result[1].metadata?.picture).toEqual(albumCover);
     expect(result[1].hasBufferedChanges).toBe(true);
     expect(result[2]).toBe(files[2]);
+  });
+
+  it("detects album cover sync by comparing image format and bytes", () => {
+    const albumCover = [
+      {
+        format: "image/jpeg",
+        type: 3,
+        description: "album cover",
+        data: new Uint8Array([1, 2, 3]),
+      },
+    ];
+    const files = [
+      readyFile({
+        id: "track-1",
+        metadata: metadata({ picture: albumCover }),
+      }),
+      readyFile({
+        id: "track-2",
+        metadata: metadata({
+          picture: [
+            {
+              format: "image/jpeg",
+              type: 3,
+              description: "same bytes",
+              data: new Uint8Array([1, 2, 3]),
+            },
+          ],
+        }),
+      }),
+    ];
+
+    expect(areAlbumTrackCoversSynced(files, ["track-1", "track-2"], albumCover)).toBe(true);
+  });
+
+  it("treats divergent track cover bytes as not synced with the album cover", () => {
+    const albumCover = [
+      {
+        format: "image/jpeg",
+        type: 3,
+        description: "album cover",
+        data: new Uint8Array([1, 2, 3]),
+      },
+    ];
+    const files = [
+      readyFile({
+        id: "track-1",
+        metadata: metadata({ picture: albumCover }),
+      }),
+      readyFile({
+        id: "track-2",
+        metadata: metadata({
+          picture: [
+            {
+              format: "image/jpeg",
+              type: 3,
+              description: "custom cover",
+              data: new Uint8Array([1, 2, 4]),
+            },
+          ],
+        }),
+      }),
+    ];
+
+    expect(areAlbumTrackCoversSynced(files, ["track-1", "track-2"], albumCover)).toBe(false);
+  });
+
+  it("treats all missing track covers as synced with a missing album cover", () => {
+    const files = [
+      readyFile({
+        id: "track-1",
+        metadata: metadata({ picture: [] }),
+      }),
+      readyFile({
+        id: "track-2",
+        metadata: metadata({ picture: [] }),
+      }),
+    ];
+
+    expect(areAlbumTrackCoversSynced(files, ["track-1", "track-2"], undefined)).toBe(true);
   });
 
   it("returns selected metadata with applied cover after buffering dirty form metadata", () => {

--- a/components/audio/fileMetadataOps.ts
+++ b/components/audio/fileMetadataOps.ts
@@ -153,6 +153,39 @@ export function applyAlbumCoverToFilesWithSelectedMetadata(
   };
 }
 
+function arePicturesEqual(
+  firstPicture: AudioMetadata["picture"] | undefined,
+  secondPicture: AudioMetadata["picture"] | undefined,
+) {
+  const [firstCover] = firstPicture ?? [];
+  const [secondCover] = secondPicture ?? [];
+
+  if (!firstCover || !secondCover) return !firstCover && !secondCover;
+  if (firstCover.format !== secondCover.format) return false;
+  if (firstCover.data.length !== secondCover.data.length) return false;
+
+  for (let index = 0; index < firstCover.data.length; index += 1) {
+    if (firstCover.data[index] !== secondCover.data[index]) return false;
+  }
+
+  return true;
+}
+
+export function areAlbumTrackCoversSynced(
+  files: TagiumFile[],
+  trackIds: string[],
+  albumCover: AudioMetadata["picture"] | undefined,
+) {
+  if (trackIds.length === 0) return false;
+
+  return trackIds.every((trackId) => {
+    const file = files.find((currentFile) => currentFile.id === trackId);
+    if (!file?.metadata) return false;
+
+    return arePicturesEqual(file.metadata.picture, albumCover);
+  });
+}
+
 export function applySoundCloudSetImportedCover(
   files: TagiumFile[],
   albums: AlbumGroup[],

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:cursor-default disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -11,7 +11,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 cursor-pointer rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -10,7 +10,7 @@ function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimiti
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex cursor-pointer items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:cursor-default group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className,
       )}
       {...props}

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import * as React from "react";
+import { Tooltip as TooltipPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 6,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md border border-border bg-card px-2.5 py-1.5 text-xs font-medium text-balance text-card-foreground shadow-md fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_1px)] rotate-45 rounded-[2px] border border-border bg-card fill-card" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,10 @@
 import AudioTagger from "@/components/audio/audioTagger";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 export default function App() {
-  return <AudioTagger />;
+  return (
+    <TooltipProvider>
+      <AudioTagger />
+    </TooltipProvider>
+  );
 }


### PR DESCRIPTION
## Summary
- soften example placeholder text and keep filename `.mp3` next to the filename value
- clarify URL import actions with arrow icons and import aria labels instead of direct-download semantics
- tighten album-cover upload space, settings label behavior, heading hierarchy, and pointer cursor consistency
- match disabled metadata fields to the filename disabled styling
- auto-sync album cover changes only when existing track covers match the previous album cover
- keep an explicit icon-only cover sync action on the album cover image with a tooltip
- restyle shared tooltips to match the app surface and animate the sync icon while syncing

## Preview
- Latest: https://codex-ui-critique-fixes-tagium.oliver-boorstein.workers.dev

## Validation
- `vp fmt`
- `vp lint`
- `vp check`
- `vp test`
- antagonistic review round 1 found 3 issues, addressed
- antagonistic review round 2 returned `NO FEEDBACK`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cover-sync action in album editing, with clearer in-context controls and feedback while syncing.
  * Added hover tooltips across the app for more helpful guidance.

* **Bug Fixes**
  * Improved album cover handling so synced cover art stays aligned across tracks when editing.
  * Refined metadata fields and filename editing to better reflect sync status and editing state.

* **Style**
  * Updated buttons, labels, checkboxes, and headings for clearer interaction cues and a more polished look.
  * Improved import/start button wording and iconography for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->