### PR TITLE
fix: explain disabled metadata fields

### DIFF
--- a/components/audio/AlbumSidebarDnd.tsx
+++ b/components/audio/AlbumSidebarDnd.tsx
@@ -22,6 +22,7 @@ import {
   X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { AlbumCoverThumb } from "./AlbumCoverThumb";
 import type { AlbumGroup, TagiumFile } from "./types";
@@ -315,27 +316,41 @@ export function SortableAlbumCard({
             </div>
           </div>
         </button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7"
-          onClick={onDownload}
-          disabled={!canDownload}
-          aria-label={`download ${album.title}`}
-        >
-          <Download className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7"
-          onClick={onEdit}
-          aria-label={`edit ${album.title}`}
-        >
-          <Pencil className="h-3.5 w-3.5" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={onDownload}
+                disabled={!canDownload}
+                aria-label={`download ${album.title}`}
+              >
+                <Download className="h-3.5 w-3.5" />
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {canDownload ? "download album" : "album needs ready tracks"}
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={onEdit}
+              aria-label={`edit ${album.title}`}
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>edit album</TooltipContent>
+        </Tooltip>
       </div>
       {children}
     </div>

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -10,6 +10,7 @@ import PlaylistDownloadQueuePanel, {
 } from "./PlaylistDownloadQueuePanel";
 import { AlbumGroup, TagiumFile } from "./types";
 import { Button } from "../ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
 interface TagSidebarPanelProps {
   loading: boolean;
@@ -84,6 +85,11 @@ export default function TagSidebarPanel({
   const dragCounterRef = useRef(0);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
   const canDownloadAll = files.length > 0 && files.every((file) => file.file && file.metadata);
+  const downloadAllReason = loading
+    ? "download in progress"
+    : files.length === 0
+      ? "add tracks first"
+      : "tracks need files and metadata";
 
   const isFileDrag = (event: React.DragEvent<HTMLDivElement>) =>
     event.dataTransfer.types.includes("Files");
@@ -176,9 +182,22 @@ export default function TagSidebarPanel({
       />
 
       <div className="px-3 py-3 border-t flex-shrink-0 flex flex-col gap-2">
-        <Button className="w-full" onClick={onDownloadAll} disabled={!canDownloadAll || loading}>
-          {loading ? "downloading..." : "download all"}
-        </Button>
+        {canDownloadAll && !loading ? (
+          <Button className="w-full" onClick={onDownloadAll}>
+            download all
+          </Button>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="block">
+                <Button className="w-full" onClick={onDownloadAll} disabled>
+                  {loading ? "downloading..." : "download all"}
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{downloadAllReason}</TooltipContent>
+          </Tooltip>
+        )}
         <Button
           variant="outline"
           className={cn(

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, ReactNode } from "react";
 import {
   Control,
   Controller,
@@ -14,6 +14,7 @@ import CoverArt from "./coverArt";
 import { AlbumGroup, AudioMetadata, TagiumFile } from "./types";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
 interface TrackMetadataEditorProps {
   selectedFile: TagiumFile | null;
@@ -30,6 +31,27 @@ interface TrackMetadataEditorProps {
     field: "filename" | "title",
     event: ChangeEvent<HTMLInputElement>,
   ) => void;
+}
+
+function DisabledReason({
+  disabled,
+  reason,
+  children,
+}: {
+  disabled: boolean;
+  reason: string;
+  children: ReactNode;
+}) {
+  if (!disabled) return children;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="block">{children}</span>
+      </TooltipTrigger>
+      <TooltipContent>{reason}</TooltipContent>
+    </Tooltip>
+  );
 }
 
 export default function TrackMetadataEditor({
@@ -49,6 +71,7 @@ export default function TrackMetadataEditor({
   const watchedFilename = useWatch({ control, name: "filename", defaultValue: "" });
   const inAlbum = !!selectedFileAlbum;
   const audioReady = Boolean(selectedFile?.file);
+  const albumFieldReason = "controlled by the album";
   const filenameRegistration = register("filename", {
     onChange: (event) => onPreviewMetadataChange("filename", event),
   });
@@ -80,10 +103,15 @@ export default function TrackMetadataEditor({
       >
         <div className="h-16 border-b flex-shrink-0 flex flex-col justify-center gap-1 px-4 max-lg:[@media(max-height:700px)]:h-12 max-lg:[@media(max-height:700px)]:px-3 lg:h-[104px] lg:p-6">
           {syncFilenames ? (
-            <h2 className="inline-flex min-w-0 max-w-full items-center text-base font-semibold max-lg:[@media(max-height:700px)]:text-sm lg:text-lg">
-              <span className="min-w-0 truncate">
-                {filenamify(watchedTitle, { replacement: "-" })}
-              </span>
+            <h2 className="inline-flex min-w-0 max-w-full items-center text-base font-semibold text-muted-foreground max-lg:[@media(max-height:700px)]:text-sm lg:text-lg">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="min-w-0 cursor-not-allowed truncate">
+                    {filenamify(watchedTitle, { replacement: "-" })}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>filename follows the title</TooltipContent>
+              </Tooltip>
               <span className="shrink-0 select-none text-muted-foreground/70">.mp3</span>
             </h2>
           ) : (
@@ -134,51 +162,64 @@ export default function TrackMetadataEditor({
               </div>
               <div>
                 <label className="mb-1 block text-xs font-medium md:text-sm">artist:</label>
-                <Input
-                  {...register("artist")}
-                  placeholder="Skrillex"
-                  disabled={inAlbum}
-                  className={`${placeholderClassName} ${syncedInputClassName}`}
-                />
+                <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
+                  <Input
+                    {...register("artist")}
+                    placeholder="Skrillex"
+                    disabled={inAlbum}
+                    className={`${placeholderClassName} ${syncedInputClassName}`}
+                  />
+                </DisabledReason>
               </div>
               <div>
                 <label className="mb-1 block text-xs font-medium md:text-sm">album:</label>
-                <Input
-                  {...register("album")}
-                  placeholder="Bangarang EP"
-                  disabled={inAlbum}
-                  className={`${placeholderClassName} ${syncedInputClassName}`}
-                />
+                <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
+                  <Input
+                    {...register("album")}
+                    placeholder="Bangarang EP"
+                    disabled={inAlbum}
+                    className={`${placeholderClassName} ${syncedInputClassName}`}
+                  />
+                </DisabledReason>
               </div>
               <div className="grid grid-cols-[minmax(4.5rem,0.8fr)_minmax(0,1.4fr)_minmax(4.5rem,0.8fr)] gap-2">
                 <div>
                   <label className="mb-1 block text-xs font-medium md:text-sm">year:</label>
-                  <Input
-                    type="number"
-                    {...register("year", { valueAsNumber: true })}
-                    placeholder="2011"
-                    disabled={inAlbum}
-                    className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
-                  />
+                  <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
+                    <Input
+                      type="number"
+                      {...register("year", { valueAsNumber: true })}
+                      placeholder="2011"
+                      disabled={inAlbum}
+                      className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
+                    />
+                  </DisabledReason>
                 </div>
                 <div>
                   <label className="mb-1 block text-xs font-medium md:text-sm">genre:</label>
-                  <Input
-                    {...register("genre")}
-                    placeholder="Dubstep"
-                    disabled={inAlbum}
-                    className={`${placeholderClassName} ${syncedInputClassName}`}
-                  />
+                  <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
+                    <Input
+                      {...register("genre")}
+                      placeholder="Dubstep"
+                      disabled={inAlbum}
+                      className={`${placeholderClassName} ${syncedInputClassName}`}
+                    />
+                  </DisabledReason>
                 </div>
                 <div>
                   <label className="mb-1 block text-xs font-medium md:text-sm">track:</label>
-                  <Input
-                    type="number"
-                    {...register("trackNumber", { valueAsNumber: true })}
-                    placeholder="2"
+                  <DisabledReason
                     disabled={inAlbum && syncTrackNumbers}
-                    className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
-                  />
+                    reason="follows album order"
+                  >
+                    <Input
+                      type="number"
+                      {...register("trackNumber", { valueAsNumber: true })}
+                      placeholder="2"
+                      disabled={inAlbum && syncTrackNumbers}
+                      className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
+                    />
+                  </DisabledReason>
                 </div>
               </div>
               <div className="grid grid-cols-2 gap-2 text-xs md:text-sm">
@@ -206,14 +247,16 @@ export default function TrackMetadataEditor({
                 </div>
               </div>
               <div className="flex min-h-0 flex-1 items-center justify-end gap-2 pt-1 max-lg:[@media(max-height:700px)]:flex-none max-lg:[@media(max-height:700px)]:pt-0 lg:flex-none lg:pt-2">
-                <Button
-                  type="button"
-                  onClick={handleSubmit(onDownloadUpdatedFile)}
-                  disabled={!audioReady}
-                  className="min-w-36 max-lg:[@media(max-height:700px)]:h-10 max-lg:[@media(max-height:700px)]:text-xs"
-                >
-                  download track
-                </Button>
+                <DisabledReason disabled={!audioReady} reason="track file is not ready">
+                  <Button
+                    type="button"
+                    onClick={handleSubmit(onDownloadUpdatedFile)}
+                    disabled={!audioReady}
+                    className="min-w-36 max-lg:[@media(max-height:700px)]:h-10 max-lg:[@media(max-height:700px)]:text-xs"
+                  >
+                    download track
+                  </Button>
+                </DisabledReason>
               </div>
             </div>
           </div>

--- a/components/audio/coverArt.tsx
+++ b/components/audio/coverArt.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import ImageCropper from "../ui/image-cropper";
 import { Crop, Upload } from "lucide-react";
 
@@ -133,25 +134,32 @@ export default function CoverArt({
         )}
         {coverSrc && (
           <Popover open={showCropper} onOpenChange={setShowCropper}>
-            <PopoverTrigger asChild>
-              <Button
-                type="button"
-                size="sm"
-                variant="secondary"
-                aria-label="crop cover art"
-                className="absolute top-2 right-2 size-10 p-0 max-lg:[@media(max-height:700px)]:top-1.5 max-lg:[@media(max-height:700px)]:right-1.5"
-                onClick={() => {
-                  if (tempImageForCropping) {
-                    URL.revokeObjectURL(tempImageForCropping);
-                  }
-                  // Use uploaded cover first, then fall back to original picture
-                  const imageUrl = uploadedCover ? URL.createObjectURL(uploadedCover) : coverSrc;
-                  setTempImageForCropping(imageUrl);
-                }}
-              >
-                <Crop className="h-4 w-4" />
-              </Button>
-            </PopoverTrigger>
+            <Tooltip>
+              <PopoverTrigger asChild>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    aria-label="crop cover art"
+                    className="absolute top-2 right-2 size-10 p-0 max-lg:[@media(max-height:700px)]:top-1.5 max-lg:[@media(max-height:700px)]:right-1.5"
+                    onClick={() => {
+                      if (tempImageForCropping) {
+                        URL.revokeObjectURL(tempImageForCropping);
+                      }
+                      // Use uploaded cover first, then fall back to original picture
+                      const imageUrl = uploadedCover
+                        ? URL.createObjectURL(uploadedCover)
+                        : coverSrc;
+                      setTempImageForCropping(imageUrl);
+                    }}
+                  >
+                    <Crop className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+              </PopoverTrigger>
+              <TooltipContent>crop cover art</TooltipContent>
+            </Tooltip>
             <PopoverContent
               className="w-auto max-w-[calc(100svw-1rem)] p-3 md:p-4"
               side="bottom"

--- a/components/ui/image-cropper.tsx
+++ b/components/ui/image-cropper.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useRef } from "react";
 import ReactCrop, { Crop, PixelCrop, centerCrop, makeAspectCrop } from "react-image-crop";
 import { Button } from "./button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
 import "react-image-crop/dist/ReactCrop.css";
 
 interface ImageCropperProps {
@@ -114,9 +115,20 @@ export default function ImageCropper({ src, onCrop, onCancel }: ImageCropperProp
         <Button variant="outline" onClick={onCancel}>
           cancel
         </Button>
-        <Button onClick={handleCrop} disabled={!completedCrop}>
-          apply crop
-        </Button>
+        {completedCrop ? (
+          <Button onClick={handleCrop}>apply crop</Button>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <Button onClick={handleCrop} disabled>
+                  apply crop
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>select a crop area first</TooltipContent>
+          </Tooltip>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- adds reason tooltips for disabled metadata fields
- explains filename sync, album-controlled fields, track-number sync, and not-ready download states
- adds cover/crop tooltips, including a disabled apply-crop reason
- adds a disabled album-download reason tooltip

## Preview
- https://codex-disabled-reason-tooltips-tagium.oliver-boorstein.workers.dev

## Validation
- `vp fmt`
- `vp lint`
- `vp check`
- `vp test`
- antagonistic review feedback addressed: download-all reason covers missing files and metadata; album download has tooltip/reason
