### PR TITLE
Deploy Cobalt changes to Fly.io

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,18 @@ name: CI
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      deploy_cobalt:
+        description: Deploy Cobalt to Fly.io after verification
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - main
+
+permissions:
+  contents: read
 
 jobs:
   verify:
@@ -23,3 +32,56 @@ jobs:
       - run: vp check
       - run: vp test
       - run: vp build
+
+  fly_changes:
+    name: Check for Cobalt deployment changes
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.changes.outputs.should_deploy }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check deployment inputs
+        id: changes
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          DEPLOY_COBALT: ${{ inputs.deploy_cobalt }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should_deploy=$DEPLOY_COBALT" >> "$GITHUB_OUTPUT"
+          elif [ -z "$BEFORE_SHA" ] || ! git cat-file -e "$BEFORE_SHA^{commit}" 2>/dev/null; then
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          elif git diff --quiet "$BEFORE_SHA" "$GITHUB_SHA" -- \
+            fly.cobalt.toml \
+            Dockerfile.cobalt \
+            .dockerignore \
+            cobalt-machine-proxy.mjs; then
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy_cobalt:
+    name: Deploy Cobalt to Fly.io
+    needs:
+      - verify
+      - fly_changes
+    if: github.ref == 'refs/heads/main' && needs.fly_changes.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    concurrency:
+      group: tagium-cobalt-production
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
+
+      - name: Deploy Cobalt
+        run: flyctl deploy --remote-only --wait-timeout 10m --config fly.cobalt.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary

- deploys `tagium-cobalt` to Fly.io after the existing CI verification succeeds on `main`
- limits automatic deployments to changes in the Fly configuration, Cobalt Docker inputs, or proxy wrapper
- adds an explicit `deploy_cobalt` opt-in for manual workflow runs
- serializes production rollouts and keeps `flyctl` attached long enough for the readiness check and graceful drain window

## Safety

- pull requests never receive deployment secrets or run the deployment job
- manual deployments are restricted to `main`
- the Fly setup action is pinned to the v1.6 commit
- deployment uses the existing GitHub `production` environment and an app-scoped `FLY_API_TOKEN`
- active rollouts are not cancelled by newer runs
- `flyctl deploy` waits up to 10 minutes so #66's 270-second drain and 300-second kill timeout can complete

## Verification

- `actionlint .github/workflows/ci.yaml`
- `vp check`
- `vp test`: 26 files, 172 tests passed
- `vp build`
- changed-file and manual-dispatch branches simulated by the implementation pass
- `git diff --check`

## Setup required

Before merging, add an app-scoped `FLY_API_TOKEN` to the GitHub `production` environment. The environment exists, but that secret is not currently configured.

## Stack

Depends on #66.