### PR TITLE
Square off app UI

### DIFF
--- a/components/audio/AlbumCoverThumb.tsx
+++ b/components/audio/AlbumCoverThumb.tsx
@@ -27,17 +27,13 @@ export function AlbumCoverThumb({ picture }: AlbumCoverThumbProps) {
 
   if (!src) {
     return (
-      <div className="w-9 h-9 rounded-md bg-muted flex items-center justify-center flex-shrink-0">
+      <div className="w-9 h-9 bg-muted flex items-center justify-center flex-shrink-0">
         <Music2 className="h-4 w-4 text-muted-foreground" />
       </div>
     );
   }
 
   return (
-    <img
-      src={src}
-      alt=""
-      className="w-9 h-9 rounded-md object-cover flex-shrink-0 ring-1 ring-border/50"
-    />
+    <img src={src} alt="" className="w-9 h-9 object-cover flex-shrink-0 ring-1 ring-border/50" />
   );
 }

--- a/components/audio/AlbumSidebarDnd.tsx
+++ b/components/audio/AlbumSidebarDnd.tsx
@@ -172,7 +172,7 @@ export function SortableTrackRow({
         ref={setActivatorNodeRef}
         variant="ghost"
         className={cn(
-          "justify-start h-auto py-2.5 px-4 pr-8 w-full text-left font-normal rounded-none hover:bg-accent/30",
+          "justify-start h-auto py-2.5 px-4 pr-8 w-full text-left font-normal hover:bg-accent/30",
           container === "loose" ? "py-3" : "",
           muted ? "opacity-65" : "",
           selectedTone === "primary" ? "bg-accent text-accent-foreground" : "",
@@ -228,7 +228,7 @@ export function SortableTrackRow({
             event.stopPropagation();
             onRetry();
           }}
-          className="absolute right-7 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded-full cursor-pointer"
+          className="absolute right-7 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent cursor-pointer"
           title="retry download"
           aria-label={`retry download for ${track.filename}`}
         >
@@ -241,7 +241,7 @@ export function SortableTrackRow({
           event.stopPropagation();
           onRemove();
         }}
-        className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
+        className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 cursor-pointer"
         title="remove track"
       >
         <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
@@ -395,7 +395,7 @@ export function SidebarDragPreview({
 }) {
   if (active.type === "album" && album) {
     return (
-      <div className="flex w-64 max-w-[calc(100vw-2rem)] items-center gap-2 rounded-md border bg-card px-3 py-3 text-left shadow-lg">
+      <div className="flex w-64 max-w-[calc(100vw-2rem)] items-center gap-2 border bg-card px-3 py-3 text-left shadow-lg">
         <AlbumCoverThumb picture={album.cover} />
         <div className="min-w-0 flex-1">
           <div className="truncate text-sm font-medium leading-tight">{album.title}</div>
@@ -410,7 +410,7 @@ export function SidebarDragPreview({
 
   if (active.type === "track" && track) {
     return (
-      <div className="flex w-64 max-w-[calc(100vw-2rem)] items-center gap-2 rounded-md border bg-card px-4 py-3 text-left shadow-lg">
+      <div className="flex w-64 max-w-[calc(100vw-2rem)] items-center gap-2 border bg-card px-4 py-3 text-left shadow-lg">
         <FileMusic className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
         <span className="min-w-0 flex-1 truncate text-sm">{track.filename}</span>
       </div>

--- a/components/audio/FileList.tsx
+++ b/components/audio/FileList.tsx
@@ -61,7 +61,7 @@ export default function FileList({
                   e.stopPropagation();
                   onRemoveFile(file.id);
                 }}
-                className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 rounded-full cursor-pointer"
+                className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-destructive/10 cursor-pointer"
                 title="remove file"
               >
                 <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />

--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -117,7 +117,7 @@ export default function LandingScreen({
           type="button"
           onClick={() => fileInputRef.current?.click()}
           className={cn(
-            "w-full rounded-3xl border-2 border-dashed transition-all duration-200 cursor-pointer",
+            "w-full border-2 border-dashed transition-all duration-200 cursor-pointer",
             "flex flex-col items-center justify-center gap-5 py-16 px-8 outline-none max-lg:[@media(max-height:700px)]:gap-3 max-lg:[@media(max-height:700px)]:py-8",
             isDragging
               ? "border-primary bg-primary/10 scale-[1.015] shadow-xl shadow-primary/10"
@@ -127,7 +127,7 @@ export default function LandingScreen({
           {isDragging ? (
             <Music4 className="h-14 w-14 text-primary" />
           ) : (
-            <div className="h-16 w-16 rounded-2xl bg-muted flex items-center justify-center">
+            <div className="h-16 w-16 bg-muted flex items-center justify-center">
               <Upload className="h-7 w-7 text-muted-foreground" />
             </div>
           )}
@@ -161,14 +161,14 @@ export default function LandingScreen({
                 }}
                 placeholder="soundcloud or youtube url"
                 disabled={downloading}
-                className="w-full h-10 rounded-lg border border-input bg-transparent pl-9 pr-3 text-sm shadow-sm outline-none focus:ring-2 focus:ring-ring transition-shadow disabled:opacity-50 placeholder:text-muted-foreground/45"
+                className="w-full h-10 border border-input bg-transparent pl-9 pr-3 text-sm shadow-sm outline-none focus:ring-2 focus:ring-ring transition-shadow disabled:opacity-50 placeholder:text-muted-foreground/45"
               />
             </div>
             <button
               type="submit"
               disabled={!url.trim() || downloading}
               aria-label="start media import"
-              className="h-10 w-10 rounded-lg bg-primary text-primary-foreground flex items-center justify-center flex-shrink-0 cursor-pointer disabled:cursor-not-allowed disabled:opacity-40 hover:bg-primary/90 transition-colors"
+              className="h-10 w-10 bg-primary text-primary-foreground flex items-center justify-center flex-shrink-0 cursor-pointer disabled:cursor-not-allowed disabled:opacity-40 hover:bg-primary/90 transition-colors"
             >
               {downloading ? (
                 <Loader2 className="h-4 w-4 animate-spin" />

--- a/components/audio/PlaylistDownloadQueuePanel.tsx
+++ b/components/audio/PlaylistDownloadQueuePanel.tsx
@@ -115,7 +115,7 @@ export default function PlaylistDownloadQueuePanel({
       )}
 
       <div
-        className="mt-2 h-1.5 overflow-hidden rounded-full bg-background"
+        className="mt-2 h-1.5 overflow-hidden bg-background"
         role="progressbar"
         aria-label="playlist download progress"
         aria-valuemin={0}

--- a/components/audio/SettingsPage.tsx
+++ b/components/audio/SettingsPage.tsx
@@ -182,7 +182,7 @@ export default function SettingsPage({ settings, onChange, onBack }: SettingsPag
               target="_blank"
               rel="noreferrer"
               aria-label="GitHub"
-              className="inline-flex size-12 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none"
+              className="inline-flex size-12 cursor-pointer items-center justify-center text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -204,7 +204,7 @@ export default function SettingsPage({ settings, onChange, onBack }: SettingsPag
               target="_blank"
               rel="noreferrer"
               aria-label="Twitter"
-              className="inline-flex size-12 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none"
+              className="inline-flex size-12 cursor-pointer items-center justify-center text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/components/audio/coverArt.tsx
+++ b/components/audio/coverArt.tsx
@@ -116,16 +116,16 @@ export default function CoverArt({
             alt="album cover"
             className={
               isCompact
-                ? "size-24 object-cover rounded-lg border md:size-44"
-                : "size-full object-cover rounded-lg border lg:size-64"
+                ? "size-24 object-cover border md:size-44"
+                : "size-full object-cover border lg:size-64"
             }
           />
         ) : (
           <div
             className={
               isCompact
-                ? "size-24 bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs md:size-44"
-                : "size-full bg-gray-200 rounded-lg border flex items-center justify-center text-gray-500 text-xs lg:size-64"
+                ? "size-24 bg-gray-200 border flex items-center justify-center text-gray-500 text-xs md:size-44"
+                : "size-full bg-gray-200 border flex items-center justify-center text-gray-500 text-xs lg:size-64"
             }
           >
             no cover

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:cursor-default disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-all disabled:pointer-events-none disabled:cursor-default disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -20,8 +20,8 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        sm: "h-8 gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 px-6 has-[>svg]:px-4",
         icon: "size-9",
       },
     },

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 border py-6 shadow-sm",
         className,
       )}
       {...props}

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -11,7 +11,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 cursor-pointer rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 cursor-pointer border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -53,7 +53,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
           className,
         )}
         {...props}
@@ -62,7 +62,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className,

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -26,7 +26,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) border p-4 shadow-md outline-hidden",
           className,
         )}
         {...props}

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -38,13 +38,13 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md border border-border bg-card px-2.5 py-1.5 text-xs font-medium text-balance text-card-foreground shadow-md fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in border border-border bg-card px-2.5 py-1.5 text-xs font-medium text-balance text-card-foreground shadow-md fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           className,
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_1px)] rotate-45 rounded-[2px] border border-border bg-card fill-card" />
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_1px)] rotate-45 border border-border bg-card fill-card" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -14,7 +14,7 @@
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
-  --radius: 0.625rem;
+  --radius: 0rem;
   --tracking-tighter: calc(var(--tracking-normal) - 0.05em);
   --tracking-tight: calc(var(--tracking-normal) - 0.025em);
   --tracking-wide: calc(var(--tracking-normal) + 0.025em);
@@ -67,14 +67,14 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --radius-sm: 0rem;
+  --radius-md: 0rem;
+  --radius-lg: 0rem;
+  --radius-xl: 0rem;
 }
 
 :root {
-  --radius: 0.625rem;
+  --radius: 0rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -167,7 +167,7 @@
   --sidebar-border: oklch(0.2463 0.0255 208.85);
   --sidebar-ring: oklch(0.9097 0.0511 151.08);
   --destructive-foreground: oklch(0.985 0 0);
-  --radius: 0.625rem;
+  --radius: 0rem;
   --font-sans:
     ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji",


### PR DESCRIPTION
## Summary
- set app radius tokens to zero so component defaults render squared off
- remove rounded utilities from shared UI components and app surfaces
- keep album covers, cover controls, crop/sync actions, drag previews, progress bars, and landing controls square

## Verification
- bun run lint
- bun run typecheck
- bun run test
- bun run build