### PR TITLE
Keep download queues in sync with track deletion

### DIFF
--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -1287,6 +1287,7 @@ export default function AudioTagger() {
     (idsToRemove: string[]) => {
       const idSet = new Set(idsToRemove);
       const removedFiles = filesRef.current.filter((file) => idSet.has(file.id));
+      playlistDownloadControllerRef.current?.remove(idsToRemove);
       const affectedAlbumIds = albumsRef.current
         .filter((album) => album.trackIds.some((trackId) => idSet.has(trackId)))
         .map((album) => album.id);

--- a/components/audio/playlistDownloadController.test.ts
+++ b/components/audio/playlistDownloadController.test.ts
@@ -218,6 +218,43 @@ describe("playlistDownloadController", () => {
     ]);
   });
 
+  it("removes deleted active and pending tracks from the current run", async () => {
+    const harness = createControllerHarness();
+
+    harness.controller.enqueue(tracks(5));
+    await flushEffects();
+    harness.controller.remove(["track-2", "track-5"]);
+    await flushEffects();
+
+    expect(harness.downloadSignals.get("track-2")?.aborted).toBe(true);
+    expect(harness.downloadStarts).not.toContain("track-5");
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      trackIds: ["track-1", "track-3", "track-4"],
+      total: 3,
+      active: [{ fileId: "track-1" }, { fileId: "track-3" }, { fileId: "track-4" }],
+      pending: 0,
+    });
+  });
+
+  it("removes a deleted completed track from both progress counts", async () => {
+    const harness = createControllerHarness();
+
+    harness.controller.enqueue(tracks(4));
+    await flushEffects();
+    harness.downloads.get("track-1")?.resolve(audioFile("track-1.mp3"));
+    await flushEffects();
+
+    expect(harness.controller.getSnapshot()).toMatchObject({ total: 4, completed: 1 });
+
+    harness.controller.remove(["track-1"]);
+
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      trackIds: ["track-2", "track-3", "track-4"],
+      total: 3,
+      completed: 0,
+    });
+  });
+
   it("keeps the local tunnel budget across repeated cancel and restart cycles", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);

--- a/components/audio/playlistDownloadController.ts
+++ b/components/audio/playlistDownloadController.ts
@@ -11,6 +11,7 @@ import {
   markPlaylistDownloadTrackCompleted,
   markPlaylistDownloadTrackFailed,
   removeActivePlaylistDownloadTrack,
+  removePlaylistDownloadTracks,
   reserveNextPlaylistDownloadTrack,
   type PlaylistDownloadQueueRun,
   type PlaylistDownloadQueueRuntimeSnapshot,
@@ -64,6 +65,7 @@ export interface PlaylistDownloadControllerDeps<Track extends PlaylistDownloadRu
 export interface PlaylistDownloadController<Track extends PlaylistDownloadRuntimeTrack> {
   enqueue: (tracks: Track[]) => void;
   cancel: () => void;
+  remove: (trackIds: string[]) => void;
   retry: (tracks: Track[]) => void;
   getSnapshot: () => PlaylistDownloadControllerSnapshot | null;
 }
@@ -183,10 +185,13 @@ export const createPlaylistDownloadController = <Track extends PlaylistDownloadR
     exit: Exit.Exit<void, unknown>,
   ) => {
     run.activeFibers.delete(track.fileId);
+    const trackWasRemoved = !run.model.items.some((item) => item.id === track.fileId);
 
     if (Exit.isFailure(exit)) {
       const error = firstCauseError(exit.cause);
-      if (Exit.hasInterrupts(exit) || isPlaylistDownloadAbort(error)) {
+      if (trackWasRemoved) {
+        deps.onTrackSettled?.({ track, outcome: "canceled" });
+      } else if (Exit.hasInterrupts(exit) || isPlaylistDownloadAbort(error)) {
         markPlaylistDownloadTrackCanceled(run, track.fileId, now());
         deps.onTrackSettled?.({ track, outcome: "canceled" });
         if (currentRun === run) {
@@ -286,6 +291,23 @@ export const createPlaylistDownloadController = <Track extends PlaylistDownloadR
       deps.onAction?.({ type: "cancel_requested", snapshot: createSnapshot(currentRun) });
       currentRun.canceled = true;
       cancelActive(currentRun);
+      publish(currentRun);
+      pump(currentRun);
+    },
+    remove: (trackIds) => {
+      if (!currentRun || trackIds.length === 0) return;
+
+      const removed = removePlaylistDownloadTracks(currentRun, trackIds);
+      if (removed.removedTrackIds.length === 0) return;
+
+      for (const track of removed.pendingTracks) {
+        deps.onTrackSettled?.({ track, outcome: "canceled" });
+      }
+      for (const trackId of removed.activeTrackIds) {
+        const fiber = currentRun.activeFibers.get(trackId);
+        if (fiber) Effect.runFork(Fiber.interrupt(fiber));
+      }
+
       publish(currentRun);
       pump(currentRun);
     },

--- a/components/audio/playlistDownloadQueueRuntime.test.ts
+++ b/components/audio/playlistDownloadQueueRuntime.test.ts
@@ -10,6 +10,7 @@ import {
   markPlaylistDownloadTrackCompleted,
   markPlaylistDownloadTrackFailed,
   removeActivePlaylistDownloadTrack,
+  removePlaylistDownloadTracks,
   reserveNextPlaylistDownloadTrack,
 } from "./playlistDownloadQueueRuntime";
 import type { PlaylistDownloadRuntimeTrack } from "./playlistDownloadQueueRuntime";
@@ -156,5 +157,32 @@ describe("playlistDownloadQueueRuntime", () => {
       "canceled",
     ]);
     expect(derivePlaylistDownloadQueueState(run, 1_000).canceledCount).toBe(3);
+  });
+
+  it("removes deleted tracks from totals while retaining active work until it settles", () => {
+    const run = createRun(5);
+    const firstTrack = reserve(run, 0);
+    const secondTrack = reserve(run, 0);
+    markPlaylistDownloadTrackActive(run, firstTrack, 0);
+    markPlaylistDownloadTrackActive(run, secondTrack, 0);
+    markPlaylistDownloadTrackCompleted(run, firstTrack.fileId, 1_000);
+    removeActivePlaylistDownloadTrack(run, firstTrack.fileId);
+
+    const result = removePlaylistDownloadTracks(run, ["track-1", "track-2", "track-5"]);
+
+    expect(result).toEqual({
+      removedTrackIds: ["track-1", "track-2", "track-5"],
+      pendingTracks: [expect.objectContaining({ fileId: "track-5" })],
+      activeTrackIds: ["track-2"],
+    });
+    expect(run.active.map((track) => track.fileId)).toEqual(["track-2"]);
+    expect(run.pending.map((track) => track.fileId)).toEqual(["track-3", "track-4"]);
+    expect(derivePlaylistDownloadQueueState(run, 1_000)).toMatchObject({
+      trackIds: ["track-3", "track-4"],
+      total: 2,
+      completed: 0,
+      active: [],
+      pending: 2,
+    });
   });
 });

--- a/components/audio/playlistDownloadQueueRuntime.ts
+++ b/components/audio/playlistDownloadQueueRuntime.ts
@@ -71,6 +71,12 @@ export type ReserveNextPlaylistDownloadResult<Track extends PlaylistDownloadRunt
       waitMs: number;
     };
 
+export type RemovePlaylistDownloadTracksResult<Track extends PlaylistDownloadRuntimeTrack> = {
+  removedTrackIds: string[];
+  pendingTracks: Track[];
+  activeTrackIds: string[];
+};
+
 export const createPlaylistDownloadQueueRun = <Track extends PlaylistDownloadRuntimeTrack>(
   id: number,
   tracks: Track[],
@@ -96,6 +102,7 @@ export const derivePlaylistDownloadQueueState = (
   nowMs: number,
 ): PlaylistDownloadQueueRuntimeSnapshot => {
   const summary = derivePlaylistDownloadQueueSummary(run.model, nowMs);
+  const queuedTrackIds = new Set(run.trackIds);
 
   return {
     id: run.id,
@@ -105,13 +112,43 @@ export const derivePlaylistDownloadQueueState = (
     failed: summary.failedCount,
     canceledCount: summary.canceledCount,
     pending: summary.pendingCount,
-    active: run.active,
+    // Deleted active work remains internal until its fiber settles, preserving the concurrency cap.
+    active: run.active.filter((track) => queuedTrackIds.has(track.fileId)),
     startedAt: run.startedAt,
     etaMs: summary.etaMs,
     canceled: run.canceled,
     done: run.done,
     waitingForTunnelBudget: !run.done && run.waitingForTunnelBudget,
   };
+};
+
+export const removePlaylistDownloadTracks = <Track extends PlaylistDownloadRuntimeTrack>(
+  run: PlaylistDownloadQueueRun<Track>,
+  trackIds: string[],
+): RemovePlaylistDownloadTracksResult<Track> => {
+  const requestedTrackIds = new Set(trackIds);
+  const removedItems = run.model.items.filter((item) => requestedTrackIds.has(item.id));
+  if (removedItems.length === 0) {
+    return { removedTrackIds: [], pendingTracks: [], activeTrackIds: [] };
+  }
+
+  const removedTrackIds = new Set(removedItems.map((item) => item.id));
+  const pendingTracks = run.pending.filter((track) => removedTrackIds.has(track.fileId));
+  const activeTrackIds = run.active
+    .filter((track) => removedTrackIds.has(track.fileId))
+    .map((track) => track.fileId);
+
+  run.pending = run.pending.filter((track) => !removedTrackIds.has(track.fileId));
+  run.trackIds = run.trackIds.filter((trackId) => !removedTrackIds.has(trackId));
+  run.model = {
+    ...run.model,
+    items: run.model.items.filter((item) => !removedTrackIds.has(item.id)),
+  };
+  run.total = run.model.items.length;
+  run.completed -= removedItems.filter((item) => item.status === "completed").length;
+  run.failed -= removedItems.filter((item) => item.status === "failed").length;
+
+  return { removedTrackIds: [...removedTrackIds], pendingTracks, activeTrackIds };
 };
 
 export const enqueuePlaylistDownloadQueueTracks = <Track extends PlaylistDownloadRuntimeTrack>(

--- a/e2e/download-queue-deletion.spec.ts
+++ b/e2e/download-queue-deletion.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+
+test("removing downloading and queued tracks updates the current run", async ({ page }) => {
+  const sourceUrls: string[] = [];
+  let releaseDownloads = () => {};
+  const downloadsReleased = new Promise<void>((resolve) => {
+    releaseDownloads = resolve;
+  });
+
+  await page.route("**/api/soundcloud-set?**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        title: "Deletion Test Set",
+        artist: "Test Artist",
+        genre: "Test",
+        isAlbum: true,
+        tracks: Array.from({ length: 5 }, (_value, index) => ({
+          title: `Track ${index + 1}`,
+          url: `https://soundcloud.com/test/track-${index + 1}`,
+          duration: 60,
+          trackNumber: index + 1,
+        })),
+      }),
+    });
+  });
+  await page.route("**/api/cobalt/audio", async (route) => {
+    const body = route.request().postDataJSON() as { url: string };
+    sourceUrls.push(body.url);
+    await downloadsReleased;
+    await route
+      .fulfill({ status: 502, contentType: "text/plain", body: "test download released" })
+      .catch(() => {});
+  });
+
+  try {
+    await page.goto("/");
+    await page
+      .getByRole("textbox", { name: "media url" })
+      .fill("https://soundcloud.com/test/sets/deletion-test");
+    await page.getByRole("button", { name: "start media import" }).click();
+
+    await expect(page.getByText("downloading 0/5", { exact: true })).toBeVisible();
+    await expect.poll(() => sourceUrls).toHaveLength(3);
+
+    const removeButtons = page.getByRole("button", { name: "remove track" });
+    await removeButtons.first().click();
+    await page
+      .getByRole("dialog", { name: "remove track?" })
+      .getByRole("button", { name: "remove track" })
+      .click();
+
+    await expect(page.getByText("downloading 0/4", { exact: true })).toBeVisible();
+    await expect.poll(() => sourceUrls).toHaveLength(4);
+
+    await removeButtons.last().click();
+    await page
+      .getByRole("dialog", { name: "remove track?" })
+      .getByRole("button", { name: "remove track" })
+      .click();
+
+    await expect(page.getByText("downloading 0/3", { exact: true })).toBeVisible();
+    expect(sourceUrls).not.toContain("https://soundcloud.com/test/track-5");
+  } finally {
+    releaseDownloads();
+  }
+});


### PR DESCRIPTION
## Summary

- add an explicit queue-controller operation for removing deleted tracks from the current download run
- abort active deleted downloads, discard pending deleted downloads before they start, and remove settled deleted tracks from progress history
- preserve already-spent admission permits so deletion cannot bypass the download-start limit
- cover the user flow with controller/runtime tests and a Playwright regression across active and pending deletion

## Root cause

Track removal updated the library and album state but never notified the playlist download controller. The controller therefore retained its original item model and denominator, producing states such as an eight-track album alongside `downloading 9/15`.

## User impact

The queue denominator and progress now immediately reflect the tracks that still exist. Deleting active work propagates cancellation, deleting pending work prevents it from reaching the server, and remaining work continues under the existing concurrency limit.

## Verification

- `vp check`
- `vp test` — 31 files, 209 tests
- `vp build`
- `bunx playwright test` — 17 passed, 1 expected Firefox skip
