### PR TITLE
feat: infer YouTube years from upload dates

### DIFF
--- a/components/audio/cobaltAudio.ts
+++ b/components/audio/cobaltAudio.ts
@@ -20,6 +20,7 @@ export type CobaltAudioDownloadLifecycleCallback = (
 export interface CobaltAudioDownloadRequest {
   sourceUrl: string;
   audioBitrate: AudioDownloadBitrate;
+  year?: number;
   onLifecycle?: CobaltAudioDownloadLifecycleCallback;
   signal?: AbortSignal;
 }
@@ -202,6 +203,7 @@ const makeCobaltAudio = Effect.fn("makeCobaltAudio")(function* () {
           body: JSON.stringify({
             url: request.sourceUrl,
             audioBitrate: request.audioBitrate,
+            ...(request.year === undefined ? {} : { year: request.year }),
           }),
         });
 

--- a/components/audio/downloadTrack.ts
+++ b/components/audio/downloadTrack.ts
@@ -290,7 +290,11 @@ export const createPlaylistDownloadPlan = ({
         trackNumber: track.trackNumber,
       }),
       true,
-      { sourceUrl: track.url, audioBitrate },
+      {
+        sourceUrl: track.url,
+        audioBitrate,
+        ...(playlist.year === undefined ? {} : { year: playlist.year }),
+      },
       createPlaylistPendingMetadataPatch(playlist, track),
     ),
   );

--- a/components/audio/soundcloudSet.test.ts
+++ b/components/audio/soundcloudSet.test.ts
@@ -276,6 +276,7 @@ describe("download track plans", () => {
         downloadRequest: {
           sourceUrl: "https://soundcloud.com/artist/first-track",
           audioBitrate: "320",
+          year: 2024,
         },
       },
       {
@@ -284,6 +285,7 @@ describe("download track plans", () => {
         downloadRequest: {
           sourceUrl: "https://soundcloud.com/artist/second-track",
           audioBitrate: "320",
+          year: 2024,
         },
       },
     ]);
@@ -313,8 +315,16 @@ describe("soundcloud set import", () => {
       },
     ]);
     expect(harness.files.map((file) => file.downloadRequest)).toEqual([
-      { sourceUrl: "https://soundcloud.com/artist/first-track", audioBitrate: "320" },
-      { sourceUrl: "https://soundcloud.com/artist/second-track", audioBitrate: "320" },
+      {
+        sourceUrl: "https://soundcloud.com/artist/first-track",
+        audioBitrate: "320",
+        year: 2024,
+      },
+      {
+        sourceUrl: "https://soundcloud.com/artist/second-track",
+        audioBitrate: "320",
+        year: 2024,
+      },
     ]);
     expect(harness.files.map((file) => file.pendingMetadataPatch)).toEqual([
       {
@@ -341,6 +351,7 @@ describe("soundcloud set import", () => {
         downloadRequest: {
           sourceUrl: "https://soundcloud.com/artist/first-track",
           audioBitrate: "320",
+          year: 2024,
         },
       },
       {
@@ -349,6 +360,7 @@ describe("soundcloud set import", () => {
         downloadRequest: {
           sourceUrl: "https://soundcloud.com/artist/second-track",
           audioBitrate: "320",
+          year: 2024,
         },
       },
     ]);

--- a/components/audio/types.ts
+++ b/components/audio/types.ts
@@ -20,6 +20,7 @@ export interface TagiumFile {
   downloadRequest?: {
     sourceUrl: string;
     audioBitrate: AudioDownloadBitrate;
+    year?: number;
   };
   pendingMetadataPatch?: MetadataPatch;
   // Compatibility for UI/status consumers that still render a buffered flag.

--- a/components/audio/youtubePlaylist.test.ts
+++ b/components/audio/youtubePlaylist.test.ts
@@ -7,6 +7,7 @@ const playlist: Playlist = {
   title: "Status Update Music",
   artist: "lucida",
   genre: "",
+  year: 2026,
   isAlbum: false,
   coverUrl: "https://i.ytimg.com/playlist.jpg",
   tracks: [
@@ -54,12 +55,14 @@ describe("YouTube playlist imports", () => {
       id: "album-1",
       title: "Status Update Music",
       artist: "lucida",
+      year: 2026,
       trackIds: ["track-1", "track-2"],
     });
     expect(plan.queuedTracks.map((track) => track.downloadRequest.sourceUrl)).toEqual([
       "https://www.youtube.com/watch?v=first-video",
       "https://www.youtube.com/watch?v=second-video",
     ]);
+    expect(plan.queuedTracks.map((track) => track.downloadRequest.year)).toEqual([2026, 2026]);
     expect(plan.pendingFiles.map((file) => file.pendingMetadataPatch?.trackNumber)).toEqual([1, 2]);
     expect(plan.coverImport?.playlist.isAlbum).toBe(false);
   });

--- a/e2e/youtube-playlist-import.spec.ts
+++ b/e2e/youtube-playlist-import.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 test("imports a YouTube playlist as an album-backed download queue", async ({ page }) => {
   const playlistUrl = "https://www.youtube.com/playlist?list=PLESiES1i-ThqUjxot6jWLDu90fxtkcpA0";
   const sourceUrls: string[] = [];
+  const sourceYears: number[] = [];
   let releaseDownloads = () => {};
   const downloadsReleased = new Promise<void>((resolve) => {
     releaseDownloads = resolve;
@@ -16,6 +17,7 @@ test("imports a YouTube playlist as an album-backed download queue", async ({ pa
         title: "YouTube Playlist",
         artist: "Playlist Owner",
         genre: "",
+        year: 2022,
         isAlbum: false,
         tracks: [
           {
@@ -35,8 +37,9 @@ test("imports a YouTube playlist as an album-backed download queue", async ({ pa
     });
   });
   await page.route("**/api/cobalt/audio", async (route) => {
-    const body = route.request().postDataJSON() as { url: string };
+    const body = route.request().postDataJSON() as { url: string; year: number };
     sourceUrls.push(body.url);
+    sourceYears.push(body.year);
     await downloadsReleased;
     await route
       .fulfill({ status: 502, contentType: "text/plain", body: "test download released" })
@@ -49,6 +52,7 @@ test("imports a YouTube playlist as an album-backed download queue", async ({ pa
     await page.getByRole("button", { name: "start media import" }).click();
 
     await expect(page.getByText("YouTube Playlist", { exact: true })).toBeVisible();
+    await expect(page.locator('input[name="year"]')).toHaveValue("2022");
     await expect(page.getByText("downloading 0/2", { exact: true })).toBeVisible();
     await expect
       .poll(() => sourceUrls)
@@ -56,6 +60,7 @@ test("imports a YouTube playlist as an album-backed download queue", async ({ pa
         "https://www.youtube.com/watch?v=first-video",
         "https://www.youtube.com/watch?v=second-video",
       ]);
+    await expect.poll(() => sourceYears).toEqual([2022, 2022]);
   } finally {
     releaseDownloads();
   }

--- a/server-tests/cobalt/audio.post.test.ts
+++ b/server-tests/cobalt/audio.post.test.ts
@@ -124,11 +124,26 @@ describe("cobalt audio endpoint", () => {
   it("infers direct YouTube track year from its upload date", async () => {
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = input instanceof Request ? input.url : new URL(input).toString();
-      if (url.startsWith("https://www.youtube.com/youtubei/v1/player?")) {
+      if (url === "https://www.youtube.com/") {
+        return new Response(
+          `<script>ytcfg.set(${JSON.stringify({
+            INNERTUBE_API_KEY: "api-key",
+            INNERTUBE_CLIENT_VERSION: "2.20260708.00.00",
+            INNERTUBE_CONTEXT: { client: { clientName: "WEB" } },
+          })});</script>`,
+        );
+      }
+      if (url.startsWith("https://www.youtube.com/youtubei/v1/next?")) {
         return Response.json({
-          microformat: {
-            playerMicroformatRenderer: {
-              uploadDate: "1987-10-25T00:00:00-07:00",
+          contents: {
+            twoColumnWatchNextResults: {
+              results: {
+                results: {
+                  contents: [
+                    { videoPrimaryInfoRenderer: { dateText: { simpleText: "Oct 25, 1987" } } },
+                  ],
+                },
+              },
             },
           },
         });
@@ -166,7 +181,7 @@ describe("cobalt audio endpoint", () => {
         },
       },
     });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it("appends Cobalt machine ids to proxied tunnel URLs", async () => {

--- a/server-tests/cobalt/audio.post.test.ts
+++ b/server-tests/cobalt/audio.post.test.ts
@@ -124,16 +124,14 @@ describe("cobalt audio endpoint", () => {
   it("infers direct YouTube track year from its upload date", async () => {
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = input instanceof Request ? input.url : new URL(input).toString();
-      if (url.startsWith("https://www.youtube.com/watch?")) {
-        return new Response(
-          `<script>var ytInitialPlayerResponse = ${JSON.stringify({
-            microformat: {
-              playerMicroformatRenderer: {
-                uploadDate: "1987-10-25T00:00:00-07:00",
-              },
+      if (url.startsWith("https://www.youtube.com/youtubei/v1/player?")) {
+        return Response.json({
+          microformat: {
+            playerMicroformatRenderer: {
+              uploadDate: "1987-10-25T00:00:00-07:00",
             },
-          })};</script>`,
-        );
+          },
+        });
       }
 
       return Response.json({

--- a/server-tests/cobalt/audio.post.test.ts
+++ b/server-tests/cobalt/audio.post.test.ts
@@ -32,7 +32,7 @@ const createRateLimitBinding = (limit: number): RateLimitBinding => {
   };
 };
 
-const makeAudioRequest = (signal?: AbortSignal) => {
+const makeAudioRequest = (signal?: AbortSignal, year: number | null = 2020) => {
   const request = new Request("https://tagium.test/api/cobalt/audio", {
     method: "POST",
     headers: {
@@ -42,6 +42,7 @@ const makeAudioRequest = (signal?: AbortSignal) => {
     body: JSON.stringify({
       url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
       audioBitrate: "128",
+      ...(year === null ? {} : { year }),
     }),
     signal,
   }) as RuntimeRequest;
@@ -113,8 +114,61 @@ describe("cobalt audio endpoint", () => {
       ],
       output: {
         filename: "download.mp3",
+        metadata: {
+          date: "2020",
+        },
       },
     });
+  });
+
+  it("infers direct YouTube track year from its upload date", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = input instanceof Request ? input.url : new URL(input).toString();
+      if (url.startsWith("https://www.youtube.com/watch?")) {
+        return new Response(
+          `<script>var ytInitialPlayerResponse = ${JSON.stringify({
+            microformat: {
+              playerMicroformatRenderer: {
+                uploadDate: "1987-10-25T00:00:00-07:00",
+              },
+            },
+          })};</script>`,
+        );
+      }
+
+      return Response.json({
+        status: "local-processing",
+        type: "audio",
+        service: "youtube",
+        tunnel: [
+          "https://cobalt.test/tunnel?id=123456789012345678901&exp=1234567890123&sig=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&sec=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb&iv=cccccccccccccccccccccc",
+        ],
+        output: {
+          type: "audio/mpeg",
+          filename: "download.mp3",
+          metadata: { title: "Download", date: "release-date-that-must-be-replaced" },
+        },
+        audio: {
+          copy: false,
+          format: "mp3",
+          bitrate: "128",
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handler(makeEvent(makeAudioRequest(undefined, null)));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      output: {
+        metadata: {
+          title: "Download",
+          date: "1987",
+        },
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("appends Cobalt machine ids to proxied tunnel URLs", async () => {

--- a/server-tests/youtube-playlist.get.test.ts
+++ b/server-tests/youtube-playlist.get.test.ts
@@ -33,6 +33,11 @@ const lockupVideo = (videoId: string, title: string, duration: string) => ({
   },
 });
 
+const playerResponseHtml = (uploadDate: string) =>
+  `<script>var ytInitialPlayerResponse = ${JSON.stringify({
+    microformat: { playerMicroformatRenderer: { uploadDate } },
+  })};</script>`;
+
 describe("youtube playlist endpoint", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -95,6 +100,10 @@ describe("youtube playlist endpoint", () => {
         expect(url).toContain("list=PLESiES1i-ThqUjxot6jWLDu90fxtkcpA0");
         return new Response(html);
       }
+      if (url.startsWith("https://www.youtube.com/watch?")) {
+        expect(url).toContain("v=first-video");
+        return new Response(playerResponseHtml("2022-08-14T12:30:00-07:00"));
+      }
 
       expect(url).toContain("https://www.youtube.com/youtubei/v1/browse?key=api-key");
       expect(typeof init?.body).toBe("string");
@@ -122,6 +131,7 @@ describe("youtube playlist endpoint", () => {
       artist: "Playlist Owner",
       genre: "",
       isAlbum: false,
+      year: 2022,
       coverUrl: "https://i.ytimg.com/large.jpg",
       tracks: [
         {
@@ -144,7 +154,7 @@ describe("youtube playlist endpoint", () => {
         },
       ],
     });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it("rejects non-playlist YouTube URLs without fetching them", async () => {

--- a/server-tests/youtube-playlist.get.test.ts
+++ b/server-tests/youtube-playlist.get.test.ts
@@ -95,12 +95,20 @@ describe("youtube playlist endpoint", () => {
         expect(url).toContain("list=PLESiES1i-ThqUjxot6jWLDu90fxtkcpA0");
         return new Response(html);
       }
-      if (url.startsWith("https://www.youtube.com/youtubei/v1/player?")) {
+      if (url.startsWith("https://www.youtube.com/youtubei/v1/next?")) {
         expect(typeof init?.body).toBe("string");
         expect(JSON.parse(init?.body as string)).toMatchObject({ videoId: "first-video" });
         return Response.json({
-          microformat: {
-            playerMicroformatRenderer: { uploadDate: "2022-08-14T12:30:00-07:00" },
+          contents: {
+            twoColumnWatchNextResults: {
+              results: {
+                results: {
+                  contents: [
+                    { videoPrimaryInfoRenderer: { dateText: { simpleText: "Aug 14, 2022" } } },
+                  ],
+                },
+              },
+            },
           },
         });
       }

--- a/server-tests/youtube-playlist.get.test.ts
+++ b/server-tests/youtube-playlist.get.test.ts
@@ -33,11 +33,6 @@ const lockupVideo = (videoId: string, title: string, duration: string) => ({
   },
 });
 
-const playerResponseHtml = (uploadDate: string) =>
-  `<script>var ytInitialPlayerResponse = ${JSON.stringify({
-    microformat: { playerMicroformatRenderer: { uploadDate } },
-  })};</script>`;
-
 describe("youtube playlist endpoint", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -100,9 +95,14 @@ describe("youtube playlist endpoint", () => {
         expect(url).toContain("list=PLESiES1i-ThqUjxot6jWLDu90fxtkcpA0");
         return new Response(html);
       }
-      if (url.startsWith("https://www.youtube.com/watch?")) {
-        expect(url).toContain("v=first-video");
-        return new Response(playerResponseHtml("2022-08-14T12:30:00-07:00"));
+      if (url.startsWith("https://www.youtube.com/youtubei/v1/player?")) {
+        expect(typeof init?.body).toBe("string");
+        expect(JSON.parse(init?.body as string)).toMatchObject({ videoId: "first-video" });
+        return Response.json({
+          microformat: {
+            playerMicroformatRenderer: { uploadDate: "2022-08-14T12:30:00-07:00" },
+          },
+        });
       }
 
       expect(url).toContain("https://www.youtube.com/youtubei/v1/browse?key=api-key");

--- a/server/api/cobalt/audio.post.ts
+++ b/server/api/cobalt/audio.post.ts
@@ -22,6 +22,7 @@ import {
   getDeployEnv,
   type CobaltRuntimeEnv as DevControlRuntimeEnv,
 } from "../../utils/dev-controls";
+import { getYouTubeVideoId, resolveYouTubeUploadYear } from "../../utils/youtube";
 
 enum CobaltResponseType {
   Error = "error",
@@ -34,6 +35,7 @@ enum CobaltResponseType {
 const audioRequestSchema = z.object({
   url: z.string().url(),
   audioBitrate: z.enum(["320", "256", "128", "96", "64"]),
+  year: z.number().int().min(1000).max(9999).optional(),
 });
 
 const cobaltResponseSchema = z.discriminatedUnion("status", [
@@ -340,6 +342,23 @@ const localProcessingResponse = (
     ),
   });
 
+const withYearMetadata = (
+  response: Extract<CobaltResponse, { status: CobaltResponseType.LocalProcessing }>,
+  year: number | undefined,
+) => {
+  if (year === undefined) return response;
+  return {
+    ...response,
+    output: {
+      ...response.output,
+      metadata: {
+        ...response.output.metadata,
+        date: String(year),
+      },
+    },
+  };
+};
+
 const parseAudioRequest = async (request: Request) => {
   try {
     return audioRequestSchema.parse(await request.json());
@@ -415,6 +434,12 @@ export default defineHandler(async (event) => {
       return respond(admissionLimitedResponse());
     }
 
+    const yearPromise =
+      body.year !== undefined
+        ? Promise.resolve(body.year)
+        : getYouTubeVideoId(body.url)
+          ? resolveYouTubeUploadYear(body.url, { signal: event.req.signal }).catch(() => undefined)
+          : Promise.resolve(undefined);
     const cobaltResult = await requestCobaltAudio(
       runtimeEnv,
       body.url,
@@ -432,8 +457,9 @@ export default defineHandler(async (event) => {
     }
 
     if (cobaltResponse.status === CobaltResponseType.LocalProcessing) {
+      const responseWithYear = withYearMetadata(cobaltResponse, await yearPromise);
       return respond(
-        localProcessingResponse(event.req, runtimeEnv, cobaltResponse, cobaltResult.machineId),
+        localProcessingResponse(event.req, runtimeEnv, responseWithYear, cobaltResult.machineId),
       );
     }
 

--- a/server/api/youtube-playlist.get.ts
+++ b/server/api/youtube-playlist.get.ts
@@ -1,10 +1,12 @@
 import { defineHandler } from "nitro";
 import { z } from "zod";
+import {
+  extractYouTubeJsonObject,
+  resolveYouTubeUploadYear,
+  YOUTUBE_ORIGIN,
+  YOUTUBE_USER_AGENT,
+} from "../utils/youtube";
 
-const YOUTUBE_ORIGIN = "https://www.youtube.com";
-const USER_AGENT =
-  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
-  "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
 const MAX_CONTINUATION_REQUESTS = 100;
 
 const textSchema = z
@@ -186,47 +188,6 @@ const collectContinuationTokens = (value: unknown, tokens: string[]) => {
   for (const entry of Object.values(value)) collectContinuationTokens(entry, tokens);
 };
 
-const extractJsonObject = (source: string, marker: string, startAt = 0) => {
-  const markerIndex = source.indexOf(marker, startAt);
-  if (markerIndex < 0) return undefined;
-  let objectStart = markerIndex + marker.length;
-  while (/\s/.test(source[objectStart] ?? "")) objectStart++;
-  if (source[objectStart] !== "{") return undefined;
-
-  let depth = 0;
-  let inString = false;
-  let escaped = false;
-  for (let index = objectStart; index < source.length; index++) {
-    const character = source[index];
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (character === "\\") {
-        escaped = true;
-      } else if (character === '"') {
-        inString = false;
-      }
-      continue;
-    }
-
-    if (character === '"') {
-      inString = true;
-      continue;
-    }
-    if (character === "{") depth++;
-    if (character === "}") {
-      depth--;
-      if (depth === 0) {
-        return {
-          value: JSON.parse(source.slice(objectStart, index + 1)) as unknown,
-          end: index + 1,
-        };
-      }
-    }
-  }
-  return undefined;
-};
-
 const getYouTubeConfig = (html: string) => {
   const config: JsonRecord = {};
   let offset = 0;
@@ -235,9 +196,9 @@ const getYouTubeConfig = (html: string) => {
     if (markerIndex < 0) break;
     offset = markerIndex + "ytcfg.set(".length;
 
-    let extracted: ReturnType<typeof extractJsonObject>;
+    let extracted: ReturnType<typeof extractYouTubeJsonObject>;
     try {
-      extracted = extractJsonObject(html, "ytcfg.set(", markerIndex);
+      extracted = extractYouTubeJsonObject(html, "ytcfg.set(", markerIndex);
     } catch {
       continue;
     }
@@ -296,7 +257,7 @@ const fetchContinuation = async (token: string, config: JsonRecord) => {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      "user-agent": USER_AGENT,
+      "user-agent": YOUTUBE_USER_AGENT,
       "x-youtube-client-name": "1",
       "x-youtube-client-version": clientVersion,
     },
@@ -330,12 +291,12 @@ export default defineHandler(async (event) => {
   const response = await fetch(playlistUrl, {
     headers: {
       "accept-language": "en-US,en;q=0.9",
-      "user-agent": USER_AGENT,
+      "user-agent": YOUTUBE_USER_AGENT,
     },
   });
   if (!response.ok) throw new Error(`youtube.playlist_failed (${response.status})`);
   const html = await response.text();
-  const initialData = extractJsonObject(html, "var ytInitialData =")?.value;
+  const initialData = extractYouTubeJsonObject(html, "var ytInitialData =")?.value;
   if (!initialData) throw new Error("youtube.initial_data");
 
   const title = getPlaylistTitle(initialData);
@@ -366,12 +327,14 @@ export default defineHandler(async (event) => {
   }
 
   if (tracks.length === 0) throw new Error("youtube.no_resolvable_tracks");
+  const year = await resolveYouTubeUploadYear(tracks[0]!.url, { signal: event.req.signal });
 
   return {
     title,
     artist: getPlaylistArtist(initialData),
     genre: "",
     isAlbum: false,
+    ...(year === undefined ? {} : { year }),
     coverUrl: getPlaylistCover(initialData),
     tracks,
   };

--- a/server/api/youtube-playlist.get.ts
+++ b/server/api/youtube-playlist.get.ts
@@ -2,6 +2,7 @@ import { defineHandler } from "nitro";
 import { z } from "zod";
 import {
   extractYouTubeJsonObject,
+  getYouTubeConfig,
   resolveYouTubeUploadYear,
   YOUTUBE_ORIGIN,
   YOUTUBE_USER_AGENT,
@@ -188,27 +189,6 @@ const collectContinuationTokens = (value: unknown, tokens: string[]) => {
   for (const entry of Object.values(value)) collectContinuationTokens(entry, tokens);
 };
 
-const getYouTubeConfig = (html: string) => {
-  const config: JsonRecord = {};
-  let offset = 0;
-  while (true) {
-    const markerIndex = html.indexOf("ytcfg.set(", offset);
-    if (markerIndex < 0) break;
-    offset = markerIndex + "ytcfg.set(".length;
-
-    let extracted: ReturnType<typeof extractYouTubeJsonObject>;
-    try {
-      extracted = extractYouTubeJsonObject(html, "ytcfg.set(", markerIndex);
-    } catch {
-      continue;
-    }
-    if (!extracted) continue;
-    if (isRecord(extracted.value)) Object.assign(config, extracted.value);
-    offset = extracted.end;
-  }
-  return config;
-};
-
 const getPlaylistTitle = (initialData: unknown) => {
   const metadata = findFirstValue(initialData, "playlistMetadataRenderer");
   return isRecord(metadata) && typeof metadata.title === "string" ? metadata.title.trim() : "";
@@ -298,6 +278,7 @@ export default defineHandler(async (event) => {
   const html = await response.text();
   const initialData = extractYouTubeJsonObject(html, "var ytInitialData =")?.value;
   if (!initialData) throw new Error("youtube.initial_data");
+  const config = getYouTubeConfig(html);
 
   const title = getPlaylistTitle(initialData);
   if (!title) throw new Error("youtube.playlist_title");
@@ -311,8 +292,6 @@ export default defineHandler(async (event) => {
     const pendingTokens: string[] = [];
     const visitedTokens = new Set<string>();
     collectContinuationTokens(initialData, pendingTokens);
-    const config = getYouTubeConfig(html);
-
     while (pendingTokens.length > 0 && visitedTokens.size < MAX_CONTINUATION_REQUESTS) {
       const token = pendingTokens.shift();
       if (!token || visitedTokens.has(token)) continue;
@@ -327,7 +306,10 @@ export default defineHandler(async (event) => {
   }
 
   if (tracks.length === 0) throw new Error("youtube.no_resolvable_tracks");
-  const year = await resolveYouTubeUploadYear(tracks[0]!.url, { signal: event.req.signal });
+  const year = await resolveYouTubeUploadYear(tracks[0]!.url, {
+    config,
+    signal: event.req.signal,
+  });
 
   return {
     title,

--- a/server/utils/youtube.test.ts
+++ b/server/utils/youtube.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import { getYouTubeVideoId, resolveYouTubeUploadYear } from "./youtube";
 
-const playerResponseHtml = (microformat: Record<string, unknown>) =>
-  `<script>var ytInitialPlayerResponse = ${JSON.stringify({
+const playerResponse = (microformat: Record<string, unknown>) =>
+  Response.json({
     microformat: { playerMicroformatRenderer: microformat },
-  })};</script>`;
+  });
 
 describe("youtube video metadata", () => {
   it.each([
@@ -28,16 +28,12 @@ describe("youtube video metadata", () => {
     const fetch = vi
       .fn<typeof globalThis.fetch>()
       .mockResolvedValueOnce(
-        new Response(
-          playerResponseHtml({
-            uploadDate: "2025-04-03T21:00:23-07:00",
-            publishDate: "2024-12-31T00:00:00-08:00",
-          }),
-        ),
+        playerResponse({
+          uploadDate: "2025-04-03T21:00:23-07:00",
+          publishDate: "2024-12-31T00:00:00-08:00",
+        }),
       )
-      .mockResolvedValueOnce(
-        new Response(playerResponseHtml({ publishDate: "2005-04-23T20:31:52-07:00" })),
-      );
+      .mockResolvedValueOnce(playerResponse({ publishDate: "2005-04-23T20:31:52-07:00" }));
 
     await expect(resolveYouTubeUploadYear("https://youtu.be/dQw4w9WgXcQ", { fetch })).resolves.toBe(
       2025,

--- a/server/utils/youtube.test.ts
+++ b/server/utils/youtube.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import { getYouTubeVideoId, resolveYouTubeUploadYear } from "./youtube";
 
-const playerResponse = (microformat: Record<string, unknown>) =>
+const youtubeConfig = {
+  INNERTUBE_API_KEY: "api-key",
+  INNERTUBE_CLIENT_VERSION: "2.20260708.00.00",
+  INNERTUBE_CONTEXT: { client: { clientName: "WEB" } },
+};
+
+const nextResponse = (dateText: string) =>
   Response.json({
-    microformat: { playerMicroformatRenderer: microformat },
+    contents: {
+      twoColumnWatchNextResults: {
+        results: {
+          results: {
+            contents: [{ videoPrimaryInfoRenderer: { dateText: { simpleText: dateText } } }],
+          },
+        },
+      },
+    },
   });
 
 describe("youtube video metadata", () => {
@@ -24,23 +38,25 @@ describe("youtube video metadata", () => {
     expect(getYouTubeVideoId("https://www.youtube.com/watch?v=short")).toBeUndefined();
   });
 
-  it("prefers the upload date year and falls back to publish date", async () => {
+  it("resolves the displayed upload year with discovered or supplied client config", async () => {
     const fetch = vi
       .fn<typeof globalThis.fetch>()
       .mockResolvedValueOnce(
-        playerResponse({
-          uploadDate: "2025-04-03T21:00:23-07:00",
-          publishDate: "2024-12-31T00:00:00-08:00",
-        }),
+        new Response(`<script>ytcfg.set(${JSON.stringify(youtubeConfig)});</script>`),
       )
-      .mockResolvedValueOnce(playerResponse({ publishDate: "2005-04-23T20:31:52-07:00" }));
+      .mockResolvedValueOnce(nextResponse("Apr 3, 2025"))
+      .mockResolvedValueOnce(nextResponse("Apr 23, 2005"));
 
     await expect(resolveYouTubeUploadYear("https://youtu.be/dQw4w9WgXcQ", { fetch })).resolves.toBe(
       2025,
     );
     await expect(
-      resolveYouTubeUploadYear("https://www.youtube.com/watch?v=jNQXAC9IVRw", { fetch }),
+      resolveYouTubeUploadYear("https://www.youtube.com/watch?v=jNQXAC9IVRw", {
+        config: youtubeConfig,
+        fetch,
+      }),
     ).resolves.toBe(2005);
+    expect(fetch).toHaveBeenCalledTimes(3);
   });
 
   it("does not fetch metadata for non-video URLs", async () => {

--- a/server/utils/youtube.test.ts
+++ b/server/utils/youtube.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { getYouTubeVideoId, resolveYouTubeUploadYear } from "./youtube";
+
+const playerResponseHtml = (microformat: Record<string, unknown>) =>
+  `<script>var ytInitialPlayerResponse = ${JSON.stringify({
+    microformat: { playerMicroformatRenderer: microformat },
+  })};</script>`;
+
+describe("youtube video metadata", () => {
+  it.each([
+    ["https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+    ["https://music.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+    ["https://youtu.be/dQw4w9WgXcQ?t=42", "dQw4w9WgXcQ"],
+    ["https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+    ["https://www.youtube.com/live/dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+    ["https://www.youtube.com/embed/dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+  ])("extracts the video id from %s", (url, expectedVideoId) => {
+    expect(getYouTubeVideoId(url)).toBe(expectedVideoId);
+  });
+
+  it("rejects playlists, non-YouTube URLs, and malformed video ids", () => {
+    expect(getYouTubeVideoId("https://www.youtube.com/playlist?list=PL123")).toBeUndefined();
+    expect(getYouTubeVideoId("https://example.com/watch?v=dQw4w9WgXcQ")).toBeUndefined();
+    expect(getYouTubeVideoId("https://www.youtube.com/watch?v=short")).toBeUndefined();
+  });
+
+  it("prefers the upload date year and falls back to publish date", async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          playerResponseHtml({
+            uploadDate: "2025-04-03T21:00:23-07:00",
+            publishDate: "2024-12-31T00:00:00-08:00",
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(playerResponseHtml({ publishDate: "2005-04-23T20:31:52-07:00" })),
+      );
+
+    await expect(resolveYouTubeUploadYear("https://youtu.be/dQw4w9WgXcQ", { fetch })).resolves.toBe(
+      2025,
+    );
+    await expect(
+      resolveYouTubeUploadYear("https://www.youtube.com/watch?v=jNQXAC9IVRw", { fetch }),
+    ).resolves.toBe(2005);
+  });
+
+  it("does not fetch metadata for non-video URLs", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>();
+    await expect(
+      resolveYouTubeUploadYear("https://soundcloud.com/artist/track", { fetch }),
+    ).resolves.toBeUndefined();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/server/utils/youtube.ts
+++ b/server/utils/youtube.ts
@@ -4,6 +4,7 @@ export const YOUTUBE_ORIGIN = "https://www.youtube.com";
 export const YOUTUBE_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
   "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
+const YOUTUBE_WEB_CLIENT_VERSION = "2.20240101.00.00";
 
 const playerResponseSchema = z
   .object({
@@ -102,22 +103,32 @@ export const resolveYouTubeUploadYear = async (
   const videoId = getYouTubeVideoId(sourceUrl);
   if (!videoId) return undefined;
 
-  const videoUrl = new URL("/watch", YOUTUBE_ORIGIN);
-  videoUrl.searchParams.set("v", videoId);
-  videoUrl.searchParams.set("hl", "en");
-  const response = await (options.fetch ?? globalThis.fetch)(videoUrl, {
+  const playerUrl = new URL("/youtubei/v1/player", YOUTUBE_ORIGIN);
+  playerUrl.searchParams.set("prettyPrint", "false");
+  const response = await (options.fetch ?? globalThis.fetch)(playerUrl, {
+    method: "POST",
     headers: {
-      "accept-language": "en-US,en;q=0.9",
+      "content-type": "application/json",
       "user-agent": YOUTUBE_USER_AGENT,
+      "x-youtube-client-name": "1",
+      "x-youtube-client-version": YOUTUBE_WEB_CLIENT_VERSION,
     },
+    body: JSON.stringify({
+      videoId,
+      context: {
+        client: {
+          clientName: "WEB",
+          clientVersion: YOUTUBE_WEB_CLIENT_VERSION,
+          hl: "en",
+          gl: "US",
+        },
+      },
+    }),
     signal: options.signal,
   });
   if (!response.ok) throw new Error(`youtube.video_failed (${response.status})`);
 
-  const html = await response.text();
-  const playerResponse = playerResponseSchema.safeParse(
-    extractYouTubeJsonObject(html, "var ytInitialPlayerResponse =")?.value,
-  );
+  const playerResponse = playerResponseSchema.safeParse(await response.json());
   if (!playerResponse.success) return undefined;
 
   const microformat = playerResponse.data.microformat.playerMicroformatRenderer;

--- a/server/utils/youtube.ts
+++ b/server/utils/youtube.ts
@@ -1,25 +1,12 @@
-import { z } from "zod";
-
 export const YOUTUBE_ORIGIN = "https://www.youtube.com";
 export const YOUTUBE_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
   "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
-const YOUTUBE_WEB_CLIENT_VERSION = "2.20240101.00.00";
 
-const playerResponseSchema = z
-  .object({
-    microformat: z
-      .object({
-        playerMicroformatRenderer: z
-          .object({
-            uploadDate: z.string().optional(),
-            publishDate: z.string().optional(),
-          })
-          .passthrough(),
-      })
-      .passthrough(),
-  })
-  .passthrough();
+type JsonRecord = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const videoIdPattern = /^[A-Za-z0-9_-]{11}$/;
 
@@ -64,6 +51,27 @@ export const extractYouTubeJsonObject = (source: string, marker: string, startAt
   return undefined;
 };
 
+export const getYouTubeConfig = (html: string) => {
+  const config: JsonRecord = {};
+  let offset = 0;
+  while (true) {
+    const markerIndex = html.indexOf("ytcfg.set(", offset);
+    if (markerIndex < 0) break;
+    offset = markerIndex + "ytcfg.set(".length;
+
+    let extracted: ReturnType<typeof extractYouTubeJsonObject>;
+    try {
+      extracted = extractYouTubeJsonObject(html, "ytcfg.set(", markerIndex);
+    } catch {
+      continue;
+    }
+    if (!extracted) continue;
+    if (isRecord(extracted.value)) Object.assign(config, extracted.value);
+    offset = extracted.end;
+  }
+  return config;
+};
+
 export const getYouTubeVideoId = (sourceUrl: string) => {
   try {
     const url = new URL(sourceUrl);
@@ -90,7 +98,7 @@ export const getYouTubeVideoId = (sourceUrl: string) => {
 };
 
 const yearFromDate = (date: string | undefined) => {
-  const match = date?.match(/^(\d{4})-/);
+  const match = date?.match(/(?:^|\D)(\d{4})(?:\D|$)/);
   if (!match) return undefined;
   const year = Number(match[1]);
   return Number.isInteger(year) && year >= 1000 && year <= 9999 ? year : undefined;
@@ -98,39 +106,67 @@ const yearFromDate = (date: string | undefined) => {
 
 export const resolveYouTubeUploadYear = async (
   sourceUrl: string,
-  options: { fetch?: typeof globalThis.fetch; signal?: AbortSignal } = {},
+  options: {
+    config?: JsonRecord;
+    fetch?: typeof globalThis.fetch;
+    signal?: AbortSignal;
+  } = {},
 ) => {
   const videoId = getYouTubeVideoId(sourceUrl);
   if (!videoId) return undefined;
+  const fetch = options.fetch ?? globalThis.fetch;
 
-  const playerUrl = new URL("/youtubei/v1/player", YOUTUBE_ORIGIN);
-  playerUrl.searchParams.set("prettyPrint", "false");
-  const response = await (options.fetch ?? globalThis.fetch)(playerUrl, {
+  let config = options.config;
+  if (!config) {
+    const homepageResponse = await fetch(YOUTUBE_ORIGIN, {
+      headers: { "user-agent": YOUTUBE_USER_AGENT },
+      signal: options.signal,
+    });
+    if (!homepageResponse.ok) {
+      throw new Error(`youtube.config_failed (${homepageResponse.status})`);
+    }
+    config = getYouTubeConfig(await homepageResponse.text());
+  }
+
+  const apiKey = config.INNERTUBE_API_KEY;
+  const context = config.INNERTUBE_CONTEXT;
+  const clientVersion = config.INNERTUBE_CLIENT_VERSION;
+  if (typeof apiKey !== "string" || !isRecord(context) || typeof clientVersion !== "string") {
+    return undefined;
+  }
+
+  const nextUrl = new URL("/youtubei/v1/next", YOUTUBE_ORIGIN);
+  nextUrl.searchParams.set("prettyPrint", "false");
+  nextUrl.searchParams.set("key", apiKey);
+  const response = await fetch(nextUrl, {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "user-agent": YOUTUBE_USER_AGENT,
       "x-youtube-client-name": "1",
-      "x-youtube-client-version": YOUTUBE_WEB_CLIENT_VERSION,
+      "x-youtube-client-version": clientVersion,
     },
-    body: JSON.stringify({
-      videoId,
-      context: {
-        client: {
-          clientName: "WEB",
-          clientVersion: YOUTUBE_WEB_CLIENT_VERSION,
-          hl: "en",
-          gl: "US",
-        },
-      },
-    }),
+    body: JSON.stringify({ videoId, context }),
     signal: options.signal,
   });
   if (!response.ok) throw new Error(`youtube.video_failed (${response.status})`);
 
-  const playerResponse = playerResponseSchema.safeParse(await response.json());
-  if (!playerResponse.success) return undefined;
-
-  const microformat = playerResponse.data.microformat.playerMicroformatRenderer;
-  return yearFromDate(microformat.uploadDate) ?? yearFromDate(microformat.publishDate);
+  const data = await response.json();
+  const primaryInfo = (() => {
+    if (!isRecord(data)) return undefined;
+    const contents = data.contents;
+    if (!isRecord(contents)) return undefined;
+    const watchResults = contents.twoColumnWatchNextResults;
+    if (!isRecord(watchResults)) return undefined;
+    const results = watchResults.results;
+    if (!isRecord(results) || !isRecord(results.results)) return undefined;
+    const resultContents = results.results.contents;
+    if (!Array.isArray(resultContents)) return undefined;
+    return resultContents
+      .map((entry) => (isRecord(entry) ? entry.videoPrimaryInfoRenderer : undefined))
+      .find(isRecord);
+  })();
+  if (!primaryInfo || !isRecord(primaryInfo.dateText)) return undefined;
+  const dateText = primaryInfo.dateText.simpleText;
+  return yearFromDate(typeof dateText === "string" ? dateText : undefined);
 };

--- a/server/utils/youtube.ts
+++ b/server/utils/youtube.ts
@@ -1,0 +1,125 @@
+import { z } from "zod";
+
+export const YOUTUBE_ORIGIN = "https://www.youtube.com";
+export const YOUTUBE_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
+
+const playerResponseSchema = z
+  .object({
+    microformat: z
+      .object({
+        playerMicroformatRenderer: z
+          .object({
+            uploadDate: z.string().optional(),
+            publishDate: z.string().optional(),
+          })
+          .passthrough(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const videoIdPattern = /^[A-Za-z0-9_-]{11}$/;
+
+export const extractYouTubeJsonObject = (source: string, marker: string, startAt = 0) => {
+  const markerIndex = source.indexOf(marker, startAt);
+  if (markerIndex < 0) return undefined;
+  let objectStart = markerIndex + marker.length;
+  while (/\s/.test(source[objectStart] ?? "")) objectStart++;
+  if (source[objectStart] !== "{") return undefined;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = objectStart; index < source.length; index++) {
+    const character = source[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character === "{") depth++;
+    if (character === "}") {
+      depth--;
+      if (depth === 0) {
+        return {
+          value: JSON.parse(source.slice(objectStart, index + 1)) as unknown,
+          end: index + 1,
+        };
+      }
+    }
+  }
+  return undefined;
+};
+
+export const getYouTubeVideoId = (sourceUrl: string) => {
+  try {
+    const url = new URL(sourceUrl);
+    const pathParts = url.pathname.split("/").filter(Boolean);
+    let videoId: string | undefined;
+
+    if (url.hostname === "youtu.be") {
+      videoId = pathParts[0];
+    } else {
+      const isYouTubeHost = url.hostname === "youtube.com" || url.hostname.endsWith(".youtube.com");
+      if (!isYouTubeHost) return undefined;
+
+      if (pathParts[0] === "watch") {
+        videoId = url.searchParams.get("v") ?? pathParts[1];
+      } else if (["embed", "live", "shorts", "v"].includes(pathParts[0] ?? "")) {
+        videoId = pathParts[1];
+      }
+    }
+
+    return videoId && videoIdPattern.test(videoId) ? videoId : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const yearFromDate = (date: string | undefined) => {
+  const match = date?.match(/^(\d{4})-/);
+  if (!match) return undefined;
+  const year = Number(match[1]);
+  return Number.isInteger(year) && year >= 1000 && year <= 9999 ? year : undefined;
+};
+
+export const resolveYouTubeUploadYear = async (
+  sourceUrl: string,
+  options: { fetch?: typeof globalThis.fetch; signal?: AbortSignal } = {},
+) => {
+  const videoId = getYouTubeVideoId(sourceUrl);
+  if (!videoId) return undefined;
+
+  const videoUrl = new URL("/watch", YOUTUBE_ORIGIN);
+  videoUrl.searchParams.set("v", videoId);
+  videoUrl.searchParams.set("hl", "en");
+  const response = await (options.fetch ?? globalThis.fetch)(videoUrl, {
+    headers: {
+      "accept-language": "en-US,en;q=0.9",
+      "user-agent": YOUTUBE_USER_AGENT,
+    },
+    signal: options.signal,
+  });
+  if (!response.ok) throw new Error(`youtube.video_failed (${response.status})`);
+
+  const html = await response.text();
+  const playerResponse = playerResponseSchema.safeParse(
+    extractYouTubeJsonObject(html, "var ytInitialPlayerResponse =")?.value,
+  );
+  if (!playerResponse.success) return undefined;
+
+  const microformat = playerResponse.data.microformat.playerMicroformatRenderer;
+  return yearFromDate(microformat.uploadDate) ?? yearFromDate(microformat.publishDate);
+};


### PR DESCRIPTION
## Summary

- infer a YouTube playlist's year from the displayed date of its first playable video
- carry that shared year through the playlist album, pending metadata, and Cobalt download plans
- infer direct YouTube track years server-side and inject them into local-processing metadata before tagging
- support watch, short, live, embed, mobile, music, and youtu.be video URL shapes
- centralize YouTube page/config parsing shared by playlist pagination and video date resolution

## Why

Cobalt only provides a date for some auto-generated videos, so ordinary YouTube uploads hydrate without a year. Playlist pages also expose relative dates rather than a dependable album year.

The Worker uses YouTube's configured `next` API because watch/player microformat payloads can be stripped for Cloudflare egress. Direct-video metadata failures remain non-fatal so downloads preserve their existing fallback behavior.

## Preview

[Open the Cloudflare preview](https://ab433517-tagium.oliver-boorstein.workers.dev)

Live validation:
- [status update music](https://www.youtube.com/playlist?list=PLESiES1i-ThqUjxot6jWLDu90fxtkcpA0) resolves year 2026 across 15 tracks
- [Revengeseekerz](https://www.youtube.com/playlist?list=PLco9ZX1KZNVdaWJKCxnkk6bA-O-nsPMWa) resolves year 2025 across 12 playable tracks
- [Me at the zoo](https://www.youtube.com/watch?v=jNQXAC9IVRw) returns a local-processing plan with year 2005

## Validation

- `bun run test` — 34 files, 226 tests
- `bun run lint`
- `bun run build`
- `bun run test:e2e e2e/youtube-playlist-import.spec.ts --project=chromium`
- live Cloudflare preview playlist and direct-track API checks
