### PR TITLE
[codex] add metadata patch download flow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "effect": "^4.0.0-beta.93",
         "fflate": "^0.8.2",
         "filenamify": "^7.0.1",
         "lucide-react": "^0.542.0",
@@ -193,6 +194,18 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.30", "", { "dependencies": { "@jridgewell/resolve-uri": "3.1.2", "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.17.4", "", { "dependencies": { "ajv": "6.12.6", "content-type": "1.0.5", "cors": "2.8.5", "cross-spawn": "7.0.6", "eventsource": "3.0.7", "eventsource-parser": "3.0.6", "express": "5.1.0", "express-rate-limit": "7.5.1", "pkce-challenge": "5.0.0", "raw-body": "3.0.0", "zod": "3.25.76", "zod-to-json-schema": "3.24.6" } }, "sha512-zq24hfuAmmlNZvik0FLI58uE5sriN0WWsQzIlYnzSuKDAHFqJtBFrl/LfB1NLgJT5Y7dEBzaX4yAKqOPrcetaw=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
     "@mswjs/interceptors": ["@mswjs/interceptors@0.39.6", "", { "dependencies": { "@open-draft/deferred-promise": "2.2.0", "@open-draft/logger": "0.3.0", "@open-draft/until": "2.1.0", "is-node-process": "1.2.0", "outvariant": "1.4.3", "strict-event-emitter": "0.5.1" } }, "sha512-bndDP83naYYkfayr/qhBHMhk0YGwS1iv6vaEGcr0SQbO0IZtbOPqjKjds/WcG+bJA+1T5vCx6kprKOzn5Bg+Vw=="],
 
@@ -690,6 +703,8 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
+    "effect": ["effect@4.0.0-beta.93", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-wNS5MKFa3C42uBfIDik2oJ78lhpoYz2hN4oBR0229BeeDCIrkg/FiOvoiPGdCVlWa7MEKxEL5I0f8AILVHSD9A=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.211", "", {}, "sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw=="],
 
     "emoji-regex": ["emoji-regex@10.5.0", "", {}, "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg=="],
@@ -754,6 +769,8 @@
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
+    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "@nodelib/fs.walk": "1.2.8", "glob-parent": "5.1.2", "merge2": "1.4.1", "micromatch": "4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
@@ -783,6 +800,8 @@
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "4.4.1", "encodeurl": "2.0.0", "escape-html": "1.0.3", "on-finished": "2.4.1", "parseurl": "1.3.3", "statuses": "2.0.2" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
+
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "6.0.0", "path-exists": "4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -868,6 +887,8 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
+    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
+
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
@@ -921,6 +942,8 @@
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "1.2.1", "type-check": "0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -998,7 +1021,13 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
     "msw": ["msw@2.10.5", "", { "dependencies": { "@bundled-es-modules/cookie": "2.0.1", "@bundled-es-modules/statuses": "1.0.1", "@bundled-es-modules/tough-cookie": "0.1.6", "@inquirer/confirm": "5.1.16", "@mswjs/interceptors": "0.39.6", "@open-draft/deferred-promise": "2.2.0", "@open-draft/until": "2.1.0", "@types/cookie": "0.6.0", "@types/statuses": "2.0.6", "graphql": "16.11.0", "headers-polyfill": "4.0.3", "is-node-process": "1.2.0", "outvariant": "1.4.3", "path-to-regexp": "6.3.0", "picocolors": "1.1.1", "strict-event-emitter": "0.5.1", "type-fest": "4.41.0", "yargs": "17.7.2" }, "optionalDependencies": { "typescript": "5.9.2" }, "bin": { "msw": "cli/index.js" } }, "sha512-0EsQCrCI1HbhpBWd89DvmxY6plmvrM96b0sCIztnvcNHQbXn5vqwm1KlXslo6u4wN9LFGLC1WFjjgljcQhe40A=="],
+
+    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
 
     "music-metadata": ["music-metadata@11.8.3", "", { "dependencies": { "@borewit/text-codec": "0.2.0", "@tokenizer/token": "0.3.0", "content-type": "1.0.5", "debug": "4.4.1", "file-type": "21.0.0", "media-typer": "1.1.0", "strtok3": "10.3.4", "token-types": "6.1.1", "uint8array-extras": "1.5.0" } }, "sha512-Tgiv4MlCgDb6XzelziB1mmL2xeoHls0KTpCm3Z3qr+LfF4mBEpkuc5vNrc927IT5+S5fv+vzStfI+HYC0igDpA=="],
 
@@ -1017,6 +1046,8 @@
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "4.0.1", "fetch-blob": "3.2.0", "formdata-polyfill": "4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "node-releases": ["node-releases@2.0.19", "", {}, "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="],
 
@@ -1101,6 +1132,8 @@
     "psl": ["psl@1.15.0", "", { "dependencies": { "punycode": "2.3.1" } }, "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
 
@@ -1236,6 +1269,8 @@
 
     "token-types": ["token-types@6.1.1", "", { "dependencies": { "@borewit/text-codec": "0.1.1", "@tokenizer/token": "0.3.0", "ieee754": "1.2.1" } }, "sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ=="],
 
+    "toml": ["toml@4.1.2", "", {}, "sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA=="],
+
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "1.15.0", "punycode": "2.3.1", "universalify": "0.2.0", "url-parse": "1.5.10" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
@@ -1286,6 +1321,8 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.5.0", "", { "peerDependencies": { "react": "19.1.0" } }, "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A=="],
 
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vite": ["vite@8.0.7", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.13", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw=="],
@@ -1309,6 +1346,8 @@
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "8.0.1", "escalade": "3.2.0", "get-caller-file": "2.0.5", "require-directory": "2.1.1", "string-width": "4.2.3", "y18n": "5.0.8", "yargs-parser": "21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 

--- a/components/audio/audioTagger.test.ts
+++ b/components/audio/audioTagger.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createDirtyMetadataPatch, getSubmittedAudioMetadata } from "./audioTagger";
+import type { AudioMetadata } from "./types";
+
+const metadata = (overrides: Partial<AudioMetadata> = {}): AudioMetadata => ({
+  filename: "old-title",
+  title: "Old Title",
+  artist: "Artist",
+  album: "Album",
+  year: 2024,
+  genre: "Genre",
+  duration: 100,
+  bitrate: 320,
+  sampleRate: 44_100,
+  picture: [],
+  trackNumber: 7,
+  ...overrides,
+});
+
+describe("audioTagger metadata patches", () => {
+  it("creates title-only preview patches without stale numeric fields", () => {
+    const patch = createDirtyMetadataPatch(
+      metadata({ title: "New Title", year: 1999, trackNumber: 3 }),
+      {},
+      false,
+      ["title"],
+    );
+
+    expect(patch).toEqual({ title: "New Title" });
+  });
+
+  it("syncs filename intent when title changes with filename sync enabled", () => {
+    const patch = createDirtyMetadataPatch(
+      metadata({ filename: "New-Title", title: "New Title", year: 1999, trackNumber: 3 }),
+      {},
+      true,
+      ["title"],
+    );
+
+    expect(patch).toEqual({ filename: "New-Title", title: "New Title" });
+  });
+
+  it("derives synced filename from submitted title before creating download hydration patches", () => {
+    const rawFormMetadata = metadata({ filename: "old-title", title: "New Title" });
+    const submittedMetadata = getSubmittedAudioMetadata(rawFormMetadata, true);
+    const patch = createDirtyMetadataPatch(submittedMetadata, { title: true }, true);
+
+    expect(patch).toEqual({ filename: "New Title", title: "New Title" });
+  });
+
+  it("buffers only dirty form fields", () => {
+    const patch = createDirtyMetadataPatch(
+      metadata({
+        title: "New Title",
+        artist: "New Artist",
+        year: 1999,
+        trackNumber: 3,
+      }),
+      { title: true, artist: true },
+      false,
+    );
+
+    expect(patch).toEqual({ title: "New Title", artist: "New Artist" });
+  });
+
+  it("creates null patches for dirty numeric fields cleared by RHF", () => {
+    const patch = createDirtyMetadataPatch(
+      metadata({
+        year: Number.NaN,
+        trackNumber: Number.NaN,
+      }),
+      { year: true, trackNumber: true },
+      false,
+    );
+
+    expect(patch).toEqual({ year: null, trackNumber: null });
+  });
+
+  it("keeps cleared numeric form values absent when fields are untouched", () => {
+    const patch = createDirtyMetadataPatch(
+      metadata({
+        title: "New Title",
+        year: Number.NaN,
+        trackNumber: Number.NaN,
+      }),
+      { title: true },
+      false,
+    );
+
+    expect(patch).toEqual({ title: "New Title" });
+  });
+});

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -34,6 +34,12 @@ import {
 import TagSidebarPanel from "./TagSidebarPanel";
 import type { PlaylistDownloadQueuePanelState } from "./PlaylistDownloadQueuePanel";
 import {
+  createSingleUrlDownloadPlan,
+  createSoundCloudSetDownloadPlan,
+  fetchImportedCover,
+  type QueuedDownloadTrack,
+} from "./downloadTrack";
+import {
   cancelActivePlaylistDownloadTracks,
   cancelPendingPlaylistDownloadTracks,
   createPlaylistDownloadQueueRun,
@@ -63,22 +69,19 @@ import {
   writeMetadataToFile,
 } from "./mp3Utils";
 import { loadAppSettings, saveAppSettings } from "./settings";
-import {
-  createDownloadMetadata,
-  createPendingDownloadTrack,
-  fetchImportedCover,
-} from "./soundcloudSetImport";
 import { getSampleAlbum } from "./sampleMetadata";
 import type { SoundCloudSet } from "./soundcloudSet";
-import { AlbumGroup, AppSettings, AudioMetadata, ImportedAlbumMetadata, TagiumFile } from "./types";
+import {
+  AlbumGroup,
+  AppSettings,
+  AudioMetadata,
+  ImportedAlbumMetadata,
+  MetadataPatch,
+  TagiumFile,
+} from "./types";
 
 type ActiveView = "editor" | "settings";
-type DownloadRequest = NonNullable<TagiumFile["downloadRequest"]>;
-type ManagedDownloadTrack = {
-  fileId: string;
-  title: string;
-  downloadRequest: DownloadRequest;
-};
+type ManagedDownloadTrack = QueuedDownloadTrack;
 type PlaylistDownloadQueueState = PlaylistDownloadQueueRuntimeSnapshot;
 type PlaylistDownloadQueueRun = PlaylistDownloadQueueRuntimeRun<ManagedDownloadTrack> & {
   budgetWakeTimeout?: ReturnType<typeof setTimeout>;
@@ -102,16 +105,6 @@ const isPlaylistDownloadAbort = (error: unknown) => {
 };
 const asUniqueTrackIds = (trackIds: string[]) => [...new Set(trackIds)];
 const getFileImportKey = (file: File) => `${file.name}:${file.size}:${file.lastModified}`;
-const titleFromSourceUrl = (sourceUrl: string) => {
-  try {
-    const url = new URL(sourceUrl);
-    const [lastPathPart] = url.pathname.split("/").filter(Boolean).slice(-1);
-    if (lastPathPart) return decodeURIComponent(lastPathPart).replaceAll("-", " ");
-    return url.hostname;
-  } catch {
-    return "downloading audio";
-  }
-};
 const getManagedDownloadTrackTitle = (file: TagiumFile) => {
   if (file.metadata?.title) return file.metadata.title;
   return file.filename;
@@ -133,6 +126,123 @@ const createPlaylistDownloadModelTrack = (track: ManagedDownloadTrack) => ({
   title: track.title,
   sourceUrl: track.downloadRequest.sourceUrl,
 });
+type MetadataPatchField = keyof MetadataPatch;
+type DirtyMetadataFields = Partial<Record<keyof AudioMetadata, unknown>>;
+
+const metadataPatchFields = [
+  "filename",
+  "title",
+  "artist",
+  "album",
+  "year",
+  "genre",
+  "picture",
+  "trackNumber",
+] as const satisfies readonly MetadataPatchField[];
+const hasOwn = <Key extends PropertyKey>(object: object, key: Key) =>
+  Object.prototype.hasOwnProperty.call(object, key);
+const getNullableNumericPatchValue = (value: AudioMetadata["year"]): MetadataPatch["year"] =>
+  value === undefined || Number.isNaN(value) ? null : value;
+const getPendingMetadataPatch = (file: TagiumFile): MetadataPatch | undefined =>
+  file.pendingMetadataPatch;
+const createSubmittedMetadataPatch = (metadata: AudioMetadata): MetadataPatch => ({
+  filename: metadata.filename,
+  title: metadata.title,
+  artist: metadata.artist,
+  album: metadata.album,
+  year: getNullableNumericPatchValue(metadata.year),
+  genre: metadata.genre,
+  picture: metadata.picture,
+  trackNumber: getNullableNumericPatchValue(metadata.trackNumber),
+});
+export const getSubmittedAudioMetadata = (
+  data: AudioMetadata,
+  syncFilenames: boolean,
+): AudioMetadata =>
+  syncFilenames ? { ...data, filename: filenamify(data.title, { replacement: "-" }) } : data;
+export const createSparseMetadataPatch = (
+  metadata: AudioMetadata,
+  fields: Iterable<MetadataPatchField>,
+  syncFilenames: boolean,
+): MetadataPatch | undefined => {
+  const patchFields = new Set(fields);
+  if (syncFilenames && patchFields.has("title")) {
+    patchFields.add("filename");
+  }
+
+  const patch: MetadataPatch = {};
+  for (const field of metadataPatchFields) {
+    if (!patchFields.has(field)) continue;
+
+    switch (field) {
+      case "filename":
+        patch.filename = metadata.filename;
+        break;
+      case "title":
+        patch.title = metadata.title;
+        break;
+      case "artist":
+        patch.artist = metadata.artist;
+        break;
+      case "album":
+        patch.album = metadata.album;
+        break;
+      case "year":
+        patch.year = getNullableNumericPatchValue(metadata.year);
+        break;
+      case "genre":
+        patch.genre = metadata.genre;
+        break;
+      case "picture":
+        patch.picture = metadata.picture;
+        break;
+      case "trackNumber":
+        patch.trackNumber = getNullableNumericPatchValue(metadata.trackNumber);
+        break;
+    }
+  }
+
+  return Object.keys(patch).length > 0 ? patch : undefined;
+};
+export const createDirtyMetadataPatch = (
+  metadata: AudioMetadata,
+  dirtyFields: DirtyMetadataFields,
+  syncFilenames: boolean,
+  extraFields: Iterable<MetadataPatchField> = [],
+): MetadataPatch | undefined => {
+  const fields = new Set<MetadataPatchField>(extraFields);
+  for (const field of metadataPatchFields) {
+    if (dirtyFields[field]) {
+      fields.add(field);
+    }
+  }
+
+  return createSparseMetadataPatch(metadata, fields, syncFilenames);
+};
+const applyMetadataPatch = (metadata: AudioMetadata, patch: MetadataPatch): AudioMetadata => ({
+  ...metadata,
+  ...(hasOwn(patch, "filename") ? { filename: patch.filename } : {}),
+  ...(hasOwn(patch, "title") ? { title: patch.title } : {}),
+  ...(hasOwn(patch, "artist") ? { artist: patch.artist } : {}),
+  ...(hasOwn(patch, "album") ? { album: patch.album } : {}),
+  ...(hasOwn(patch, "year") ? { year: patch.year } : {}),
+  ...(hasOwn(patch, "genre") ? { genre: patch.genre } : {}),
+  ...(hasOwn(patch, "picture") ? { picture: patch.picture } : {}),
+  ...(hasOwn(patch, "trackNumber") ? { trackNumber: patch.trackNumber } : {}),
+});
+const getFilenameFromPatch = (file: TagiumFile, patch: MetadataPatch) =>
+  hasOwn(patch, "filename") && patch.filename ? `${patch.filename}.mp3` : file.filename;
+const withPendingMetadataPatch = (
+  file: TagiumFile,
+  pendingMetadataPatch: MetadataPatch | undefined,
+) => ({
+  ...file,
+  pendingMetadataPatch,
+  hasBufferedChanges: Boolean(pendingMetadataPatch),
+});
+const withMergedPendingMetadataPatch = (file: TagiumFile, patch: MetadataPatch | undefined) =>
+  patch ? withPendingMetadataPatch(file, { ...file.pendingMetadataPatch, ...patch }) : file;
+const clearPendingMetadataPatch = (file: TagiumFile) => withPendingMetadataPatch(file, undefined);
 
 export default function AudioTagger() {
   const [files, setFiles] = useState<TagiumFile[]>([]);
@@ -245,13 +355,15 @@ export default function AudioTagger() {
       };
       const nextFiles = filesRef.current.map((file) =>
         file.id === fileToUpdate.id
-          ? {
-              ...file,
-              filename: newTags.filename ? `${newTags.filename}.mp3` : file.filename,
-              metadata,
-              status: "pending" as const,
-              hasBufferedChanges: true,
-            }
+          ? withPendingMetadataPatch(
+              {
+                ...file,
+                filename: newTags.filename ? `${newTags.filename}.mp3` : file.filename,
+                metadata,
+                status: "pending" as const,
+              },
+              createSubmittedMetadataPatch(metadata),
+            )
           : file,
       );
       filesRef.current = nextFiles;
@@ -275,7 +387,7 @@ export default function AudioTagger() {
       };
       const nextFiles = filesRef.current.map((file) =>
         file.id === fileToUpdate.id
-          ? {
+          ? clearPendingMetadataPatch({
               ...file,
               file: updatedFile,
               filename: updatedFile.name,
@@ -283,8 +395,7 @@ export default function AudioTagger() {
               status: "saved" as const,
               downloadStatus: "ready" as const,
               downloadError: undefined,
-              hasBufferedChanges: false,
-            }
+            })
           : file,
       );
       filesRef.current = nextFiles;
@@ -299,24 +410,26 @@ export default function AudioTagger() {
       }
       const nextFiles = filesRef.current.map((file) =>
         file.id === fileToUpdate.id
-          ? {
-              ...file,
-              status: "error" as const,
-              metadata: {
-                ...newTags,
-                year: Number.isNaN(newTags.year as number) ? undefined : newTags.year,
-                trackNumber: Number.isNaN(newTags.trackNumber as number)
-                  ? undefined
-                  : newTags.trackNumber,
-                duration: file.metadata?.duration || 0,
-                bitrate: file.metadata?.bitrate || 0,
-                sampleRate: file.metadata?.sampleRate || 0,
-                picture: newTags.picture || [],
+          ? withPendingMetadataPatch(
+              {
+                ...file,
+                status: "error" as const,
+                metadata: {
+                  ...newTags,
+                  year: Number.isNaN(newTags.year as number) ? undefined : newTags.year,
+                  trackNumber: Number.isNaN(newTags.trackNumber as number)
+                    ? undefined
+                    : newTags.trackNumber,
+                  duration: file.metadata?.duration || 0,
+                  bitrate: file.metadata?.bitrate || 0,
+                  sampleRate: file.metadata?.sampleRate || 0,
+                  picture: newTags.picture || [],
+                },
+                filename: newTags.filename ? `${newTags.filename}.mp3` : file.filename,
+                downloadError: message,
               },
-              filename: newTags.filename ? `${newTags.filename}.mp3` : file.filename,
-              downloadError: message,
-              hasBufferedChanges: true,
-            }
+              createSubmittedMetadataPatch(newTags),
+            )
           : file,
       );
       filesRef.current = nextFiles;
@@ -325,10 +438,7 @@ export default function AudioTagger() {
     }
   };
   const getSubmittedMetadata = useCallback(
-    (data: AudioMetadata) =>
-      settings.syncFilenames
-        ? { ...data, filename: filenamify(data.title, { replacement: "-" }) }
-        : data,
+    (data: AudioMetadata) => getSubmittedAudioMetadata(data, settings.syncFilenames),
     [settings.syncFilenames],
   );
 
@@ -339,19 +449,29 @@ export default function AudioTagger() {
       if (trackIds && !trackIds.includes(selectedId)) return filesToSync;
 
       const submittedData = getSubmittedMetadata(getValues());
+      const metadataPatch = createDirtyMetadataPatch(
+        submittedData,
+        dirtyFields,
+        settings.syncFilenames,
+      );
+      if (!metadataPatch) return filesToSync;
       return filesToSync.map((file) =>
         file.id === selectedId
-          ? {
-              ...file,
-              filename: submittedData.filename ? `${submittedData.filename}.mp3` : file.filename,
-              metadata: submittedData,
-              status: file.status === "saved" ? "pending" : file.status,
-              hasBufferedChanges: true,
-            }
+          ? withMergedPendingMetadataPatch(
+              {
+                ...file,
+                filename: getFilenameFromPatch(file, metadataPatch),
+                metadata: file.metadata
+                  ? applyMetadataPatch(file.metadata, metadataPatch)
+                  : submittedData,
+                status: file.status === "saved" ? "pending" : file.status,
+              },
+              metadataPatch,
+            )
           : file,
       );
     },
-    [getSubmittedMetadata, getValues],
+    [dirtyFields, getSubmittedMetadata, getValues, settings.syncFilenames],
   );
 
   const handlePreviewMetadataChange = useCallback(
@@ -364,21 +484,32 @@ export default function AudioTagger() {
         ...getValues(),
         [field]: value,
       });
+      const metadataPatch = createDirtyMetadataPatch(
+        submittedData,
+        dirtyFields,
+        settings.syncFilenames,
+        [field],
+      );
+      if (!metadataPatch) return;
       const nextFiles = filesRef.current.map((file) =>
         file.id === selectedId
-          ? {
-              ...file,
-              filename: submittedData.filename ? `${submittedData.filename}.mp3` : file.filename,
-              metadata: submittedData,
-              status: file.status === "saved" ? "pending" : file.status,
-              hasBufferedChanges: true,
-            }
+          ? withMergedPendingMetadataPatch(
+              {
+                ...file,
+                filename: getFilenameFromPatch(file, metadataPatch),
+                metadata: file.metadata
+                  ? applyMetadataPatch(file.metadata, metadataPatch)
+                  : submittedData,
+                status: file.status === "saved" ? "pending" : file.status,
+              },
+              metadataPatch,
+            )
           : file,
       );
       filesRef.current = nextFiles;
       setFiles(nextFiles);
     },
-    [getSubmittedMetadata, getValues],
+    [dirtyFields, getSubmittedMetadata, getValues, settings.syncFilenames],
   );
 
   const bufferCurrentFormMetadata = useCallback(
@@ -621,12 +752,18 @@ export default function AudioTagger() {
     const parsedFile = parsedUpload.file;
     const formMetadata =
       selectedFileIdRef.current === fileId && formDirtyRef.current && currentFile.metadata
-        ? getValues()
+        ? getSubmittedMetadata(getValues())
         : undefined;
+    const currentPendingPatch = formMetadata
+      ? createDirtyMetadataPatch(formMetadata, dirtyFields, settings.syncFilenames)
+      : getPendingMetadataPatch(currentFile);
+    const currentFileWithPendingPatch = currentPendingPatch
+      ? withPendingMetadataPatch(currentFile, currentPendingPatch)
+      : currentFile;
     let { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
-      currentFile,
+      currentFileWithPendingPatch,
       parsedFile,
-      formMetadata,
+      currentPendingPatch,
     );
 
     if (metadataToWrite) {
@@ -637,15 +774,26 @@ export default function AudioTagger() {
         const latestFile = filesRef.current.find((file) => file.id === fileId);
         if (!latestFile) return;
         const latestFormMetadata =
-          selectedFileIdRef.current === fileId && formDirtyRef.current ? getValues() : undefined;
+          selectedFileIdRef.current === fileId && formDirtyRef.current
+            ? getSubmittedMetadata(getValues())
+            : undefined;
+        const latestFormPatch = latestFormMetadata
+          ? createDirtyMetadataPatch(latestFormMetadata, dirtyFields, settings.syncFilenames)
+          : undefined;
+        const latestMetadataForResolve =
+          latestFormPatch && latestFile.metadata
+            ? applyMetadataPatch(latestFile.metadata, latestFormPatch)
+            : latestFormMetadata;
         hydratedFile = resolveDownloadedTrackHydrationWrite(
-          currentFile,
-          latestFile,
+          currentFileWithPendingPatch,
+          latestFormPatch
+            ? withMergedPendingMetadataPatch(latestFile, latestFormPatch)
+            : latestFile,
           parsedFile,
           hydratedFile,
           updatedFile,
           metadataToWrite,
-          latestFormMetadata,
+          latestMetadataForResolve,
         );
       } catch (error) {
         const latestFile = filesRef.current.find((file) => file.id === fileId);
@@ -655,7 +803,7 @@ export default function AudioTagger() {
           message = error.message;
         }
         hydratedFile = resolveDownloadedTrackHydrationWriteError(
-          currentFile,
+          currentFileWithPendingPatch,
           latestFile,
           parsedFile,
           hydratedFile,
@@ -665,7 +813,14 @@ export default function AudioTagger() {
     }
 
     signal?.throwIfAborted();
-    replaceFileById(fileId, hydratedFile);
+    const hydratedPendingPatch =
+      metadataToWrite && hydratedFile.status !== "saved"
+        ? (getPendingMetadataPatch(hydratedFile) ??
+          (hydratedFile.metadata
+            ? createSubmittedMetadataPatch(hydratedFile.metadata)
+            : metadataToWrite))
+        : undefined;
+    replaceFileById(fileId, withPendingMetadataPatch(hydratedFile, hydratedPendingPatch));
   };
   const replacePlaylistQueueState = (nextQueue: PlaylistDownloadQueueState) => {
     playlistDownloadQueueRef.current = nextQueue;
@@ -886,79 +1041,47 @@ export default function AudioTagger() {
   const handleAudioDownload = (sourceUrl: string) => {
     bufferCurrentFormMetadata();
     setActiveView("editor");
-    const id = crypto.randomUUID();
-    const title = titleFromSourceUrl(sourceUrl);
-    const pendingFile = createPendingDownloadTrack(
-      id,
-      createDownloadMetadata({
-        title,
-        artist: "",
-        album: "",
-        genre: "",
-      }),
-      false,
-      { sourceUrl, audioBitrate: settings.audioBitrate },
-    );
-    const nextFiles = [...filesRef.current, pendingFile];
+    const plan = createSingleUrlDownloadPlan({
+      sourceUrl,
+      audioBitrate: settings.audioBitrate,
+      createId: () => crypto.randomUUID(),
+    });
+    const nextFiles = [...filesRef.current, ...plan.pendingFiles];
     filesRef.current = nextFiles;
     setFiles(nextFiles);
-    setLooseTrackIds((prevLooseTrackIds) => asUniqueTrackIds([...prevLooseTrackIds, id]));
-    setSelectedAlbumId(null);
-    setSelectedFileId(id);
-    setSelectedFileIds(new Set([id]));
-    setLastSelectedFileId(id);
-    queueDownloadTracks([
-      {
-        fileId: id,
-        title,
-        downloadRequest: { sourceUrl, audioBitrate: settings.audioBitrate },
-      },
-    ]);
+    setLooseTrackIds((prevLooseTrackIds) =>
+      asUniqueTrackIds([...prevLooseTrackIds, ...plan.looseTrackIds]),
+    );
+    setSelectedAlbumId(plan.selection.selectedAlbumId);
+    setSelectedFileId(plan.selection.selectedFileId);
+    setSelectedFileIds(plan.selection.selectedFileIds);
+    setLastSelectedFileId(plan.selection.lastSelectedFileId);
+    queueDownloadTracks(plan.queuedTracks);
   };
   const handleSoundCloudSetDownload = (set: SoundCloudSet) => {
     bufferCurrentFormMetadata();
     setActiveView("editor");
-    const albumId = crypto.randomUUID();
-    const pendingFiles = set.tracks.map((track) =>
-      createPendingDownloadTrack(
-        crypto.randomUUID(),
-        createDownloadMetadata({
-          title: track.title,
-          artist: set.artist,
-          album: set.title,
-          genre: set.genre,
-          year: set.year,
-          duration: track.duration,
-          trackNumber: track.trackNumber,
-        }),
-        true,
-        { sourceUrl: track.url, audioBitrate: settings.audioBitrate },
-      ),
-    );
-    const album: AlbumGroup = {
-      id: albumId,
-      title: set.title,
-      artist: set.artist,
-      genre: set.genre,
-      trackIds: pendingFiles.map((file) => file.id),
-      year: set.year,
-    };
-    const nextFiles = [...filesRef.current, ...pendingFiles];
-    const nextAlbums = [...albumsRef.current, album];
+    const plan = createSoundCloudSetDownloadPlan({
+      set,
+      audioBitrate: settings.audioBitrate,
+      createId: () => crypto.randomUUID(),
+    });
+    const nextFiles = [...filesRef.current, ...plan.pendingFiles];
+    const nextAlbums = [...albumsRef.current, plan.album];
     filesRef.current = nextFiles;
     albumsRef.current = nextAlbums;
     setFiles(nextFiles);
     setAlbums(nextAlbums);
-    setSelectedAlbumId(albumId);
-    setSelectedFileId(pendingFiles[0]?.id ?? null);
-    setSelectedFileIds(new Set(pendingFiles[0] ? [pendingFiles[0].id] : []));
-    setLastSelectedFileId(pendingFiles[0]?.id ?? null);
+    setSelectedAlbumId(plan.selection.selectedAlbumId);
+    setSelectedFileId(plan.selection.selectedFileId);
+    setSelectedFileIds(plan.selection.selectedFileIds);
+    setLastSelectedFileId(plan.selection.lastSelectedFileId);
 
-    const coverUrl = set.coverUrl;
-    if (coverUrl) {
+    const coverImport = plan.coverImport;
+    if (coverImport) {
       void (async () => {
         try {
-          const cover = await fetchImportedCover(coverUrl);
+          const cover = await fetchImportedCover(coverImport.coverUrl);
           const {
             albums: coveredAlbums,
             files: coveredFiles,
@@ -966,9 +1089,9 @@ export default function AudioTagger() {
           } = applySoundCloudSetImportedCover(
             filesRef.current,
             albumsRef.current,
-            albumId,
-            album.trackIds,
-            set,
+            coverImport.albumId,
+            coverImport.trackIds,
+            coverImport.set,
             settings,
             cover,
             selectedFileIdRef.current,
@@ -982,7 +1105,7 @@ export default function AudioTagger() {
           if (selectedMetadata) {
             reset(selectedMetadata);
           }
-          const trackIdSet = new Set(album.trackIds);
+          const trackIdSet = new Set(coverImport.trackIds);
           await Promise.all(
             coveredFiles
               .filter((file) => trackIdSet.has(file.id) && Boolean(file.file) && file.metadata)
@@ -1001,10 +1124,7 @@ export default function AudioTagger() {
       })();
     }
 
-    const tracksToDownload = pendingFiles
-      .map((pendingFile) => managedDownloadTrackFromFile(pendingFile))
-      .filter((track): track is ManagedDownloadTrack => Boolean(track));
-    queueDownloadTracks(tracksToDownload);
+    queueDownloadTracks(plan.queuedTracks);
   };
   const handleRetryDownload = (fileId: string) => {
     const fileToRetry = filesRef.current.find((file) => file.id === fileId);

--- a/components/audio/downloadTrack.ts
+++ b/components/audio/downloadTrack.ts
@@ -1,0 +1,309 @@
+import filenamify from "filenamify";
+import type { SoundCloudSet } from "./soundcloudSet";
+import type { AlbumGroup, AppSettings, AudioMetadata, MetadataPatch, TagiumFile } from "./types";
+
+export type DownloadRequest = NonNullable<TagiumFile["downloadRequest"]>;
+
+export interface PendingDownloadTrack extends TagiumFile {
+  metadata: AudioMetadata;
+  downloadRequest: DownloadRequest;
+}
+
+export interface QueuedDownloadTrack {
+  fileId: string;
+  title: string;
+  downloadRequest: DownloadRequest;
+}
+
+export interface DownloadPlanSelection {
+  selectedAlbumId: string | null;
+  selectedFileId: string | null;
+  selectedFileIds: Set<string>;
+  lastSelectedFileId: string | null;
+}
+
+interface DownloadTrackPlanBase {
+  pendingFiles: PendingDownloadTrack[];
+  queuedTracks: QueuedDownloadTrack[];
+  selection: DownloadPlanSelection;
+}
+
+export interface SingleUrlDownloadPlan extends DownloadTrackPlanBase {
+  source: "single-url";
+  looseTrackIds: string[];
+}
+
+export interface SoundCloudSetCoverImportPlan {
+  albumId: string;
+  trackIds: string[];
+  coverUrl: string;
+  set: SoundCloudSet;
+}
+
+export interface SoundCloudSetDownloadPlan extends DownloadTrackPlanBase {
+  source: "soundcloud-set";
+  album: AlbumGroup;
+  coverImport: SoundCloudSetCoverImportPlan | null;
+}
+
+export type DownloadTrackPlan = SingleUrlDownloadPlan | SoundCloudSetDownloadPlan;
+
+export interface CreateSingleUrlDownloadPlanInput {
+  sourceUrl: string;
+  audioBitrate: AppSettings["audioBitrate"];
+  createId: () => string;
+}
+
+export interface CreateSoundCloudSetDownloadPlanInput {
+  set: SoundCloudSet;
+  audioBitrate: AppSettings["audioBitrate"];
+  createId: () => string;
+}
+
+export interface DownloadTrackWorkflowDeps {
+  bufferCurrentFormMetadata: () => void;
+  setActiveView: (view: "editor") => void;
+  getFiles: () => TagiumFile[];
+  setFiles: (files: TagiumFile[]) => void;
+  setSelectedAlbumId: (albumId: string | null) => void;
+  setSelectedFileId: (fileId: string | null) => void;
+  setSelectedFileIds: (fileIds: Set<string>) => void;
+  setLastSelectedFileId: (fileId: string | null) => void;
+  queueDownloadTracks: (tracks: QueuedDownloadTrack[]) => void;
+  addLooseTrackIds?: (trackIds: string[]) => void;
+}
+
+export type SingleUrlDownloadTrackWorkflowDeps = DownloadTrackWorkflowDeps;
+
+export interface SoundCloudSetDownloadWorkflowDeps extends DownloadTrackWorkflowDeps {
+  getAlbums: () => AlbumGroup[];
+  setAlbums: (albums: AlbumGroup[]) => void;
+}
+
+const filenameFromTitle = (title: string) => {
+  const filename = filenamify(title.trim(), { replacement: "-" });
+  if (filename) return `${filename}.mp3`;
+  return "downloading-track.mp3";
+};
+
+export const titleFromSourceUrl = (sourceUrl: string) => {
+  try {
+    const url = new URL(sourceUrl);
+    const [lastPathPart] = url.pathname.split("/").filter(Boolean).slice(-1);
+    if (lastPathPart) return decodeURIComponent(lastPathPart).replaceAll("-", " ");
+    return url.hostname;
+  } catch {
+    return "downloading audio";
+  }
+};
+
+export const createDownloadMetadata = ({
+  title,
+  artist,
+  album,
+  genre,
+  year,
+  duration,
+  trackNumber,
+}: {
+  title: string;
+  artist: string;
+  album: string;
+  genre: string;
+  year?: number;
+  duration?: number;
+  trackNumber?: number;
+}): AudioMetadata => ({
+  filename: filenameFromTitle(title).replace(/\.mp3$/i, ""),
+  title,
+  artist,
+  album,
+  year,
+  genre,
+  duration: duration ?? 0,
+  bitrate: 0,
+  sampleRate: 0,
+  picture: [],
+  trackNumber,
+});
+
+export const createPendingDownloadTrack = (
+  id: string,
+  metadata: AudioMetadata,
+  hasBufferedChanges: boolean,
+  downloadRequest: DownloadRequest,
+  pendingMetadataPatch?: MetadataPatch,
+): PendingDownloadTrack => ({
+  id,
+  filename: `${metadata.filename}.mp3`,
+  status: "pending",
+  downloadStatus: "downloading",
+  downloadRequest,
+  hasBufferedChanges,
+  pendingMetadataPatch,
+  metadata,
+});
+
+export const fetchImportedCover = async (coverUrl: string): Promise<AudioMetadata["picture"]> => {
+  const response = await fetch(coverUrl);
+
+  if (!response.ok) {
+    throw new Error(`album cover request failed (${response.status})`);
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (!contentType) {
+    throw new Error("album cover response missing content type.");
+  }
+
+  return [
+    {
+      format: contentType,
+      type: 3,
+      data: new Uint8Array(await response.arrayBuffer()),
+      description: "album cover",
+    },
+  ];
+};
+
+export const createQueuedDownloadTrack = (file: PendingDownloadTrack): QueuedDownloadTrack => ({
+  fileId: file.id,
+  title: file.metadata.title || file.filename.replace(/\.mp3$/i, "") || "downloading audio",
+  downloadRequest: file.downloadRequest,
+});
+
+export const createQueuedDownloadTracks = (
+  files: readonly PendingDownloadTrack[],
+): QueuedDownloadTrack[] => files.map(createQueuedDownloadTrack);
+
+const createSoundCloudSetPendingMetadataPatch = (
+  set: SoundCloudSet,
+  track: SoundCloudSet["tracks"][number],
+): MetadataPatch => ({
+  title: track.title,
+  artist: set.artist,
+  album: set.title,
+  genre: set.genre,
+  ...(set.year !== undefined ? { year: set.year } : {}),
+  ...(track.trackNumber !== undefined ? { trackNumber: track.trackNumber } : {}),
+});
+
+export const createSingleUrlDownloadPlan = ({
+  sourceUrl,
+  audioBitrate,
+  createId,
+}: CreateSingleUrlDownloadPlanInput): SingleUrlDownloadPlan => {
+  const id = createId();
+  const title = titleFromSourceUrl(sourceUrl);
+  const pendingFile = createPendingDownloadTrack(
+    id,
+    createDownloadMetadata({
+      title,
+      artist: "",
+      album: "",
+      genre: "",
+    }),
+    false,
+    { sourceUrl, audioBitrate },
+  );
+
+  return {
+    source: "single-url",
+    pendingFiles: [pendingFile],
+    queuedTracks: createQueuedDownloadTracks([pendingFile]),
+    selection: {
+      selectedAlbumId: null,
+      selectedFileId: id,
+      selectedFileIds: new Set([id]),
+      lastSelectedFileId: id,
+    },
+    looseTrackIds: [id],
+  };
+};
+
+export const createSoundCloudSetDownloadPlan = ({
+  set,
+  audioBitrate,
+  createId,
+}: CreateSoundCloudSetDownloadPlanInput): SoundCloudSetDownloadPlan => {
+  const albumId = createId();
+  const pendingFiles = set.tracks.map((track) =>
+    createPendingDownloadTrack(
+      createId(),
+      createDownloadMetadata({
+        title: track.title,
+        artist: set.artist,
+        album: set.title,
+        genre: set.genre,
+        year: set.year,
+        duration: track.duration,
+        trackNumber: track.trackNumber,
+      }),
+      true,
+      { sourceUrl: track.url, audioBitrate },
+      createSoundCloudSetPendingMetadataPatch(set, track),
+    ),
+  );
+  const album: AlbumGroup = {
+    id: albumId,
+    title: set.title,
+    artist: set.artist,
+    genre: set.genre,
+    trackIds: pendingFiles.map((file) => file.id),
+    year: set.year,
+  };
+  const firstPendingFileId = pendingFiles[0]?.id ?? null;
+
+  return {
+    source: "soundcloud-set",
+    pendingFiles,
+    queuedTracks: createQueuedDownloadTracks(pendingFiles),
+    selection: {
+      selectedAlbumId: albumId,
+      selectedFileId: firstPendingFileId,
+      selectedFileIds: new Set(firstPendingFileId ? [firstPendingFileId] : []),
+      lastSelectedFileId: firstPendingFileId,
+    },
+    album,
+    coverImport: set.coverUrl
+      ? {
+          albumId,
+          trackIds: album.trackIds,
+          coverUrl: set.coverUrl,
+          set,
+        }
+      : null,
+  };
+};
+
+export function startDownloadTrackPlan(
+  plan: SingleUrlDownloadPlan,
+  deps: SingleUrlDownloadTrackWorkflowDeps,
+): void;
+export function startDownloadTrackPlan(
+  plan: SoundCloudSetDownloadPlan,
+  deps: SoundCloudSetDownloadWorkflowDeps,
+): void;
+export function startDownloadTrackPlan(
+  plan: DownloadTrackPlan,
+  deps: SingleUrlDownloadTrackWorkflowDeps | SoundCloudSetDownloadWorkflowDeps,
+): void {
+  deps.bufferCurrentFormMetadata();
+  deps.setActiveView("editor");
+
+  const nextFiles = [...deps.getFiles(), ...plan.pendingFiles];
+  deps.setFiles(nextFiles);
+
+  if (plan.source === "soundcloud-set") {
+    const albumDeps = deps as SoundCloudSetDownloadWorkflowDeps;
+    albumDeps.setAlbums([...albumDeps.getAlbums(), plan.album]);
+  } else {
+    deps.addLooseTrackIds?.(plan.looseTrackIds);
+  }
+
+  deps.setSelectedAlbumId(plan.selection.selectedAlbumId);
+  deps.setSelectedFileId(plan.selection.selectedFileId);
+  deps.setSelectedFileIds(plan.selection.selectedFileIds);
+  deps.setLastSelectedFileId(plan.selection.lastSelectedFileId);
+  deps.queueDownloadTracks(plan.queuedTracks);
+}

--- a/components/audio/fileMetadataOps.test.ts
+++ b/components/audio/fileMetadataOps.test.ts
@@ -102,8 +102,10 @@ describe("fileMetadataOps", () => {
 
     expect(result[0].status).toBe("pending");
     expect(result[0].hasBufferedChanges).toBe(true);
+    expect(result[0].pendingMetadataPatch?.trackNumber).toBe(2);
     expect(result[0].metadata?.trackNumber).toBe(2);
     expect(result[1].metadata?.trackNumber).toBe(1);
+    expect(result[1].pendingMetadataPatch?.trackNumber).toBe(1);
   });
 
   it("applies shared album metadata without applying album cover", () => {
@@ -166,6 +168,14 @@ describe("fileMetadataOps", () => {
     expect(updatedFile.metadata?.genre).toBe("Ambient");
     expect(updatedFile.metadata?.trackNumber).toBe(9);
     expect(updatedFile.metadata?.picture).toEqual(originalCover);
+    expect(updatedFile.pendingMetadataPatch).toMatchObject({
+      artist: "New Artist",
+      album: "New Album",
+      genre: "Ambient",
+    });
+    expect(
+      Object.prototype.hasOwnProperty.call(updatedFile.pendingMetadataPatch ?? {}, "year"),
+    ).toBe(false);
   });
 
   it("explicitly applies album cover to album tracks", () => {
@@ -207,6 +217,7 @@ describe("fileMetadataOps", () => {
     expect(result[0].metadata?.picture).toEqual(albumCover);
     expect(result[0].status).toBe("pending");
     expect(result[0].hasBufferedChanges).toBe(true);
+    expect(result[0].pendingMetadataPatch?.picture).toEqual(albumCover);
     expect(result[1].metadata?.picture).toEqual(albumCover);
     expect(result[1].hasBufferedChanges).toBe(true);
     expect(result[2]).toBe(files[2]);
@@ -362,6 +373,7 @@ describe("fileMetadataOps", () => {
     expect(result[0].metadata?.filename).toBe("New Track Title");
     expect(result[0].status).toBe("pending");
     expect(result[0].hasBufferedChanges).toBe(true);
+    expect(result[0].pendingMetadataPatch?.filename).toBe("New Track Title");
     expect(result[1].filename).toBe("Same.mp3");
     expect(result[1].metadata?.filename).toBe("Same");
   });
@@ -430,6 +442,234 @@ describe("fileMetadataOps", () => {
     expect(result.hydratedFile.metadata?.picture).toEqual(parsedCover);
     expect(result.hydratedFile.status).toBe("pending");
     expect(result.hydratedFile.downloadStatus).toBe("ready");
+  });
+
+  it("keeps parsed metadata for an unedited single URL placeholder", () => {
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      filename: "download-slug.mp3",
+      downloadStatus: "downloading",
+      hasBufferedChanges: false,
+      pendingMetadataPatch: undefined,
+      metadata: metadata({
+        filename: "download-slug",
+        title: "download slug",
+        artist: "",
+        album: "",
+      }),
+    });
+    const parsedFile = readyFile({
+      filename: "parsed-file.mp3",
+      metadata: metadata({
+        filename: "parsed-file",
+        title: "Parsed ID3 Title",
+        artist: "Parsed Artist",
+        album: "Parsed Album",
+        duration: 123,
+        bitrate: 320,
+        sampleRate: 44100,
+      }),
+    });
+
+    const { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
+      currentFile,
+      parsedFile,
+    );
+
+    expect(metadataToWrite).toBeUndefined();
+    expect(hydratedFile.filename).toBe("parsed-file.mp3");
+    expect(hydratedFile.metadata?.title).toBe("Parsed ID3 Title");
+    expect(hydratedFile.metadata?.artist).toBe("Parsed Artist");
+    expect(hydratedFile.metadata?.album).toBe("Parsed Album");
+    expect(hydratedFile.hasBufferedChanges).toBe(false);
+    expect(hydratedFile.pendingMetadataPatch).toBeUndefined();
+  });
+
+  it("does not inherit provider year or track number when parsed download has none", () => {
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      filename: "provider-title.mp3",
+      downloadStatus: "downloading",
+      hasBufferedChanges: true,
+      pendingMetadataPatch: { title: "Provider Title" },
+      metadata: metadata({
+        filename: "provider-title",
+        title: "Provider Title",
+        year: 2024,
+        trackNumber: 7,
+      }),
+    });
+    const parsedFile = readyFile({
+      filename: "parsed-title.mp3",
+      metadata: metadata({
+        filename: "parsed-title",
+        title: "Parsed Title",
+        year: undefined,
+        trackNumber: undefined,
+      }),
+    });
+
+    const { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
+      currentFile,
+      parsedFile,
+    );
+
+    expect(hydratedFile.metadata?.title).toBe("Provider Title");
+    expect(hydratedFile.metadata?.year).toBeUndefined();
+    expect(hydratedFile.metadata?.trackNumber).toBeUndefined();
+    expect(metadataToWrite?.year).toBeUndefined();
+    expect(metadataToWrite?.trackNumber).toBeUndefined();
+    expect(hydratedFile.pendingMetadataPatch?.title).toBe("Provider Title");
+    expect(
+      Object.prototype.hasOwnProperty.call(hydratedFile.pendingMetadataPatch ?? {}, "year"),
+    ).toBe(false);
+  });
+
+  it("applies explicit pending patch year and track number during hydration", () => {
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      downloadStatus: "downloading",
+      metadata: metadata({
+        filename: "provider-title",
+        title: "Provider Title",
+        year: 2024,
+        trackNumber: 7,
+      }),
+    });
+    const parsedFile = readyFile({
+      metadata: metadata({
+        filename: "parsed-title",
+        title: "Parsed Title",
+        year: undefined,
+        trackNumber: undefined,
+      }),
+    });
+
+    const { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
+      currentFile,
+      parsedFile,
+      {
+        year: 2025,
+        trackNumber: 3,
+      },
+    );
+
+    expect(hydratedFile.metadata?.year).toBe(2025);
+    expect(hydratedFile.metadata?.trackNumber).toBe(3);
+    expect(metadataToWrite?.year).toBe(2025);
+    expect(metadataToWrite?.trackNumber).toBe(3);
+  });
+
+  it("preserves sparse SoundCloud set intent while hydrating parsed downloads", () => {
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      filename: "first-track.mp3",
+      downloadStatus: "downloading",
+      hasBufferedChanges: true,
+      pendingMetadataPatch: {
+        title: "First Track",
+        artist: "Set Artist",
+        album: "Imported Set",
+        genre: "Electronic",
+        year: 2024,
+        trackNumber: 1,
+      },
+      metadata: metadata({
+        filename: "first-track",
+        title: "First Track",
+        artist: "Set Artist",
+        album: "Imported Set",
+        genre: "Electronic",
+        year: 2024,
+        trackNumber: 1,
+      }),
+    });
+    const parsedFile = readyFile({
+      filename: "parsed-file.mp3",
+      metadata: metadata({
+        filename: "parsed-file",
+        title: "Parsed ID3 Title",
+        artist: "Parsed Artist",
+        album: "Parsed Album",
+        genre: "Parsed Genre",
+        year: undefined,
+        trackNumber: undefined,
+        duration: 123,
+        bitrate: 320,
+        sampleRate: 44100,
+      }),
+    });
+
+    const { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
+      currentFile,
+      parsedFile,
+    );
+
+    expect(metadataToWrite).toMatchObject({
+      title: "First Track",
+      artist: "Set Artist",
+      album: "Imported Set",
+      genre: "Electronic",
+      year: 2024,
+      trackNumber: 1,
+    });
+    expect(hydratedFile.metadata).toMatchObject({
+      title: "First Track",
+      artist: "Set Artist",
+      album: "Imported Set",
+      genre: "Electronic",
+      year: 2024,
+      trackNumber: 1,
+      duration: 123,
+      bitrate: 320,
+      sampleRate: 44100,
+    });
+    expect(hydratedFile.pendingMetadataPatch).toEqual({
+      title: "First Track",
+      artist: "Set Artist",
+      album: "Imported Set",
+      genre: "Electronic",
+      year: 2024,
+      trackNumber: 1,
+    });
+  });
+
+  it("clears parsed year and track number when pending patch sets them to null", () => {
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      downloadStatus: "downloading",
+      metadata: metadata({
+        filename: "provider-title",
+        title: "Provider Title",
+      }),
+    });
+    const parsedFile = readyFile({
+      metadata: metadata({
+        filename: "parsed-title",
+        title: "Parsed Title",
+        year: 2024,
+        trackNumber: 9,
+      }),
+    });
+
+    const { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
+      currentFile,
+      parsedFile,
+      {
+        year: null,
+        trackNumber: null,
+      },
+    );
+
+    expect(hydratedFile.metadata?.year).toBeNull();
+    expect(hydratedFile.metadata?.trackNumber).toBeNull();
+    expect(metadataToWrite?.year).toBeNull();
+    expect(metadataToWrite?.trackNumber).toBeNull();
   });
 
   it("keeps later buffered edits when stale hydration write resolves", () => {
@@ -526,6 +766,7 @@ describe("fileMetadataOps", () => {
     expect(result.metadata?.duration).toBe(101);
     expect(result.status).toBe("saved");
     expect(result.hasBufferedChanges).toBe(false);
+    expect(result.pendingMetadataPatch).toBeUndefined();
   });
 
   it("keeps latest dirty form metadata when hydration write resolves", () => {
@@ -619,6 +860,7 @@ describe("fileMetadataOps", () => {
     expect(result.downloadStatus).toBe("ready");
     expect(result.downloadError).toBe("Unable to save metadata");
     expect(result.hasBufferedChanges).toBe(true);
+    expect(result.pendingMetadataPatch?.title).toBe("Edited Title");
   });
 
   it("keeps later edits when stale hydration write fails", () => {
@@ -663,6 +905,7 @@ describe("fileMetadataOps", () => {
     expect(result.metadata?.sampleRate).toBe(32000);
     expect(result.status).toBe("error");
     expect(result.downloadError).toBe("Unable to save metadata");
+    expect(result.pendingMetadataPatch?.title).toBe("New Edit");
   });
 
   it("uses dirty form metadata during hydration while preserving parsed technical fields", () => {
@@ -697,6 +940,83 @@ describe("fileMetadataOps", () => {
     expect(hydratedFile.metadata?.bitrate).toBe(256);
     expect(hydratedFile.metadata?.sampleRate).toBe(48000);
     expect(hydratedFile.hasBufferedChanges).toBe(true);
+  });
+
+  it("does not leak a stale form year into a newly downloaded track with no parsed year", () => {
+    const currentFile = readyFile({
+      id: "new-download",
+      file: undefined,
+      originalFile: undefined,
+      filename: "new-download.mp3",
+      downloadStatus: "downloading",
+      hasBufferedChanges: false,
+      metadata: metadata({
+        filename: "new-download",
+        title: "New Download",
+        year: undefined,
+      }),
+    });
+    const parsedFile = readyFile({
+      id: "new-download",
+      filename: "new-download.mp3",
+      metadata: metadata({
+        filename: "new-download",
+        title: "New Download",
+        year: undefined,
+        duration: 64,
+        bitrate: 320,
+        sampleRate: 44100,
+      }),
+    });
+    const pendingMetadataPatch = {
+      filename: "new-download",
+      title: "New Download",
+    };
+
+    const { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
+      currentFile,
+      parsedFile,
+      pendingMetadataPatch,
+    );
+
+    expect(metadataToWrite?.year).toBeUndefined();
+    expect(hydratedFile.metadata?.year).toBeUndefined();
+    expect(hydratedFile.metadata?.duration).toBe(64);
+    expect(hydratedFile.metadata?.bitrate).toBe(320);
+    expect(hydratedFile.metadata?.sampleRate).toBe(44100);
+  });
+
+  it("keeps an explicitly buffered form year while hydrating a downloaded track", () => {
+    const currentFile = readyFile({
+      file: undefined,
+      originalFile: undefined,
+      downloadStatus: "downloading",
+      hasBufferedChanges: true,
+      pendingMetadataPatch: { year: 2026 },
+      metadata: metadata({
+        filename: "edited-download",
+        title: "Edited Download",
+        year: 2026,
+      }),
+    });
+    const parsedFile = readyFile({
+      metadata: metadata({
+        filename: "parsed-download",
+        title: "Parsed Download",
+        year: undefined,
+        duration: 71,
+      }),
+    });
+
+    const { hydratedFile, metadataToWrite } = prepareDownloadedTrackHydration(
+      currentFile,
+      parsedFile,
+    );
+
+    expect(metadataToWrite?.year).toBe(2026);
+    expect(hydratedFile.metadata?.year).toBe(2026);
+    expect(hydratedFile.metadata?.duration).toBe(71);
+    expect(hydratedFile.pendingMetadataPatch?.year).toBe(2026);
   });
 
   it("uses dirty form cover during hydration", () => {

--- a/components/audio/fileMetadataOps.ts
+++ b/components/audio/fileMetadataOps.ts
@@ -1,11 +1,60 @@
 import filenamify from "filenamify";
 import type { SoundCloudSet } from "./soundcloudSet";
-import { AlbumGroup, AudioMetadata, TagiumFile } from "./types";
+import type { AlbumGroup, AudioMetadata, MetadataPatch, TagiumFile } from "./types";
 
 export interface DownloadedTrackHydration {
   hydratedFile: TagiumFile;
   metadataToWrite?: AudioMetadata;
 }
+
+type DownloadedTrackWritableMetadataField = keyof MetadataPatch;
+
+export type DownloadedTrackMetadataPatch = MetadataPatch;
+
+interface ReconciledDownloadedTrackMetadata {
+  metadata?: AudioMetadata;
+  metadataToWrite?: AudioMetadata;
+}
+
+const patchFields = [
+  "filename",
+  "title",
+  "artist",
+  "album",
+  "year",
+  "genre",
+  "picture",
+  "trackNumber",
+] as const satisfies readonly DownloadedTrackWritableMetadataField[];
+
+const nullableNumericPatchFields = ["year", "trackNumber"] as const;
+
+const markPendingMetadataPatch = (
+  file: TagiumFile,
+  patch: DownloadedTrackMetadataPatch,
+): TagiumFile => {
+  const pendingMetadataPatch = {
+    ...file.pendingMetadataPatch,
+    ...patch,
+  };
+
+  return {
+    ...file,
+    pendingMetadataPatch,
+    hasBufferedChanges: true,
+  };
+};
+
+const createMetadataPatch = (metadata: AudioMetadata): DownloadedTrackMetadataPatch => ({
+  filename: metadata.filename,
+  title: metadata.title,
+  artist: metadata.artist,
+  album: metadata.album,
+  year: metadata.year,
+  genre: metadata.genre,
+  picture: metadata.picture,
+  trackNumber: metadata.trackNumber,
+});
 
 const mergeLatestMetadataWithHydratedTechnicalFields = (
   latestFile: TagiumFile,
@@ -25,6 +74,120 @@ const mergeLatestMetadataWithHydratedTechnicalFields = (
         : hydratedFile.metadata.picture,
   };
 };
+
+const hasOwn = <Key extends PropertyKey>(object: object, key: Key) =>
+  Object.prototype.hasOwnProperty.call(object, key);
+
+const areGenresEqual = (
+  firstGenre: AudioMetadata["genre"],
+  secondGenre: AudioMetadata["genre"],
+) => {
+  if (Array.isArray(firstGenre) || Array.isArray(secondGenre)) {
+    if (!Array.isArray(firstGenre) || !Array.isArray(secondGenre)) return false;
+    if (firstGenre.length !== secondGenre.length) return false;
+    return firstGenre.every((genre, index) => genre === secondGenre[index]);
+  }
+
+  return firstGenre === secondGenre;
+};
+
+const areWritableMetadataFieldsEqual = (
+  firstMetadata: AudioMetadata,
+  secondMetadata: AudioMetadata,
+) =>
+  firstMetadata.filename === secondMetadata.filename &&
+  firstMetadata.title === secondMetadata.title &&
+  firstMetadata.artist === secondMetadata.artist &&
+  firstMetadata.album === secondMetadata.album &&
+  firstMetadata.year === secondMetadata.year &&
+  areGenresEqual(firstMetadata.genre, secondMetadata.genre) &&
+  arePicturesEqual(firstMetadata.picture, secondMetadata.picture) &&
+  firstMetadata.trackNumber === secondMetadata.trackNumber;
+
+const applyProviderDisplayMetadata = (
+  parsedMetadata: AudioMetadata,
+  providerMetadata?: AudioMetadata,
+): AudioMetadata => {
+  if (!providerMetadata) return parsedMetadata;
+
+  return {
+    ...parsedMetadata,
+    filename: providerMetadata.filename || parsedMetadata.filename,
+    title: providerMetadata.title || parsedMetadata.title,
+    artist: providerMetadata.artist || parsedMetadata.artist,
+    album: providerMetadata.album || parsedMetadata.album,
+    genre: providerMetadata.genre || parsedMetadata.genre,
+    picture:
+      providerMetadata.picture.length > 0 ? providerMetadata.picture : parsedMetadata.picture,
+  };
+};
+
+const applyPendingMetadataPatch = (
+  metadata: AudioMetadata,
+  pendingPatch?: DownloadedTrackMetadataPatch,
+): AudioMetadata => {
+  if (!pendingPatch) return metadata;
+
+  return patchFields.reduce<AudioMetadata>((nextMetadata, field) => {
+    if (!hasOwn(pendingPatch, field)) return nextMetadata;
+
+    const value = pendingPatch[field];
+    if (value === undefined) return nextMetadata;
+
+    return {
+      ...nextMetadata,
+      [field]: value,
+    };
+  }, metadata);
+};
+
+const normalizePendingMetadataPatch = (
+  pendingPatch?: DownloadedTrackMetadataPatch,
+): DownloadedTrackMetadataPatch | undefined => {
+  if (!pendingPatch) return undefined;
+  if (
+    !hasOwn(pendingPatch, "duration") &&
+    !hasOwn(pendingPatch, "bitrate") &&
+    !hasOwn(pendingPatch, "sampleRate")
+  ) {
+    return pendingPatch;
+  }
+
+  return patchFields.reduce<DownloadedTrackMetadataPatch>((nextPatch, field) => {
+    if (!hasOwn(pendingPatch, field)) return nextPatch;
+    if (nullableNumericPatchFields.includes(field as (typeof nullableNumericPatchFields)[number])) {
+      return nextPatch;
+    }
+
+    return {
+      ...nextPatch,
+      [field]: pendingPatch[field],
+    };
+  }, {});
+};
+
+export function reconcileDownloadedTrackMetadata(
+  parsedMetadata: AudioMetadata | undefined,
+  providerMetadata?: AudioMetadata,
+  pendingPatch?: DownloadedTrackMetadataPatch,
+): ReconciledDownloadedTrackMetadata {
+  if (!parsedMetadata) {
+    return { metadata: providerMetadata };
+  }
+
+  const providerDisplayMetadata = applyProviderDisplayMetadata(parsedMetadata, providerMetadata);
+  const metadata = applyPendingMetadataPatch(
+    providerDisplayMetadata,
+    normalizePendingMetadataPatch(pendingPatch),
+  );
+
+  return {
+    metadata,
+    metadataToWrite: areWritableMetadataFieldsEqual(parsedMetadata, metadata)
+      ? undefined
+      : metadata,
+  };
+}
 
 export function applyTrackOrderNumbersToFiles(
   files: TagiumFile[],
@@ -47,15 +210,17 @@ export function applyTrackOrderNumbersToFiles(
     const trackNumber = numbersByTrackId.get(file.id);
     if (trackNumber === undefined || !file.metadata) return file;
 
-    return {
-      ...file,
-      status: file.status === "saved" ? "pending" : file.status,
-      hasBufferedChanges: true,
-      metadata: {
-        ...file.metadata,
-        trackNumber,
+    return markPendingMetadataPatch(
+      {
+        ...file,
+        status: file.status === "saved" ? "pending" : file.status,
+        metadata: {
+          ...file.metadata,
+          trackNumber,
+        },
       },
-    };
+      { trackNumber },
+    );
   });
 }
 
@@ -72,16 +237,18 @@ export function applySyncedFilenamesToFiles(files: TagiumFile[], trackIds?: stri
       return file;
     }
 
-    return {
-      ...file,
-      filename: `${syncedFilename}.mp3`,
-      status: file.status === "saved" ? "pending" : file.status,
-      hasBufferedChanges: true,
-      metadata: {
-        ...file.metadata,
-        filename: syncedFilename,
+    return markPendingMetadataPatch(
+      {
+        ...file,
+        filename: `${syncedFilename}.mp3`,
+        status: file.status === "saved" ? "pending" : file.status,
+        metadata: {
+          ...file.metadata,
+          filename: syncedFilename,
+        },
       },
-    };
+      { filename: syncedFilename },
+    );
   });
 }
 
@@ -93,18 +260,27 @@ export function applyAlbumSharedTagsToFiles(files: TagiumFile[], album: AlbumGro
   return files.map((file) => {
     if (!trackSet.has(file.id) || !file.metadata) return file;
 
-    return {
-      ...file,
-      status: file.status === "saved" ? "pending" : file.status,
-      hasBufferedChanges: true,
-      metadata: {
-        ...file.metadata,
+    const yearPatch = album.year !== undefined ? { year: album.year } : {};
+
+    return markPendingMetadataPatch(
+      {
+        ...file,
+        status: file.status === "saved" ? "pending" : file.status,
+        metadata: {
+          ...file.metadata,
+          artist: album.artist,
+          album: album.title,
+          genre: album.genre,
+          year: album.year !== undefined ? album.year : file.metadata.year,
+        },
+      },
+      {
         artist: album.artist,
         album: album.title,
         genre: album.genre,
-        year: album.year !== undefined ? album.year : file.metadata.year,
+        ...yearPatch,
       },
-    };
+    );
   });
 }
 
@@ -120,15 +296,17 @@ export function applyAlbumCoverToFiles(
   return files.map((file) => {
     if (!trackSet.has(file.id) || !file.metadata) return file;
 
-    return {
-      ...file,
-      status: file.status === "saved" ? "pending" : file.status,
-      hasBufferedChanges: true,
-      metadata: {
-        ...file.metadata,
-        picture: cover,
+    return markPendingMetadataPatch(
+      {
+        ...file,
+        status: file.status === "saved" ? "pending" : file.status,
+        metadata: {
+          ...file.metadata,
+          picture: cover,
+        },
       },
-    };
+      { picture: cover },
+    );
   });
 }
 
@@ -213,43 +391,37 @@ export function applySoundCloudSetImportedCover(
 export function prepareDownloadedTrackHydration(
   currentFile: TagiumFile,
   parsedFile: TagiumFile,
-  formMetadata?: AudioMetadata,
+  pendingMetadataPatch?: DownloadedTrackMetadataPatch,
 ): DownloadedTrackHydration {
   const parsedMetadata = parsedFile.metadata;
-  const bufferedMetadata = formMetadata ?? currentFile.metadata;
-  const shouldApplyBufferedMetadata = currentFile.hasBufferedChanges || Boolean(formMetadata);
-  const nextMetadata =
-    shouldApplyBufferedMetadata && bufferedMetadata
-      ? {
-          ...bufferedMetadata,
-          duration: parsedMetadata?.duration ?? bufferedMetadata.duration,
-          bitrate: parsedMetadata?.bitrate ?? bufferedMetadata.bitrate,
-          sampleRate: parsedMetadata?.sampleRate ?? bufferedMetadata.sampleRate,
-          picture:
-            bufferedMetadata.picture.length > 0
-              ? bufferedMetadata.picture
-              : (parsedMetadata?.picture ?? []),
-        }
-      : (parsedMetadata ?? currentFile.metadata);
+  const pendingPatch = pendingMetadataPatch ?? currentFile.pendingMetadataPatch;
+  const shouldApplyProviderDisplayMetadata =
+    currentFile.hasBufferedChanges || Boolean(pendingPatch);
+  const { metadata: nextMetadata, metadataToWrite } = reconcileDownloadedTrackMetadata(
+    parsedMetadata,
+    shouldApplyProviderDisplayMetadata ? currentFile.metadata : undefined,
+    pendingPatch,
+  );
+  const shouldWriteMetadata = Boolean(metadataToWrite);
 
   const hydratedFile: TagiumFile = {
     ...currentFile,
     file: parsedFile.file,
     originalFile: parsedFile.originalFile,
-    filename:
-      shouldApplyBufferedMetadata && nextMetadata?.filename
-        ? `${nextMetadata.filename}.mp3`
-        : parsedFile.filename,
+    filename: nextMetadata?.filename ? `${nextMetadata.filename}.mp3` : parsedFile.filename,
     metadata: nextMetadata,
     downloadStatus: "ready",
     downloadError: parsedFile.downloadError,
-    status: shouldApplyBufferedMetadata ? "pending" : parsedFile.status,
-    hasBufferedChanges: shouldApplyBufferedMetadata,
+    status: shouldWriteMetadata ? "pending" : parsedFile.status,
+    hasBufferedChanges: shouldWriteMetadata,
+    pendingMetadataPatch: shouldWriteMetadata
+      ? normalizePendingMetadataPatch(pendingPatch)
+      : undefined,
   };
 
   return {
     hydratedFile,
-    metadataToWrite: shouldApplyBufferedMetadata ? nextMetadata : undefined,
+    metadataToWrite,
   };
 }
 
@@ -280,6 +452,11 @@ export function resolveDownloadedTrackHydrationWrite(
       downloadError: undefined,
       status: "pending" as const,
       hasBufferedChanges: true,
+      pendingMetadataPatch:
+        nextFile.pendingMetadataPatch ??
+        (latestFormMetadata
+          ? createMetadataPatch(latestFormMetadata)
+          : hydratedFile.pendingMetadataPatch),
     };
   }
 
@@ -293,6 +470,7 @@ export function resolveDownloadedTrackHydrationWrite(
     },
     status: "saved" as const,
     hasBufferedChanges: false,
+    pendingMetadataPatch: undefined,
   };
 }
 
@@ -304,15 +482,20 @@ export function resolveDownloadedTrackHydrationWriteError(
   errorMessage: string,
 ) {
   const nextFile = latestFile !== currentFile ? latestFile : hydratedFile;
+  const metadata = mergeLatestMetadataWithHydratedTechnicalFields(nextFile, hydratedFile);
 
   return {
     ...nextFile,
     file: parsedFile.file,
     originalFile: parsedFile.originalFile,
-    metadata: mergeLatestMetadataWithHydratedTechnicalFields(nextFile, hydratedFile),
+    metadata,
     downloadStatus: "ready" as const,
     downloadError: errorMessage,
     status: "error" as const,
     hasBufferedChanges: true,
+    pendingMetadataPatch:
+      nextFile.pendingMetadataPatch ??
+      hydratedFile.pendingMetadataPatch ??
+      (metadata ? createMetadataPatch(metadata) : undefined),
   };
 }

--- a/components/audio/metadata.ts
+++ b/components/audio/metadata.ts
@@ -1,0 +1,56 @@
+import { Schema } from "effect";
+
+const optionalMutableKey = <S extends Schema.Constraint>(schema: S) =>
+  Schema.optionalKey(Schema.mutableKey(schema));
+
+const metadataPictureDataSchema = Schema.declare<Uint8Array<ArrayBuffer>>(
+  (input): input is Uint8Array<ArrayBuffer> =>
+    input instanceof Uint8Array && input.buffer instanceof ArrayBuffer,
+  { expected: "Uint8Array" },
+);
+
+export const metadataPictureSchema = Schema.Struct({
+  format: Schema.mutableKey(Schema.String),
+  type: Schema.mutableKey(Schema.Number),
+  description: Schema.mutableKey(Schema.String),
+  data: Schema.mutableKey(metadataPictureDataSchema),
+});
+
+const metadataGenreSchema = Schema.Union([
+  Schema.String,
+  Schema.mutable(Schema.Array(Schema.String)),
+]);
+
+const metadataPictureArraySchema = Schema.mutable(Schema.Array(metadataPictureSchema));
+
+export const metadataSnapshotSchema = Schema.Struct({
+  filename: Schema.mutableKey(Schema.String),
+  title: Schema.mutableKey(Schema.String),
+  artist: Schema.mutableKey(Schema.String),
+  album: Schema.mutableKey(Schema.String),
+  year: optionalMutableKey(Schema.NullOr(Schema.Number)),
+  genre: Schema.mutableKey(metadataGenreSchema),
+  duration: Schema.mutableKey(Schema.Number),
+  bitrate: Schema.mutableKey(Schema.Number),
+  sampleRate: Schema.mutableKey(Schema.Number),
+  picture: Schema.mutableKey(metadataPictureArraySchema),
+  trackNumber: optionalMutableKey(Schema.NullOr(Schema.Number)),
+});
+
+export const metadataPatchSchema = Schema.Struct({
+  filename: optionalMutableKey(Schema.String),
+  title: optionalMutableKey(Schema.String),
+  artist: optionalMutableKey(Schema.String),
+  album: optionalMutableKey(Schema.String),
+  year: optionalMutableKey(Schema.NullOr(Schema.Number)),
+  genre: optionalMutableKey(metadataGenreSchema),
+  picture: optionalMutableKey(metadataPictureArraySchema),
+  trackNumber: optionalMutableKey(Schema.NullOr(Schema.Number)),
+});
+
+export const audioMetadataSchema = metadataSnapshotSchema;
+
+export type MetadataPicture = Schema.Schema.Type<typeof metadataPictureSchema>;
+export type MetadataSnapshot = Schema.Schema.Type<typeof metadataSnapshotSchema>;
+export type MetadataPatch = Schema.Schema.Type<typeof metadataPatchSchema>;
+export type AudioMetadata = MetadataSnapshot;

--- a/components/audio/soundcloudSet.test.ts
+++ b/components/audio/soundcloudSet.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
+import {
+  createSingleUrlDownloadPlan,
+  createSoundCloudSetDownloadPlan,
+  type QueuedDownloadTrack,
+} from "./downloadTrack";
 import { startSoundCloudSetImport } from "./soundcloudSetImport";
 import type { SoundCloudSet } from "./soundcloudSet";
 import type { AlbumGroup, AppSettings, AudioMetadata, TagiumFile } from "./types";
@@ -75,10 +80,9 @@ const createHarness = (settings: AppSettings = defaultSettings) => {
   let lastSelectedFileId: string | null = null;
   let bufferCount = 0;
   const events: string[] = [];
-  const hydratedPictures: Array<AudioMetadata["picture"] | undefined> = [];
+  const queuedTracks: QueuedDownloadTrack[] = [];
   const updateTagsCalls: string[] = [];
   const coverRequest = deferred<AudioMetadata["picture"]>();
-  const downloads = new Map<string, Deferred<File>>();
   const ids = ["album-1", "track-1", "track-2"];
 
   const start = (set: SoundCloudSet) =>
@@ -119,33 +123,29 @@ const createHarness = (settings: AppSettings = defaultSettings) => {
         events.push(`cover:${coverUrl}`);
         return coverRequest.promise;
       },
-      downloadCobaltAudio: (request) => {
-        events.push(`download:${request.sourceUrl}:${request.audioBitrate}`);
-        const download = deferred<File>();
-        downloads.set(request.sourceUrl, download);
-        return download.promise;
+      queueDownloadTracks: (tracks) => {
+        queuedTracks.push(...tracks);
       },
-      hydrateDownloadedTrack: async (fileId, downloadedFile) => {
-        const currentFile = files.find((file) => file.id === fileId);
-        hydratedPictures.push(currentFile?.metadata?.picture);
-        files = files.map((file) =>
-          file.id === fileId
-            ? {
-                ...file,
-                file: downloadedFile,
-                originalFile: downloadedFile,
-                status: file.hasBufferedChanges ? "pending" : "saved",
-                downloadStatus: "ready",
-              }
-            : file,
-        );
-      },
-      markDownloadError: () => {},
       updateTags: async (file) => {
         updateTagsCalls.push(file.id);
       },
       warn: () => {},
     });
+
+  const markDownloaded = (fileId: string) => {
+    const downloadedFile = new File([fileId], `${fileId}.mp3`, { type: "audio/mpeg" });
+    files = files.map((file) =>
+      file.id === fileId
+        ? {
+            ...file,
+            file: downloadedFile,
+            originalFile: downloadedFile,
+            status: file.hasBufferedChanges ? "pending" : "saved",
+            downloadStatus: "ready",
+          }
+        : file,
+    );
+  };
 
   return {
     get activeView() {
@@ -158,16 +158,16 @@ const createHarness = (settings: AppSettings = defaultSettings) => {
       return bufferCount;
     },
     coverRequest,
-    downloads,
     events,
     get files() {
       return files;
     },
-    get hydratedPictures() {
-      return hydratedPictures;
-    },
     get lastSelectedFileId() {
       return lastSelectedFileId;
+    },
+    markDownloaded,
+    get queuedTracks() {
+      return queuedTracks;
     },
     get selectedAlbumId() {
       return selectedAlbumId;
@@ -183,8 +183,80 @@ const createHarness = (settings: AppSettings = defaultSettings) => {
   };
 };
 
+describe("download track plans", () => {
+  it("creates the same queued track shape for single URL and SoundCloud set plans", () => {
+    const singlePlan = createSingleUrlDownloadPlan({
+      sourceUrl: "https://soundcloud.com/artist/direct-track",
+      audioBitrate: "320",
+      createId: () => "single-track",
+    });
+    const ids = ["album-1", "set-track-1", "set-track-2"];
+    const setPlan = createSoundCloudSetDownloadPlan({
+      set: soundCloudSet(),
+      audioBitrate: "320",
+      createId: () => {
+        const id = ids.shift();
+        if (!id) throw new Error("missing test id");
+        return id;
+      },
+    });
+
+    expect(singlePlan.queuedTracks).toEqual([
+      {
+        fileId: "single-track",
+        title: "direct track",
+        downloadRequest: {
+          sourceUrl: "https://soundcloud.com/artist/direct-track",
+          audioBitrate: "320",
+        },
+      },
+    ]);
+    expect(singlePlan.pendingFiles[0].hasBufferedChanges).toBe(false);
+    expect(singlePlan.pendingFiles[0].pendingMetadataPatch).toBeUndefined();
+    expect(Object.keys(singlePlan.queuedTracks[0]).sort()).toEqual(
+      Object.keys(setPlan.queuedTracks[0]).sort(),
+    );
+    expect(setPlan.pendingFiles.map((file) => file.pendingMetadataPatch)).toEqual([
+      {
+        title: "First Track",
+        artist: "Set Artist",
+        album: "Imported Set",
+        genre: "Electronic",
+        year: 2024,
+        trackNumber: 1,
+      },
+      {
+        title: "Second Track",
+        artist: "Set Artist",
+        album: "Imported Set",
+        genre: "Electronic",
+        year: 2024,
+        trackNumber: 2,
+      },
+    ]);
+    expect(setPlan.queuedTracks).toEqual([
+      {
+        fileId: "set-track-1",
+        title: "First Track",
+        downloadRequest: {
+          sourceUrl: "https://soundcloud.com/artist/first-track",
+          audioBitrate: "320",
+        },
+      },
+      {
+        fileId: "set-track-2",
+        title: "Second Track",
+        downloadRequest: {
+          sourceUrl: "https://soundcloud.com/artist/second-track",
+          audioBitrate: "320",
+        },
+      },
+    ]);
+  });
+});
+
 describe("soundcloud set import", () => {
-  it("imports an album through the shipped operation across cover and hydration ordering", async () => {
+  it("imports an album plan, queues shared download tracks, and applies cover to downloaded files", async () => {
     const harness = createHarness();
 
     harness.start(soundCloudSet());
@@ -209,19 +281,45 @@ describe("soundcloud set import", () => {
       { sourceUrl: "https://soundcloud.com/artist/first-track", audioBitrate: "320" },
       { sourceUrl: "https://soundcloud.com/artist/second-track", audioBitrate: "320" },
     ]);
-    expect(harness.events).toEqual([
-      "cover:https://img.example/cover.jpg",
-      "download:https://soundcloud.com/artist/first-track:320",
-      "download:https://soundcloud.com/artist/second-track:320",
+    expect(harness.files.map((file) => file.pendingMetadataPatch)).toEqual([
+      {
+        title: "First Track",
+        artist: "Set Artist",
+        album: "Imported Set",
+        genre: "Electronic",
+        year: 2024,
+        trackNumber: 1,
+      },
+      {
+        title: "Second Track",
+        artist: "Set Artist",
+        album: "Imported Set",
+        genre: "Electronic",
+        year: 2024,
+        trackNumber: 2,
+      },
     ]);
+    expect(harness.queuedTracks).toEqual([
+      {
+        fileId: "track-1",
+        title: "First Track",
+        downloadRequest: {
+          sourceUrl: "https://soundcloud.com/artist/first-track",
+          audioBitrate: "320",
+        },
+      },
+      {
+        fileId: "track-2",
+        title: "Second Track",
+        downloadRequest: {
+          sourceUrl: "https://soundcloud.com/artist/second-track",
+          audioBitrate: "320",
+        },
+      },
+    ]);
+    expect(harness.events).toEqual(["cover:https://img.example/cover.jpg"]);
 
-    harness.downloads
-      .get("https://soundcloud.com/artist/first-track")
-      ?.resolve(new File(["first"], "first.mp3", { type: "audio/mpeg" }));
-    await settle();
-
-    expect(harness.hydratedPictures).toEqual([[]]);
-
+    harness.markDownloaded("track-1");
     harness.coverRequest.resolve(cover);
     await settle();
 
@@ -229,32 +327,19 @@ describe("soundcloud set import", () => {
     expect(harness.files.map((file) => file.metadata?.picture)).toEqual([cover, cover]);
     expect(harness.files.map((file) => file.hasBufferedChanges)).toEqual([true, true]);
     expect(harness.updateTagsCalls).toEqual(["track-1"]);
-
-    harness.downloads
-      .get("https://soundcloud.com/artist/second-track")
-      ?.resolve(new File(["second"], "second.mp3", { type: "audio/mpeg" }));
-    await settle();
-
-    expect(harness.hydratedPictures).toEqual([[], cover]);
   });
 
   it("keeps SoundCloud playlist cover off track metadata even when setting is enabled", async () => {
     const harness = createHarness();
 
     harness.start(soundCloudSet({ isAlbum: false }));
+    harness.markDownloaded("track-1");
     harness.coverRequest.resolve(cover);
     await settle();
 
     expect(harness.albums[0].cover).toEqual(cover);
     expect(harness.files.map((file) => file.metadata?.picture)).toEqual([[], []]);
     expect(harness.updateTagsCalls).toEqual([]);
-
-    harness.downloads
-      .get("https://soundcloud.com/artist/first-track")
-      ?.resolve(new File(["first"], "first.mp3", { type: "audio/mpeg" }));
-    await settle();
-
-    expect(harness.hydratedPictures).toEqual([[]]);
   });
 
   it("keeps SoundCloud album cover off track metadata when the setting is disabled", async () => {
@@ -264,6 +349,7 @@ describe("soundcloud set import", () => {
     });
 
     harness.start(soundCloudSet());
+    harness.markDownloaded("track-1");
     harness.coverRequest.resolve(cover);
     await settle();
 

--- a/components/audio/soundcloudSetImport.ts
+++ b/components/audio/soundcloudSetImport.ts
@@ -1,201 +1,104 @@
-import filenamify from "filenamify";
+import {
+  createDownloadMetadata,
+  createPendingDownloadTrack,
+  createSoundCloudSetDownloadPlan,
+  fetchImportedCover as fetchImportedCoverFromDownloadTrack,
+  startDownloadTrackPlan,
+  type SoundCloudSetDownloadWorkflowDeps,
+  type SoundCloudSetDownloadPlan,
+} from "./downloadTrack";
 import { applySoundCloudSetImportedCover } from "./fileMetadataOps";
 import type { SoundCloudSet } from "./soundcloudSet";
-import type { AlbumGroup, AppSettings, AudioMetadata, TagiumFile } from "./types";
+import type { AppSettings, AudioMetadata, TagiumFile } from "./types";
 
-const filenameFromTitle = (title: string) => {
-  const filename = filenamify(title.trim(), { replacement: "-" });
-  if (filename) return `${filename}.mp3`;
-  return "downloading-track.mp3";
-};
+export { createDownloadMetadata, createPendingDownloadTrack };
 
-export const createDownloadMetadata = ({
-  title,
-  artist,
-  album,
-  genre,
-  year,
-  duration,
-  trackNumber,
-}: {
-  title: string;
-  artist: string;
-  album: string;
-  genre: string;
-  year?: number;
-  duration?: number;
-  trackNumber?: number;
-}): AudioMetadata => ({
-  filename: filenameFromTitle(title).replace(/\.mp3$/i, ""),
-  title,
-  artist,
-  album,
-  year,
-  genre,
-  duration: duration ?? 0,
-  bitrate: 0,
-  sampleRate: 0,
-  picture: [],
-  trackNumber,
-});
+export const fetchImportedCover = fetchImportedCoverFromDownloadTrack;
 
-export const createPendingDownloadTrack = (
-  id: string,
-  metadata: AudioMetadata,
-  hasBufferedChanges: boolean,
-  downloadRequest: NonNullable<TagiumFile["downloadRequest"]>,
-): TagiumFile => ({
-  id,
-  filename: `${metadata.filename}.mp3`,
-  status: "pending",
-  downloadStatus: "downloading",
-  downloadRequest,
-  hasBufferedChanges,
-  metadata,
-});
-
-export const fetchImportedCover = async (coverUrl: string): Promise<AudioMetadata["picture"]> => {
-  const response = await fetch(coverUrl);
-
-  if (!response.ok) {
-    throw new Error(`album cover request failed (${response.status})`);
-  }
-
-  const contentType = response.headers.get("content-type");
-  if (!contentType) {
-    throw new Error("album cover response missing content type.");
-  }
-
-  return [
-    {
-      format: contentType,
-      type: 3,
-      data: new Uint8Array(await response.arrayBuffer()),
-      description: "album cover",
-    },
-  ];
-};
-
-interface SoundCloudSetImportDeps {
+interface SoundCloudSetImportDeps extends SoundCloudSetDownloadWorkflowDeps {
   settings: Pick<AppSettings, "audioBitrate" | "applySoundCloudAlbumCoverToTracks">;
-  bufferCurrentFormMetadata: () => void;
-  setActiveView: (view: "editor") => void;
-  getFiles: () => TagiumFile[];
-  setFiles: (files: TagiumFile[]) => void;
-  getAlbums: () => AlbumGroup[];
-  setAlbums: (albums: AlbumGroup[]) => void;
-  setSelectedAlbumId: (albumId: string | null) => void;
-  setSelectedFileId: (fileId: string | null) => void;
-  setSelectedFileIds: (fileIds: Set<string>) => void;
-  setLastSelectedFileId: (fileId: string | null) => void;
   createId: () => string;
   fetchImportedCover: (coverUrl: string) => Promise<AudioMetadata["picture"]>;
-  downloadCobaltAudio: (request: NonNullable<TagiumFile["downloadRequest"]>) => Promise<File>;
-  hydrateDownloadedTrack: (fileId: string, downloadedFile: File) => Promise<void>;
-  markDownloadError: (fileId: string, error: unknown) => void;
   updateTags: (file: TagiumFile, metadata: AudioMetadata) => Promise<void>;
   warn: (message: string, error: unknown) => void;
+  getSelectedFileId?: () => string | null;
+  setSelectedMetadata?: (metadata: AudioMetadata) => void;
 }
 
-export const startSoundCloudSetImport = (set: SoundCloudSet, deps: SoundCloudSetImportDeps) => {
-  deps.bufferCurrentFormMetadata();
-  deps.setActiveView("editor");
+export const startSoundCloudSetCoverImport = (
+  plan: SoundCloudSetDownloadPlan,
+  deps: Pick<
+    SoundCloudSetImportDeps,
+    | "settings"
+    | "getFiles"
+    | "setFiles"
+    | "getAlbums"
+    | "setAlbums"
+    | "fetchImportedCover"
+    | "updateTags"
+    | "warn"
+    | "getSelectedFileId"
+    | "setSelectedMetadata"
+  >,
+) => {
+  const coverImport = plan.coverImport;
+  if (!coverImport) return;
 
-  const albumId = deps.createId();
-  const pendingFiles = set.tracks.map((track) =>
-    createPendingDownloadTrack(
-      deps.createId(),
-      createDownloadMetadata({
-        title: track.title,
-        artist: set.artist,
-        album: set.title,
-        genre: set.genre,
-        year: set.year,
-        duration: track.duration,
-        trackNumber: track.trackNumber,
-      }),
-      true,
-      { sourceUrl: track.url, audioBitrate: deps.settings.audioBitrate },
-    ),
-  );
-  const album: AlbumGroup = {
-    id: albumId,
-    title: set.title,
-    artist: set.artist,
-    genre: set.genre,
-    trackIds: pendingFiles.map((file) => file.id),
-    year: set.year,
-  };
-  const nextFiles = [...deps.getFiles(), ...pendingFiles];
-  const nextAlbums = [...deps.getAlbums(), album];
-  deps.setFiles(nextFiles);
-  deps.setAlbums(nextAlbums);
-  deps.setSelectedAlbumId(albumId);
+  void (async () => {
+    try {
+      const cover = await deps.fetchImportedCover(coverImport.coverUrl);
+      const {
+        albums: coveredAlbums,
+        files: coveredFiles,
+        selectedMetadata,
+      } = applySoundCloudSetImportedCover(
+        deps.getFiles(),
+        deps.getAlbums(),
+        coverImport.albumId,
+        coverImport.trackIds,
+        coverImport.set,
+        deps.settings,
+        cover,
+        deps.getSelectedFileId?.() ?? null,
+      );
+      deps.setAlbums(coveredAlbums);
+      if (coveredFiles === deps.getFiles()) return;
 
-  let firstPendingFileId: string | null = null;
-  const firstPendingFile = pendingFiles[0];
-  if (firstPendingFile) {
-    firstPendingFileId = firstPendingFile.id;
-  }
-  deps.setSelectedFileId(firstPendingFileId);
-  const selectedFileIds = new Set<string>();
-  if (firstPendingFileId) {
-    selectedFileIds.add(firstPendingFileId);
-  }
-  deps.setSelectedFileIds(selectedFileIds);
-  deps.setLastSelectedFileId(firstPendingFileId);
-
-  const coverUrl = set.coverUrl;
-  if (coverUrl) {
-    void (async () => {
-      try {
-        const cover = await deps.fetchImportedCover(coverUrl);
-        const { albums: coveredAlbums, files: coveredFiles } = applySoundCloudSetImportedCover(
-          deps.getFiles(),
-          deps.getAlbums(),
-          albumId,
-          album.trackIds,
-          set,
-          deps.settings,
-          cover,
-          null,
-        );
-        deps.setAlbums(coveredAlbums);
-        if (coveredFiles === deps.getFiles()) return;
-
-        deps.setFiles(coveredFiles);
-        const trackIdSet = new Set(album.trackIds);
-        await Promise.all(
-          coveredFiles
-            .filter((file) => trackIdSet.has(file.id) && Boolean(file.file) && file.metadata)
-            .map(async (file) => {
-              if (!file.metadata) return;
-              try {
-                await deps.updateTags(file, file.metadata);
-              } catch {
-                // updateTags records the per-track error state.
-              }
-            }),
-        );
-      } catch (error) {
-        deps.warn("failed to import album cover:", error);
+      deps.setFiles(coveredFiles);
+      if (selectedMetadata) {
+        deps.setSelectedMetadata?.(selectedMetadata);
       }
-    })();
-  }
 
-  pendingFiles.forEach((pendingFile, index) => {
-    const track = set.tracks[index];
-    if (!track) return;
-    void (async () => {
-      try {
-        const downloadedFile = await deps.downloadCobaltAudio({
-          sourceUrl: track.url,
-          audioBitrate: deps.settings.audioBitrate,
-        });
-        await deps.hydrateDownloadedTrack(pendingFile.id, downloadedFile);
-      } catch (error) {
-        deps.markDownloadError(pendingFile.id, error);
-      }
-    })();
+      const trackIdSet = new Set(coverImport.trackIds);
+      await Promise.all(
+        coveredFiles
+          .filter((file) => trackIdSet.has(file.id) && Boolean(file.file) && file.metadata)
+          .map(async (file) => {
+            if (!file.metadata) return;
+            try {
+              await deps.updateTags(file, file.metadata);
+            } catch {
+              // updateTags records the per-track error state.
+            }
+          }),
+      );
+    } catch (error) {
+      deps.warn("failed to import album cover:", error);
+    }
+  })();
+};
+
+export const startSoundCloudSetImport = (
+  set: SoundCloudSet,
+  deps: SoundCloudSetImportDeps,
+): SoundCloudSetDownloadPlan => {
+  const plan = createSoundCloudSetDownloadPlan({
+    set,
+    audioBitrate: deps.settings.audioBitrate,
+    createId: deps.createId,
   });
+
+  startDownloadTrackPlan(plan, deps);
+  startSoundCloudSetCoverImport(plan, deps);
+  return plan;
 };

--- a/components/audio/types.ts
+++ b/components/audio/types.ts
@@ -1,28 +1,13 @@
-import { z } from "zod";
 import type { AudioDownloadBitrate } from "./cobaltDownload";
+import type { AudioMetadata, MetadataPatch } from "./metadata";
 
-export const audioMetadataSchema = z.object({
-  filename: z.string(),
-  title: z.string(),
-  artist: z.string(),
-  album: z.string(),
-  year: z.number().nullish(),
-  genre: z.string().or(z.array(z.string())),
-  duration: z.number(),
-  bitrate: z.number(),
-  sampleRate: z.number(),
-  picture: z.array(
-    z.object({
-      format: z.string(),
-      type: z.number(),
-      description: z.string(),
-      data: z.instanceof(Uint8Array),
-    }),
-  ),
-  trackNumber: z.number().nullish(),
-});
-
-export type AudioMetadata = z.infer<typeof audioMetadataSchema>;
+export {
+  audioMetadataSchema,
+  metadataPatchSchema,
+  metadataPictureSchema,
+  metadataSnapshotSchema,
+} from "./metadata";
+export type { AudioMetadata, MetadataPatch, MetadataPicture, MetadataSnapshot } from "./metadata";
 
 export interface TagiumFile {
   id: string;
@@ -35,7 +20,10 @@ export interface TagiumFile {
     sourceUrl: string;
     audioBitrate: AudioDownloadBitrate;
   };
-  hasBufferedChanges: boolean;
+  pendingMetadataPatch?: MetadataPatch;
+  // Compatibility for UI/status consumers that still render a buffered flag.
+  // Lazy metadata writes must derive from pendingMetadataPatch instead.
+  hasBufferedChanges?: boolean;
   filename: string;
   metadata?: AudioMetadata;
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "effect": "^4.0.0-beta.93",
     "fflate": "^0.8.2",
     "filenamify": "^7.0.1",
     "lucide-react": "^0.542.0",


### PR DESCRIPTION
## Summary
- add Effect v4 dependency and local Effect reference subtree/docs
- introduce Effect Schema-backed audio metadata snapshots and sparse metadata patches
- route single URL and SoundCloud set downloads through shared download plan helpers
- replace boolean-driven lazy metadata writes with explicit pending metadata patches
- cover stale year/trackNumber, SoundCloud metadata preservation, synced filename hydration, and test discovery regressions

## Root Cause
The metadata form reused full form snapshots and a broad `hasBufferedChanges` boolean to decide what should be written after downloads completed. Provider defaults, user edits, album sync, and parsed ID3 metadata could all be treated as the same kind of buffered state, which allowed stale year/track values to leak between downloads.

## Validation
- `vp fmt`
- `vp lint .`
- `vp check`
- `vp test`

## Notes
This PR includes the current Effect subtree/bootstrap commits already present in this worktree. Follow-up discussion: stacked PR with Graphite for a fuller Effect workflow rewrite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio downloads now open in a more guided flow, with automatic track setup, cover import, and queued downloads.
  * Metadata edits are now buffered more reliably, making partial changes and filename syncing behave more consistently.

* **Bug Fixes**
  * Fixed cases where downloaded tracks could inherit stale metadata, such as year, track number, or title.
  * Improved handling of cleared fields so empty numeric values are saved correctly and only changed fields are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->