### PR TITLE
fix: install Bun for production deploy

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -68,6 +68,10 @@ jobs:
           node-version: "24"
           cache: true
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.10"
+
       - run: vp install
       - name: Build production Worker
         run: vp build


### PR DESCRIPTION
## What changed\nInstall Bun 1.3.10 in the production deploy job before running the existing Bun deploy script.\n\n## Why\nPost-merge deployments failed with `bun: command not found` even though CI and E2E passed.\n\n## Impact\nMerged changes can deploy to the production Cloudflare Worker again.\n\n## Validation\n- `bun run lint`\n- `bun run typecheck`\n- `bun run build`