### PR TITLE
fix: align media URL placeholder

### DIFF
--- a/components/audio/AudioDownloader.tsx
+++ b/components/audio/AudioDownloader.tsx
@@ -59,7 +59,7 @@ export default function AudioDownloader({ onUrlImport }: AudioDownloaderProps) {
                 void handleDownload();
               }
             }}
-            placeholder="paste media url"
+            placeholder="soundcloud or youtube url"
             className="pl-9 placeholder:text-muted-foreground/45"
             disabled={downloading}
           />


### PR DESCRIPTION
## What changed\nUpdated the tag editor media URL input placeholder to match the landing page: `soundcloud or youtube url`.\n\n## Why\nThe two import entry points presented inconsistent guidance despite accepting the same sources.\n\n## Validation\n- `bun run lint`\n- `bun run typecheck`