### PR TITLE
Propagate canceled downloads to Cobalt

### DIFF
--- a/server-tests/cobalt/audio.post.test.ts
+++ b/server-tests/cobalt/audio.post.test.ts
@@ -14,7 +14,7 @@ type RuntimeRequest = Request & {
 
 const machineAffinitySecret = "test-machine-affinity-secret";
 
-const makeAudioRequest = () => {
+const makeAudioRequest = (signal?: AbortSignal) => {
   const request = new Request("https://tagium.test/api/cobalt/audio", {
     method: "POST",
     headers: {
@@ -25,6 +25,7 @@ const makeAudioRequest = () => {
       url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
       audioBitrate: "128",
     }),
+    signal,
   }) as RuntimeRequest;
 
   request.runtime = {
@@ -210,6 +211,44 @@ describe("cobalt audio endpoint", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(response.status).toBe(502);
     expect(await response.text()).toBe("error.api.fetch.fail");
+  });
+
+  it("propagates client cancellation to the upstream Cobalt request", async () => {
+    const clientAbort = new AbortController();
+    let upstreamSignal: AbortSignal | undefined;
+    let releaseUpstream!: () => void;
+    const upstreamReleased = new Promise<void>((resolve) => {
+      releaseUpstream = resolve;
+    });
+    let upstreamStarted!: () => void;
+    const upstreamStart = new Promise<void>((resolve) => {
+      upstreamStarted = resolve;
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+        upstreamSignal = init?.signal ?? undefined;
+        upstreamStarted();
+        await upstreamReleased;
+        return Response.json({
+          status: "error",
+          error: { code: "error.api.fetch.fail" },
+        });
+      }),
+    );
+
+    const responsePromise = handler(makeEvent(makeAudioRequest(clientAbort.signal)));
+    await upstreamStart;
+    clientAbort.abort(new DOMException("canceled", "AbortError"));
+    await Promise.resolve();
+
+    try {
+      expect(upstreamSignal?.aborted).toBe(true);
+    } finally {
+      releaseUpstream();
+      await responsePromise;
+    }
   });
 
   it("preserves Cobalt capacity overload responses", async () => {

--- a/server/api/cobalt/audio.post.ts
+++ b/server/api/cobalt/audio.post.ts
@@ -177,6 +177,7 @@ const requestCobaltAudio = async (
   runtimeEnv: CobaltRuntimeEnv,
   url: string,
   audioBitrate: string,
+  requestSignal: AbortSignal,
 ): Promise<CobaltAudioResult> => {
   let response: Response;
 
@@ -185,7 +186,7 @@ const requestCobaltAudio = async (
     response = await fetch(endpoint, {
       method: "POST",
       redirect: "manual",
-      signal: AbortSignal.timeout(COBALT_REQUEST_TIMEOUT_MS),
+      signal: AbortSignal.any([requestSignal, AbortSignal.timeout(COBALT_REQUEST_TIMEOUT_MS)]),
       headers: getCobaltHeaders(runtimeEnv),
       body: JSON.stringify({
         url,
@@ -362,7 +363,12 @@ export default defineHandler(async (event) => {
       return new Response("Invalid audio download request.", { status: 400 });
     }
 
-    const cobaltResult = await requestCobaltAudio(runtimeEnv, body.url, body.audioBitrate);
+    const cobaltResult = await requestCobaltAudio(
+      runtimeEnv,
+      body.url,
+      body.audioBitrate,
+      event.req.signal,
+    );
     const cobaltResponse = cobaltResult.response;
 
     if (isCobaltCapacityError(cobaltResponse)) {


### PR DESCRIPTION
## Summary

- combines the incoming audio request signal with the existing five-minute Cobalt timeout
- aborts the Worker-to-Fly fetch when the browser cancels the queue
- preserves timeout protection while allowing the Fly proxy's existing disconnect cleanup to destroy upstream Cobalt work
- adds a route-level regression that holds the upstream fetch open and verifies cancellation reaches its signal

## Root cause

The browser canceled `/api/cobalt/audio`, but `requestCobaltAudio` replaced that signal with `AbortSignal.timeout(...)`. The Worker could therefore continue waiting on Fly after the user had canceled locally.

## Verification

- red-before-fix regression: upstream signal remained un-aborted
- `vp test run server-tests/cobalt/audio.post.test.ts`
- `bun run test server-tests/cobalt-machine-proxy.test.js`
- top-of-stack full checks, build, and E2E pass

## Stack

Depends on #71.

## Manual propagation check

1. Start `fly logs -a tagium-cobalt` in a terminal and filter for `client response closed`, `client request aborted`, or `client aborted while queued`.
2. Open the Cloudflare preview for this stack, start a multi-track SoundCloud set, and click X while several tracks are active.
3. Confirm cancellation log entries appear within seconds with `path: "/"`. Each entry is the Fly proxy destroying or removing work because its Worker client disconnected.
4. For an in-flight request ID that logged cancellation, confirm no later `upstream response ended` entry appears for that same ID.

Automated equivalents:

- `vp test run server-tests/cobalt/audio.post.test.ts -t "propagates client cancellation"`
- `vp test run server-tests/cobalt-machine-proxy.test.js -t "destroys the upstream tunnel"`