### PR TITLE
Normalize UI capitalization

### DIFF
--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -105,7 +105,7 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
                   {isDragging ? "drop to import" : "drop your mp3s here"}
                 </p>
                 <p className="text-sm text-muted-foreground mt-1">
-                  MP3 files only · or click to browse
+                  mp3 files only · or click to browse
                 </p>
               </div>
             </button>

--- a/components/audio/SettingsPage.tsx
+++ b/components/audio/SettingsPage.tsx
@@ -136,7 +136,7 @@ export default function SettingsPage({ settings, onChange, onBack }: SettingsPag
                 tagium exists to make device-local music more accessible to everyone.
               </p>
               <p className="text-sm leading-6 text-muted-foreground">
-                listening guide: Tagium currently imports, edits, and downloads MP3 audio only.
+                listening guide: tagium currently imports, edits, and downloads mp3 audio only.
               </p>
             </div>
 

--- a/components/audio/audioMetadataIO.test.ts
+++ b/components/audio/audioMetadataIO.test.ts
@@ -175,9 +175,9 @@ describe("AudioMetadataIO", () => {
     ]);
     expect(uploads[0]?.file.filename).toBe("valid.mp3");
     expect(uploads.slice(1).map((upload) => upload.file.downloadError)).toEqual([
-      "empty.mp3 is empty. Choose a valid MP3 file.",
-      "corrupt.mp3 is not a valid MP3. The file may be corrupt or renamed.",
-      "unsupported.flac is not an MP3. Tagium currently supports MP3 files only.",
+      "empty.mp3 is empty. Choose a valid mp3 file.",
+      "corrupt.mp3 is not a valid mp3. The file may be corrupt or renamed.",
+      "unsupported.flac is not an mp3. tagium currently supports mp3 files only.",
     ]);
   });
 

--- a/components/audio/audioTagger.test.ts
+++ b/components/audio/audioTagger.test.ts
@@ -55,7 +55,7 @@ describe("audioTagger metadata patches", () => {
   });
 
   it("consolidates every rejected file error into one presentation", () => {
-    const rejectedUploads = ["empty.mp3 is empty.", "song.wav is not an MP3."].map(
+    const rejectedUploads = ["empty.mp3 is empty.", "song.wav is not an mp3."].map(
       (downloadError, index) =>
         ({
           file: {
@@ -70,7 +70,7 @@ describe("audioTagger metadata patches", () => {
     );
 
     expect(getUploadRejectionMessage(rejectedUploads)).toBe(
-      "empty.mp3 is empty.\nsong.wav is not an MP3.",
+      "empty.mp3 is empty.\nsong.wav is not an mp3.",
     );
   });
 

--- a/components/audio/audioUpload.tsx
+++ b/components/audio/audioUpload.tsx
@@ -46,7 +46,7 @@ export default function AudioUpload({ onAudioUpload }: AudioUploadProps) {
         aria-label="upload audio files"
       >
         <Upload className="h-6 w-6 text-muted-foreground" />
-        <span className="text-xs text-muted-foreground">upload MP3 files only</span>
+        <span className="text-xs text-muted-foreground">upload mp3 files only</span>
       </Button>
     </div>
   );

--- a/components/audio/cobaltAudio.test.ts
+++ b/components/audio/cobaltAudio.test.ts
@@ -402,7 +402,7 @@ describe("CobaltAudio download", () => {
         sourceUrl: "https://soundcloud.com/artist/track",
         audioBitrate: "128",
       }),
-    ).rejects.toThrow("malformed Cobalt local processing message.");
+    ).rejects.toThrow("malformed cobalt local processing message.");
   });
 
   it("processes local audio with cover art through the worker and mp3tag", async () => {

--- a/components/audio/cobaltAudio.ts
+++ b/components/audio/cobaltAudio.ts
@@ -180,7 +180,7 @@ const decodeCobaltDownloadPlan = Effect.fn("decodeCobaltDownloadPlan")(function*
     Effect.mapError(
       (cause) =>
         new AudioDecodeError({
-          message: "malformed Cobalt audio plan.",
+          message: "malformed cobalt audio plan.",
           cause,
         }),
     ),

--- a/components/audio/coverArtProcessing.ts
+++ b/components/audio/coverArtProcessing.ts
@@ -24,7 +24,7 @@ export const getCoverArtTargetSize = (
 
 export const validateCoverArtUpload = (file: File) => {
   if (!supportedCoverArtTypes.has(file.type.toLowerCase())) {
-    throw new Error("cover art image must be a JPEG or PNG.");
+    throw new Error("cover art image must be a jpeg or png.");
   }
   if (file.size > MAX_COVER_ART_UPLOAD_BYTES) {
     throw new Error("cover art must be 25 MB or smaller.");
@@ -34,7 +34,7 @@ export const validateCoverArtUpload = (file: File) => {
 export const normalizeCoverArtType = (contentType: string) => {
   const normalized = contentType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
   if (!supportedCoverArtTypes.has(normalized)) {
-    throw new Error("cover art image must be a JPEG or PNG.");
+    throw new Error("cover art image must be a jpeg or png.");
   }
   return normalized === "image/jpg" ? "image/jpeg" : normalized;
 };

--- a/components/audio/downloadPresentation.test.tsx
+++ b/components/audio/downloadPresentation.test.tsx
@@ -21,7 +21,7 @@ describe("download presentation", () => {
     );
 
     expect(markup).toContain("waiting to start more downloads...");
-    expect(markup).not.toContain("Cobalt");
+    expect(markup.toLowerCase()).not.toContain("cobalt");
     expect(markup).not.toContain("tunnel budget");
   });
 

--- a/components/audio/downloadTrack.test.ts
+++ b/components/audio/downloadTrack.test.ts
@@ -59,7 +59,7 @@ describe("imported cover downloads", () => {
 
     await expect(
       fetchImportedCover("https://example.com/cover", { fetch: async () => response }),
-    ).rejects.toThrow("JPEG or PNG");
+    ).rejects.toThrow("jpeg or png");
     expect(readBody).not.toHaveBeenCalled();
   });
 

--- a/components/audio/localAudioProcessor.ts
+++ b/components/audio/localAudioProcessor.ts
@@ -86,7 +86,7 @@ const decodeCobaltLocalProcessingMessage = Effect.fn("decodeCobaltLocalProcessin
       Effect.mapError(
         (cause) =>
           new AudioDecodeError({
-            message: "malformed Cobalt local processing message.",
+            message: "malformed cobalt local processing message.",
             cause,
           }),
       ),

--- a/components/audio/mp3Compatibility.test.ts
+++ b/components/audio/mp3Compatibility.test.ts
@@ -45,7 +45,7 @@ describe("MP3 compatibility", () => {
     const file = new File([bytes], "wrapped.wav", { type: "audio/wav" });
 
     expect(getMp3AdmissionError(file, bytes)).toBe(
-      "wrapped.wav is not an MP3. Tagium currently supports MP3 files only.",
+      "wrapped.wav is not an mp3. tagium currently supports mp3 files only.",
     );
   });
 
@@ -59,9 +59,9 @@ describe("MP3 compatibility", () => {
 
   it.each([
     ["empty", new Uint8Array(), "is empty"],
-    ["renamed WAV", new TextEncoder().encode("RIFF0000WAVEdata"), "is not an MP3"],
-    ["corrupt MP3", new TextEncoder().encode("not audio"), "is not a valid MP3"],
-    ["unsupported audio", new TextEncoder().encode("fLaC0000"), "is not an MP3"],
+    ["renamed WAV", new TextEncoder().encode("RIFF0000WAVEdata"), "is not an mp3"],
+    ["corrupt MP3", new TextEncoder().encode("not audio"), "is not a valid mp3"],
+    ["unsupported audio", new TextEncoder().encode("fLaC0000"), "is not an mp3"],
   ])("rejects %s with an actionable error", (_case, bytes, message) => {
     const file = new File([bytes], "track.mp3", { type: MP3_MIME_TYPE });
     expect(getMp3AdmissionError(file, bytes)).toContain(message);

--- a/components/audio/mp3Compatibility.ts
+++ b/components/audio/mp3Compatibility.ts
@@ -119,9 +119,9 @@ const startsWithAscii = (bytes: Uint8Array, value: string, offset = 0) =>
   Array.from(value).every((character, index) => bytes[offset + index] === character.charCodeAt(0));
 
 export const getMp3AdmissionError = (file: File, bytes: Uint8Array) => {
-  if (bytes.length === 0) return `${file.name} is empty. Choose a valid MP3 file.`;
+  if (bytes.length === 0) return `${file.name} is empty. Choose a valid mp3 file.`;
   if (!/\.mp3$/i.test(file.name)) {
-    return `${file.name} is not an MP3. Tagium currently supports MP3 files only.`;
+    return `${file.name} is not an mp3. tagium currently supports mp3 files only.`;
   }
   const knownUnsupported =
     startsWithAscii(bytes, "RIFF") ||
@@ -129,10 +129,10 @@ export const getMp3AdmissionError = (file: File, bytes: Uint8Array) => {
     startsWithAscii(bytes, "OggS") ||
     startsWithAscii(bytes, "ftyp", 4);
   if (knownUnsupported) {
-    return `${file.name} is not an MP3. Tagium currently supports MP3 files only.`;
+    return `${file.name} is not an mp3. tagium currently supports mp3 files only.`;
   }
   if (isMp3Bytes(bytes)) return null;
-  return `${file.name} is not a valid MP3. The file may be corrupt or renamed.`;
+  return `${file.name} is not a valid mp3. The file may be corrupt or renamed.`;
 };
 
 export const normalizeMp3Filename = (filename: string) => {

--- a/components/audio/systemFailure.test.ts
+++ b/components/audio/systemFailure.test.ts
@@ -18,10 +18,10 @@ beforeEach(() => {
 
 describe("system failure reporting", () => {
   it.each([
-    ["error.api.capacity_exceeded", "capacity", "Downloads are busy"],
-    ["Cobalt tunnel request failed (429)", "rate_limited", "Too many download requests"],
-    ["error.api.timed_out", "timeout", "The download took too long"],
-    ["error.api.unreachable", "service_unavailable", "Downloads are temporarily unavailable"],
+    ["error.api.capacity_exceeded", "capacity", "downloads are busy"],
+    ["Cobalt tunnel request failed (429)", "rate_limited", "too many download requests"],
+    ["error.api.timed_out", "timeout", "the download took too long"],
+    ["error.api.unreachable", "service_unavailable", "downloads are temporarily unavailable"],
   ] as const)("maps %s to safe public copy", (message, code, title) => {
     expect(getSystemFailurePresentation(new Error(message), "download")).toMatchObject({
       code,
@@ -37,8 +37,8 @@ describe("system failure reporting", () => {
 
     expect(presentation).toMatchObject({
       code: "unknown",
-      title: "Export failed",
-      description: "Tagium could not prepare your download. Your tracks are still in the library.",
+      title: "export failed",
+      description: "tagium could not prepare your download. Your tracks are still in the library.",
     });
     expect(JSON.stringify(presentation)).not.toContain("private upstream");
   });
@@ -48,8 +48,8 @@ describe("system failure reporting", () => {
     reportSystemFailure(new Error("second private cause"), "export");
 
     expect(toastMocks.error).toHaveBeenCalledTimes(2);
-    expect(toastMocks.error).toHaveBeenLastCalledWith("Export failed", {
-      description: "Tagium could not prepare your download. Your tracks are still in the library.",
+    expect(toastMocks.error).toHaveBeenLastCalledWith("export failed", {
+      description: "tagium could not prepare your download. Your tracks are still in the library.",
     });
   });
 
@@ -68,7 +68,7 @@ describe("system failure reporting", () => {
 
     expect(presentation.trackDescription).toBe("download failed. try again or use another link.");
     expect(getTrackFailureDisplay(presentation.trackDescription)).toEqual({
-      title: "Download failed",
+      title: "download failed",
       description: "download failed. try again or use another link.",
     });
   });
@@ -80,7 +80,7 @@ describe("system failure reporting", () => {
     );
 
     expect(getTrackFailureDisplay(presentation.trackDescription)).toEqual({
-      title: "Metadata could not be saved",
+      title: "metadata could not be saved",
       description: "metadata could not be saved. try again.",
     });
   });
@@ -90,7 +90,7 @@ describe("system failure reporting", () => {
       getSystemFailurePresentation(new Error("metadata record not found"), "metadata"),
     ).toMatchObject({
       code: "unknown",
-      title: "Metadata could not be saved",
+      title: "metadata could not be saved",
       description: "Your edits are still visible. Try the action again.",
     });
 
@@ -98,7 +98,7 @@ describe("system failure reporting", () => {
       getSystemFailurePresentation(new Error("export failed with rate limit 429"), "export"),
     ).toMatchObject({
       code: "unknown",
-      title: "Export failed",
+      title: "export failed",
     });
   });
 
@@ -107,8 +107,8 @@ describe("system failure reporting", () => {
       getSystemFailurePresentation(new Error("remote cover not found"), "cover-import"),
     ).toMatchObject({
       code: "unknown",
-      title: "Cover art was not imported",
-      description: "The tracks were imported without cover art. Upload a JPEG or PNG manually.",
+      title: "cover art was not imported",
+      description: "The tracks were imported without cover art. Upload a jpeg or png manually.",
     });
   });
 });

--- a/components/audio/systemFailure.ts
+++ b/components/audio/systemFailure.ts
@@ -37,7 +37,7 @@ const lastDownloadNotificationAt = new Map<string, number>();
 const KNOWN_FAILURES = {
   capacity: {
     code: "capacity",
-    title: "Downloads are busy",
+    title: "downloads are busy",
     description: "Too many downloads are running right now. Try again in a moment.",
     trackDescription: "downloads are busy. try again in a moment.",
     retryable: true,
@@ -45,7 +45,7 @@ const KNOWN_FAILURES = {
   },
   rate_limited: {
     code: "rate_limited",
-    title: "Too many download requests",
+    title: "too many download requests",
     description: "Wait a moment, then try the download again.",
     trackDescription: "too many download requests. try again shortly.",
     retryable: true,
@@ -53,7 +53,7 @@ const KNOWN_FAILURES = {
   },
   timeout: {
     code: "timeout",
-    title: "The download took too long",
+    title: "the download took too long",
     description: "Try again. If it keeps failing, try another link.",
     trackDescription: "download timed out. try again.",
     retryable: true,
@@ -61,15 +61,15 @@ const KNOWN_FAILURES = {
   },
   service_unavailable: {
     code: "service_unavailable",
-    title: "Downloads are temporarily unavailable",
-    description: "Tagium could not reach the download service. Try again soon.",
+    title: "downloads are temporarily unavailable",
+    description: "tagium could not reach the download service. Try again soon.",
     trackDescription: "audio downloads are temporarily unavailable.",
     retryable: true,
     dedupeKey: "system-download-service-unavailable",
   },
   unsupported_source: {
     code: "unsupported_source",
-    title: "This link is not supported",
+    title: "this link is not supported",
     description: "Try a public SoundCloud or YouTube track URL.",
     trackDescription: "this link is not supported.",
     retryable: false,
@@ -77,7 +77,7 @@ const KNOWN_FAILURES = {
   },
   private_or_missing: {
     code: "private_or_missing",
-    title: "We could not access this media",
+    title: "we could not access this media",
     description: "Check that the link is public and still available, then try again.",
     trackDescription: "media is private, unavailable, or no longer exists.",
     retryable: false,
@@ -85,7 +85,7 @@ const KNOWN_FAILURES = {
   },
   invalid_response: {
     code: "invalid_response",
-    title: "We could not read this media",
+    title: "we could not read this media",
     description: "The provider returned an unexpected response. Try again or use another link.",
     trackDescription: "the media provider returned an unexpected response.",
     retryable: true,
@@ -95,43 +95,43 @@ const KNOWN_FAILURES = {
 
 const FALLBACKS = {
   download: {
-    title: "Download failed",
-    description: "Tagium could not download this track. Try again or use another link.",
+    title: "download failed",
+    description: "tagium could not download this track. Try again or use another link.",
     trackDescription: "download failed. try again or use another link.",
   },
   import: {
-    title: "Import failed",
-    description: "Tagium could not import this media. Try again in a moment.",
+    title: "import failed",
+    description: "tagium could not import this media. Try again in a moment.",
     trackDescription: "import failed. try again.",
   },
   upload: {
-    title: "Some files could not be imported",
-    description: "Tagium could not read one or more audio files. Try another MP3 file.",
+    title: "some files could not be imported",
+    description: "tagium could not read one or more audio files. Try another mp3 file.",
     trackDescription: "one or more audio files could not be read.",
   },
   export: {
-    title: "Export failed",
-    description: "Tagium could not prepare your download. Your tracks are still in the library.",
+    title: "export failed",
+    description: "tagium could not prepare your download. Your tracks are still in the library.",
     trackDescription: "export failed. your tracks are still in the library.",
   },
   "cover-art": {
-    title: "Cover art failed",
-    description: "Tagium could not process this cover image. Try another JPEG or PNG.",
+    title: "cover art failed",
+    description: "tagium could not process this cover image. Try another jpeg or png.",
     trackDescription: "cover art could not be processed.",
   },
   "cover-import": {
-    title: "Cover art was not imported",
-    description: "The tracks were imported without cover art. Upload a JPEG or PNG manually.",
+    title: "cover art was not imported",
+    description: "The tracks were imported without cover art. Upload a jpeg or png manually.",
     trackDescription: "cover art was not imported. upload an image manually.",
   },
   metadata: {
-    title: "Metadata could not be saved",
+    title: "metadata could not be saved",
     description: "Your edits are still visible. Try the action again.",
     trackDescription: "metadata could not be saved. try again.",
   },
   storage: {
-    title: "Settings could not be saved",
-    description: "Your browser did not allow Tagium to store these settings.",
+    title: "settings could not be saved",
+    description: "Your browser did not allow tagium to store these settings.",
     trackDescription: "settings could not be saved.",
   },
 } as const satisfies Record<
@@ -265,7 +265,7 @@ export const getTrackFailureDisplay = (message: string): TrackFailureDisplay => 
   if (known) return { title: known.title, description: known.trackDescription };
 
   return {
-    title: "Track error",
+    title: "track error",
     description: "this track needs attention before it can be exported.",
   };
 };

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -65,7 +65,7 @@ function DialogContent({
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">close</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Content>
@@ -100,7 +100,7 @@ function DialogFooter({
       {children}
       {showCloseButton && (
         <DialogPrimitive.Close asChild>
-          <Button variant="outline">Close</Button>
+          <Button variant="outline">close</Button>
         </DialogPrimitive.Close>
       )}
     </div>

--- a/components/ui/image-cropper.tsx
+++ b/components/ui/image-cropper.tsx
@@ -104,7 +104,7 @@ export default function ImageCropper({ src, onCrop, onCancel }: ImageCropperProp
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             ref={imgRef}
-            alt="Crop preview"
+            alt="crop preview"
             style={{ maxWidth: "100%", maxHeight: "100%" }}
             src={src}
             onLoad={onImageLoad}


### PR DESCRIPTION
## What changed

- normalize the `tagium` brand to lowercase in user-facing settings and error copy
- normalize `mp3`, `jpeg`, `png`, and user-facing `cobalt` casing
- make system notification titles, shared dialog close labels, and crop-preview accessibility copy follow the app's lowercase UI style
- update copy assertions to match

## Why

The app's interface predominantly uses lowercase copy, but recent compatibility and error-reporting changes reintroduced sentence-case labels and inconsistent capitalization. This pass restores a consistent voice while preserving provider names such as YouTube and SoundCloud and keeping internal code identifiers unchanged.

## Stack

This PR is intentionally based on #88 and should merge after it.

## Validation

- `bun run test` (38 files, 256 tests)
- affected follow-up tests (5 files, 36 tests)
- `bun run typecheck`
- `bun run build`
- `bun run lint`
- `git diff --check`

Bulk copy audit and mechanical updates were completed by the Luna subagent, followed by a maintainer review and final normalization.