### PR TITLE
fix: align canceled track icon hover behavior

### DIFF
--- a/components/audio/AlbumSidebarDnd.tsx
+++ b/components/audio/AlbumSidebarDnd.tsx
@@ -206,7 +206,7 @@ export function SortableTrackRow({
               />
             )}
             {track.downloadStatus === "canceled" && (
-              <Ban className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+              <Ban className="h-3 w-3 text-muted-foreground flex-shrink-0 group-hover:opacity-0" />
             )}
           </div>
         </div>

--- a/components/audio/downloadPresentation.test.tsx
+++ b/components/audio/downloadPresentation.test.tsx
@@ -48,5 +48,6 @@ describe("download presentation", () => {
     );
 
     expect(markup).not.toContain(">canceled<");
+    expect(markup).toContain("h-3 w-3 text-muted-foreground flex-shrink-0 group-hover:opacity-0");
   });
 });


### PR DESCRIPTION
## What changed

- Hide the canceled-status icon when its track row is hovered.
- Keep the canceled, retry, and remove controls in one hover interaction.

## Why

The canceled icon remained visible while the retry and remove controls appeared, making the track-row actions feel split across different hover states.

## Validation

- `bunx vp test components/audio/downloadPresentation.test.tsx`
- Commit hook: `vp check --fix`