### PR TITLE
Enforce server-side Cobalt request admission

### DIFF
--- a/server-tests/cobalt/audio.post.test.ts
+++ b/server-tests/cobalt/audio.post.test.ts
@@ -7,12 +7,30 @@ type RuntimeRequest = Request & {
       env: {
         COBALT_API_URL: string;
         COBALT_MACHINE_AFFINITY_SECRET: string;
+        COBALT_SESSION_RATE_LIMITER?: RateLimitBinding;
+        COBALT_CLIENT_RATE_LIMITER?: RateLimitBinding;
+        TAGIUM_DEPLOY_ENV: "local" | "preview" | "production";
       };
     };
   };
 };
 
+type RateLimitBinding = {
+  limit: (input: { key: string }) => Promise<{ success: boolean }>;
+};
+
 const machineAffinitySecret = "test-machine-affinity-secret";
+
+const createRateLimitBinding = (limit: number): RateLimitBinding => {
+  const counts = new Map<string, number>();
+  return {
+    limit: async ({ key }) => {
+      const count = (counts.get(key) ?? 0) + 1;
+      counts.set(key, count);
+      return { success: count <= limit };
+    },
+  };
+};
 
 const makeAudioRequest = (signal?: AbortSignal) => {
   const request = new Request("https://tagium.test/api/cobalt/audio", {
@@ -33,6 +51,7 @@ const makeAudioRequest = (signal?: AbortSignal) => {
       env: {
         COBALT_API_URL: "https://cobalt.test/",
         COBALT_MACHINE_AFFINITY_SECRET: machineAffinitySecret,
+        TAGIUM_DEPLOY_ENV: "local",
       },
     },
   };
@@ -249,6 +268,96 @@ describe("cobalt audio endpoint", () => {
       releaseUpstream();
       await responsePromise;
     }
+  });
+
+  it("rejects the twenty-first session plan before calling Cobalt", async () => {
+    const sessionLimiter = createRateLimitBinding(20);
+    const clientLimiter = createRateLimitBinding(60);
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        status: "tunnel",
+        url: "https://cobalt.test/tunnel?id=123456789012345678901",
+        filename: "download.mp3",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const responses: Response[] = [];
+    for (let index = 0; index < 21; index += 1) {
+      const request = makeAudioRequest();
+      request.headers.set("Cookie", "tagium_client_id=session-1");
+      request.headers.set("CF-Connecting-IP", "203.0.113.10");
+      request.runtime.cloudflare.env.COBALT_SESSION_RATE_LIMITER = sessionLimiter;
+      request.runtime.cloudflare.env.COBALT_CLIENT_RATE_LIMITER = clientLimiter;
+      responses.push(await handler(makeEvent(request)));
+    }
+
+    expect(responses.slice(0, 20).every((response) => response.status === 200)).toBe(true);
+    expect(responses[20].status).toBe(429);
+    expect(responses[20].headers.get("Retry-After")).toBe("60");
+    expect(fetchMock).toHaveBeenCalledTimes(20);
+  });
+
+  it("limits rotating sessions with the coarse client backstop", async () => {
+    const sessionLimiter = createRateLimitBinding(20);
+    const clientLimiter = createRateLimitBinding(60);
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        status: "tunnel",
+        url: "https://cobalt.test/tunnel?id=123456789012345678901",
+        filename: "download.mp3",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    let lastResponse: Response | undefined;
+    for (let index = 0; index < 61; index += 1) {
+      const request = makeAudioRequest();
+      request.headers.set("Cookie", `tagium_client_id=session-${index}`);
+      request.headers.set("CF-Connecting-IP", "203.0.113.10");
+      request.runtime.cloudflare.env.COBALT_SESSION_RATE_LIMITER = sessionLimiter;
+      request.runtime.cloudflare.env.COBALT_CLIENT_RATE_LIMITER = clientLimiter;
+      lastResponse = await handler(makeEvent(request));
+    }
+
+    expect(lastResponse?.status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledTimes(60);
+  });
+
+  it("fails closed when production admission bindings are missing", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const request = makeAudioRequest();
+    request.runtime.cloudflare.env.TAGIUM_DEPLOY_ENV = "production";
+
+    const response = await handler(makeEvent(request));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("2");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("sets an anonymous admission cookie on the first admitted request", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          status: "tunnel",
+          url: "https://cobalt.test/tunnel?id=123456789012345678901",
+          filename: "download.mp3",
+        }),
+      ),
+    );
+    const request = makeAudioRequest();
+    request.runtime.cloudflare.env.COBALT_SESSION_RATE_LIMITER = createRateLimitBinding(20);
+    request.runtime.cloudflare.env.COBALT_CLIENT_RATE_LIMITER = createRateLimitBinding(60);
+
+    const response = await handler(makeEvent(request));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Set-Cookie")).toMatch(
+      /^tagium_client_id=[\w-]+; Path=\/; Max-Age=2592000; HttpOnly; Secure; SameSite=Lax$/,
+    );
   });
 
   it("preserves Cobalt capacity overload responses", async () => {

--- a/server/api/cobalt/audio.post.ts
+++ b/server/api/cobalt/audio.post.ts
@@ -11,8 +11,15 @@ import { env as processEnv } from "node:process";
 import { z } from "zod";
 import { parseCobaltMachineId, signCobaltMachine } from "../../utils/cobalt-machine-affinity";
 import {
+  createCloudflareCobaltRequestAdmission,
+  createInMemoryCobaltRequestAdmission,
+  type CloudflareRateLimitBinding,
+  type CobaltRequestAdmission,
+} from "../../utils/cobalt-request-admission";
+import {
   consumeAudioDevFault,
   enforceRateLimit,
+  getDeployEnv,
   type CobaltRuntimeEnv as DevControlRuntimeEnv,
 } from "../../utils/dev-controls";
 
@@ -85,7 +92,9 @@ type CobaltRuntimeEnv = {
   COBALT_ALLOWED_ORIGIN?: string;
   COBALT_API_KEY?: string;
   COBALT_API_URL?: string;
+  COBALT_CLIENT_RATE_LIMITER?: CloudflareRateLimitBinding;
   COBALT_MACHINE_AFFINITY_SECRET?: string;
+  COBALT_SESSION_RATE_LIMITER?: CloudflareRateLimitBinding;
 } & DevControlRuntimeEnv;
 type CloudflareRequest = Request & {
   runtime?: {
@@ -339,6 +348,41 @@ const parseAudioRequest = async (request: Request) => {
   }
 };
 
+const getCobaltRequestAdmission = (
+  request: Request,
+  runtimeEnv: CobaltRuntimeEnv,
+): CobaltRequestAdmission | undefined => {
+  if (runtimeEnv.COBALT_SESSION_RATE_LIMITER && runtimeEnv.COBALT_CLIENT_RATE_LIMITER) {
+    return createCloudflareCobaltRequestAdmission({
+      sessionLimiter: runtimeEnv.COBALT_SESSION_RATE_LIMITER,
+      clientLimiter: runtimeEnv.COBALT_CLIENT_RATE_LIMITER,
+    });
+  }
+
+  if (getDeployEnv(request, runtimeEnv).deployEnv === "local") {
+    return createInMemoryCobaltRequestAdmission(enforceRateLimit);
+  }
+
+  return undefined;
+};
+
+const admissionUnavailableResponse = () =>
+  new Response("Download admission is unavailable.", {
+    status: 503,
+    headers: { "Retry-After": "2" },
+  });
+
+const admissionLimitedResponse = () =>
+  new Response("Download rate limit exceeded.", {
+    status: 429,
+    headers: { "Retry-After": "60" },
+  });
+
+const withAdmissionCookie = (response: Response, setCookie: string | undefined) => {
+  if (setCookie) response.headers.append("Set-Cookie", setCookie);
+  return response;
+};
+
 export default defineHandler(async (event) => {
   try {
     const runtimeEnv = getRuntimeEnv(event.req);
@@ -353,14 +397,22 @@ export default defineHandler(async (event) => {
       return devFaultResponse;
     }
 
-    const limited = enforceRateLimit(event.req);
-    if (limited) {
-      return limited;
-    }
-
     const body = await parseAudioRequest(event.req);
     if (!body) {
       return new Response("Invalid audio download request.", { status: 400 });
+    }
+
+    const admission = getCobaltRequestAdmission(event.req, runtimeEnv);
+    if (!admission) return admissionUnavailableResponse();
+
+    const admissionDecision = await admission.admit(event.req);
+    const respond = (response: Response) =>
+      withAdmissionCookie(response, admissionDecision.setCookie);
+    if (admissionDecision.status === "unavailable") {
+      return respond(admissionUnavailableResponse());
+    }
+    if (admissionDecision.status === "limited") {
+      return respond(admissionLimitedResponse());
     }
 
     const cobaltResult = await requestCobaltAudio(
@@ -372,35 +424,43 @@ export default defineHandler(async (event) => {
     const cobaltResponse = cobaltResult.response;
 
     if (isCobaltCapacityError(cobaltResponse)) {
-      return cobaltCapacityErrorResponse(cobaltResponse, cobaltResult.retryAfter);
+      return respond(cobaltCapacityErrorResponse(cobaltResponse, cobaltResult.retryAfter));
     }
 
     if (cobaltResponse.status === CobaltResponseType.Error) {
-      return cobaltErrorResponse(cobaltResponse.error.code);
+      return respond(cobaltErrorResponse(cobaltResponse.error.code));
     }
 
     if (cobaltResponse.status === CobaltResponseType.LocalProcessing) {
-      return localProcessingResponse(event.req, runtimeEnv, cobaltResponse, cobaltResult.machineId);
+      return respond(
+        localProcessingResponse(event.req, runtimeEnv, cobaltResponse, cobaltResult.machineId),
+      );
     }
 
     if (cobaltResponse.status === CobaltResponseType.Picker) {
       if (!cobaltResponse.audio || !cobaltResponse.audioFilename) {
-        return cobaltErrorResponse("Cobalt returned multiple items without a single audio file.");
+        return respond(
+          cobaltErrorResponse("Cobalt returned multiple items without a single audio file."),
+        );
       }
 
-      return proxiedTunnelResponse(
-        event.req,
-        runtimeEnv,
-        {
-          status: CobaltResponseType.Tunnel,
-          url: cobaltResponse.audio,
-          filename: cobaltResponse.audioFilename,
-        },
-        cobaltResult.machineId,
+      return respond(
+        proxiedTunnelResponse(
+          event.req,
+          runtimeEnv,
+          {
+            status: CobaltResponseType.Tunnel,
+            url: cobaltResponse.audio,
+            filename: cobaltResponse.audioFilename,
+          },
+          cobaltResult.machineId,
+        ),
       );
     }
 
-    return proxiedTunnelResponse(event.req, runtimeEnv, cobaltResponse, cobaltResult.machineId);
+    return respond(
+      proxiedTunnelResponse(event.req, runtimeEnv, cobaltResponse, cobaltResult.machineId),
+    );
   } catch (error) {
     if (error instanceof Error) {
       return cobaltErrorResponse(error.message);

--- a/server/utils/cobalt-request-admission.test.ts
+++ b/server/utils/cobalt-request-admission.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  createCloudflareCobaltRequestAdmission,
+  createInMemoryCobaltRequestAdmission,
+  type CloudflareRateLimitBinding,
+} from "./cobalt-request-admission";
+
+const binding = (success: boolean): CloudflareRateLimitBinding => ({
+  limit: vi.fn(async () => ({ success })),
+});
+
+const request = (headers: Record<string, string> = {}) =>
+  new Request("https://tagium.test/api/cobalt/audio", { headers });
+
+describe("cobaltRequestAdmission", () => {
+  it("uses the anonymous session and Cloudflare client keys", async () => {
+    const sessionLimiter = binding(true);
+    const clientLimiter = binding(true);
+    const admission = createCloudflareCobaltRequestAdmission({ sessionLimiter, clientLimiter });
+
+    await expect(
+      admission.admit(
+        request({
+          Cookie: "tagium_client_id=session-1",
+          "CF-Connecting-IP": "203.0.113.10",
+        }),
+      ),
+    ).resolves.toEqual({ status: "allowed", setCookie: undefined });
+    expect(sessionLimiter.limit).toHaveBeenCalledWith({ key: "session-1" });
+    expect(clientLimiter.limit).toHaveBeenCalledWith({ key: "203.0.113.10" });
+  });
+
+  it("issues an HttpOnly session cookie when one is missing", async () => {
+    const admission = createCloudflareCobaltRequestAdmission({
+      sessionLimiter: binding(true),
+      clientLimiter: binding(true),
+    });
+
+    const decision = await admission.admit(request({ "CF-Connecting-IP": "203.0.113.10" }));
+
+    expect(decision).toMatchObject({ status: "allowed" });
+    expect(decision.setCookie).toMatch(
+      /^tagium_client_id=[\w-]+; Path=\/; Max-Age=2592000; HttpOnly; Secure; SameSite=Lax$/,
+    );
+  });
+
+  it("gives the coarse client backstop precedence", async () => {
+    const admission = createCloudflareCobaltRequestAdmission({
+      sessionLimiter: binding(false),
+      clientLimiter: binding(false),
+    });
+
+    await expect(admission.admit(request())).resolves.toMatchObject({
+      status: "limited",
+      scope: "client",
+    });
+  });
+
+  it("fails closed when a binding is unavailable", async () => {
+    const admission = createCloudflareCobaltRequestAdmission({
+      sessionLimiter: {
+        limit: async () => {
+          throw new Error("binding unavailable");
+        },
+      },
+      clientLimiter: binding(true),
+    });
+
+    await expect(admission.admit(request())).resolves.toMatchObject({ status: "unavailable" });
+  });
+
+  it("normalizes the local in-memory limiter behind the same interface", async () => {
+    const allowed = createInMemoryCobaltRequestAdmission(() => undefined);
+    const limited = createInMemoryCobaltRequestAdmission(
+      () => new Response("limited", { status: 429 }),
+    );
+
+    await expect(allowed.admit(request())).resolves.toEqual({ status: "allowed" });
+    await expect(limited.admit(request())).resolves.toEqual({
+      status: "limited",
+      scope: "client",
+    });
+  });
+});

--- a/server/utils/cobalt-request-admission.ts
+++ b/server/utils/cobalt-request-admission.ts
@@ -1,0 +1,82 @@
+export type CloudflareRateLimitBinding = {
+  limit: (input: { key: string }) => Promise<{ success: boolean }>;
+};
+
+export type CobaltRequestAdmissionDecision =
+  | { status: "allowed"; setCookie?: string }
+  | { status: "limited"; scope: "session" | "client"; setCookie?: string }
+  | { status: "unavailable"; setCookie?: string };
+
+export interface CobaltRequestAdmission {
+  admit: (request: Request) => Promise<CobaltRequestAdmissionDecision>;
+}
+
+const SESSION_COOKIE_NAME = "tagium_client_id";
+const SESSION_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+const SESSION_KEY_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+const readCookie = (request: Request, name: string) => {
+  const cookieHeader = request.headers.get("cookie");
+  if (!cookieHeader) return undefined;
+
+  for (const entry of cookieHeader.split(";")) {
+    const separatorIndex = entry.indexOf("=");
+    if (separatorIndex < 0) continue;
+    const entryName = entry.slice(0, separatorIndex).trim();
+    if (entryName !== name) continue;
+    const value = entry.slice(separatorIndex + 1).trim();
+    if (SESSION_KEY_PATTERN.test(value)) return value;
+  }
+
+  return undefined;
+};
+
+const getSessionIdentity = (request: Request) => {
+  const existingKey = readCookie(request, SESSION_COOKIE_NAME);
+  if (existingKey) return { key: existingKey };
+
+  const key = crypto.randomUUID();
+  return {
+    key,
+    setCookie: `${SESSION_COOKIE_NAME}=${key}; Path=/; Max-Age=${SESSION_COOKIE_MAX_AGE_SECONDS}; HttpOnly; Secure; SameSite=Lax`,
+  };
+};
+
+const getClientKey = (request: Request) =>
+  request.headers.get("cf-connecting-ip") || "unknown-client";
+
+export const createCloudflareCobaltRequestAdmission = ({
+  sessionLimiter,
+  clientLimiter,
+}: {
+  sessionLimiter: CloudflareRateLimitBinding;
+  clientLimiter: CloudflareRateLimitBinding;
+}): CobaltRequestAdmission => ({
+  admit: async (request) => {
+    const session = getSessionIdentity(request);
+
+    try {
+      const [sessionResult, clientResult] = await Promise.all([
+        sessionLimiter.limit({ key: session.key }),
+        clientLimiter.limit({ key: getClientKey(request) }),
+      ]);
+
+      if (!clientResult.success) {
+        return { status: "limited", scope: "client", setCookie: session.setCookie };
+      }
+      if (!sessionResult.success) {
+        return { status: "limited", scope: "session", setCookie: session.setCookie };
+      }
+      return { status: "allowed", setCookie: session.setCookie };
+    } catch {
+      return { status: "unavailable", setCookie: session.setCookie };
+    }
+  },
+});
+
+export const createInMemoryCobaltRequestAdmission = (
+  enforce: (request: Request) => Response | undefined,
+): CobaltRequestAdmission => ({
+  admit: async (request) =>
+    enforce(request) ? { status: "limited", scope: "client" } : { status: "allowed" },
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,5 +1,23 @@
 {
   "name": "tagium",
+  "ratelimits": [
+    {
+      "name": "COBALT_SESSION_RATE_LIMITER",
+      "namespace_id": "1042701",
+      "simple": {
+        "limit": 20,
+        "period": 60,
+      },
+    },
+    {
+      "name": "COBALT_CLIENT_RATE_LIMITER",
+      "namespace_id": "1042702",
+      "simple": {
+        "limit": 60,
+        "period": 60,
+      },
+    },
+  ],
   "observability": {
     "enabled": false,
     "head_sampling_rate": 1,


### PR DESCRIPTION
## Summary

- adds a production Cobalt admission module with Cloudflare and in-memory adapters behind one interface
- limits anonymous sessions to 20 plan starts per 60 seconds
- adds a 60-start client/IP backstop to constrain session-cookie rotation
- issues a 30-day HttpOnly, Secure, SameSite=Lax anonymous admission cookie
- rejects denied requests with `429` and `Retry-After: 60` before calling Fly
- fails closed with `503` when production bindings are missing or unavailable
- configures both Cloudflare Rate Limiting bindings in `wrangler.jsonc`

## Protection model

The browser ledger prevents accidental restart spam and provides queue feedback. This server gate remains authoritative if client state resets or is bypassed. Fly's existing gates continue to protect Machine concurrency separately.

## Verification

- red-before-fix route regression: the 21st session request reached Cobalt and returned 200
- the 21st request now returns 429 while Fly is called exactly 20 times
- rotating session identifiers are stopped by the 60-request client backstop
- missing production bindings fail before the Fly fetch
- generated Wrangler config contains both 20/60s and 60/60s bindings
- `bun run deploy:production --dry-run` passed
- `vp check`
- full `vp test`: 31 files, 206 tests passed
- `vp build`
- `CI=1 bun run test:e2e`: 14 passed, 1 expected Firefox skip

## Stack

Depends on #72.