### PR TITLE
feat: add dev panel

### DIFF
--- a/components/dev/DevPanel.tsx
+++ b/components/dev/DevPanel.tsx
@@ -1,0 +1,298 @@
+import { useEffect, useState } from "react";
+import { AlertTriangle, RotateCcw, SlidersHorizontal, Zap } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+type DevConfig = {
+  enabled: boolean;
+  deployEnv: "local" | "preview" | "production";
+  detectedFrom: string;
+  productionBranch: string;
+  rateLimit: {
+    windowMs: number;
+    maxRequests: number;
+    bucketCount: number;
+    client: {
+      key: string;
+      count: number;
+      remaining: number;
+      resetAt?: number;
+    };
+  };
+  faults: {
+    nextAudioFault?: AudioFault;
+    nextTunnelFault?: TunnelFault;
+  };
+};
+
+type AudioFault = "rate-limit" | "capacity" | "timeout" | "unreachable" | "malformed";
+type TunnelFault = "rate-limit" | "capacity" | "timeout" | "empty-body";
+
+const audioFaults: Array<{ value: AudioFault; label: string }> = [
+  { value: "rate-limit", label: "429" },
+  { value: "capacity", label: "capacity" },
+  { value: "timeout", label: "timeout" },
+  { value: "unreachable", label: "offline" },
+  { value: "malformed", label: "bad json" },
+];
+
+const tunnelFaults: Array<{ value: TunnelFault; label: string }> = [
+  { value: "rate-limit", label: "429" },
+  { value: "capacity", label: "capacity" },
+  { value: "timeout", label: "timeout" },
+  { value: "empty-body", label: "empty" },
+];
+
+const readDevConfig = async () => {
+  const response = await fetch("/api/dev/config");
+  if (!response.ok) return null;
+  return (await response.json()) as DevConfig;
+};
+
+const formatReset = (resetAt: number | undefined) => {
+  if (!resetAt) return "none";
+
+  const seconds = Math.max(Math.ceil((resetAt - Date.now()) / 1_000), 0);
+  return `${seconds}s`;
+};
+
+export function DevPanel() {
+  const [config, setConfig] = useState<DevConfig | null>(null);
+  const [windowMs, setWindowMs] = useState("60000");
+  const [maxRequests, setMaxRequests] = useState("60");
+  const [busy, setBusy] = useState(false);
+
+  const refresh = async () => {
+    const nextConfig = await readDevConfig();
+    setConfig(nextConfig);
+    if (nextConfig) {
+      setWindowMs(String(nextConfig.rateLimit.windowMs));
+      setMaxRequests(String(nextConfig.rateLimit.maxRequests));
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  if (!config?.enabled) return null;
+
+  const patchConfig = async (body: unknown) => {
+    setBusy(true);
+    try {
+      const response = await fetch("/api/dev/config", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (response.ok) {
+        const nextConfig = (await response.json()) as DevConfig;
+        setConfig(nextConfig);
+        setWindowMs(String(nextConfig.rateLimit.windowMs));
+        setMaxRequests(String(nextConfig.rateLimit.maxRequests));
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const setFault = async (target: "audio" | "tunnel", fault: AudioFault | TunnelFault | null) => {
+    setBusy(true);
+    try {
+      const response = await fetch("/api/dev/fault", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ target, fault }),
+      });
+      if (response.ok) {
+        setConfig((await response.json()) as DevConfig);
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="fixed right-4 bottom-4 z-50">
+      <Popover>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                size="icon"
+                className="size-10 border border-foreground/15 bg-foreground text-background shadow-lg hover:bg-foreground/90"
+                aria-label="open dev panel"
+              >
+                <SlidersHorizontal />
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="left">dev panel</TooltipContent>
+        </Tooltip>
+        <PopoverContent
+          align="end"
+          side="top"
+          className="w-[min(24rem,calc(100vw-2rem))] border-foreground/10 bg-background/95 p-0 shadow-xl backdrop-blur"
+        >
+          <div className="border-b border-border px-4 py-3">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold leading-tight">dev panel</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {config.deployEnv} / {config.detectedFrom}
+                </p>
+              </div>
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className="size-8"
+                onClick={() => void refresh()}
+                disabled={busy}
+                aria-label="refresh dev config"
+              >
+                <RotateCcw />
+              </Button>
+            </div>
+          </div>
+
+          <div className="grid gap-4 p-4">
+            <section className="grid gap-3">
+              <div className="flex items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
+                <Zap className="size-3.5" />
+                rate limit
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <Label className="grid gap-1.5 text-xs">
+                  window ms
+                  <Input
+                    type="number"
+                    min={1000}
+                    max={600000}
+                    step={1000}
+                    value={windowMs}
+                    onChange={(event) => setWindowMs(event.target.value)}
+                  />
+                </Label>
+                <Label className="grid gap-1.5 text-xs">
+                  max
+                  <Input
+                    type="number"
+                    min={1}
+                    max={500}
+                    value={maxRequests}
+                    onChange={(event) => setMaxRequests(event.target.value)}
+                  />
+                </Label>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() =>
+                    void patchConfig({
+                      rateLimit: {
+                        windowMs: Number(windowMs),
+                        maxRequests: Number(maxRequests),
+                      },
+                    })
+                  }
+                  disabled={busy}
+                >
+                  apply
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void patchConfig({ resetRateLimitBuckets: true })}
+                  disabled={busy}
+                >
+                  reset buckets
+                </Button>
+              </div>
+              <div className="grid grid-cols-3 gap-2 rounded-md border border-border bg-muted/40 p-2 text-xs">
+                <div>
+                  <p className="text-muted-foreground">count</p>
+                  <p className="font-mono">{config.rateLimit.client.count}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">left</p>
+                  <p className="font-mono">{config.rateLimit.client.remaining}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">reset</p>
+                  <p className="font-mono">{formatReset(config.rateLimit.client.resetAt)}</p>
+                </div>
+              </div>
+            </section>
+
+            <section className="grid gap-3">
+              <div className="flex items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
+                <AlertTriangle className="size-3.5" />
+                next audio
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {audioFaults.map((fault) => (
+                  <Button
+                    key={fault.value}
+                    type="button"
+                    size="sm"
+                    variant={config.faults.nextAudioFault === fault.value ? "default" : "outline"}
+                    onClick={() => void setFault("audio", fault.value)}
+                    disabled={busy}
+                  >
+                    {fault.label}
+                  </Button>
+                ))}
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => void setFault("audio", null)}
+                  disabled={busy}
+                >
+                  clear
+                </Button>
+              </div>
+            </section>
+
+            <section className="grid gap-3">
+              <div className="flex items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
+                <AlertTriangle className="size-3.5" />
+                next tunnel
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {tunnelFaults.map((fault) => (
+                  <Button
+                    key={fault.value}
+                    type="button"
+                    size="sm"
+                    variant={config.faults.nextTunnelFault === fault.value ? "default" : "outline"}
+                    onClick={() => void setFault("tunnel", fault.value)}
+                    disabled={busy}
+                  >
+                    {fault.label}
+                  </Button>
+                ))}
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => void setFault("tunnel", null)}
+                  disabled={busy}
+                >
+                  clear
+                </Button>
+              </div>
+            </section>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/nitro.config.ts
+++ b/nitro.config.ts
@@ -1,5 +1,13 @@
 import { defineNitroConfig } from "nitro/config";
 
+const wrangler = {
+  keep_vars: true,
+  vars: {
+    COBALT_API_URL: "https://tagium-cobalt.fly.dev/",
+    TAGIUM_DEPLOY_ENV: "production",
+  },
+};
+
 export default defineNitroConfig({
   compatibilityDate: "2026-04-08",
   serverDir: "server",
@@ -7,11 +15,6 @@ export default defineNitroConfig({
   cloudflare: {
     deployConfig: true,
     nodeCompat: true,
-    wrangler: {
-      keep_vars: true,
-      vars: {
-        COBALT_API_URL: "https://tagium-cobalt.fly.dev/",
-      },
-    },
+    wrangler,
   },
 });

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vp test run",
     "typecheck": "tsc -b",
     "prepare": "vp config",
+    "deploy:preview": "bun run scripts/deploy-preview.ts",
     "load-test:cobalt": "bun run scripts/load-test-cobalt.ts"
   },
   "dependencies": {

--- a/scripts/deploy-preview.ts
+++ b/scripts/deploy-preview.ts
@@ -1,0 +1,26 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { argv, exit } from "node:process";
+
+const WRANGLER_CONFIG_PATH = ".output/server/wrangler.json";
+
+type WranglerConfig = {
+  vars?: Record<string, string>;
+};
+
+const config = JSON.parse(readFileSync(WRANGLER_CONFIG_PATH, "utf8")) as WranglerConfig;
+config.vars = {
+  ...config.vars,
+  TAGIUM_DEPLOY_ENV: "preview",
+};
+writeFileSync(WRANGLER_CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`);
+
+if (argv.includes("--no-upload")) {
+  exit(0);
+}
+
+const upload = spawnSync("npx", ["wrangler", "versions", "upload"], {
+  stdio: "inherit",
+});
+
+exit(upload.status ?? 1);

--- a/server/api/cobalt/audio.post.ts
+++ b/server/api/cobalt/audio.post.ts
@@ -10,6 +10,11 @@ import { defineHandler } from "nitro";
 import { env as processEnv } from "node:process";
 import { z } from "zod";
 import { parseCobaltMachineId, signCobaltMachine } from "../../utils/cobalt-machine-affinity";
+import {
+  consumeAudioDevFault,
+  enforceRateLimit,
+  type CobaltRuntimeEnv as DevControlRuntimeEnv,
+} from "../../utils/dev-controls";
 
 enum CobaltResponseType {
   Error = "error",
@@ -81,7 +86,7 @@ type CobaltRuntimeEnv = {
   COBALT_API_KEY?: string;
   COBALT_API_URL?: string;
   COBALT_MACHINE_AFFINITY_SECRET?: string;
-};
+} & DevControlRuntimeEnv;
 type CloudflareRequest = Request & {
   runtime?: {
     cloudflare?: {
@@ -90,10 +95,7 @@ type CloudflareRequest = Request & {
   };
 };
 
-const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX_REQUESTS = 60;
 const COBALT_REQUEST_TIMEOUT_MS = 300_000;
-const rateLimitBuckets = new Map<string, { startedAt: number; count: number }>();
 
 const getRuntimeEnv = (request: Request): CobaltRuntimeEnv => ({
   ...processEnv,
@@ -143,15 +145,6 @@ const getAllowedOrigin = (
   return new URL(request.url, requestOrigin).origin;
 };
 
-const getClientKey = (request: Request) => {
-  const cloudflareIp = request.headers.get("cf-connecting-ip");
-  if (cloudflareIp) {
-    return cloudflareIp;
-  }
-
-  return "unknown";
-};
-
 const enforceSameOrigin = (request: Request, runtimeEnv: CobaltRuntimeEnv) => {
   const requestOrigin = getRequestOrigin(request);
   if (!requestOrigin) {
@@ -163,24 +156,6 @@ const enforceSameOrigin = (request: Request, runtimeEnv: CobaltRuntimeEnv) => {
     return new Response("Download origin is not allowed.", { status: 403 });
   }
 
-  return undefined;
-};
-
-const enforceRateLimit = (request: Request) => {
-  const clientKey = getClientKey(request);
-  const now = Date.now();
-  const bucket = rateLimitBuckets.get(clientKey);
-
-  if (!bucket || now - bucket.startedAt >= RATE_LIMIT_WINDOW_MS) {
-    rateLimitBuckets.set(clientKey, { startedAt: now, count: 1 });
-    return undefined;
-  }
-
-  if (bucket.count >= RATE_LIMIT_MAX_REQUESTS) {
-    return new Response("Download rate limit exceeded.", { status: 429 });
-  }
-
-  bucket.count += 1;
   return undefined;
 };
 
@@ -282,6 +257,39 @@ const cobaltCapacityErrorResponse = (response: CobaltResponse, retryAfter: strin
   });
 };
 
+const cobaltDevCapacityResponse = () =>
+  cobaltCapacityErrorResponse(
+    {
+      status: CobaltResponseType.Error,
+      error: { code: "error.api.capacity_exceeded" },
+    },
+    "2",
+  );
+
+const cobaltDevFaultResponse = (fault: ReturnType<typeof consumeAudioDevFault>) => {
+  if (fault === "rate-limit") {
+    return new Response("Download rate limit exceeded.", { status: 429 });
+  }
+
+  if (fault === "capacity") {
+    return cobaltDevCapacityResponse();
+  }
+
+  if (fault === "timeout") {
+    return cobaltErrorResponse("error.api.timed_out");
+  }
+
+  if (fault === "unreachable") {
+    return cobaltErrorResponse("error.api.unreachable");
+  }
+
+  if (fault === "malformed") {
+    return Response.json({ status: "dev.malformed" });
+  }
+
+  return undefined;
+};
+
 const toTunnelProxyUrl = (
   request: Request,
   runtimeEnv: CobaltRuntimeEnv,
@@ -336,6 +344,12 @@ export default defineHandler(async (event) => {
     const forbidden = enforceSameOrigin(event.req, runtimeEnv);
     if (forbidden) {
       return forbidden;
+    }
+
+    const devFault = consumeAudioDevFault(event.req, runtimeEnv);
+    const devFaultResponse = cobaltDevFaultResponse(devFault);
+    if (devFaultResponse) {
+      return devFaultResponse;
     }
 
     const limited = enforceRateLimit(event.req);

--- a/server/api/cobalt/tunnel.get.ts
+++ b/server/api/cobalt/tunnel.get.ts
@@ -4,11 +4,15 @@ import {
   isCobaltMachineId,
   isValidCobaltMachineSignature,
 } from "../../utils/cobalt-machine-affinity";
+import {
+  consumeTunnelDevFault,
+  type CobaltRuntimeEnv as DevControlRuntimeEnv,
+} from "../../utils/dev-controls";
 
 type CobaltRuntimeEnv = {
   COBALT_API_URL?: string;
   COBALT_MACHINE_AFFINITY_SECRET?: string;
-};
+} & DevControlRuntimeEnv;
 
 type CloudflareRequest = Request & {
   runtime?: {
@@ -127,6 +131,32 @@ const cobaltCapacityErrorResponse = (body: unknown, retryAfter: string | null) =
   });
 };
 
+const cobaltDevTunnelFaultResponse = (fault: ReturnType<typeof consumeTunnelDevFault>) => {
+  if (fault === "rate-limit") {
+    return new Response("Cobalt tunnel request failed (429).", { status: 502 });
+  }
+
+  if (fault === "capacity") {
+    return cobaltCapacityErrorResponse(
+      {
+        status: "error",
+        error: { code: "error.api.capacity_exceeded" },
+      },
+      "2",
+    );
+  }
+
+  if (fault === "timeout") {
+    return new Response("Cobalt tunnel request timed out.", { status: 502 });
+  }
+
+  if (fault === "empty-body") {
+    return new Response("Cobalt tunnel response was empty.", { status: 502 });
+  }
+
+  return undefined;
+};
+
 const parseTunnelRequest = (request: Request, runtimeEnv: CobaltRuntimeEnv) => {
   const requestUrl = new URL(request.url);
   const tunnelUrlParam = requestUrl.searchParams.get("url");
@@ -175,6 +205,12 @@ export default defineHandler(async (event) => {
 
   try {
     const runtimeEnv = getRuntimeEnv(event.req);
+    const devFault = consumeTunnelDevFault(event.req, runtimeEnv);
+    const devFaultResponse = cobaltDevTunnelFaultResponse(devFault);
+    if (devFaultResponse) {
+      return devFaultResponse;
+    }
+
     const tunnelRequest = parseTunnelRequest(event.req, runtimeEnv);
     if (!tunnelRequest) {
       logTunnelFailure("invalid tunnel url", { requestId, elapsedMs: Date.now() - startedAt });

--- a/server/api/dev/config.get.ts
+++ b/server/api/dev/config.get.ts
@@ -1,0 +1,29 @@
+import { defineHandler } from "nitro";
+import { env as processEnv } from "node:process";
+import {
+  getDevControlSnapshot,
+  isDevToolsEnabled,
+  type CobaltRuntimeEnv,
+} from "../../utils/dev-controls";
+
+type CloudflareRequest = Request & {
+  runtime?: {
+    cloudflare?: {
+      env?: CobaltRuntimeEnv;
+    };
+  };
+};
+
+const getRuntimeEnv = (request: Request): CobaltRuntimeEnv => ({
+  ...processEnv,
+  ...(request as CloudflareRequest).runtime?.cloudflare?.env,
+});
+
+export default defineHandler((event) => {
+  const runtimeEnv = getRuntimeEnv(event.req);
+  if (!isDevToolsEnabled(event.req, runtimeEnv)) {
+    return new Response("Not found.", { status: 404 });
+  }
+
+  return Response.json(getDevControlSnapshot(event.req, runtimeEnv));
+});

--- a/server/api/dev/config.post.ts
+++ b/server/api/dev/config.post.ts
@@ -1,0 +1,33 @@
+import { defineHandler } from "nitro";
+import { env as processEnv } from "node:process";
+import {
+  devConfigUpdateSchema,
+  getDevControlSnapshot,
+  isDevToolsEnabled,
+  updateDevConfig,
+  type CobaltRuntimeEnv,
+} from "../../utils/dev-controls";
+
+type CloudflareRequest = Request & {
+  runtime?: {
+    cloudflare?: {
+      env?: CobaltRuntimeEnv;
+    };
+  };
+};
+
+const getRuntimeEnv = (request: Request): CobaltRuntimeEnv => ({
+  ...processEnv,
+  ...(request as CloudflareRequest).runtime?.cloudflare?.env,
+});
+
+export default defineHandler(async (event) => {
+  const runtimeEnv = getRuntimeEnv(event.req);
+  if (!isDevToolsEnabled(event.req, runtimeEnv)) {
+    return new Response("Not found.", { status: 404 });
+  }
+
+  const body = devConfigUpdateSchema.parse(await event.req.json());
+  updateDevConfig(body);
+  return Response.json(getDevControlSnapshot(event.req, runtimeEnv));
+});

--- a/server/api/dev/fault.post.ts
+++ b/server/api/dev/fault.post.ts
@@ -1,0 +1,33 @@
+import { defineHandler } from "nitro";
+import { env as processEnv } from "node:process";
+import {
+  devFaultUpdateSchema,
+  getDevControlSnapshot,
+  isDevToolsEnabled,
+  setDevFault,
+  type CobaltRuntimeEnv,
+} from "../../utils/dev-controls";
+
+type CloudflareRequest = Request & {
+  runtime?: {
+    cloudflare?: {
+      env?: CobaltRuntimeEnv;
+    };
+  };
+};
+
+const getRuntimeEnv = (request: Request): CobaltRuntimeEnv => ({
+  ...processEnv,
+  ...(request as CloudflareRequest).runtime?.cloudflare?.env,
+});
+
+export default defineHandler(async (event) => {
+  const runtimeEnv = getRuntimeEnv(event.req);
+  if (!isDevToolsEnabled(event.req, runtimeEnv)) {
+    return new Response("Not found.", { status: 404 });
+  }
+
+  const body = devFaultUpdateSchema.parse(await event.req.json());
+  setDevFault(body);
+  return Response.json(getDevControlSnapshot(event.req, runtimeEnv));
+});

--- a/server/utils/dev-controls.test.ts
+++ b/server/utils/dev-controls.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  consumeAudioDevFault,
+  enforceRateLimit,
+  getDeployEnv,
+  getDevControlSnapshot,
+  resetRateLimitBuckets,
+  setDevFault,
+  updateDevConfig,
+} from "./dev-controls";
+
+const request = (url = "https://tagium.app/api/cobalt/audio") => new Request(url);
+
+describe("dev controls", () => {
+  beforeEach(() => {
+    resetRateLimitBuckets();
+    updateDevConfig({
+      rateLimit: { windowMs: 60_000, maxRequests: 60 },
+    });
+    setDevFault({ target: "audio", fault: null });
+    setDevFault({ target: "tunnel", fault: null });
+  });
+
+  it("enables dev controls on localhost", () => {
+    expect(getDeployEnv(request("http://localhost:5173/api/dev/config"), {}).deployEnv).toBe(
+      "local",
+    );
+  });
+
+  it("detects Cloudflare Pages preview branches", () => {
+    expect(
+      getDeployEnv(request(), {
+        CF_PAGES: "1",
+        CF_PAGES_BRANCH: "codex/dev-panel",
+        TAGIUM_PRODUCTION_BRANCH: "main",
+      }).deployEnv,
+    ).toBe("preview");
+  });
+
+  it("keeps Cloudflare Pages production branch disabled", () => {
+    expect(
+      getDeployEnv(request(), {
+        CF_PAGES: "1",
+        CF_PAGES_BRANCH: "main",
+      }).deployEnv,
+    ).toBe("production");
+  });
+
+  it("adjusts rate limits at runtime", () => {
+    updateDevConfig({
+      rateLimit: { windowMs: 60_000, maxRequests: 1 },
+    });
+
+    expect(enforceRateLimit(request())).toBeUndefined();
+    expect(enforceRateLimit(request())?.status).toBe(429);
+  });
+
+  it("reports current rate limit bucket state", () => {
+    updateDevConfig({
+      rateLimit: { windowMs: 60_000, maxRequests: 2 },
+    });
+    enforceRateLimit(request());
+
+    const snapshot = getDevControlSnapshot(request("http://localhost:5173/api/dev/config"), {});
+
+    expect(snapshot.rateLimit.client.count).toBe(1);
+    expect(snapshot.rateLimit.client.remaining).toBe(1);
+  });
+
+  it("consumes preview audio faults once", () => {
+    const runtimeEnv = { TAGIUM_DEPLOY_ENV: "preview" };
+    setDevFault({ target: "audio", fault: "rate-limit" });
+
+    expect(consumeAudioDevFault(request(), runtimeEnv)).toBe("rate-limit");
+    expect(consumeAudioDevFault(request(), runtimeEnv)).toBeUndefined();
+  });
+
+  it("does not consume audio faults in production", () => {
+    setDevFault({ target: "audio", fault: "rate-limit" });
+
+    expect(consumeAudioDevFault(request(), { TAGIUM_DEPLOY_ENV: "production" })).toBeUndefined();
+  });
+});

--- a/server/utils/dev-controls.ts
+++ b/server/utils/dev-controls.ts
@@ -1,0 +1,201 @@
+import { z } from "zod";
+
+export type CobaltRuntimeEnv = {
+  CF_PAGES?: string;
+  CF_PAGES_BRANCH?: string;
+  NODE_ENV?: string;
+  TAGIUM_DEPLOY_ENV?: string;
+  TAGIUM_PRODUCTION_BRANCH?: string;
+};
+
+export type DeployEnv = "local" | "preview" | "production";
+export type AudioDevFault = "rate-limit" | "capacity" | "timeout" | "unreachable" | "malformed";
+export type TunnelDevFault = "rate-limit" | "capacity" | "timeout" | "empty-body";
+
+type RateLimitBucket = {
+  startedAt: number;
+  count: number;
+};
+
+type DevState = {
+  rateLimitWindowMs: number;
+  rateLimitMaxRequests: number;
+  nextAudioFault: AudioDevFault | undefined;
+  nextTunnelFault: TunnelDevFault | undefined;
+};
+
+const DEFAULT_RATE_LIMIT_WINDOW_MS = 60_000;
+const DEFAULT_RATE_LIMIT_MAX_REQUESTS = 60;
+
+const rateLimitBuckets = new Map<string, RateLimitBucket>();
+const devState: DevState = {
+  rateLimitWindowMs: DEFAULT_RATE_LIMIT_WINDOW_MS,
+  rateLimitMaxRequests: DEFAULT_RATE_LIMIT_MAX_REQUESTS,
+  nextAudioFault: undefined,
+  nextTunnelFault: undefined,
+};
+
+export const devConfigUpdateSchema = z.object({
+  rateLimit: z
+    .object({
+      windowMs: z.number().int().min(1_000).max(600_000),
+      maxRequests: z.number().int().min(1).max(500),
+    })
+    .optional(),
+  resetRateLimitBuckets: z.boolean().optional(),
+});
+
+export const devFaultUpdateSchema = z.discriminatedUnion("target", [
+  z.object({
+    target: z.literal("audio"),
+    fault: z.enum(["rate-limit", "capacity", "timeout", "unreachable", "malformed"]).nullable(),
+  }),
+  z.object({
+    target: z.literal("tunnel"),
+    fault: z.enum(["rate-limit", "capacity", "timeout", "empty-body"]).nullable(),
+  }),
+]);
+
+export const getProductionBranch = (runtimeEnv: CobaltRuntimeEnv) =>
+  runtimeEnv.TAGIUM_PRODUCTION_BRANCH || "main";
+
+export const getRequestHostname = (request: Request) => {
+  try {
+    return new URL(request.url).hostname;
+  } catch {
+    return "";
+  }
+};
+
+export const isLocalHostname = (hostname: string) =>
+  hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+
+export const getDeployEnv = (
+  request: Request,
+  runtimeEnv: CobaltRuntimeEnv,
+): { deployEnv: DeployEnv; detectedFrom: string } => {
+  if (
+    runtimeEnv.TAGIUM_DEPLOY_ENV === "local" ||
+    runtimeEnv.TAGIUM_DEPLOY_ENV === "preview" ||
+    runtimeEnv.TAGIUM_DEPLOY_ENV === "production"
+  ) {
+    return { deployEnv: runtimeEnv.TAGIUM_DEPLOY_ENV, detectedFrom: "TAGIUM_DEPLOY_ENV" };
+  }
+
+  const hostname = getRequestHostname(request);
+  if (isLocalHostname(hostname) || runtimeEnv.NODE_ENV === "development") {
+    return { deployEnv: "local", detectedFrom: "local runtime" };
+  }
+
+  if (runtimeEnv.CF_PAGES === "1") {
+    const productionBranch = getProductionBranch(runtimeEnv);
+    const branch = runtimeEnv.CF_PAGES_BRANCH;
+    return {
+      deployEnv: branch && branch !== productionBranch ? "preview" : "production",
+      detectedFrom: "CF_PAGES_BRANCH",
+    };
+  }
+
+  return { deployEnv: "production", detectedFrom: "default" };
+};
+
+export const isDevToolsEnabled = (request: Request, runtimeEnv: CobaltRuntimeEnv) =>
+  getDeployEnv(request, runtimeEnv).deployEnv !== "production";
+
+export const getClientKey = (request: Request) =>
+  request.headers.get("cf-connecting-ip") || "unknown";
+
+export const resetRateLimitBuckets = () => {
+  rateLimitBuckets.clear();
+};
+
+export const updateDevConfig = (input: z.infer<typeof devConfigUpdateSchema>) => {
+  if (input.rateLimit) {
+    devState.rateLimitWindowMs = input.rateLimit.windowMs;
+    devState.rateLimitMaxRequests = input.rateLimit.maxRequests;
+  }
+
+  if (input.resetRateLimitBuckets) {
+    resetRateLimitBuckets();
+  }
+};
+
+export const setDevFault = (input: z.infer<typeof devFaultUpdateSchema>) => {
+  if (input.target === "audio") {
+    devState.nextAudioFault = input.fault ?? undefined;
+    return;
+  }
+
+  devState.nextTunnelFault = input.fault ?? undefined;
+};
+
+export const consumeAudioDevFault = (
+  request: Request,
+  runtimeEnv: CobaltRuntimeEnv,
+): AudioDevFault | undefined => {
+  if (!isDevToolsEnabled(request, runtimeEnv)) return undefined;
+
+  const fault = devState.nextAudioFault;
+  devState.nextAudioFault = undefined;
+  return fault;
+};
+
+export const consumeTunnelDevFault = (
+  request: Request,
+  runtimeEnv: CobaltRuntimeEnv,
+): TunnelDevFault | undefined => {
+  if (!isDevToolsEnabled(request, runtimeEnv)) return undefined;
+
+  const fault = devState.nextTunnelFault;
+  devState.nextTunnelFault = undefined;
+  return fault;
+};
+
+export const enforceRateLimit = (request: Request) => {
+  const clientKey = getClientKey(request);
+  const now = Date.now();
+  const bucket = rateLimitBuckets.get(clientKey);
+
+  if (!bucket || now - bucket.startedAt >= devState.rateLimitWindowMs) {
+    rateLimitBuckets.set(clientKey, { startedAt: now, count: 1 });
+    return undefined;
+  }
+
+  if (bucket.count >= devState.rateLimitMaxRequests) {
+    return new Response("Download rate limit exceeded.", { status: 429 });
+  }
+
+  bucket.count += 1;
+  return undefined;
+};
+
+export const getDevControlSnapshot = (request: Request, runtimeEnv: CobaltRuntimeEnv) => {
+  const { deployEnv, detectedFrom } = getDeployEnv(request, runtimeEnv);
+  const clientKey = getClientKey(request);
+  const bucket = rateLimitBuckets.get(clientKey);
+  const now = Date.now();
+  const resetAt = bucket ? bucket.startedAt + devState.rateLimitWindowMs : undefined;
+  const count = bucket && resetAt && resetAt > now ? bucket.count : 0;
+
+  return {
+    enabled: deployEnv !== "production",
+    deployEnv,
+    detectedFrom,
+    productionBranch: getProductionBranch(runtimeEnv),
+    rateLimit: {
+      windowMs: devState.rateLimitWindowMs,
+      maxRequests: devState.rateLimitMaxRequests,
+      bucketCount: rateLimitBuckets.size,
+      client: {
+        key: clientKey,
+        count,
+        remaining: Math.max(devState.rateLimitMaxRequests - count, 0),
+        resetAt,
+      },
+    },
+    faults: {
+      nextAudioFault: devState.nextAudioFault,
+      nextTunnelFault: devState.nextTunnelFault,
+    },
+  };
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import AudioTagger from "@/components/audio/audioTagger";
+import { DevPanel } from "@/components/dev/DevPanel";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -6,6 +7,7 @@ export default function App() {
   return (
     <TooltipProvider>
       <AudioTagger />
+      <DevPanel />
       <Toaster position="bottom-right" richColors closeButton />
     </TooltipProvider>
   );


### PR DESCRIPTION
## What changed

- Adds a gated Dev panel that appears on localhost and preview deploys.
- Adds `/api/dev/config` and `/api/dev/fault` endpoints for runtime limiter controls and one-shot Cobalt fault injection.
- Moves the audio download rate-limit bucket/config into shared dev controls so the panel can adjust/reset it.
- Hooks audio and tunnel proxy routes into dev-only one-shot faults for 429, capacity, timeout, unreachable, malformed, and empty tunnel cases.
- Configures Nitro-generated Wrangler vars with `TAGIUM_DEPLOY_ENV=production` by default.
- Adds `bun run deploy:preview`, which patches the generated redirected Wrangler config to `TAGIUM_DEPLOY_ENV=preview` before running `npx wrangler versions upload`.

## Deploy gating

- Localhost and `NODE_ENV=development` resolve to `local`.
- `TAGIUM_DEPLOY_ENV=preview` enables the panel.
- `TAGIUM_DEPLOY_ENV=production` disables the panel.
- Unknown environments default to `production`, and dev endpoints return 404 there.
- Cloudflare non-production branch deploy command should use `bun run deploy:preview`.

## Why not Wrangler env blocks

- Wrangler rejects `env` in redirected generated configs (`.wrangler/deploy/config.json` -> `.output/server/wrangler.json`).
- The preview script avoids that by mutating only the flat generated `vars` immediately before upload.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- Verified generated `.output/server/wrangler.json` contains no `env` block.
- Verified `bun run scripts/deploy-preview.ts --no-upload` flips flat `vars.TAGIUM_DEPLOY_ENV` from `production` to `preview`.
- Browser smoke: opened `http://localhost:3000`, opened Dev panel, verified rate-limit/audio/tunnel controls and no console errors.
- API smoke: adjusted limiter to 1 request/window and verified second audio POST returns 429; forced one-shot audio 429 and verified next request consumed it.
