### PR TITLE
Enforce MP3 compatibility across imports and exports

### DIFF
--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -242,8 +242,7 @@ export default function AlbumSidebar({
 
     event.preventDefault();
     event.stopPropagation();
-    const audioFiles = droppedFiles.filter((file) => file.type.startsWith("audio/"));
-    if (audioFiles.length > 0) onUpload(audioFiles);
+    onUpload(droppedFiles);
   };
 
   if (albums.length === 0 && looseTracks.length === 0) {

--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -35,7 +35,7 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
     e.preventDefault();
     dragCounterRef.current = 0;
     setIsDragging(false);
-    const dropped = Array.from(e.dataTransfer.files).filter((f) => f.type.startsWith("audio/"));
+    const dropped = Array.from(e.dataTransfer.files);
     if (dropped.length > 0) void onAudioUpload(dropped);
   };
 
@@ -82,7 +82,6 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
               <h1 className="text-7xl font-bold tracking-tighter text-foreground">tagium</h1>
               <p className="text-muted-foreground mt-3 text-base">tag your music</p>
             </div>
-
             <button
               type="button"
               onClick={() => fileInputRef.current?.click()}
@@ -105,7 +104,9 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
                 <p className="text-lg font-semibold text-foreground">
                   {isDragging ? "drop to import" : "drop your mp3s here"}
                 </p>
-                <p className="text-sm text-muted-foreground mt-1">or click to browse files</p>
+                <p className="text-sm text-muted-foreground mt-1">
+                  MP3 files only · or click to browse
+                </p>
               </div>
             </button>
           </>

--- a/components/audio/SettingsPage.tsx
+++ b/components/audio/SettingsPage.tsx
@@ -135,6 +135,9 @@ export default function SettingsPage({ settings, onChange, onBack }: SettingsPag
               <p className="text-sm leading-6 text-muted-foreground">
                 tagium exists to make device-local music more accessible to everyone.
               </p>
+              <p className="text-sm leading-6 text-muted-foreground">
+                listening guide: Tagium currently imports, edits, and downloads MP3 audio only.
+              </p>
             </div>
 
             <div className="flex flex-col gap-2">

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -126,10 +126,7 @@ export default function TagSidebarPanel({
     event.preventDefault();
     dragCounterRef.current = 0;
     setIsDraggingFile(false);
-    const audioFiles = files.filter((file) => file.type.startsWith("audio/"));
-    if (audioFiles.length > 0) {
-      onAudioUpload(audioFiles);
-    }
+    onAudioUpload(files);
   };
 
   return (

--- a/components/audio/audioMetadataIO.test.ts
+++ b/components/audio/audioMetadataIO.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import { AudioMetadataIO, AudioMetadataIOLive } from "./audioMetadataIO";
 import { makeAudioRuntime } from "./audioRuntime";
 import type { AudioMetadata, TagiumFile } from "./types";
+import { validMp3Bytes } from "./mp3TestFixtures";
 
 const mp3tagMock = vi.hoisted(() => ({
   instances: [] as Array<{
@@ -47,13 +48,6 @@ const mp3tagMock = vi.hoisted(() => ({
   },
   nextReadError: undefined as string | undefined,
 }));
-
-const validMp3Bytes = () => {
-  const bytes = new Uint8Array(834);
-  bytes.set([0xff, 0xfb, 0x90, 0x00], 0);
-  bytes.set([0xff, 0xfb, 0x90, 0x00], 417);
-  return bytes;
-};
 
 vi.mock("mp3tag.js", () => ({
   default: class MP3Tag {
@@ -163,6 +157,28 @@ describe("AudioMetadataIO", () => {
     expect(upload.file.metadata?.picture[0]?.data).toBeInstanceOf(Uint8Array);
     expect(Array.from(upload.file.metadata?.picture[0]?.data ?? [])).toEqual([1, 2, 3]);
     expect(upload.albumSeed.cover).toBe(upload.file.metadata?.picture);
+  });
+
+  it("accepts a valid MP3 while returning actionable errors for mixed invalid inputs", async () => {
+    const uploads = await parseUploadedTracks([
+      new File([validMp3Bytes()], "valid.bin"),
+      new File([], "empty.mp3", { type: "audio/mpeg" }),
+      new File(["not audio"], "corrupt.mp3", { type: "audio/mpeg" }),
+      new File(["fLaC0000"], "unsupported.flac", { type: "audio/flac" }),
+    ]);
+
+    expect(uploads.map((upload) => upload.file.status)).toEqual([
+      "pending",
+      "error",
+      "error",
+      "error",
+    ]);
+    expect(uploads[0]?.file.filename).toBe("valid.mp3");
+    expect(uploads.slice(1).map((upload) => upload.file.downloadError)).toEqual([
+      "empty.mp3 is empty. Choose a valid MP3 file.",
+      "corrupt.mp3 is not a valid MP3. The file may be corrupt or renamed.",
+      "unsupported.flac is not an MP3. Tagium currently supports MP3 files only.",
+    ]);
   });
 
   it("normalizes missing numeric tags to null in parsed metadata snapshots", async () => {

--- a/components/audio/audioMetadataIO.test.ts
+++ b/components/audio/audioMetadataIO.test.ts
@@ -48,6 +48,13 @@ const mp3tagMock = vi.hoisted(() => ({
   nextReadError: undefined as string | undefined,
 }));
 
+const validMp3Bytes = () => {
+  const bytes = new Uint8Array(834);
+  bytes.set([0xff, 0xfb, 0x90, 0x00], 0);
+  bytes.set([0xff, 0xfb, 0x90, 0x00], 417);
+  return bytes;
+};
+
 vi.mock("mp3tag.js", () => ({
   default: class MP3Tag {
     tags = structuredClone(mp3tagMock.nextTags);
@@ -79,8 +86,8 @@ const metadata = (overrides: Partial<AudioMetadata> = {}): AudioMetadata => ({
 
 const tagiumFile = (overrides: Partial<TagiumFile> = {}): TagiumFile => ({
   id: "track-1",
-  file: new File(["audio"], "track-1.mp3", { type: "audio/mpeg" }),
-  originalFile: new File(["audio"], "track-1.mp3", { type: "audio/mpeg" }),
+  file: new File([validMp3Bytes()], "track-1.mp3", { type: "audio/mpeg" }),
+  originalFile: new File([validMp3Bytes()], "track-1.mp3", { type: "audio/mpeg" }),
   filename: "track-1.mp3",
   status: "pending",
   downloadStatus: "ready",
@@ -139,7 +146,7 @@ afterEach(() => {
 describe("AudioMetadataIO", () => {
   it("parses uploaded tracks through mp3tag and converts APIC bytes", async () => {
     const [upload] = await parseUploadedTracks([
-      new File(["audio"], "artist.track.mp3", { type: "audio/mpeg" }),
+      new File([validMp3Bytes()], "artist.track.mp3", { type: "audio/mpeg" }),
     ]);
 
     expect(upload.file.status).toBe("pending");
@@ -165,7 +172,7 @@ describe("AudioMetadataIO", () => {
     delete nextTags.track;
 
     const [upload] = await parseUploadedTracks([
-      new File(["audio"], "untagged.mp3", { type: "audio/mpeg" }),
+      new File([validMp3Bytes()], "untagged.mp3", { type: "audio/mpeg" }),
     ]);
 
     mp3tagMock.nextTags = originalTags;
@@ -179,7 +186,7 @@ describe("AudioMetadataIO", () => {
     mp3tagMock.nextReadError = "Invalid ID3 tag";
 
     const [upload] = await parseUploadedTracks([
-      new File(["audio"], "broken.mp3", { type: "audio/mpeg" }),
+      new File([validMp3Bytes()], "broken.mp3", { type: "audio/mpeg" }),
     ]);
 
     expect(upload.file.status).toBe("error");
@@ -196,7 +203,7 @@ describe("AudioMetadataIO", () => {
     });
 
     const [upload] = await parseUploadedTracks([
-      new File(["audio"], "duration-failure.mp3", { type: "audio/mpeg" }),
+      new File([validMp3Bytes()], "duration-failure.mp3", { type: "audio/mpeg" }),
     ]);
 
     expect(upload.file.status).toBe("error");

--- a/components/audio/audioMetadataIO.test.ts
+++ b/components/audio/audioMetadataIO.test.ts
@@ -161,7 +161,7 @@ describe("AudioMetadataIO", () => {
 
   it("accepts a valid MP3 while returning actionable errors for mixed invalid inputs", async () => {
     const uploads = await parseUploadedTracks([
-      new File([validMp3Bytes()], "valid.bin"),
+      new File([validMp3Bytes()], "valid.mp3"),
       new File([], "empty.mp3", { type: "audio/mpeg" }),
       new File(["not audio"], "corrupt.mp3", { type: "audio/mpeg" }),
       new File(["fLaC0000"], "unsupported.flac", { type: "audio/flac" }),

--- a/components/audio/audioMetadataIO.ts
+++ b/components/audio/audioMetadataIO.ts
@@ -3,6 +3,12 @@ import { AudioMetadataReadError, AudioMetadataWriteError, toPublicAudioError } f
 import { audioMetadataSchema } from "./metadata";
 import { parseTrackTagNumber, toGenreString, type UploadedTrack } from "./mp3Utils";
 import type { AudioMetadata, TagiumFile } from "./types";
+import {
+  getMp3AdmissionError,
+  MP3_MIME_TYPE,
+  normalizeMp3File,
+  normalizeMp3Filename,
+} from "./mp3Compatibility";
 
 interface MP3TagPicture {
   format: string;
@@ -141,10 +147,17 @@ const parseUploadedTrack = (file: File) =>
     const id = crypto.randomUUID();
 
     return yield* Effect.gen(function* () {
-      const MP3Tag = yield* loadMP3Tag;
       const arrayBuffer = yield* readArrayBuffer(file);
+      const admissionError = getMp3AdmissionError(file, new Uint8Array(arrayBuffer));
+      if (admissionError) {
+        return yield* Effect.fail(
+          new AudioMetadataReadError({ message: admissionError, cause: undefined }),
+        );
+      }
+      const normalizedFile = normalizeMp3File(file);
+      const MP3Tag = yield* loadMP3Tag;
       const mp3tag = yield* readMp3Tags(MP3Tag, arrayBuffer, false);
-      const duration = yield* getDuration(file);
+      const duration = yield* getDuration(normalizedFile);
       const pictureData =
         mp3tag.tags.v2?.APIC?.map((picture) => ({
           format: picture.format,
@@ -154,7 +167,7 @@ const parseUploadedTrack = (file: File) =>
         })) ?? [];
 
       const metadata = yield* decodeReadMetadata({
-        filename: file.name.split(".").slice(0, -1).join("."),
+        filename: normalizeMp3Filename(file.name).replace(/\.mp3$/i, ""),
         title: mp3tag.tags.title || "",
         artist: mp3tag.tags.artist || "",
         album: mp3tag.tags.album || "",
@@ -170,9 +183,9 @@ const parseUploadedTrack = (file: File) =>
       return {
         file: {
           id,
-          file,
+          file: normalizedFile,
           originalFile: file,
-          filename: file.name,
+          filename: normalizedFile.name,
           status: "pending",
           downloadStatus: "ready",
           hasBufferedChanges: false,
@@ -282,7 +295,7 @@ const writeMetadata = (fileToUpdate: TagiumFile, newTags: AudioMetadata) =>
       [new Uint8Array(buffer)],
       metadataToWrite.filename ? `${metadataToWrite.filename}.mp3` : fileToUpdate.filename,
       {
-        type: fileToUpdate.file.type,
+        type: MP3_MIME_TYPE,
       },
     );
   });

--- a/components/audio/audioTagger.test.ts
+++ b/components/audio/audioTagger.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   createDirtyMetadataPatch,
   getAcceptedUploadParseResult,
+  getUploadRejectionMessage,
   getFileImportKey,
   getSubmittedAudioMetadata,
   getTagiumFileImportKey,
@@ -51,6 +52,26 @@ describe("audioTagger metadata patches", () => {
       acceptedUploads: [accepted],
       parseRejectedCount: 1,
     });
+  });
+
+  it("consolidates every rejected file error into one presentation", () => {
+    const rejectedUploads = ["empty.mp3 is empty.", "song.wav is not an MP3."].map(
+      (downloadError, index) =>
+        ({
+          file: {
+            id: `rejected-${index}`,
+            filename: index === 0 ? "empty.mp3" : "song.wav",
+            status: "error",
+            downloadStatus: "ready",
+            downloadError,
+          },
+          albumSeed: { title: "", artist: "", genre: "" },
+        }) satisfies UploadedTrack,
+    );
+
+    expect(getUploadRejectionMessage(rejectedUploads)).toBe(
+      "empty.mp3 is empty.\nsong.wav is not an MP3.",
+    );
   });
 
   it("keeps a lightweight source identity after releasing the original file", () => {

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -121,6 +121,10 @@ export const getAcceptedUploadParseResult = (uploads: UploadedTrack[]) => {
     parseRejectedCount: uploads.length - acceptedUploads.length,
   };
 };
+export const getUploadRejectionMessage = (rejectedUploads: UploadedTrack[]) =>
+  rejectedUploads
+    .map((upload) => upload.file.downloadError ?? `${upload.file.filename} could not be imported.`)
+    .join("\n");
 const getManagedDownloadTrackTitle = (file: TagiumFile) => {
   if (file.metadata?.title) return file.metadata.title;
   return file.filename;
@@ -679,13 +683,13 @@ export default function AudioTagger() {
         const acceptedUploads = parseResult.acceptedUploads;
         acceptedCount = acceptedUploads.length;
         parseRejectedCount = parseResult.parseRejectedCount;
-        parsedUploads
-          .filter((upload) => upload.file.status === "error")
-          .forEach((upload) =>
-            toast.error(
-              upload.file.downloadError ?? `${upload.file.filename} could not be imported.`,
-            ),
+        const rejectedUploads = parsedUploads.filter((upload) => upload.file.status === "error");
+        if (rejectedUploads.length > 0) {
+          toast.error(
+            `${rejectedUploads.length} ${rejectedUploads.length === 1 ? "file" : "files"} could not be imported`,
+            { description: getUploadRejectionMessage(rejectedUploads) },
           );
+        }
         if (acceptedUploads.length === 0) return;
         const orderedUploads = sortUploadedTracksByTrackNumber(acceptedUploads);
         const nextFiles = [

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -82,6 +82,7 @@ import { resolveTrackMetadata, type TrackMetadata } from "./trackMetadata";
 import { isYouTubePlaylistUrl, resolveYouTubePlaylist } from "./youtubePlaylist";
 import { getSystemFailurePresentation, reportSystemFailure } from "./systemFailure";
 import { isValidFilenameBase, sanitizeFilenameBase } from "./filename";
+import { toast } from "sonner";
 import {
   AlbumGroup,
   AppSettings,
@@ -678,9 +679,13 @@ export default function AudioTagger() {
         const acceptedUploads = parseResult.acceptedUploads;
         acceptedCount = acceptedUploads.length;
         parseRejectedCount = parseResult.parseRejectedCount;
-        if (parseRejectedCount > 0) {
-          reportSystemFailure(new Error("audio upload parsing failed"), "upload");
-        }
+        parsedUploads
+          .filter((upload) => upload.file.status === "error")
+          .forEach((upload) =>
+            toast.error(
+              upload.file.downloadError ?? `${upload.file.filename} could not be imported.`,
+            ),
+          );
         if (acceptedUploads.length === 0) return;
         const orderedUploads = sortUploadedTracksByTrackNumber(acceptedUploads);
         const nextFiles = [
@@ -843,7 +848,7 @@ export default function AudioTagger() {
         yield* Effect.sync(() => signal.throwIfAborted());
         const [parsedUpload] = yield* parseUploads([downloadedFile]);
         yield* Effect.sync(() => signal.throwIfAborted());
-        if (!parsedUpload) {
+        if (!parsedUpload || parsedUpload.file.status === "error") {
           return yield* Effect.fail(new Error("downloaded track could not be parsed."));
         }
 

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -82,7 +82,6 @@ import { resolveTrackMetadata, type TrackMetadata } from "./trackMetadata";
 import { isYouTubePlaylistUrl, resolveYouTubePlaylist } from "./youtubePlaylist";
 import { getSystemFailurePresentation, reportSystemFailure } from "./systemFailure";
 import { isValidFilenameBase, sanitizeFilenameBase } from "./filename";
-import { toast } from "sonner";
 import {
   AlbumGroup,
   AppSettings,

--- a/components/audio/audioUpload.tsx
+++ b/components/audio/audioUpload.tsx
@@ -15,9 +15,6 @@ export default function AudioUpload({ onAudioUpload }: AudioUploadProps) {
 
   const handleAudioUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
-    // The accept=".mp3,audio/mpeg" attribute on the Input component already filters for MP3 files.
-    // No need for explicit filtering here unless more specific audio types are required.
-
     if (files.length > 0) {
       onAudioUpload(files);
     }
@@ -49,6 +46,7 @@ export default function AudioUpload({ onAudioUpload }: AudioUploadProps) {
         aria-label="upload audio files"
       >
         <Upload className="h-6 w-6 text-muted-foreground" />
+        <span className="text-xs text-muted-foreground">upload MP3 files only</span>
       </Button>
     </div>
   );

--- a/components/audio/downloadLibrary.test.ts
+++ b/components/audio/downloadLibrary.test.ts
@@ -150,7 +150,7 @@ describe("downloadLibrary", () => {
     expect(entries[1]?.file.type).toBe("image/png");
   });
 
-  it("preserves cover-like track filenames when adding album cover files", () => {
+  it("normalizes a cover-like track filename without colliding with album art", () => {
     const entries = getLibraryDownloadEntries({
       albums: [{ ...album("album", "Album", ["track"]), cover }],
       looseTrackIds: [],
@@ -158,8 +158,8 @@ describe("downloadLibrary", () => {
     });
 
     expect(entries.map((entry) => entry.path)).toEqual([
+      "albums/Album/cover.mp3",
       "albums/Album/cover.jpg",
-      "albums/Album/cover-2.jpg",
     ]);
   });
 

--- a/components/audio/downloadLibrary.ts
+++ b/components/audio/downloadLibrary.ts
@@ -1,6 +1,7 @@
 import filenamify from "filenamify";
 import type { AlbumGroup, TagiumFile } from "./types";
 import { isValidFilenameBase } from "./filename";
+import { normalizeMp3Filename } from "./mp3Compatibility";
 
 export interface DownloadZipEntry {
   path: string;
@@ -119,7 +120,7 @@ const addTrackEntry = (
   track: TagiumFile | undefined,
 ) => {
   if (!track || !isTrackReadyForDownload(track) || !track.file) return;
-  const filename = cleanPathPart(track.filename, "track.mp3");
+  const filename = normalizeMp3Filename(cleanPathPart(track.filename, "track.mp3"));
   entries.push({
     path: uniquePath(`${folderPath}/${filename}`, usedPaths),
     file: track.file,

--- a/components/audio/mp3Compatibility.test.ts
+++ b/components/audio/mp3Compatibility.test.ts
@@ -5,19 +5,43 @@ import {
   MP3_MIME_TYPE,
   normalizeMp3File,
 } from "./mp3Compatibility";
-
-const mp3Bytes = () => {
-  const bytes = new Uint8Array(834);
-  bytes.set([0xff, 0xfb, 0x90, 0x00], 0);
-  bytes.set([0xff, 0xfb, 0x90, 0x00], 417);
-  return bytes;
-};
+import { validFreeFormatMp3Bytes, validMp3Bytes } from "./mp3TestFixtures";
 
 describe("MP3 compatibility", () => {
   it("accepts MP3 frame contents when browser metadata is missing or inconsistent", () => {
-    const bytes = mp3Bytes();
+    const bytes = validMp3Bytes();
     expect(isMp3Bytes(bytes)).toBe(true);
     expect(getMp3AdmissionError(new File([bytes], "track.bin"), bytes)).toBeNull();
+  });
+
+  it("rejects a single complete frame ending at EOF", () => {
+    expect(isMp3Bytes(validMp3Bytes().slice(0, 417))).toBe(false);
+  });
+
+  it("rejects a truncated second frame", () => {
+    expect(isMp3Bytes(validMp3Bytes().slice(0, 500))).toBe(false);
+  });
+
+  it("rejects incompatible and payload-like second headers", () => {
+    const incompatible = validMp3Bytes();
+    incompatible.set([0xff, 0xf3, 0x90, 0x00], 417);
+    expect(isMp3Bytes(incompatible)).toBe(false);
+
+    const falseHeader = validMp3Bytes().slice(0, 500);
+    falseHeader.set([0xff, 0xfb, 0x90, 0x00], 417);
+    expect(isMp3Bytes(falseHeader)).toBe(false);
+  });
+
+  it("accepts synchronized complete free-format MP3 frames", () => {
+    expect(isMp3Bytes(validFreeFormatMp3Bytes())).toBe(true);
+  });
+
+  it("rejects truncated or irregular free-format synchronization", () => {
+    expect(isMp3Bytes(validFreeFormatMp3Bytes().slice(0, 750))).toBe(false);
+    const irregular = validFreeFormatMp3Bytes();
+    irregular.copyWithin(650, 600, 604);
+    irregular.fill(0, 600, 604);
+    expect(isMp3Bytes(irregular)).toBe(false);
   });
 
   it.each([
@@ -31,7 +55,7 @@ describe("MP3 compatibility", () => {
   });
 
   it("normalizes an admitted file's extension and MIME type", () => {
-    const file = normalizeMp3File(new File([mp3Bytes()], "track.wav", { type: "audio/wav" }));
+    const file = normalizeMp3File(new File([validMp3Bytes()], "track.wav", { type: "audio/wav" }));
     expect(file.name).toBe("track.mp3");
     expect(file.type).toBe(MP3_MIME_TYPE);
   });

--- a/components/audio/mp3Compatibility.test.ts
+++ b/components/audio/mp3Compatibility.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  getMp3AdmissionError,
+  isMp3Bytes,
+  MP3_MIME_TYPE,
+  normalizeMp3File,
+} from "./mp3Compatibility";
+
+const mp3Bytes = () => {
+  const bytes = new Uint8Array(834);
+  bytes.set([0xff, 0xfb, 0x90, 0x00], 0);
+  bytes.set([0xff, 0xfb, 0x90, 0x00], 417);
+  return bytes;
+};
+
+describe("MP3 compatibility", () => {
+  it("accepts MP3 frame contents when browser metadata is missing or inconsistent", () => {
+    const bytes = mp3Bytes();
+    expect(isMp3Bytes(bytes)).toBe(true);
+    expect(getMp3AdmissionError(new File([bytes], "track.bin"), bytes)).toBeNull();
+  });
+
+  it.each([
+    ["empty", new Uint8Array(), "is empty"],
+    ["renamed WAV", new TextEncoder().encode("RIFF0000WAVEdata"), "is not an MP3"],
+    ["corrupt MP3", new TextEncoder().encode("not audio"), "is not a valid MP3"],
+    ["unsupported audio", new TextEncoder().encode("fLaC0000"), "is not an MP3"],
+  ])("rejects %s with an actionable error", (_case, bytes, message) => {
+    const file = new File([bytes], "track.mp3", { type: MP3_MIME_TYPE });
+    expect(getMp3AdmissionError(file, bytes)).toContain(message);
+  });
+
+  it("normalizes an admitted file's extension and MIME type", () => {
+    const file = normalizeMp3File(new File([mp3Bytes()], "track.wav", { type: "audio/wav" }));
+    expect(file.name).toBe("track.mp3");
+    expect(file.type).toBe(MP3_MIME_TYPE);
+  });
+});

--- a/components/audio/mp3Compatibility.test.ts
+++ b/components/audio/mp3Compatibility.test.ts
@@ -8,10 +8,12 @@ import {
 import { validFreeFormatMp3Bytes, validMp3Bytes } from "./mp3TestFixtures";
 
 describe("MP3 compatibility", () => {
-  it("accepts MP3 frame contents when browser metadata is missing or inconsistent", () => {
+  it("accepts MP3 frame contents when browser MIME metadata is missing or inconsistent", () => {
     const bytes = validMp3Bytes();
     expect(isMp3Bytes(bytes)).toBe(true);
-    expect(getMp3AdmissionError(new File([bytes], "track.bin"), bytes)).toBeNull();
+    expect(
+      getMp3AdmissionError(new File([bytes], "track.mp3", { type: "audio/wav" }), bytes),
+    ).toBeNull();
   });
 
   it("rejects a single complete frame ending at EOF", () => {
@@ -36,6 +38,17 @@ describe("MP3 compatibility", () => {
     expect(isMp3Bytes(validFreeFormatMp3Bytes())).toBe(true);
   });
 
+  it("rejects a WAV container even when its payload contains valid MP3 frames", () => {
+    const bytes = new Uint8Array(12 + validMp3Bytes().length);
+    bytes.set(new TextEncoder().encode("RIFF0000WAVE"));
+    bytes.set(validMp3Bytes(), 12);
+    const file = new File([bytes], "wrapped.wav", { type: "audio/wav" });
+
+    expect(getMp3AdmissionError(file, bytes)).toBe(
+      "wrapped.wav is not an MP3. Tagium currently supports MP3 files only.",
+    );
+  });
+
   it("rejects truncated or irregular free-format synchronization", () => {
     expect(isMp3Bytes(validFreeFormatMp3Bytes().slice(0, 750))).toBe(false);
     const irregular = validFreeFormatMp3Bytes();
@@ -54,8 +67,8 @@ describe("MP3 compatibility", () => {
     expect(getMp3AdmissionError(file, bytes)).toContain(message);
   });
 
-  it("normalizes an admitted file's extension and MIME type", () => {
-    const file = normalizeMp3File(new File([validMp3Bytes()], "track.wav", { type: "audio/wav" }));
+  it("normalizes an admitted file's MIME type", () => {
+    const file = normalizeMp3File(new File([validMp3Bytes()], "track.mp3", { type: "audio/wav" }));
     expect(file.name).toBe("track.mp3");
     expect(file.type).toBe(MP3_MIME_TYPE);
   });

--- a/components/audio/mp3Compatibility.ts
+++ b/components/audio/mp3Compatibility.ts
@@ -120,16 +120,18 @@ const startsWithAscii = (bytes: Uint8Array, value: string, offset = 0) =>
 
 export const getMp3AdmissionError = (file: File, bytes: Uint8Array) => {
   if (bytes.length === 0) return `${file.name} is empty. Choose a valid MP3 file.`;
-  if (isMp3Bytes(bytes)) return null;
-
+  if (!/\.mp3$/i.test(file.name)) {
+    return `${file.name} is not an MP3. Tagium currently supports MP3 files only.`;
+  }
   const knownUnsupported =
     startsWithAscii(bytes, "RIFF") ||
     startsWithAscii(bytes, "fLaC") ||
     startsWithAscii(bytes, "OggS") ||
     startsWithAscii(bytes, "ftyp", 4);
-  if (knownUnsupported || (!/\.mp3$/i.test(file.name) && file.type !== MP3_MIME_TYPE)) {
+  if (knownUnsupported) {
     return `${file.name} is not an MP3. Tagium currently supports MP3 files only.`;
   }
+  if (isMp3Bytes(bytes)) return null;
   return `${file.name} is not a valid MP3. The file may be corrupt or renamed.`;
 };
 

--- a/components/audio/mp3Compatibility.ts
+++ b/components/audio/mp3Compatibility.ts
@@ -1,0 +1,101 @@
+export const MP3_MIME_TYPE = "audio/mpeg";
+
+const bitrateKbps = {
+  mpeg1Layer1: [0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448],
+  mpeg1Layer2: [0, 32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384],
+  mpeg1Layer3: [0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320],
+  mpeg2Layer1: [0, 32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256],
+  mpeg2Layer23: [0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160],
+} as const;
+
+const getFrameLength = (bytes: Uint8Array, offset: number) => {
+  if (offset + 4 > bytes.length || bytes[offset] !== 0xff || (bytes[offset + 1]! & 0xe0) !== 0xe0) {
+    return 0;
+  }
+
+  const versionBits = (bytes[offset + 1]! >> 3) & 0x03;
+  const layerBits = (bytes[offset + 1]! >> 1) & 0x03;
+  const bitrateIndex = (bytes[offset + 2]! >> 4) & 0x0f;
+  const sampleRateIndex = (bytes[offset + 2]! >> 2) & 0x03;
+  const padding = (bytes[offset + 2]! >> 1) & 0x01;
+  if (
+    versionBits === 1 ||
+    layerBits === 0 ||
+    bitrateIndex === 0 ||
+    bitrateIndex === 15 ||
+    sampleRateIndex === 3
+  ) {
+    return 0;
+  }
+
+  const isMpeg1 = versionBits === 3;
+  const layer = 4 - layerBits;
+  const baseSampleRates = [44_100, 48_000, 32_000];
+  const divisor = isMpeg1 ? 1 : versionBits === 2 ? 2 : 4;
+  const sampleRate = baseSampleRates[sampleRateIndex]! / divisor;
+  const table = isMpeg1
+    ? layer === 1
+      ? bitrateKbps.mpeg1Layer1
+      : layer === 2
+        ? bitrateKbps.mpeg1Layer2
+        : bitrateKbps.mpeg1Layer3
+    : layer === 1
+      ? bitrateKbps.mpeg2Layer1
+      : bitrateKbps.mpeg2Layer23;
+  const bitrate = table[bitrateIndex]! * 1_000;
+  return layer === 1
+    ? Math.floor(((12 * bitrate) / sampleRate + padding) * 4)
+    : Math.floor(((layer === 3 && !isMpeg1 ? 72 : 144) * bitrate) / sampleRate + padding);
+};
+
+const getAudioStart = (bytes: Uint8Array) => {
+  if (bytes.length < 10 || bytes[0] !== 0x49 || bytes[1] !== 0x44 || bytes[2] !== 0x33) return 0;
+  if ([bytes[6], bytes[7], bytes[8], bytes[9]].some((value) => (value! & 0x80) !== 0)) return -1;
+  const tagSize = (bytes[6]! << 21) | (bytes[7]! << 14) | (bytes[8]! << 7) | bytes[9]!;
+  return 10 + tagSize + ((bytes[5]! & 0x10) !== 0 ? 10 : 0);
+};
+
+export const isMp3Bytes = (bytes: Uint8Array) => {
+  const audioStart = getAudioStart(bytes);
+  if (audioStart < 0 || audioStart >= bytes.length) return false;
+  const scanEnd = Math.min(bytes.length - 4, audioStart + 16_384);
+
+  for (let offset = audioStart; offset <= scanEnd; offset++) {
+    const firstLength = getFrameLength(bytes, offset);
+    if (firstLength === 0 || offset + firstLength > bytes.length) continue;
+    const nextOffset = offset + firstLength;
+    if (nextOffset === bytes.length || getFrameLength(bytes, nextOffset) > 0) return true;
+  }
+  return false;
+};
+
+const startsWithAscii = (bytes: Uint8Array, value: string, offset = 0) =>
+  Array.from(value).every((character, index) => bytes[offset + index] === character.charCodeAt(0));
+
+export const getMp3AdmissionError = (file: File, bytes: Uint8Array) => {
+  if (bytes.length === 0) return `${file.name} is empty. Choose a valid MP3 file.`;
+  if (isMp3Bytes(bytes)) return null;
+
+  const knownUnsupported =
+    startsWithAscii(bytes, "RIFF") ||
+    startsWithAscii(bytes, "fLaC") ||
+    startsWithAscii(bytes, "OggS") ||
+    startsWithAscii(bytes, "ftyp", 4);
+  if (knownUnsupported || (!/\.mp3$/i.test(file.name) && file.type !== MP3_MIME_TYPE)) {
+    return `${file.name} is not an MP3. Tagium currently supports MP3 files only.`;
+  }
+  return `${file.name} is not a valid MP3. The file may be corrupt or renamed.`;
+};
+
+export const normalizeMp3Filename = (filename: string) => {
+  const basename = filename.replace(/\.[^.]+$/, "") || "track";
+  return `${basename}.mp3`;
+};
+
+export const normalizeMp3File = (file: File) =>
+  file.type === MP3_MIME_TYPE && /\.mp3$/i.test(file.name)
+    ? file
+    : new File([file], normalizeMp3Filename(file.name), {
+        type: MP3_MIME_TYPE,
+        lastModified: file.lastModified,
+      });

--- a/components/audio/mp3Compatibility.ts
+++ b/components/audio/mp3Compatibility.ts
@@ -8,9 +8,17 @@ const bitrateKbps = {
   mpeg2Layer23: [0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160],
 } as const;
 
-const getFrameLength = (bytes: Uint8Array, offset: number) => {
+interface FrameHeader {
+  versionBits: number;
+  layer: number;
+  sampleRate: number;
+  bitrateIndex: number;
+  frameLength: number | null;
+}
+
+const getFrameHeader = (bytes: Uint8Array, offset: number): FrameHeader | null => {
   if (offset + 4 > bytes.length || bytes[offset] !== 0xff || (bytes[offset + 1]! & 0xe0) !== 0xe0) {
-    return 0;
+    return null;
   }
 
   const versionBits = (bytes[offset + 1]! >> 3) & 0x03;
@@ -18,21 +26,18 @@ const getFrameLength = (bytes: Uint8Array, offset: number) => {
   const bitrateIndex = (bytes[offset + 2]! >> 4) & 0x0f;
   const sampleRateIndex = (bytes[offset + 2]! >> 2) & 0x03;
   const padding = (bytes[offset + 2]! >> 1) & 0x01;
-  if (
-    versionBits === 1 ||
-    layerBits === 0 ||
-    bitrateIndex === 0 ||
-    bitrateIndex === 15 ||
-    sampleRateIndex === 3
-  ) {
-    return 0;
+  if (versionBits === 1 || layerBits === 0 || bitrateIndex === 15 || sampleRateIndex === 3) {
+    return null;
   }
 
   const isMpeg1 = versionBits === 3;
   const layer = 4 - layerBits;
-  const baseSampleRates = [44_100, 48_000, 32_000];
   const divisor = isMpeg1 ? 1 : versionBits === 2 ? 2 : 4;
-  const sampleRate = baseSampleRates[sampleRateIndex]! / divisor;
+  const sampleRate = [44_100, 48_000, 32_000][sampleRateIndex]! / divisor;
+  if (bitrateIndex === 0) {
+    return { versionBits, layer, sampleRate, bitrateIndex, frameLength: null };
+  }
+
   const table = isMpeg1
     ? layer === 1
       ? bitrateKbps.mpeg1Layer1
@@ -43,9 +48,46 @@ const getFrameLength = (bytes: Uint8Array, offset: number) => {
       ? bitrateKbps.mpeg2Layer1
       : bitrateKbps.mpeg2Layer23;
   const bitrate = table[bitrateIndex]! * 1_000;
-  return layer === 1
-    ? Math.floor(((12 * bitrate) / sampleRate + padding) * 4)
-    : Math.floor(((layer === 3 && !isMpeg1 ? 72 : 144) * bitrate) / sampleRate + padding);
+  const frameLength =
+    layer === 1
+      ? Math.floor(((12 * bitrate) / sampleRate + padding) * 4)
+      : Math.floor(((layer === 3 && !isMpeg1 ? 72 : 144) * bitrate) / sampleRate + padding);
+  return { versionBits, layer, sampleRate, bitrateIndex, frameLength };
+};
+
+const headersAreCompatible = (first: FrameHeader, next: FrameHeader) =>
+  first.versionBits === next.versionBits &&
+  first.layer === next.layer &&
+  first.sampleRate === next.sampleRate &&
+  (first.bitrateIndex === 0) === (next.bitrateIndex === 0);
+
+const hasCompleteKnownLengthFrames = (bytes: Uint8Array, offset: number, first: FrameHeader) => {
+  if (first.frameLength === null || offset + first.frameLength > bytes.length) return false;
+  const nextOffset = offset + first.frameLength;
+  const next = getFrameHeader(bytes, nextOffset);
+  return (
+    next !== null &&
+    next.frameLength !== null &&
+    headersAreCompatible(first, next) &&
+    nextOffset + next.frameLength <= bytes.length
+  );
+};
+
+const hasCompleteFreeFormatFrames = (bytes: Uint8Array, offset: number, first: FrameHeader) => {
+  // Free-format headers omit bitrate, so infer frame size from repeated, equally spaced syncs.
+  // Requiring three complete frames avoids treating payload bytes or truncated data as evidence.
+  const searchEnd = Math.min(bytes.length - 4, offset + 16_384);
+  for (let secondOffset = offset + 4; secondOffset <= searchEnd; secondOffset++) {
+    const second = getFrameHeader(bytes, secondOffset);
+    if (!second || !headersAreCompatible(first, second)) continue;
+    const spacing = secondOffset - offset;
+    const thirdOffset = secondOffset + spacing;
+    const third = getFrameHeader(bytes, thirdOffset);
+    if (third && headersAreCompatible(first, third) && thirdOffset + spacing <= bytes.length) {
+      return true;
+    }
+  }
+  return false;
 };
 
 const getAudioStart = (bytes: Uint8Array) => {
@@ -61,10 +103,14 @@ export const isMp3Bytes = (bytes: Uint8Array) => {
   const scanEnd = Math.min(bytes.length - 4, audioStart + 16_384);
 
   for (let offset = audioStart; offset <= scanEnd; offset++) {
-    const firstLength = getFrameLength(bytes, offset);
-    if (firstLength === 0 || offset + firstLength > bytes.length) continue;
-    const nextOffset = offset + firstLength;
-    if (nextOffset === bytes.length || getFrameLength(bytes, nextOffset) > 0) return true;
+    const first = getFrameHeader(bytes, offset);
+    if (!first) continue;
+    if (
+      (first.frameLength === null && hasCompleteFreeFormatFrames(bytes, offset, first)) ||
+      hasCompleteKnownLengthFrames(bytes, offset, first)
+    ) {
+      return true;
+    }
   }
   return false;
 };

--- a/components/audio/mp3TestFixtures.ts
+++ b/components/audio/mp3TestFixtures.ts
@@ -1,0 +1,15 @@
+export const validMp3Bytes = () => {
+  const bytes = new Uint8Array(834);
+  bytes.set([0xff, 0xfb, 0x90, 0x00], 0);
+  bytes.set([0xff, 0xfb, 0x90, 0x00], 417);
+  return bytes;
+};
+
+export const validFreeFormatMp3Bytes = () => {
+  const frameLength = 300;
+  const bytes = new Uint8Array(frameLength * 3);
+  for (let offset = 0; offset < bytes.length; offset += frameLength) {
+    bytes.set([0xff, 0xfb, 0x00, 0x00], offset);
+  }
+  return bytes;
+};


### PR DESCRIPTION
Closes #80

## What changed

- validate upload contents by parsing MP3 frame headers instead of trusting filenames or browser MIME metadata
- require complete, compatible frame sequences, including synchronized free-format MP3 streams
- report actionable per-file errors for empty, corrupt, renamed, and unsupported inputs while retaining valid files from mixed selections
- route every drag-and-drop upload surface through the shared content validator
- reject invalid Cobalt/URL download payloads before tracks become ready
- normalize admitted files, metadata writes, and ZIP entries to `.mp3` and `audio/mpeg`
- make MP3-only support explicit in upload surfaces and the listening guide
- add automated coverage for valid, free-format, truncated, corrupt, misleadingly named, unsupported, empty, and mixed inputs

## Root cause

The file picker’s `accept` attribute and several drag-and-drop MIME checks were treated as enforcement even though browser metadata is only a hint. Parsing failures were represented as error uploads but then discarded without feedback, and URL hydration did not reject those error records before continuing.

## Impact

Valid MP3 files remain importable even with missing or inconsistent browser metadata. Invalid payloads now fail before library insertion, mixed selections preserve successful imports and consolidate all rejection details, and all export paths consistently use the MP3 contract.

## Review follow-up

Two independent review agents checked repository standards and issue #80 compliance. A fresh remediation agent addressed their findings: hardened frame validation, free-format support, remaining MIME prefilters, mixed-input coverage, bounded rejection presentation, and shared test fixtures.

## Validation

- `bun run test` (34 files, 229 tests)
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `vp check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stronger MP3 validation, including clear handling for empty, corrupt, unsupported, or incorrectly formatted files.
  - Upload errors now display specific messages for each rejected file.
  - MP3 filenames and file types are normalized automatically.
  - Downloaded ZIP files now use consistent `.mp3` track names.

- **UI Improvements**
  - Upload areas now clearly indicate that MP3 files are supported.
  - Updated landing and settings guidance to explain MP3-only support.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->