### PR TITLE
[codex] focus metadata text fields first

### DIFF
--- a/components/audio/AlbumMetadataDialog.tsx
+++ b/components/audio/AlbumMetadataDialog.tsx
@@ -57,6 +57,7 @@ export default function AlbumMetadataDialog({
   const canSyncCoverToTracks =
     mode === "edit" && draft.cover && draft.cover.length > 0 && onSyncCoverToTracks;
   const syncCoverLabel = isSyncingCover ? "syncing cover to tracks" : "sync cover to tracks";
+  const placeholderClassName = "placeholder:text-muted-foreground/45";
 
   const handleSyncCoverToTracks = () => {
     if (!onSyncCoverToTracks) return;
@@ -125,10 +126,80 @@ export default function AlbumMetadataDialog({
           </DialogHeader>
           <div className="p-5 overflow-y-auto">
             <div className="grid grid-cols-1 md:grid-cols-[11rem_minmax(0,1fr)] gap-4 md:min-h-[236px] items-stretch">
+              <div className="order-2 min-w-0 h-full flex flex-col justify-between gap-3 md:order-2">
+                <div className="flex flex-col gap-3">
+                  <div>
+                    <label className="block text-sm font-medium mb-1">album title:</label>
+                    <Input
+                      value={draft.title}
+                      onChange={(event) =>
+                        onChange({
+                          ...draft,
+                          title: event.target.value,
+                        })
+                      }
+                      placeholder={placeholder.title}
+                      aria-invalid={showErrors && !draft.title.trim()}
+                      className={placeholderClassName}
+                    />
+                    {showErrors && !draft.title.trim() && (
+                      <p className="text-xs text-destructive mt-1">album title is required</p>
+                    )}
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">artist:</label>
+                    <Input
+                      value={draft.artist}
+                      onChange={(event) =>
+                        onChange({
+                          ...draft,
+                          artist: event.target.value,
+                        })
+                      }
+                      placeholder={placeholder.artist}
+                      aria-invalid={showErrors && !draft.artist.trim()}
+                      className={placeholderClassName}
+                    />
+                    {showErrors && !draft.artist.trim() && (
+                      <p className="text-xs text-destructive mt-1">artist is required</p>
+                    )}
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">genre:</label>
+                    <Input
+                      value={draft.genre}
+                      onChange={(event) =>
+                        onChange({
+                          ...draft,
+                          genre: event.target.value,
+                        })
+                      }
+                      placeholder={placeholder.genre}
+                      className={placeholderClassName}
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">year:</label>
+                    <Input
+                      type="number"
+                      value={draft.year ?? ""}
+                      onChange={(event) =>
+                        onChange({
+                          ...draft,
+                          year: event.target.value ? Number(event.target.value) : undefined,
+                        })
+                      }
+                      placeholder={placeholder.year}
+                      className={`${placeholderClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
+                    />
+                  </div>
+                </div>
+              </div>
               <CoverArt
                 picture={draft.cover}
                 onCoverUpload={handleCoverUpload}
                 size="compact"
+                className="order-1 md:order-1"
                 coverOverlay={
                   canSyncCoverToTracks && (
                     <Tooltip>
@@ -157,72 +228,6 @@ export default function AlbumMetadataDialog({
                   )
                 }
               />
-              <div className="min-w-0 h-full flex flex-col justify-between gap-3">
-                <div className="flex flex-col gap-3">
-                  <div>
-                    <label className="block text-sm font-medium mb-1">album title:</label>
-                    <Input
-                      value={draft.title}
-                      onChange={(event) =>
-                        onChange({
-                          ...draft,
-                          title: event.target.value,
-                        })
-                      }
-                      placeholder={placeholder.title}
-                      aria-invalid={showErrors && !draft.title.trim()}
-                    />
-                    {showErrors && !draft.title.trim() && (
-                      <p className="text-xs text-destructive mt-1">album title is required</p>
-                    )}
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium mb-1">artist:</label>
-                    <Input
-                      value={draft.artist}
-                      onChange={(event) =>
-                        onChange({
-                          ...draft,
-                          artist: event.target.value,
-                        })
-                      }
-                      placeholder={placeholder.artist}
-                      aria-invalid={showErrors && !draft.artist.trim()}
-                    />
-                    {showErrors && !draft.artist.trim() && (
-                      <p className="text-xs text-destructive mt-1">artist is required</p>
-                    )}
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium mb-1">genre:</label>
-                    <Input
-                      value={draft.genre}
-                      onChange={(event) =>
-                        onChange({
-                          ...draft,
-                          genre: event.target.value,
-                        })
-                      }
-                      placeholder={placeholder.genre}
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium mb-1">year:</label>
-                    <Input
-                      type="number"
-                      value={draft.year ?? ""}
-                      onChange={(event) =>
-                        onChange({
-                          ...draft,
-                          year: event.target.value ? Number(event.target.value) : undefined,
-                        })
-                      }
-                      placeholder={placeholder.year}
-                      className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                    />
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
           <DialogFooter className="border-t p-5 flex items-center justify-end gap-2">

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback, useRef } from "react";
 import type { ChangeEvent, ReactNode } from "react";
 import {
   Control,
@@ -79,9 +80,22 @@ export default function TrackMetadataEditor({
   const titleRegistration = register("title", {
     onChange: (event) => onPreviewMetadataChange("title", event),
   });
+  const { ref: titleRegistrationRef, ...titleInputRegistration } = titleRegistration;
   const placeholderClassName = "placeholder:text-muted-foreground/45";
   const syncedInputClassName =
     "disabled:pointer-events-auto disabled:cursor-not-allowed disabled:border-dashed disabled:bg-muted/10 disabled:text-muted-foreground disabled:opacity-100 dark:disabled:bg-muted/10";
+  const focusedTitleFileIdRef = useRef<string | null>(null);
+  const titleInputRef = useCallback(
+    (node: HTMLInputElement | null) => {
+      titleRegistrationRef(node);
+      if (!node || !selectedFileId) return;
+      if (focusedTitleFileIdRef.current === selectedFileId) return;
+
+      focusedTitleFileIdRef.current = selectedFileId;
+      node.focus({ preventScroll: true });
+    },
+    [selectedFileId, titleRegistrationRef],
+  );
 
   if (!selectedFile || !selectedFile.metadata) {
     return (
@@ -158,7 +172,8 @@ export default function TrackMetadataEditor({
               <div>
                 <label className="mb-1 block text-xs font-medium md:text-sm">title:</label>
                 <Input
-                  {...titleRegistration}
+                  {...titleInputRegistration}
+                  ref={titleInputRef}
                   placeholder={placeholder.title}
                   className={placeholderClassName}
                 />

--- a/components/audio/coverArt.tsx
+++ b/components/audio/coverArt.tsx
@@ -19,6 +19,7 @@ interface CoverArtProps {
   coverOverlay?: React.ReactNode;
   size?: "default" | "compact";
   resetKey?: string | null;
+  className?: string;
 }
 
 export default function CoverArt({
@@ -27,6 +28,7 @@ export default function CoverArt({
   coverOverlay,
   size = "default",
   resetKey,
+  className,
 }: CoverArtProps) {
   const [uploadedCover, setUploadedCover] = useState<File | null>(null);
   const [tempImageForCropping, setTempImageForCropping] = useState<string | null>(null);
@@ -67,6 +69,9 @@ export default function CoverArt({
 
   const [coverSrc, setCoverSrc] = useState<string | null>(null);
   const isCompact = size === "compact";
+  const containerClassName = isCompact
+    ? "flex-shrink-0 flex gap-2 md:h-full md:flex-col"
+    : "flex-shrink-0 flex flex-col items-center gap-2 lg:grid lg:grid-rows-2 lg:items-start";
 
   useEffect(() => {
     setUploadedCover(null);
@@ -97,13 +102,7 @@ export default function CoverArt({
   }, [uploadedCover, picture]);
 
   return (
-    <div
-      className={
-        isCompact
-          ? "flex-shrink-0 flex gap-2 md:h-full md:flex-col"
-          : "flex-shrink-0 flex flex-col items-center gap-2 lg:grid lg:grid-rows-2 lg:items-start"
-      }
-    >
+    <div className={className ? `${containerClassName} ${className}` : containerClassName}>
       <div
         className={
           isCompact


### PR DESCRIPTION
## Summary

Keeps metadata text fields first in focus order across the album dialog and track editor.

## Details

- Moves album dialog text fields before cover controls in DOM order while preserving the cover-left visual layout.
- Keeps cover crop/sync controls keyboard accessible after the text fields.
- Focuses the track title field once when a different track is selected.
- Keeps album dialog placeholder text aligned with the song editor style.
- Stacked on #44 (`codex/randomized-placeholders`) via Graphite.

## Validation

- `vp fmt`
- `vp lint`
- `vp check`
- `vp test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus behavior in the audio metadata editor so the title field is automatically focused when switching files.
  * Refined the album metadata dialog layout to keep fields and cover art arranged more consistently.
  * Updated cover art display styling to better support custom layout spacing in the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->