### PR TITLE
fix: animate empty settings entry

### DIFF
--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -68,8 +68,14 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
         />
       )}
 
-      {active && (
-        <div className="flex w-full max-w-md flex-col items-center gap-10 max-lg:[@media(max-height:700px)]:gap-6">
+      <div
+        className={
+          active
+            ? "flex w-full max-w-md flex-col items-center gap-10 max-lg:[@media(max-height:700px)]:gap-6"
+            : "contents"
+        }
+      >
+        {active && (
           <>
             <div className="text-center select-none">
               <h1 className="text-7xl font-bold tracking-tighter text-foreground">tagium</h1>
@@ -102,9 +108,9 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
               </div>
             </button>
           </>
-        </div>
-      )}
-      {children}
+        )}
+        {children}
+      </div>
     </div>
   );
 }

--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import { Music4, Upload } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -14,21 +14,6 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragCounterRef = useRef(0);
   const [isDragging, setIsDragging] = useState(false);
-  const [contentMounted, setContentMounted] = useState(active);
-  const [contentVisible, setContentVisible] = useState(active);
-
-  useEffect(() => {
-    if (active) {
-      setContentMounted(true);
-      const frame = requestAnimationFrame(() => setContentVisible(true));
-      return () => cancelAnimationFrame(frame);
-    }
-
-    setContentVisible(false);
-    const timeout = window.setTimeout(() => setContentMounted(false), 180);
-    return () => window.clearTimeout(timeout);
-  }, [active]);
-
   const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault();
     dragCounterRef.current++;
@@ -83,16 +68,8 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
         />
       )}
 
-      {contentMounted && (
-        <div
-          aria-hidden={!active || undefined}
-          inert={!active || undefined}
-          className={cn(
-            "flex w-full max-w-md flex-col items-center gap-10 transition-opacity duration-180 motion-reduce:transition-none max-lg:[@media(max-height:700px)]:gap-6",
-            contentVisible ? "opacity-100" : "pointer-events-none opacity-0",
-            !active && "absolute inset-0 z-20 m-auto h-fit p-8",
-          )}
-        >
+      {active && (
+        <div className="flex w-full max-w-md flex-col items-center gap-10 max-lg:[@media(max-height:700px)]:gap-6">
           <>
             <div className="text-center select-none">
               <h1 className="text-7xl font-bold tracking-tighter text-foreground">tagium</h1>

--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Music4, Upload } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -14,6 +14,20 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragCounterRef = useRef(0);
   const [isDragging, setIsDragging] = useState(false);
+  const [contentMounted, setContentMounted] = useState(active);
+  const [contentVisible, setContentVisible] = useState(active);
+
+  useEffect(() => {
+    if (active) {
+      setContentMounted(true);
+      const frame = requestAnimationFrame(() => setContentVisible(true));
+      return () => cancelAnimationFrame(frame);
+    }
+
+    setContentVisible(false);
+    const timeout = window.setTimeout(() => setContentMounted(false), 180);
+    return () => window.clearTimeout(timeout);
+  }, [active]);
 
   const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault();
@@ -69,14 +83,16 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
         />
       )}
 
-      <div
-        className={
-          active
-            ? "flex w-full max-w-md flex-col items-center gap-10 max-lg:[@media(max-height:700px)]:gap-6"
-            : "contents"
-        }
-      >
-        {active && (
+      {contentMounted && (
+        <div
+          aria-hidden={!active || undefined}
+          inert={!active || undefined}
+          className={cn(
+            "flex w-full max-w-md flex-col items-center gap-10 transition-opacity duration-180 motion-reduce:transition-none max-lg:[@media(max-height:700px)]:gap-6",
+            contentVisible ? "opacity-100" : "pointer-events-none opacity-0",
+            !active && "absolute inset-0 z-20 m-auto h-fit p-8",
+          )}
+        >
           <>
             <div className="text-center select-none">
               <h1 className="text-7xl font-bold tracking-tighter text-foreground">tagium</h1>
@@ -109,9 +125,9 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
               </div>
             </button>
           </>
-        )}
-        {children}
-      </div>
+        </div>
+      )}
+      {children}
     </div>
   );
 }

--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -71,7 +71,7 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
       <div
         className={
           active
-            ? "flex w-full max-w-md flex-col items-center gap-10 max-lg:[@media(max-height:700px)]:gap-6"
+            ? "editor-view-content flex w-full max-w-md flex-col items-center gap-10 max-lg:[@media(max-height:700px)]:gap-6"
             : "contents"
         }
       >

--- a/components/audio/MediaUrlEntry.tsx
+++ b/components/audio/MediaUrlEntry.tsx
@@ -10,6 +10,7 @@ import { getSystemFailurePresentation, reportSystemFailure } from "./systemFailu
 interface MediaUrlEntryProps {
   layout: "landing" | "editor";
   hidden: boolean;
+  animateLayout?: boolean;
   onUrlImport: (sourceUrl: string) => void | Promise<void>;
 }
 
@@ -24,7 +25,12 @@ const validateMediaUrl = (value: string) => {
   return "enter a complete http or https url";
 };
 
-export default function MediaUrlEntry({ layout, hidden, onUrlImport }: MediaUrlEntryProps) {
+export default function MediaUrlEntry({
+  layout,
+  hidden,
+  animateLayout = true,
+  onUrlImport,
+}: MediaUrlEntryProps) {
   const [sourceUrl, setSourceUrl] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
@@ -46,17 +52,21 @@ export default function MediaUrlEntry({ layout, hidden, onUrlImport }: MediaUrlE
     const layoutChanged = previousLayoutRef.current !== layout;
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-    if (previousRect && layoutChanged && !reducedMotion) {
+    if (previousRect && layoutChanged && animateLayout && !reducedMotion) {
       const deltaX = previousRect.left - nextRect.left;
       const deltaY = previousRect.top - nextRect.top;
-      const scaleX = previousRect.width / Math.max(1, nextRect.width);
       form.animate(
         [
           {
-            transform: `translate(${deltaX}px, ${deltaY}px) scaleX(${scaleX})`,
+            transform: `translate(${deltaX}px, ${deltaY}px)`,
             transformOrigin: "top left",
+            width: `${previousRect.width}px`,
           },
-          { transform: "translate(0, 0) scaleX(1)", transformOrigin: "top left" },
+          {
+            transform: "translate(0, 0)",
+            transformOrigin: "top left",
+            width: `${nextRect.width}px`,
+          },
         ],
         { duration: 420, easing: "cubic-bezier(0.22, 1, 0.36, 1)" },
       );
@@ -64,7 +74,7 @@ export default function MediaUrlEntry({ layout, hidden, onUrlImport }: MediaUrlE
 
     previousRectRef.current = nextRect;
     previousLayoutRef.current = layout;
-  }, [hidden, layout]);
+  }, [animateLayout, hidden, layout]);
 
   const showValidationError = (message: string) => {
     setValidationError(message);
@@ -143,7 +153,12 @@ export default function MediaUrlEntry({ layout, hidden, onUrlImport }: MediaUrlE
             <div className="h-px flex-1 bg-border" />
           </div>
         )}
-        <form ref={formRef} noValidate onSubmit={handleSubmit} className="flex items-start gap-2">
+        <form
+          ref={formRef}
+          noValidate
+          onSubmit={handleSubmit}
+          className="media-url-entry flex items-start gap-2"
+        >
           <div className="min-w-0 flex-1">
             <div className="relative">
               <Link2 className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />

--- a/components/audio/SettingsPage.tsx
+++ b/components/audio/SettingsPage.tsx
@@ -19,7 +19,7 @@ export default function SettingsPage({ settings, onChange, onBack }: SettingsPag
   const [bitrateOpen, setBitrateOpen] = useState(false);
 
   return (
-    <div className="min-h-0 flex-1 flex flex-col overflow-hidden">
+    <div className="editor-view-content min-h-0 flex-1 flex flex-col overflow-hidden">
       <div className="p-6 h-[104px] border-b flex-shrink-0 flex flex-col justify-center gap-1">
         <div className="flex min-w-0 items-center gap-2">
           <button

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -128,7 +128,7 @@ export default function TrackMetadataEditor({
     downloadErrorDisplay;
 
   return (
-    <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+    <div className="editor-view-content flex-1 min-h-0 flex flex-col overflow-hidden">
       <form
         onSubmit={(event) => {
           event.preventDefault();

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -301,6 +301,11 @@ export default function AudioTagger() {
     }
     document.startViewTransition(updateView);
   };
+  const handleSettingsOpen = () => {
+    if (isTrackCoverProcessing) return;
+    changeActiveView("settings");
+  };
+  const handleSettingsClose = () => changeActiveView("editor");
   const hasRecoverableWork = hasRecoverableSessionWork({
     fileCount: files.length,
     albumCount: albums.length,
@@ -1921,10 +1926,7 @@ export default function AudioTagger() {
           onReorderAlbums={handleReorderAlbums}
           playlistDownloadQueue={playlistSidebarQueue}
           onDownloadAll={handleDownloadAll}
-          onOpenSettings={() => {
-            if (isTrackCoverProcessing) return;
-            changeActiveView(activeView === "settings" ? "editor" : "settings");
-          }}
+          onOpenSettings={activeView === "settings" ? handleSettingsClose : handleSettingsOpen}
           onCancelPlaylistDownloadQueue={handleCancelPlaylistDownloads}
           onRetryPlaylistDownloadQueue={handleRetryPlaylistDownloads}
         />
@@ -1940,7 +1942,7 @@ export default function AudioTagger() {
               <SettingsPage
                 settings={settings}
                 onChange={handleSettingsChange}
-                onBack={() => changeActiveView("editor")}
+                onBack={handleSettingsClose}
               />
             ) : !libraryIsEmpty ? (
               <TrackMetadataEditor

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -1,6 +1,7 @@
 "use client";
-import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react";
+import { flushSync } from "react-dom";
 import { Cause, Effect, Exit } from "effect";
 import { SubmitHandler, useForm } from "react-hook-form";
 import filenamify from "filenamify";
@@ -73,7 +74,6 @@ import type { Playlist } from "./playlist";
 import { isYouTubePlaylistUrl, resolveYouTubePlaylist } from "./youtubePlaylist";
 import { getSystemFailurePresentation, reportSystemFailure } from "./systemFailure";
 import { isValidFilenameBase, sanitizeFilenameBase } from "./filename";
-import { cn } from "@/lib/utils";
 import {
   AlbumGroup,
   AppSettings,
@@ -135,41 +135,6 @@ const createPlaylistDownloadModelTrack = (track: ManagedDownloadTrack) => ({
 });
 type MetadataPatchField = keyof MetadataPatch;
 type DirtyMetadataFields = Partial<Record<keyof AudioMetadata, unknown>>;
-
-const VIEW_FADE_DURATION = 180;
-
-function ViewFade({ show, children }: { show: boolean; children: ReactNode }) {
-  const [mounted, setMounted] = useState(show);
-  const [visible, setVisible] = useState(show);
-
-  useEffect(() => {
-    if (show) {
-      setMounted(true);
-      const frame = requestAnimationFrame(() => setVisible(true));
-      return () => cancelAnimationFrame(frame);
-    }
-
-    setVisible(false);
-    const timeout = window.setTimeout(() => setMounted(false), VIEW_FADE_DURATION);
-    return () => window.clearTimeout(timeout);
-  }, [show]);
-
-  if (!mounted) return null;
-
-  return (
-    <div
-      aria-hidden={!show || undefined}
-      inert={!show || undefined}
-      className={cn(
-        "min-h-0 flex flex-1 flex-col transition-opacity duration-180 motion-reduce:transition-none",
-        visible ? "opacity-100" : "pointer-events-none opacity-0",
-        !show && "absolute inset-0 z-20",
-      )}
-    >
-      {children}
-    </div>
-  );
-}
 
 const metadataPatchFields = [
   "filename",
@@ -325,6 +290,17 @@ export default function AudioTagger() {
   const [settings, setSettings] = useState<AppSettings>(loadAppSettings);
   const [playlistDownloadQueue, setPlaylistDownloadQueue] =
     useState<PlaylistDownloadQueueState | null>(null);
+  const changeActiveView = (nextView: ActiveView) => {
+    const updateView = () => flushSync(() => setActiveView(nextView));
+    if (
+      !document.startViewTransition ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      updateView();
+      return;
+    }
+    document.startViewTransition(updateView);
+  };
   const hasRecoverableWork = hasRecoverableSessionWork({
     fileCount: files.length,
     albumCount: albums.length,
@@ -1827,6 +1803,7 @@ export default function AudioTagger() {
 
   const libraryIsEmpty = files.length === 0 && albums.length === 0 && looseTrackIds.length === 0;
   const landingIsActive = libraryIsEmpty && activeView === "editor";
+  const supportsViewTransitions = "startViewTransition" in document;
   const playlistQueueDownloaded = playlistDownloadQueue ? playlistDownloadQueue.completed : 0;
   const playlistQueueEta = playlistDownloadQueue
     ? formatPlaylistQueueEta(playlistDownloadQueue.etaMs)
@@ -1946,7 +1923,7 @@ export default function AudioTagger() {
           onDownloadAll={handleDownloadAll}
           onOpenSettings={() => {
             if (isTrackCoverProcessing) return;
-            setActiveView((currentView) => (currentView === "settings" ? "editor" : "settings"));
+            changeActiveView(activeView === "settings" ? "editor" : "settings");
           }}
           onCancelPlaylistDownloadQueue={handleCancelPlaylistDownloads}
           onRetryPlaylistDownloadQueue={handleRetryPlaylistDownloads}
@@ -1959,14 +1936,13 @@ export default function AudioTagger() {
                 : "h-svh min-h-0 flex flex-col overflow-hidden md:h-auto md:min-h-0 md:flex-1"
             }
           >
-            <ViewFade show={activeView === "settings"}>
+            {activeView === "settings" ? (
               <SettingsPage
                 settings={settings}
                 onChange={handleSettingsChange}
-                onBack={() => setActiveView("editor")}
+                onBack={() => changeActiveView("editor")}
               />
-            </ViewFade>
-            <ViewFade show={activeView === "editor" && !libraryIsEmpty}>
+            ) : !libraryIsEmpty ? (
               <TrackMetadataEditor
                 selectedFile={selectedFile}
                 selectedFileId={selectedFileId}
@@ -1984,12 +1960,13 @@ export default function AudioTagger() {
                   handlePreviewMetadataChange(field, event.target.value)
                 }
               />
-            </ViewFade>
+            ) : null}
           </div>
           <LandingScreen active={landingIsActive} onAudioUpload={handleAudioUpload}>
             <MediaUrlEntry
               layout={landingIsActive ? "landing" : "editor"}
               hidden={activeView !== "editor" && !libraryIsEmpty}
+              animateLayout={!libraryIsEmpty || !supportsViewTransitions}
               onUrlImport={handleUrlImport}
             />
           </LandingScreen>

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -1,5 +1,5 @@
 "use client";
-import type { MouseEvent as ReactMouseEvent } from "react";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react";
 import { Cause, Effect, Exit } from "effect";
 import { SubmitHandler, useForm } from "react-hook-form";
@@ -73,6 +73,7 @@ import type { Playlist } from "./playlist";
 import { isYouTubePlaylistUrl, resolveYouTubePlaylist } from "./youtubePlaylist";
 import { getSystemFailurePresentation, reportSystemFailure } from "./systemFailure";
 import { isValidFilenameBase, sanitizeFilenameBase } from "./filename";
+import { cn } from "@/lib/utils";
 import {
   AlbumGroup,
   AppSettings,
@@ -134,6 +135,41 @@ const createPlaylistDownloadModelTrack = (track: ManagedDownloadTrack) => ({
 });
 type MetadataPatchField = keyof MetadataPatch;
 type DirtyMetadataFields = Partial<Record<keyof AudioMetadata, unknown>>;
+
+const VIEW_FADE_DURATION = 180;
+
+function ViewFade({ show, children }: { show: boolean; children: ReactNode }) {
+  const [mounted, setMounted] = useState(show);
+  const [visible, setVisible] = useState(show);
+
+  useEffect(() => {
+    if (show) {
+      setMounted(true);
+      const frame = requestAnimationFrame(() => setVisible(true));
+      return () => cancelAnimationFrame(frame);
+    }
+
+    setVisible(false);
+    const timeout = window.setTimeout(() => setMounted(false), VIEW_FADE_DURATION);
+    return () => window.clearTimeout(timeout);
+  }, [show]);
+
+  if (!mounted) return null;
+
+  return (
+    <div
+      aria-hidden={!show || undefined}
+      inert={!show || undefined}
+      className={cn(
+        "min-h-0 flex flex-1 flex-col transition-opacity duration-180 motion-reduce:transition-none",
+        visible ? "opacity-100" : "pointer-events-none opacity-0",
+        !show && "absolute inset-0 z-20",
+      )}
+    >
+      {children}
+    </div>
+  );
+}
 
 const metadataPatchFields = [
   "filename",
@@ -1923,13 +1959,14 @@ export default function AudioTagger() {
                 : "h-svh min-h-0 flex flex-col overflow-hidden md:h-auto md:min-h-0 md:flex-1"
             }
           >
-            {activeView === "settings" ? (
+            <ViewFade show={activeView === "settings"}>
               <SettingsPage
                 settings={settings}
                 onChange={handleSettingsChange}
                 onBack={() => setActiveView("editor")}
               />
-            ) : !libraryIsEmpty ? (
+            </ViewFade>
+            <ViewFade show={activeView === "editor" && !libraryIsEmpty}>
               <TrackMetadataEditor
                 selectedFile={selectedFile}
                 selectedFileId={selectedFileId}
@@ -1947,12 +1984,12 @@ export default function AudioTagger() {
                   handlePreviewMetadataChange(field, event.target.value)
                 }
               />
-            ) : null}
+            </ViewFade>
           </div>
           <LandingScreen active={landingIsActive} onAudioUpload={handleAudioUpload}>
             <MediaUrlEntry
-              layout={libraryIsEmpty ? "landing" : "editor"}
-              hidden={activeView !== "editor"}
+              layout={landingIsActive ? "landing" : "editor"}
+              hidden={activeView !== "editor" && !libraryIsEmpty}
               onUrlImport={handleUrlImport}
             />
           </LandingScreen>

--- a/components/audio/urlImportGateway.test.tsx
+++ b/components/audio/urlImportGateway.test.tsx
@@ -139,6 +139,16 @@ describe("media URL entry", () => {
 
   it("anchors width-changing layout motion to the measured left edge", () => {
     expect(mediaUrlEntrySource.match(/transformOrigin: "top left"/g)).toHaveLength(2);
+    expect(mediaUrlEntrySource).not.toContain("scaleX(");
+    expect(mediaUrlEntrySource).toContain("width: `${previousRect.width}px`");
+  });
+
+  it("uses a native shared-element transition for empty-library settings changes", () => {
+    expect(audioTaggerSource).toContain("document.startViewTransition(updateView)");
+    expect(audioTaggerSource).toContain(
+      "animateLayout={!libraryIsEmpty || !supportsViewTransitions}",
+    );
+    expect(mediaUrlEntrySource).toContain("media-url-entry flex");
   });
 
   it("keeps malformed URL feedback local to the input", async () => {

--- a/components/audio/urlImportGateway.test.tsx
+++ b/components/audio/urlImportGateway.test.tsx
@@ -115,6 +115,9 @@ describe("media URL entry", () => {
 
   it("keeps the URL entry in the centered landing stack instead of pinning it to the bottom", () => {
     expect(landingScreenSource).toContain("{children}");
+    expect(landingScreenSource).toContain(
+      '? "flex w-full max-w-md flex-col items-center gap-10 max-lg:[@media(max-height:700px)]:gap-6"',
+    );
     expect(mediaUrlEntrySource).not.toContain("bottom-[clamp(");
   });
 
@@ -149,6 +152,13 @@ describe("media URL entry", () => {
       "animateLayout={!libraryIsEmpty || !supportsViewTransitions}",
     );
     expect(mediaUrlEntrySource).toContain("media-url-entry flex");
+  });
+
+  it("routes both settings exit controls through the same transition handler", () => {
+    expect(audioTaggerSource).toContain(
+      'activeView === "settings" ? handleSettingsClose : handleSettingsOpen',
+    );
+    expect(audioTaggerSource).toContain("onBack={handleSettingsClose}");
   });
 
   it("keeps malformed URL feedback local to the input", async () => {

--- a/components/audio/urlImportGateway.test.tsx
+++ b/components/audio/urlImportGateway.test.tsx
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import audioTaggerSource from "./audioTagger.tsx?raw";
 import landingScreenSource from "./LandingScreen.tsx?raw";
 import mediaUrlEntrySource from "./MediaUrlEntry.tsx?raw";
+import settingsPageSource from "./SettingsPage.tsx?raw";
+import trackMetadataEditorSource from "./TrackMetadataEditor.tsx?raw";
 import MediaUrlEntry from "./MediaUrlEntry";
 
 const reactHookMocks = vi.hoisted(() => ({
@@ -116,7 +118,7 @@ describe("media URL entry", () => {
   it("keeps the URL entry in the centered landing stack instead of pinning it to the bottom", () => {
     expect(landingScreenSource).toContain("{children}");
     expect(landingScreenSource).toContain(
-      '? "flex w-full max-w-md flex-col items-center gap-10 max-lg:[@media(max-height:700px)]:gap-6"',
+      '? "editor-view-content flex w-full max-w-md flex-col items-center gap-10 max-lg:[@media(max-height:700px)]:gap-6"',
     );
     expect(mediaUrlEntrySource).not.toContain("bottom-[clamp(");
   });
@@ -152,6 +154,12 @@ describe("media URL entry", () => {
       "animateLayout={!libraryIsEmpty || !supportsViewTransitions}",
     );
     expect(mediaUrlEntrySource).toContain("media-url-entry flex");
+  });
+
+  it("fades editor view content independently from the shared URL entry", () => {
+    expect(landingScreenSource).toContain("editor-view-content flex w-full");
+    expect(settingsPageSource).toContain("editor-view-content min-h-0");
+    expect(trackMetadataEditorSource).toContain("editor-view-content flex-1");
   });
 
   it("routes both settings exit controls through the same transition handler", () => {

--- a/src/index.css
+++ b/src/index.css
@@ -216,14 +216,48 @@
     view-transition-name: media-url-entry;
   }
 
+  .editor-view-content {
+    view-transition-name: editor-view-content;
+  }
+
   ::view-transition-group(media-url-entry) {
     animation-duration: 420ms;
     animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
   }
 
+  ::view-transition-group(editor-view-content) {
+    animation-duration: 180ms;
+  }
+
+  ::view-transition-old(editor-view-content) {
+    animation: editor-view-fade-out 180ms ease-out both;
+  }
+
+  ::view-transition-new(editor-view-content) {
+    animation: editor-view-fade-in 180ms ease-in both;
+  }
+
   ::view-transition-old(root),
   ::view-transition-new(root) {
-    animation-duration: 180ms;
+    animation: none;
+  }
+
+  @keyframes editor-view-fade-out {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+
+  @keyframes editor-view-fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/index.css
+++ b/src/index.css
@@ -212,6 +212,26 @@
 }
 
 @layer components {
+  .media-url-entry {
+    view-transition-name: media-url-entry;
+  }
+
+  ::view-transition-group(media-url-entry) {
+    animation-duration: 420ms;
+    animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: 180ms;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    ::view-transition-group(*) {
+      animation-duration: 0.01ms;
+    }
+  }
+
   @media (min-width: 768px) {
     [data-sonner-toaster].tagium-toaster {
       --width: 28rem;


### PR DESCRIPTION
## Summary

- keep the URL media entry visible in its editor layout while viewing settings with an empty library
- use named View Transitions for the shared URL entry and an explicit 180ms fade between landing, metadata editor, and settings content
- preserve the original landing stack spacing around the drop area, separator, and URL form
- route both the settings sidebar toggle and back arrow through the same close-transition handler
- interpolate real form width for track-import layout changes instead of applying `scaleX()` to the live controls

## Why

With no tracks added, changing to Settings left the URL entry in its landing treatment. Subsequent testing exposed reduced landing spacing, inconsistent return animation, and an imperceptible metadata-editor fade because the implementation relied on the browser's default root crossfade.

The revised implementation keeps the original layout hierarchy and gives editor content and the URL entry separate named transitions, so the editor visibly fades while the form moves independently.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run test` (246 tests)
- `bun run build`
- Local layout measurement: 40px drop area → separator and 40px separator → URL form
- Preview: https://65bd6c6b-tagium.oliver-boorstein.workers.dev