### PR TITLE
fix: keep tagged single uploads loose

### DIFF
--- a/components/audio/albumOps.test.ts
+++ b/components/audio/albumOps.test.ts
@@ -77,6 +77,33 @@ describe("albumOps", () => {
     expect(result.albumsToSync).toEqual([]);
   });
 
+  it("keeps a single upload with album metadata loose", () => {
+    const result = mergeUploadedTracksIntoAlbums(
+      [],
+      [upload("track-1", { title: "Tagged Album", artist: "Tagged Artist", genre: "Rock" })],
+    );
+
+    expect(result.albums).toEqual([]);
+    expect(result.firstSelectedAlbumId).toBeNull();
+    expect(result.unassignedTrackIds).toEqual(["track-1"]);
+    expect(result.albumsToSync).toEqual([]);
+  });
+
+  it("groups only matching album metadata from a multi-track upload", () => {
+    const result = mergeUploadedTracksIntoAlbums(
+      [],
+      [
+        upload("track-1", { title: "Tagged Album", artist: "Tagged Artist", genre: "Rock" }),
+        upload("track-2", { title: "Tagged Album", artist: "Tagged Artist", genre: "Rock" }),
+        upload("track-3", { title: "Single Metadata", artist: "Tagged Artist", genre: "Rock" }),
+      ],
+    );
+
+    expect(result.albums).toHaveLength(1);
+    expect(result.albums[0].trackIds).toEqual(["track-1", "track-2"]);
+    expect(result.unassignedTrackIds).toEqual(["track-3"]);
+  });
+
   it("moves tracks between album and loose sidebar lists", () => {
     const result = moveTrackInSidebar(
       [album("album-1", ["a", "b"]), album("album-2", ["c"])],

--- a/components/audio/albumOps.ts
+++ b/components/audio/albumOps.ts
@@ -93,6 +93,12 @@ export function mergeUploadedTracksIntoAlbums(
   const albumByKey = new Map(
     nextAlbums.map((album) => [buildAlbumKey(album.title, album.artist), album]),
   );
+  const uploadedAlbumCounts = new Map<string, number>();
+  for (const { albumSeed } of parsedUploads) {
+    if (!albumSeed.title.trim()) continue;
+    const key = buildAlbumKey(albumSeed.title, albumSeed.artist);
+    uploadedAlbumCounts.set(key, (uploadedAlbumCounts.get(key) ?? 0) + 1);
+  }
   let firstSelectedAlbumId: string | null = null;
   const unassignedTrackIds: string[] = [];
   const albumsToSync = new Set<string>();
@@ -100,12 +106,12 @@ export function mergeUploadedTracksIntoAlbums(
   parsedUploads.forEach((upload, index) => {
     const { albumSeed } = upload;
 
-    if (!albumSeed.title.trim()) {
+    const key = buildAlbumKey(albumSeed.title, albumSeed.artist);
+    if (!albumSeed.title.trim() || (uploadedAlbumCounts.get(key) ?? 0) < 2) {
       unassignedTrackIds.push(upload.file.id);
       return;
     }
 
-    const key = buildAlbumKey(albumSeed.title, albumSeed.artist);
     let targetAlbum = albumByKey.get(key);
 
     if (!targetAlbum) {

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -761,7 +761,7 @@ export default function AudioTagger() {
             setFiles(syncedFiles);
           }
           const firstUploadedTrack = orderedUploads[0];
-          const firstTrackIsLoose = !forceSingleAlbum && !firstUploadedTrack.albumSeed.title.trim();
+          const firstTrackIsLoose = merged.unassignedTrackIds.includes(firstUploadedTrack.file.id);
           targetKind = firstTrackIsLoose ? "loose" : "album";
           setSelectedFileId(firstUploadedTrack.file.id);
           setSelectedAlbumId(firstTrackIsLoose ? null : firstSelectedAlbumId);


### PR DESCRIPTION
## What changed

- Keep a one-track upload loose even when its metadata includes an album.
- Create metadata-derived album groups only when at least two uploaded tracks share the same album title and artist.
- Select loose uploads correctly after import.

## Why

Single releases commonly carry an album tag but should not automatically become sidebar album groups.

## Validation

- `bunx vp test components/audio/albumOps.test.ts`
- `bun run typecheck`
- Commit hook: `vp check --fix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio import grouping so tracks are only assigned to an album when at least two uploads share matching album information.
  * Tracks without a matching album group remain unassigned instead of creating single-track albums.
  * Updated post-import selection behavior to correctly reflect loose, unassigned tracks.

* **Tests**
  * Added coverage for single-track uploads and mixed matching/non-matching album metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->