### PR TITLE
feat: support YouTube playlist downloads

### DIFF
--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -27,7 +27,7 @@ import {
   applyAlbumSharedTagsToFiles,
   applySyncedFilenamesToFiles,
   applyTrackOrderNumbersToFiles,
-  applySoundCloudSetImportedCover,
+  applyPlaylistImportedCover,
   areAlbumTrackCoversSynced,
   prepareDownloadedTrackHydration,
   resolveDownloadedTrackHydrationWrite,
@@ -44,7 +44,7 @@ import TagSidebarPanel from "./TagSidebarPanel";
 import type { PlaylistDownloadQueuePanelState } from "./PlaylistDownloadQueuePanel";
 import {
   createSingleUrlDownloadPlan,
-  createSoundCloudSetDownloadPlan,
+  createPlaylistDownloadPlan,
   fetchImportedCover,
   type QueuedDownloadTrack,
 } from "./downloadTrack";
@@ -67,7 +67,9 @@ import { loadAppSettings, saveAppSettings } from "./settings";
 import { getSampleAlbum } from "./sampleMetadata";
 import { hasRecoverableSessionWork, useBeforeUnloadProtection } from "./sessionSafety";
 import { createImportLifecycleTracker, type ImportLifecycleTracker } from "./importLifecycle";
-import { isSoundCloudSetUrl, resolveSoundCloudSet, type SoundCloudSet } from "./soundcloudSet";
+import { isSoundCloudSetUrl, resolveSoundCloudSet } from "./soundcloudSet";
+import type { Playlist } from "./playlist";
+import { isYouTubePlaylistUrl, resolveYouTubePlaylist } from "./youtubePlaylist";
 import { getDownloadErrorMessage, notifyDownloadError } from "./downloadErrorMessage";
 import {
   AlbumGroup,
@@ -1021,11 +1023,11 @@ export default function AudioTagger() {
     });
     queueDownloadTracks(plan.queuedTracks.map((track) => ({ ...track, importOperationId })));
   };
-  const handleSoundCloudSetDownload = (set: SoundCloudSet, importOperationId: string) => {
+  const handlePlaylistDownload = (playlist: Playlist, importOperationId: string) => {
     bufferCurrentFormMetadata();
     setActiveView("editor");
-    const plan = createSoundCloudSetDownloadPlan({
-      set,
+    const plan = createPlaylistDownloadPlan({
+      playlist,
       audioBitrate: settings.audioBitrate,
       createId: () => crypto.randomUUID(),
     });
@@ -1049,12 +1051,12 @@ export default function AudioTagger() {
             albums: coveredAlbums,
             files: coveredFiles,
             selectedMetadata,
-          } = applySoundCloudSetImportedCover(
+          } = applyPlaylistImportedCover(
             filesRef.current,
             albumsRef.current,
             coverImport.albumId,
             coverImport.trackIds,
-            coverImport.set,
+            coverImport.playlist,
             settings,
             cover,
             selectedFileIdRef.current,
@@ -1089,7 +1091,7 @@ export default function AudioTagger() {
 
     importLifecycleTrackerRef.current?.resolve(importOperationId, {
       trackIds: plan.queuedTracks.map((track) => track.fileId),
-      hasCover: Boolean(set.coverUrl),
+      hasCover: Boolean(playlist.coverUrl),
     });
     queueDownloadTracks(plan.queuedTracks.map((track) => ({ ...track, importOperationId })));
   };
@@ -1097,17 +1099,25 @@ export default function AudioTagger() {
     const trimmedUrl = sourceUrl.trim();
     if (!trimmedUrl) return;
 
-    const importKind = isSoundCloudSetUrl(trimmedUrl) ? "set" : "single";
+    const playlistProvider = isSoundCloudSetUrl(trimmedUrl)
+      ? "soundcloud"
+      : isYouTubePlaylistUrl(trimmedUrl)
+        ? "youtube"
+        : null;
+    const importKind = playlistProvider ? "set" : "single";
     const importOperationId = importLifecycleTrackerRef.current!.start({
       sourceUrl: trimmedUrl,
       importKind,
     });
     setUrlImporting(true);
     try {
-      if (importKind === "set") {
+      if (playlistProvider) {
         try {
-          const set = await resolveSoundCloudSet(trimmedUrl);
-          handleSoundCloudSetDownload(set, importOperationId);
+          const playlist =
+            playlistProvider === "soundcloud"
+              ? await resolveSoundCloudSet(trimmedUrl)
+              : await resolveYouTubePlaylist(trimmedUrl);
+          handlePlaylistDownload(playlist, importOperationId);
         } catch (error) {
           importLifecycleTrackerRef.current?.fail(importOperationId, error, "resolve");
           throw error;

--- a/components/audio/downloadTrack.ts
+++ b/components/audio/downloadTrack.ts
@@ -5,6 +5,7 @@ import {
   normalizeCoverArtType,
   optimizeCoverArt,
 } from "./coverArtProcessing";
+import type { Playlist } from "./playlist";
 import type { SoundCloudSet } from "./soundcloudSet";
 import type { AlbumGroup, AppSettings, AudioMetadata, MetadataPatch, TagiumFile } from "./types";
 
@@ -39,20 +40,22 @@ export interface SingleUrlDownloadPlan extends DownloadTrackPlanBase {
   looseTrackIds: string[];
 }
 
-export interface SoundCloudSetCoverImportPlan {
+export interface PlaylistCoverImportPlan {
   albumId: string;
   trackIds: string[];
   coverUrl: string;
-  set: SoundCloudSet;
+  playlist: Playlist;
 }
 
-export interface SoundCloudSetDownloadPlan extends DownloadTrackPlanBase {
-  source: "soundcloud-set";
+export interface PlaylistDownloadPlan extends DownloadTrackPlanBase {
+  source: "playlist";
   album: AlbumGroup;
-  coverImport: SoundCloudSetCoverImportPlan | null;
+  coverImport: PlaylistCoverImportPlan | null;
 }
 
-export type DownloadTrackPlan = SingleUrlDownloadPlan | SoundCloudSetDownloadPlan;
+export type SoundCloudSetCoverImportPlan = PlaylistCoverImportPlan;
+export type SoundCloudSetDownloadPlan = PlaylistDownloadPlan;
+export type DownloadTrackPlan = SingleUrlDownloadPlan | PlaylistDownloadPlan;
 
 export interface CreateSingleUrlDownloadPlanInput {
   sourceUrl: string;
@@ -62,6 +65,12 @@ export interface CreateSingleUrlDownloadPlanInput {
 
 export interface CreateSoundCloudSetDownloadPlanInput {
   set: SoundCloudSet;
+  audioBitrate: AppSettings["audioBitrate"];
+  createId: () => string;
+}
+
+export interface CreatePlaylistDownloadPlanInput {
+  playlist: Playlist;
   audioBitrate: AppSettings["audioBitrate"];
   createId: () => string;
 }
@@ -81,10 +90,12 @@ export interface DownloadTrackWorkflowDeps {
 
 export type SingleUrlDownloadTrackWorkflowDeps = DownloadTrackWorkflowDeps;
 
-export interface SoundCloudSetDownloadWorkflowDeps extends DownloadTrackWorkflowDeps {
+export interface PlaylistDownloadWorkflowDeps extends DownloadTrackWorkflowDeps {
   getAlbums: () => AlbumGroup[];
   setAlbums: (albums: AlbumGroup[]) => void;
 }
+
+export type SoundCloudSetDownloadWorkflowDeps = PlaylistDownloadWorkflowDeps;
 
 const filenameFromTitle = (title: string) => {
   const filename = filenamify(title.trim(), { replacement: "-" });
@@ -215,15 +226,15 @@ export const createQueuedDownloadTracks = (
   files: readonly PendingDownloadTrack[],
 ): QueuedDownloadTrack[] => files.map(createQueuedDownloadTrack);
 
-const createSoundCloudSetPendingMetadataPatch = (
-  set: SoundCloudSet,
-  track: SoundCloudSet["tracks"][number],
+const createPlaylistPendingMetadataPatch = (
+  playlist: Playlist,
+  track: Playlist["tracks"][number],
 ): MetadataPatch => ({
   title: track.title,
-  artist: set.artist,
-  album: set.title,
-  genre: set.genre,
-  ...(set.year !== undefined ? { year: set.year } : {}),
+  artist: playlist.artist,
+  album: playlist.title,
+  genre: playlist.genre,
+  ...(playlist.year !== undefined ? { year: playlist.year } : {}),
   ...(track.trackNumber !== undefined ? { trackNumber: track.trackNumber } : {}),
 });
 
@@ -260,41 +271,41 @@ export const createSingleUrlDownloadPlan = ({
   };
 };
 
-export const createSoundCloudSetDownloadPlan = ({
-  set,
+export const createPlaylistDownloadPlan = ({
+  playlist,
   audioBitrate,
   createId,
-}: CreateSoundCloudSetDownloadPlanInput): SoundCloudSetDownloadPlan => {
+}: CreatePlaylistDownloadPlanInput): PlaylistDownloadPlan => {
   const albumId = createId();
-  const pendingFiles = set.tracks.map((track) =>
+  const pendingFiles = playlist.tracks.map((track) =>
     createPendingDownloadTrack(
       createId(),
       createDownloadMetadata({
         title: track.title,
-        artist: set.artist,
-        album: set.title,
-        genre: set.genre,
-        year: set.year,
+        artist: playlist.artist,
+        album: playlist.title,
+        genre: playlist.genre,
+        year: playlist.year,
         duration: track.duration,
         trackNumber: track.trackNumber,
       }),
       true,
       { sourceUrl: track.url, audioBitrate },
-      createSoundCloudSetPendingMetadataPatch(set, track),
+      createPlaylistPendingMetadataPatch(playlist, track),
     ),
   );
   const album: AlbumGroup = {
     id: albumId,
-    title: set.title,
-    artist: set.artist,
-    genre: set.genre,
+    title: playlist.title,
+    artist: playlist.artist,
+    genre: playlist.genre,
     trackIds: pendingFiles.map((file) => file.id),
-    year: set.year,
+    year: playlist.year,
   };
   const firstPendingFileId = pendingFiles[0]?.id ?? null;
 
   return {
-    source: "soundcloud-set",
+    source: "playlist",
     pendingFiles,
     queuedTracks: createQueuedDownloadTracks(pendingFiles),
     selection: {
@@ -304,24 +315,31 @@ export const createSoundCloudSetDownloadPlan = ({
       lastSelectedFileId: firstPendingFileId,
     },
     album,
-    coverImport: set.coverUrl
+    coverImport: playlist.coverUrl
       ? {
           albumId,
           trackIds: album.trackIds,
-          coverUrl: set.coverUrl,
-          set,
+          coverUrl: playlist.coverUrl,
+          playlist,
         }
       : null,
   };
 };
+
+export const createSoundCloudSetDownloadPlan = ({
+  set,
+  audioBitrate,
+  createId,
+}: CreateSoundCloudSetDownloadPlanInput): SoundCloudSetDownloadPlan =>
+  createPlaylistDownloadPlan({ playlist: set, audioBitrate, createId });
 
 export function startDownloadTrackPlan(
   plan: SingleUrlDownloadPlan,
   deps: SingleUrlDownloadTrackWorkflowDeps,
 ): void;
 export function startDownloadTrackPlan(
-  plan: SoundCloudSetDownloadPlan,
-  deps: SoundCloudSetDownloadWorkflowDeps,
+  plan: PlaylistDownloadPlan,
+  deps: PlaylistDownloadWorkflowDeps,
 ): void;
 export function startDownloadTrackPlan(
   plan: DownloadTrackPlan,
@@ -333,8 +351,8 @@ export function startDownloadTrackPlan(
   const nextFiles = [...deps.getFiles(), ...plan.pendingFiles];
   deps.setFiles(nextFiles);
 
-  if (plan.source === "soundcloud-set") {
-    const albumDeps = deps as SoundCloudSetDownloadWorkflowDeps;
+  if (plan.source === "playlist") {
+    const albumDeps = deps as PlaylistDownloadWorkflowDeps;
     albumDeps.setAlbums([...albumDeps.getAlbums(), plan.album]);
   } else {
     deps.addLooseTrackIds?.(plan.looseTrackIds);

--- a/components/audio/fileMetadataOps.ts
+++ b/components/audio/fileMetadataOps.ts
@@ -1,4 +1,5 @@
 import filenamify from "filenamify";
+import type { Playlist } from "./playlist";
 import type { SoundCloudSet } from "./soundcloudSet";
 import type { AlbumGroup, AudioMetadata, MetadataPatch, TagiumFile } from "./types";
 
@@ -364,12 +365,12 @@ export function areAlbumTrackCoversSynced(
   });
 }
 
-export function applySoundCloudSetImportedCover(
+export function applyPlaylistImportedCover(
   files: TagiumFile[],
   albums: AlbumGroup[],
   albumId: string,
   trackIds: string[],
-  set: Pick<SoundCloudSet, "isAlbum">,
+  playlist: Pick<Playlist, "isAlbum">,
   settings: { applySoundCloudAlbumCoverToTracks: boolean },
   cover: AudioMetadata["picture"],
   selectedFileId: string | null,
@@ -378,7 +379,7 @@ export function applySoundCloudSetImportedCover(
     currentAlbum.id === albumId ? { ...currentAlbum, cover } : currentAlbum,
   );
 
-  if (!set.isAlbum || !settings.applySoundCloudAlbumCoverToTracks) {
+  if (!playlist.isAlbum || !settings.applySoundCloudAlbumCoverToTracks) {
     return { albums: coveredAlbums, files };
   }
 
@@ -387,6 +388,27 @@ export function applySoundCloudSetImportedCover(
     ...applyAlbumCoverToFilesWithSelectedMetadata(files, trackIds, cover, selectedFileId),
   };
 }
+
+export const applySoundCloudSetImportedCover = (
+  files: TagiumFile[],
+  albums: AlbumGroup[],
+  albumId: string,
+  trackIds: string[],
+  set: Pick<SoundCloudSet, "isAlbum">,
+  settings: { applySoundCloudAlbumCoverToTracks: boolean },
+  cover: AudioMetadata["picture"],
+  selectedFileId: string | null,
+) =>
+  applyPlaylistImportedCover(
+    files,
+    albums,
+    albumId,
+    trackIds,
+    set,
+    settings,
+    cover,
+    selectedFileId,
+  );
 
 export function prepareDownloadedTrackHydration(
   currentFile: TagiumFile,

--- a/components/audio/playlist.ts
+++ b/components/audio/playlist.ts
@@ -1,0 +1,62 @@
+import { Effect, Schema } from "effect";
+import { AudioDecodeError, toPublicAudioError } from "./audioErrors";
+import { runAudioEffectWithoutServices } from "./audioRuntime";
+import type { ImportedAlbumMetadata } from "./types";
+
+const urlStringSchema = Schema.String.pipe(
+  Schema.refine((value): value is string => {
+    try {
+      new URL(value);
+      return true;
+    } catch {
+      return false;
+    }
+  }),
+);
+
+const playlistTrackSchema = Schema.Struct({
+  title: Schema.String,
+  url: urlStringSchema,
+  duration: Schema.optionalKey(Schema.Number),
+  trackNumber: Schema.Number,
+});
+
+const playlistSchema = Schema.Struct({
+  title: Schema.String,
+  artist: Schema.String,
+  genre: Schema.String,
+  year: Schema.optionalKey(Schema.Number),
+  isAlbum: Schema.Boolean,
+  coverUrl: Schema.optionalKey(Schema.String),
+  tracks: Schema.Array(playlistTrackSchema),
+});
+
+const decodePlaylistEffect = Schema.decodeUnknownEffect(playlistSchema);
+
+export type Playlist = Schema.Schema.Type<typeof playlistSchema>;
+
+export const decodePlaylist = async (input: unknown, providerName: string) => {
+  try {
+    return await runAudioEffectWithoutServices(
+      decodePlaylistEffect(input).pipe(
+        Effect.mapError(
+          (cause) =>
+            new AudioDecodeError({
+              message: `malformed ${providerName} playlist response.`,
+              cause,
+            }),
+        ),
+      ),
+    );
+  } catch (error) {
+    throw toPublicAudioError(error);
+  }
+};
+
+export const toImportedAlbumMetadata = (playlist: Playlist): ImportedAlbumMetadata => ({
+  title: playlist.title,
+  artist: playlist.artist,
+  genre: playlist.genre,
+  year: playlist.year,
+  coverUrl: playlist.coverUrl,
+});

--- a/components/audio/soundcloudSet.ts
+++ b/components/audio/soundcloudSet.ts
@@ -1,39 +1,6 @@
-import { Effect, Schema } from "effect";
-import { AudioDecodeError, toPublicAudioError } from "./audioErrors";
-import { runAudioEffectWithoutServices } from "./audioRuntime";
-import type { ImportedAlbumMetadata } from "./types";
+import { decodePlaylist, toImportedAlbumMetadata, type Playlist } from "./playlist";
 
-const urlStringSchema = Schema.String.pipe(
-  Schema.refine((value): value is string => {
-    try {
-      new URL(value);
-      return true;
-    } catch {
-      return false;
-    }
-  }),
-);
-
-const soundCloudSetTrackSchema = Schema.Struct({
-  title: Schema.String,
-  url: urlStringSchema,
-  duration: Schema.optionalKey(Schema.Number),
-  trackNumber: Schema.Number,
-});
-
-const soundCloudSetSchema = Schema.Struct({
-  title: Schema.String,
-  artist: Schema.String,
-  genre: Schema.String,
-  year: Schema.optionalKey(Schema.Number),
-  isAlbum: Schema.Boolean,
-  coverUrl: Schema.optionalKey(Schema.String),
-  tracks: Schema.Array(soundCloudSetTrackSchema),
-});
-
-const decodeSoundCloudSetEffect = Schema.decodeUnknownEffect(soundCloudSetSchema);
-
-export type SoundCloudSet = Schema.Schema.Type<typeof soundCloudSetSchema>;
+export type SoundCloudSet = Playlist;
 
 export const isSoundCloudSetUrl = (url: string) => {
   try {
@@ -60,27 +27,7 @@ export const resolveSoundCloudSet = async (url: string) => {
     throw new Error("soundcloud set route returned non-json. restart tagium dev server.");
   }
 
-  try {
-    return await runAudioEffectWithoutServices(
-      decodeSoundCloudSetEffect(await response.json()).pipe(
-        Effect.mapError(
-          (cause) =>
-            new AudioDecodeError({
-              message: "malformed SoundCloud set response.",
-              cause,
-            }),
-        ),
-      ),
-    );
-  } catch (error) {
-    throw toPublicAudioError(error);
-  }
+  return decodePlaylist(await response.json(), "SoundCloud");
 };
 
-export const toImportedAlbumMetadata = (set: SoundCloudSet): ImportedAlbumMetadata => ({
-  title: set.title,
-  artist: set.artist,
-  genre: set.genre,
-  year: set.year,
-  coverUrl: set.coverUrl,
-});
+export { toImportedAlbumMetadata };

--- a/components/audio/soundcloudSetImport.ts
+++ b/components/audio/soundcloudSetImport.ts
@@ -56,7 +56,7 @@ export const startSoundCloudSetCoverImport = (
         deps.getAlbums(),
         coverImport.albumId,
         coverImport.trackIds,
-        coverImport.set,
+        coverImport.playlist,
         deps.settings,
         cover,
         deps.getSelectedFileId?.() ?? null,

--- a/components/audio/youtubePlaylist.test.ts
+++ b/components/audio/youtubePlaylist.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { createPlaylistDownloadPlan } from "./downloadTrack";
+import type { Playlist } from "./playlist";
+import { isYouTubePlaylistUrl, resolveYouTubePlaylist } from "./youtubePlaylist";
+
+const playlist: Playlist = {
+  title: "Status Update Music",
+  artist: "lucida",
+  genre: "",
+  isAlbum: false,
+  coverUrl: "https://i.ytimg.com/playlist.jpg",
+  tracks: [
+    {
+      title: "First Track",
+      url: "https://www.youtube.com/watch?v=first-video",
+      duration: 254,
+      trackNumber: 1,
+    },
+    {
+      title: "Second Track",
+      url: "https://www.youtube.com/watch?v=second-video",
+      duration: 229,
+      trackNumber: 2,
+    },
+  ],
+};
+
+describe("YouTube playlist imports", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("recognizes canonical YouTube and YouTube Music playlist links", () => {
+    expect(
+      isYouTubePlaylistUrl(
+        "https://www.youtube.com/playlist?list=PLESiES1i-ThqUjxot6jWLDu90fxtkcpA0",
+      ),
+    ).toBe(true);
+    expect(isYouTubePlaylistUrl("https://music.youtube.com/playlist?list=PL123")).toBe(true);
+    expect(isYouTubePlaylistUrl("https://www.youtube.com/watch?v=video&list=PL123")).toBe(false);
+    expect(isYouTubePlaylistUrl("https://example.com/playlist?list=PL123")).toBe(false);
+  });
+
+  it("creates an album group and queues each playlist video independently", () => {
+    const ids = ["album-1", "track-1", "track-2"];
+    const plan = createPlaylistDownloadPlan({
+      playlist,
+      audioBitrate: "320",
+      createId: () => ids.shift()!,
+    });
+
+    expect(plan.source).toBe("playlist");
+    expect(plan.album).toMatchObject({
+      id: "album-1",
+      title: "Status Update Music",
+      artist: "lucida",
+      trackIds: ["track-1", "track-2"],
+    });
+    expect(plan.queuedTracks.map((track) => track.downloadRequest.sourceUrl)).toEqual([
+      "https://www.youtube.com/watch?v=first-video",
+      "https://www.youtube.com/watch?v=second-video",
+    ]);
+    expect(plan.pendingFiles.map((file) => file.pendingMetadataPatch?.trackNumber)).toEqual([1, 2]);
+    expect(plan.coverImport?.playlist.isAlbum).toBe(false);
+  });
+
+  it("rejects malformed playlist responses", async () => {
+    vi.stubGlobal("window", { location: { origin: "https://tagium.test" } });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          ...playlist,
+          tracks: [{ title: "Broken", url: "not-a-url", trackNumber: 1 }],
+        }),
+      ),
+    );
+
+    await expect(
+      resolveYouTubePlaylist("https://www.youtube.com/playlist?list=PL123"),
+    ).rejects.toThrow();
+  });
+});

--- a/components/audio/youtubePlaylist.ts
+++ b/components/audio/youtubePlaylist.ts
@@ -1,0 +1,35 @@
+import { decodePlaylist, type Playlist } from "./playlist";
+
+export type YouTubePlaylist = Playlist;
+
+export const isYouTubePlaylistUrl = (url: string) => {
+  try {
+    const parsedUrl = new URL(url);
+    const isYouTubeHost =
+      parsedUrl.hostname === "youtube.com" || parsedUrl.hostname.endsWith(".youtube.com");
+    return (
+      isYouTubeHost &&
+      parsedUrl.pathname.replace(/\/+$/, "") === "/playlist" &&
+      Boolean(parsedUrl.searchParams.get("list"))
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const resolveYouTubePlaylist = async (url: string) => {
+  const endpoint = new URL("/api/youtube-playlist", window.location.origin);
+  endpoint.searchParams.set("url", url);
+
+  const response = await fetch(endpoint);
+  if (!response.ok) {
+    throw new Error(`youtube playlist request failed (${response.status})`);
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (!contentType?.includes("application/json")) {
+    throw new Error("youtube playlist route returned non-json. restart tagium dev server.");
+  }
+
+  return decodePlaylist(await response.json(), "YouTube");
+};

--- a/e2e/youtube-playlist-import.spec.ts
+++ b/e2e/youtube-playlist-import.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+
+test("imports a YouTube playlist as an album-backed download queue", async ({ page }) => {
+  const playlistUrl = "https://www.youtube.com/playlist?list=PLESiES1i-ThqUjxot6jWLDu90fxtkcpA0";
+  const sourceUrls: string[] = [];
+  let releaseDownloads = () => {};
+  const downloadsReleased = new Promise<void>((resolve) => {
+    releaseDownloads = resolve;
+  });
+
+  await page.route("**/api/youtube-playlist?**", async (route) => {
+    expect(new URL(route.request().url()).searchParams.get("url")).toBe(playlistUrl);
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        title: "YouTube Playlist",
+        artist: "Playlist Owner",
+        genre: "",
+        isAlbum: false,
+        tracks: [
+          {
+            title: "First Video",
+            url: "https://www.youtube.com/watch?v=first-video",
+            duration: 120,
+            trackNumber: 1,
+          },
+          {
+            title: "Second Video",
+            url: "https://www.youtube.com/watch?v=second-video",
+            duration: 180,
+            trackNumber: 2,
+          },
+        ],
+      }),
+    });
+  });
+  await page.route("**/api/cobalt/audio", async (route) => {
+    const body = route.request().postDataJSON() as { url: string };
+    sourceUrls.push(body.url);
+    await downloadsReleased;
+    await route
+      .fulfill({ status: 502, contentType: "text/plain", body: "test download released" })
+      .catch(() => {});
+  });
+
+  try {
+    await page.goto("/");
+    await page.getByRole("textbox", { name: "media url" }).fill(playlistUrl);
+    await page.getByRole("button", { name: "start media import" }).click();
+
+    await expect(page.getByText("YouTube Playlist", { exact: true })).toBeVisible();
+    await expect(page.getByText("downloading 0/2", { exact: true })).toBeVisible();
+    await expect
+      .poll(() => sourceUrls)
+      .toEqual([
+        "https://www.youtube.com/watch?v=first-video",
+        "https://www.youtube.com/watch?v=second-video",
+      ]);
+  } finally {
+    releaseDownloads();
+  }
+});

--- a/server-tests/youtube-playlist.get.test.ts
+++ b/server-tests/youtube-playlist.get.test.ts
@@ -81,6 +81,7 @@ describe("youtube playlist endpoint", () => {
     };
     const html = [
       `<script>var ytInitialData = ${JSON.stringify(initialData)};</script>`,
+      `<script>ytcfg.set("EMERGENCY_BASE_URL", "/error"); window.onerror = function() { window.failed = true; };</script>`,
       `<script>ytcfg.set(${JSON.stringify({
         INNERTUBE_API_KEY: "api-key",
         INNERTUBE_CLIENT_VERSION: "2.20260708.00.00",

--- a/server-tests/youtube-playlist.get.test.ts
+++ b/server-tests/youtube-playlist.get.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import handler from "../server/api/youtube-playlist.get";
+
+const sourceUrl = "https://www.youtube.com/playlist?list=PLESiES1i-ThqUjxot6jWLDu90fxtkcpA0";
+
+const makeEvent = (url = sourceUrl) => {
+  const request = new Request(
+    `https://tagium.test/api/youtube-playlist?url=${encodeURIComponent(url)}`,
+  );
+  return { req: request } as unknown as Parameters<typeof handler>[0];
+};
+
+const lockupVideo = (videoId: string, title: string, duration: string) => ({
+  lockupViewModel: {
+    contentId: videoId,
+    contentType: "LOCKUP_CONTENT_TYPE_VIDEO",
+    contentImage: {
+      thumbnailViewModel: {
+        overlays: [
+          {
+            thumbnailBottomOverlayViewModel: {
+              badges: [{ thumbnailBadgeViewModel: { text: duration } }],
+            },
+          },
+        ],
+      },
+    },
+    metadata: {
+      lockupMetadataViewModel: {
+        title: { content: title },
+      },
+    },
+  },
+});
+
+describe("youtube playlist endpoint", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves current and legacy YouTube playlist entries across continuations", async () => {
+    const initialData = {
+      metadata: {
+        playlistMetadataRenderer: { title: " Test Playlist " },
+      },
+      sidebar: {
+        playlistSidebarRenderer: {
+          items: [
+            {
+              playlistSidebarPrimaryInfoRenderer: {
+                stats: [{ runs: [{ text: "3" }, { text: " videos" }] }],
+                thumbnailRenderer: {
+                  playlistVideoThumbnailRenderer: {
+                    thumbnail: {
+                      thumbnails: [
+                        { url: "https://i.ytimg.com/small.jpg", width: 120, height: 90 },
+                        { url: "https://i.ytimg.com/large.jpg", width: 1280, height: 720 },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+            {
+              playlistSidebarSecondaryInfoRenderer: {
+                videoOwner: {
+                  videoOwnerRenderer: {
+                    title: { runs: [{ text: "Playlist Owner" }] },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+      contents: [
+        lockupVideo("first-video", "First Track", "4:14"),
+        lockupVideo("second-video", "Second Track", "1:02:03"),
+        { continuationItemRenderer: { continuationCommand: { token: "next-page" } } },
+      ],
+    };
+    const html = [
+      `<script>var ytInitialData = ${JSON.stringify(initialData)};</script>`,
+      `<script>ytcfg.set(${JSON.stringify({
+        INNERTUBE_API_KEY: "api-key",
+        INNERTUBE_CLIENT_VERSION: "2.20260708.00.00",
+        INNERTUBE_CONTEXT: { client: { clientName: "WEB" } },
+      })});</script>`,
+    ].join("");
+
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : new URL(input).toString();
+      if (url.startsWith("https://www.youtube.com/playlist?")) {
+        expect(url).toContain("list=PLESiES1i-ThqUjxot6jWLDu90fxtkcpA0");
+        return new Response(html);
+      }
+
+      expect(url).toContain("https://www.youtube.com/youtubei/v1/browse?key=api-key");
+      expect(typeof init?.body).toBe("string");
+      expect(JSON.parse(init?.body as string)).toMatchObject({ continuation: "next-page" });
+      return Response.json({
+        continuationContents: {
+          playlistVideoListContinuation: {
+            contents: [
+              {
+                playlistVideoRenderer: {
+                  videoId: "third-video",
+                  title: { runs: [{ text: "Third Track" }] },
+                  lengthSeconds: "65",
+                },
+              },
+            ],
+          },
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(handler(makeEvent())).resolves.toEqual({
+      title: "Test Playlist",
+      artist: "Playlist Owner",
+      genre: "",
+      isAlbum: false,
+      coverUrl: "https://i.ytimg.com/large.jpg",
+      tracks: [
+        {
+          title: "First Track",
+          url: "https://www.youtube.com/watch?v=first-video",
+          duration: 254,
+          trackNumber: 1,
+        },
+        {
+          title: "Second Track",
+          url: "https://www.youtube.com/watch?v=second-video",
+          duration: 3723,
+          trackNumber: 2,
+        },
+        {
+          title: "Third Track",
+          url: "https://www.youtube.com/watch?v=third-video",
+          duration: 65,
+          trackNumber: 3,
+        },
+      ],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects non-playlist YouTube URLs without fetching them", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(handler(makeEvent("https://www.youtube.com/watch?v=video"))).rejects.toThrow(
+      "youtube.playlist_url_required",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/server/api/youtube-playlist.get.ts
+++ b/server/api/youtube-playlist.get.ts
@@ -1,0 +1,368 @@
+import { defineHandler } from "nitro";
+import { z } from "zod";
+
+const YOUTUBE_ORIGIN = "https://www.youtube.com";
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
+const MAX_CONTINUATION_REQUESTS = 100;
+
+const textSchema = z
+  .object({
+    simpleText: z.string().optional(),
+    content: z.string().optional(),
+    runs: z.array(z.object({ text: z.string() }).passthrough()).optional(),
+  })
+  .passthrough();
+
+const legacyVideoSchema = z
+  .object({
+    videoId: z.string().min(1),
+    title: textSchema,
+    lengthSeconds: z.string().optional(),
+    lengthText: textSchema.optional(),
+  })
+  .passthrough();
+
+const lockupVideoSchema = z
+  .object({
+    contentId: z.string().min(1),
+    contentType: z.string().optional(),
+    metadata: z
+      .object({
+        lockupMetadataViewModel: z
+          .object({
+            title: textSchema,
+          })
+          .passthrough(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const thumbnailSchema = z
+  .object({
+    thumbnail: z
+      .object({
+        thumbnails: z.array(
+          z
+            .object({
+              url: z.string().url(),
+              width: z.number().optional(),
+              height: z.number().optional(),
+            })
+            .passthrough(),
+        ),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+type JsonRecord = Record<string, unknown>;
+
+interface YouTubeTrack {
+  title: string;
+  url: string;
+  duration?: number;
+  trackNumber: number;
+}
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getText = (value: unknown) => {
+  const parsed = textSchema.safeParse(value);
+  if (!parsed.success) return undefined;
+  if (parsed.data.simpleText) return parsed.data.simpleText;
+  if (parsed.data.content) return parsed.data.content;
+  const runs = parsed.data.runs?.map((run) => run.text).join("");
+  return runs || undefined;
+};
+
+const findFirstValue = (value: unknown, key: string): unknown => {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const found = findFirstValue(entry, key);
+      if (found !== undefined) return found;
+    }
+    return undefined;
+  }
+  if (!isRecord(value)) return undefined;
+  if (value[key] !== undefined) return value[key];
+
+  for (const entry of Object.values(value)) {
+    const found = findFirstValue(entry, key);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+};
+
+const parseDuration = (value: string | undefined) => {
+  if (!value) return undefined;
+  const parts = value.trim().split(":");
+  if (parts.length < 2 || parts.some((part) => !/^\d+$/.test(part))) return undefined;
+  return parts.reduce((seconds, part) => seconds * 60 + Number(part), 0);
+};
+
+const findDuration = (value: unknown): number | undefined => {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const duration = findDuration(entry);
+      if (duration !== undefined) return duration;
+    }
+    return undefined;
+  }
+  if (!isRecord(value)) return undefined;
+
+  const directText = typeof value.text === "string" ? value.text : undefined;
+  const parsedDuration = parseDuration(directText);
+  if (parsedDuration !== undefined) return parsedDuration;
+
+  for (const entry of Object.values(value)) {
+    const duration = findDuration(entry);
+    if (duration !== undefined) return duration;
+  }
+  return undefined;
+};
+
+const collectTracks = (value: unknown, seenVideoIds: Set<string>, tracks: YouTubeTrack[]) => {
+  if (Array.isArray(value)) {
+    for (const entry of value) collectTracks(entry, seenVideoIds, tracks);
+    return;
+  }
+  if (!isRecord(value)) return;
+
+  const legacyVideo = legacyVideoSchema.safeParse(value.playlistVideoRenderer);
+  if (legacyVideo.success && !seenVideoIds.has(legacyVideo.data.videoId)) {
+    const title = getText(legacyVideo.data.title)?.trim();
+    if (title) {
+      const durationFromSeconds = Number(legacyVideo.data.lengthSeconds);
+      seenVideoIds.add(legacyVideo.data.videoId);
+      tracks.push({
+        title,
+        url: `${YOUTUBE_ORIGIN}/watch?v=${encodeURIComponent(legacyVideo.data.videoId)}`,
+        duration: Number.isFinite(durationFromSeconds)
+          ? durationFromSeconds
+          : parseDuration(getText(legacyVideo.data.lengthText)),
+        trackNumber: tracks.length + 1,
+      });
+    }
+  }
+
+  const lockupVideo = lockupVideoSchema.safeParse(value.lockupViewModel);
+  if (
+    lockupVideo.success &&
+    (!lockupVideo.data.contentType ||
+      lockupVideo.data.contentType === "LOCKUP_CONTENT_TYPE_VIDEO") &&
+    !seenVideoIds.has(lockupVideo.data.contentId)
+  ) {
+    const title = getText(lockupVideo.data.metadata.lockupMetadataViewModel.title)?.trim();
+    if (title) {
+      seenVideoIds.add(lockupVideo.data.contentId);
+      tracks.push({
+        title,
+        url: `${YOUTUBE_ORIGIN}/watch?v=${encodeURIComponent(lockupVideo.data.contentId)}`,
+        duration: findDuration(lockupVideo.data),
+        trackNumber: tracks.length + 1,
+      });
+    }
+  }
+
+  for (const entry of Object.values(value)) collectTracks(entry, seenVideoIds, tracks);
+};
+
+const collectContinuationTokens = (value: unknown, tokens: string[]) => {
+  if (Array.isArray(value)) {
+    for (const entry of value) collectContinuationTokens(entry, tokens);
+    return;
+  }
+  if (!isRecord(value)) return;
+
+  const continuationCommand = value.continuationCommand;
+  if (isRecord(continuationCommand) && typeof continuationCommand.token === "string") {
+    tokens.push(continuationCommand.token);
+  }
+
+  for (const entry of Object.values(value)) collectContinuationTokens(entry, tokens);
+};
+
+const extractJsonObject = (source: string, marker: string, startAt = 0) => {
+  const markerIndex = source.indexOf(marker, startAt);
+  if (markerIndex < 0) return undefined;
+  const objectStart = source.indexOf("{", markerIndex + marker.length);
+  if (objectStart < 0) return undefined;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = objectStart; index < source.length; index++) {
+    const character = source[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character === "{") depth++;
+    if (character === "}") {
+      depth--;
+      if (depth === 0) {
+        return {
+          value: JSON.parse(source.slice(objectStart, index + 1)) as unknown,
+          end: index + 1,
+        };
+      }
+    }
+  }
+  return undefined;
+};
+
+const getYouTubeConfig = (html: string) => {
+  const config: JsonRecord = {};
+  let offset = 0;
+  while (true) {
+    const extracted = extractJsonObject(html, "ytcfg.set(", offset);
+    if (!extracted) break;
+    if (isRecord(extracted.value)) Object.assign(config, extracted.value);
+    offset = extracted.end;
+  }
+  return config;
+};
+
+const getPlaylistTitle = (initialData: unknown) => {
+  const metadata = findFirstValue(initialData, "playlistMetadataRenderer");
+  return isRecord(metadata) && typeof metadata.title === "string" ? metadata.title.trim() : "";
+};
+
+const getPlaylistArtist = (initialData: unknown) => {
+  const owner = findFirstValue(initialData, "videoOwnerRenderer");
+  return isRecord(owner) ? (getText(owner.title)?.trim() ?? "") : "";
+};
+
+const getPlaylistCover = (initialData: unknown) => {
+  const parsed = thumbnailSchema.safeParse(
+    findFirstValue(initialData, "playlistVideoThumbnailRenderer"),
+  );
+  if (!parsed.success || parsed.data.thumbnail.thumbnails.length === 0) return undefined;
+  return parsed.data.thumbnail.thumbnails.reduce((largest, thumbnail) => {
+    const largestArea = (largest.width ?? 0) * (largest.height ?? 0);
+    const thumbnailArea = (thumbnail.width ?? 0) * (thumbnail.height ?? 0);
+    return thumbnailArea >= largestArea ? thumbnail : largest;
+  }).url;
+};
+
+const getDeclaredTrackCount = (initialData: unknown) => {
+  const primaryInfo = findFirstValue(initialData, "playlistSidebarPrimaryInfoRenderer");
+  if (!isRecord(primaryInfo) || !Array.isArray(primaryInfo.stats)) return undefined;
+  for (const stat of primaryInfo.stats) {
+    const match = getText(stat)?.match(/([\d,]+)\s+videos?/i);
+    if (!match) continue;
+    const count = Number(match[1]?.replaceAll(",", ""));
+    if (Number.isFinite(count)) return count;
+  }
+  return undefined;
+};
+
+const fetchContinuation = async (token: string, config: JsonRecord) => {
+  const apiKey = config.INNERTUBE_API_KEY;
+  const context = config.INNERTUBE_CONTEXT;
+  const clientVersion = config.INNERTUBE_CLIENT_VERSION;
+  if (typeof apiKey !== "string" || !isRecord(context) || typeof clientVersion !== "string") {
+    return undefined;
+  }
+
+  const endpoint = new URL("/youtubei/v1/browse", YOUTUBE_ORIGIN);
+  endpoint.searchParams.set("key", apiKey);
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "user-agent": USER_AGENT,
+      "x-youtube-client-name": "1",
+      "x-youtube-client-version": clientVersion,
+    },
+    body: JSON.stringify({ context, continuation: token }),
+  });
+  if (!response.ok) throw new Error(`youtube.continuation_failed (${response.status})`);
+  return response.json() as Promise<unknown>;
+};
+
+const parseSourceUrl = (sourceUrl: string) => {
+  const parsed = new URL(sourceUrl);
+  const isYouTubeHost =
+    parsed.hostname === "youtube.com" || parsed.hostname.endsWith(".youtube.com");
+  const playlistId = parsed.searchParams.get("list");
+  if (!isYouTubeHost || parsed.pathname.replace(/\/+$/, "") !== "/playlist" || !playlistId) {
+    throw new Error("youtube.playlist_url_required");
+  }
+  return playlistId;
+};
+
+export default defineHandler(async (event) => {
+  const requestUrl = new URL(event.req.url, "http://tagium.local");
+  const sourceUrl = requestUrl.searchParams.get("url");
+  if (!sourceUrl) throw new Error("youtube.url_required");
+
+  const playlistId = parseSourceUrl(sourceUrl);
+  const playlistUrl = new URL("/playlist", YOUTUBE_ORIGIN);
+  playlistUrl.searchParams.set("list", playlistId);
+  playlistUrl.searchParams.set("hl", "en");
+
+  const response = await fetch(playlistUrl, {
+    headers: {
+      "accept-language": "en-US,en;q=0.9",
+      "user-agent": USER_AGENT,
+    },
+  });
+  if (!response.ok) throw new Error(`youtube.playlist_failed (${response.status})`);
+  const html = await response.text();
+  const initialData = extractJsonObject(html, "var ytInitialData =")?.value;
+  if (!initialData) throw new Error("youtube.initial_data");
+
+  const title = getPlaylistTitle(initialData);
+  if (!title) throw new Error("youtube.playlist_title");
+
+  const tracks: YouTubeTrack[] = [];
+  const seenVideoIds = new Set<string>();
+  collectTracks(initialData, seenVideoIds, tracks);
+
+  const declaredTrackCount = getDeclaredTrackCount(initialData);
+  if (declaredTrackCount === undefined || tracks.length < declaredTrackCount) {
+    const pendingTokens: string[] = [];
+    const visitedTokens = new Set<string>();
+    collectContinuationTokens(initialData, pendingTokens);
+    const config = getYouTubeConfig(html);
+
+    while (pendingTokens.length > 0 && visitedTokens.size < MAX_CONTINUATION_REQUESTS) {
+      const token = pendingTokens.shift();
+      if (!token || visitedTokens.has(token)) continue;
+      visitedTokens.add(token);
+
+      const continuation = await fetchContinuation(token, config);
+      if (!continuation) break;
+      collectTracks(continuation, seenVideoIds, tracks);
+      if (declaredTrackCount !== undefined && tracks.length >= declaredTrackCount) break;
+      collectContinuationTokens(continuation, pendingTokens);
+    }
+  }
+
+  if (tracks.length === 0) throw new Error("youtube.no_resolvable_tracks");
+
+  return {
+    title,
+    artist: getPlaylistArtist(initialData),
+    genre: "",
+    isAlbum: false,
+    coverUrl: getPlaylistCover(initialData),
+    tracks,
+  };
+});

--- a/server/api/youtube-playlist.get.ts
+++ b/server/api/youtube-playlist.get.ts
@@ -189,8 +189,9 @@ const collectContinuationTokens = (value: unknown, tokens: string[]) => {
 const extractJsonObject = (source: string, marker: string, startAt = 0) => {
   const markerIndex = source.indexOf(marker, startAt);
   if (markerIndex < 0) return undefined;
-  const objectStart = source.indexOf("{", markerIndex + marker.length);
-  if (objectStart < 0) return undefined;
+  let objectStart = markerIndex + marker.length;
+  while (/\s/.test(source[objectStart] ?? "")) objectStart++;
+  if (source[objectStart] !== "{") return undefined;
 
   let depth = 0;
   let inString = false;
@@ -230,8 +231,17 @@ const getYouTubeConfig = (html: string) => {
   const config: JsonRecord = {};
   let offset = 0;
   while (true) {
-    const extracted = extractJsonObject(html, "ytcfg.set(", offset);
-    if (!extracted) break;
+    const markerIndex = html.indexOf("ytcfg.set(", offset);
+    if (markerIndex < 0) break;
+    offset = markerIndex + "ytcfg.set(".length;
+
+    let extracted: ReturnType<typeof extractJsonObject>;
+    try {
+      extracted = extractJsonObject(html, "ytcfg.set(", markerIndex);
+    } catch {
+      continue;
+    }
+    if (!extracted) continue;
     if (isRecord(extracted.value)) Object.assign(config, extracted.value);
     offset = extracted.end;
   }


### PR DESCRIPTION
## Summary

- resolve public YouTube playlists, including current and legacy item layouts plus continuation pages
- import playlist metadata, artwork, ordering, and individual video URLs through the existing download queue
- share the playlist planning path with SoundCloud sets while preserving SoundCloud album-cover behavior
- skip scalar and non-JSON `ytcfg.set` calls so playlists with hidden entries can paginate safely
- cover URL classification, resolver parsing, queue planning, and the browser import flow

## Preview

[Open the Cloudflare preview](https://312028af-tagium.oliver-boorstein.workers.dev)

Validated against:
- [status update music](https://www.youtube.com/playlist?list=PLESiES1i-ThqUjxot6jWLDu90fxtkcpA0): 15 tracks resolved in order
- [Revengeseekerz](https://www.youtube.com/playlist?list=PLco9ZX1KZNVdaWJKCxnkk6bA-O-nsPMWa): 12 playable tracks resolved despite YouTube declaring 13 entries

## Validation

- `bun run test` — 33 files, 214 tests
- `bun run lint`
- `bun run build`
- `bun run test:e2e e2e/youtube-playlist-import.spec.ts --project=chromium`
- live preview playlist endpoints returned HTTP 200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing YouTube playlists alongside SoundCloud sets.
  * YouTube playlist imports now include playlist metadata, cover art, track ordering, and album grouping.
  * Added validation for YouTube playlist URLs and clearer errors for invalid or unavailable playlist data.
* **Bug Fixes**
  * Improved cover-art handling for imported playlists.
* **Tests**
  * Added unit, integration, and end-to-end coverage for YouTube playlist detection, resolution, planning, and downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->