### PR TITLE
feat: resolve single-track metadata before download

### DIFF
--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -70,6 +70,7 @@ import { hasRecoverableSessionWork, useBeforeUnloadProtection } from "./sessionS
 import { createImportLifecycleTracker, type ImportLifecycleTracker } from "./importLifecycle";
 import { isSoundCloudSetUrl, resolveSoundCloudSet } from "./soundcloudSet";
 import type { Playlist } from "./playlist";
+import { resolveTrackMetadata, type TrackMetadata } from "./trackMetadata";
 import { isYouTubePlaylistUrl, resolveYouTubePlaylist } from "./youtubePlaylist";
 import { getSystemFailurePresentation, reportSystemFailure } from "./systemFailure";
 import { isValidFilenameBase, sanitizeFilenameBase } from "./filename";
@@ -997,13 +998,18 @@ export default function AudioTagger() {
       downloadRequest: file.downloadRequest,
     };
   };
-  const handleAudioDownload = (sourceUrl: string, importOperationId: string) => {
+  const handleAudioDownload = (
+    sourceUrl: string,
+    importOperationId: string,
+    metadata?: TrackMetadata,
+  ) => {
     bufferCurrentFormMetadata();
     setActiveView("editor");
     const plan = createSingleUrlDownloadPlan({
       sourceUrl,
       audioBitrate: settings.audioBitrate,
       createId: () => crypto.randomUUID(),
+      metadata,
     });
     const nextFiles = [...filesRef.current, ...plan.pendingFiles];
     filesRef.current = nextFiles;
@@ -1123,7 +1129,13 @@ export default function AudioTagger() {
         return;
       }
 
-      handleAudioDownload(trimmedUrl, importOperationId);
+      let trackMetadata: TrackMetadata | undefined;
+      try {
+        trackMetadata = await resolveTrackMetadata(trimmedUrl);
+      } catch {
+        // Metadata enrichment is optional; the download retains its URL-derived fallback.
+      }
+      handleAudioDownload(trimmedUrl, importOperationId, trackMetadata);
     } finally {
       setUrlImporting(false);
     }

--- a/components/audio/downloadTrack.test.ts
+++ b/components/audio/downloadTrack.test.ts
@@ -1,6 +1,31 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import { MAX_COVER_ART_UPLOAD_BYTES } from "./coverArtProcessing";
-import { fetchImportedCover } from "./downloadTrack";
+import { createSingleUrlDownloadPlan, fetchImportedCover } from "./downloadTrack";
+
+describe("single URL download plans", () => {
+  it("seeds pending tracks with metadata resolved before download", () => {
+    const plan = createSingleUrlDownloadPlan({
+      sourceUrl: "https://youtube.com/watch?v=abcdefghijk",
+      audioBitrate: "320",
+      createId: () => "track-1",
+      metadata: {
+        title: "Burial - Archangel (Official Audio)",
+        artist: "Burial",
+        coverUrl: "https://example.com/cover.jpg",
+      },
+    });
+
+    expect(plan.pendingFiles[0]).toMatchObject({
+      filename: "Burial - Archangel (Official Audio).mp3",
+      downloadStatus: "downloading",
+      metadata: {
+        title: "Burial - Archangel (Official Audio)",
+        artist: "Burial",
+      },
+    });
+    expect(plan.queuedTracks[0]?.title).toBe("Burial - Archangel (Official Audio)");
+  });
+});
 
 const streamedResponse = (chunks: Uint8Array[], contentType: string) =>
   new Response(

--- a/components/audio/downloadTrack.ts
+++ b/components/audio/downloadTrack.ts
@@ -7,6 +7,7 @@ import {
 } from "./coverArtProcessing";
 import type { Playlist } from "./playlist";
 import type { SoundCloudSet } from "./soundcloudSet";
+import type { TrackMetadata } from "./trackMetadata";
 import type { AlbumGroup, AppSettings, AudioMetadata, MetadataPatch, TagiumFile } from "./types";
 
 export type DownloadRequest = NonNullable<TagiumFile["downloadRequest"]>;
@@ -61,6 +62,7 @@ export interface CreateSingleUrlDownloadPlanInput {
   sourceUrl: string;
   audioBitrate: AppSettings["audioBitrate"];
   createId: () => string;
+  metadata?: TrackMetadata;
 }
 
 export interface CreateSoundCloudSetDownloadPlanInput {
@@ -242,14 +244,15 @@ export const createSingleUrlDownloadPlan = ({
   sourceUrl,
   audioBitrate,
   createId,
+  metadata,
 }: CreateSingleUrlDownloadPlanInput): SingleUrlDownloadPlan => {
   const id = createId();
-  const title = titleFromSourceUrl(sourceUrl);
+  const title = metadata?.title || titleFromSourceUrl(sourceUrl);
   const pendingFile = createPendingDownloadTrack(
     id,
     createDownloadMetadata({
       title,
-      artist: "",
+      artist: metadata?.artist ?? "",
       album: "",
       genre: "",
     }),

--- a/components/audio/trackMetadata.test.ts
+++ b/components/audio/trackMetadata.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { decodeTrackMetadata } from "./trackMetadata";
+
+describe("track metadata", () => {
+  it("decodes provider metadata used before download", async () => {
+    await expect(
+      decodeTrackMetadata({
+        title: "Archangel",
+        artist: "Burial",
+        coverUrl: "https://example.com/cover.jpg",
+      }),
+    ).resolves.toEqual({
+      title: "Archangel",
+      artist: "Burial",
+      coverUrl: "https://example.com/cover.jpg",
+    });
+  });
+
+  it("rejects malformed provider metadata", async () => {
+    await expect(decodeTrackMetadata({ title: 42, artist: "Burial" })).rejects.toThrow(
+      "malformed track metadata response",
+    );
+  });
+});

--- a/components/audio/trackMetadata.ts
+++ b/components/audio/trackMetadata.ts
@@ -1,0 +1,43 @@
+import { Effect, Schema } from "effect";
+import { AudioDecodeError, toPublicAudioError } from "./audioErrors";
+import { runAudioEffectWithoutServices } from "./audioRuntime";
+
+const trackMetadataSchema = Schema.Struct({
+  title: Schema.String,
+  artist: Schema.String,
+  coverUrl: Schema.optionalKey(Schema.String),
+});
+
+const decodeTrackMetadataEffect = Schema.decodeUnknownEffect(trackMetadataSchema);
+
+export type TrackMetadata = Schema.Schema.Type<typeof trackMetadataSchema>;
+
+export const decodeTrackMetadata = async (input: unknown) => {
+  try {
+    return await runAudioEffectWithoutServices(
+      decodeTrackMetadataEffect(input).pipe(
+        Effect.mapError(
+          (cause) =>
+            new AudioDecodeError({
+              message: "malformed track metadata response.",
+              cause,
+            }),
+        ),
+      ),
+    );
+  } catch (error) {
+    throw toPublicAudioError(error);
+  }
+};
+
+export const resolveTrackMetadata = async (
+  sourceUrl: string,
+): Promise<TrackMetadata | undefined> => {
+  const endpoint = new URL("/api/track-metadata", window.location.origin);
+  endpoint.searchParams.set("url", sourceUrl);
+
+  const response = await fetch(endpoint);
+  if (response.status === 204) return undefined;
+  if (!response.ok) throw new Error(`track metadata request failed (${response.status})`);
+  return decodeTrackMetadata(await response.json());
+};

--- a/server-tests/track-metadata.get.test.ts
+++ b/server-tests/track-metadata.get.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  getTrackMetadataEndpoint,
+  normalizeTrackMetadataArtist,
+  resolveSoundCloudTrackMetadata,
+} from "../server/api/track-metadata.get";
+
+describe("track metadata provider routing", () => {
+  it("routes only YouTube tracks through oEmbed", () => {
+    expect(getTrackMetadataEndpoint("https://youtu.be/abcdefghijk")?.origin).toBe(
+      "https://www.youtube.com",
+    );
+    expect(getTrackMetadataEndpoint("https://soundcloud.com/burial/archangel")).toBeUndefined();
+  });
+
+  it("does not fetch metadata for unsupported providers", () => {
+    expect(getTrackMetadataEndpoint("https://example.com/audio")).toBeUndefined();
+  });
+
+  it("normalizes YouTube Topic artists to match hydrated Cobalt metadata", () => {
+    expect(
+      normalizeTrackMetadataArtist("Burial - Topic", new URL("https://www.youtube.com/oembed")),
+    ).toBe("Burial");
+    expect(
+      normalizeTrackMetadataArtist("Burial - Topic", new URL("https://soundcloud.com/oembed")),
+    ).toBe("Burial - Topic");
+  });
+
+  it("uses SoundCloud's canonical track title instead of its oEmbed display title", async () => {
+    const metadata = await resolveSoundCloudTrackMetadata(
+      "https://soundcloud.com/youngkimj/get-up-get-down-everybodyyy",
+      {
+        getClientId: async () => "client-id",
+        fetch: async () =>
+          new Response(
+            JSON.stringify({
+              title: "Get Up Get Down Everybodyyy",
+              user: { username: "kimj" },
+              artwork_url: null,
+            }),
+          ),
+      },
+    );
+
+    expect(metadata).toEqual({
+      title: "Get Up Get Down Everybodyyy",
+      artist: "kimj",
+      coverUrl: undefined,
+    });
+  });
+});

--- a/server/api/soundcloud-set.get.ts
+++ b/server/api/soundcloud-set.get.ts
@@ -4,11 +4,8 @@
  */
 import { defineHandler } from "nitro";
 import { z } from "zod";
+import { getSoundCloudClientId } from "../utils/soundcloud";
 
-const cachedClient = {
-  version: "",
-  id: "",
-};
 const TRACK_RESOLVE_CONCURRENCY = 4;
 
 const soundCloudTrackSchema = z.object({
@@ -43,44 +40,6 @@ const soundCloudResolvedTrackSchema = soundCloudTrackSchema.extend({
   title: z.string(),
   permalink_url: z.string().url(),
 });
-
-const findClientId = async () => {
-  const html = await fetch("https://soundcloud.com/").then((response) => response.text());
-  const version = html
-    .match(/<script>window\.__sc_version="[0-9]{10}"<\/script>/)?.[0]
-    .match(/[0-9]{10}/)?.[0];
-
-  if (version && cachedClient.version === version) {
-    return cachedClient.id;
-  }
-
-  const hydratedClientId = html.match(
-    /"hydratable"\s*:\s*"apiClient"\s*,\s*"data"\s*:\s*\{\s*"id"\s*:\s*"([^"]+)"/,
-  )?.[1];
-
-  if (hydratedClientId) {
-    cachedClient.version = version ?? "";
-    cachedClient.id = hydratedClientId;
-    return hydratedClientId;
-  }
-
-  for (const script of html.matchAll(/<script.+src="(.+)">/g)) {
-    const scriptUrl = script[1];
-    if (!scriptUrl?.startsWith("https://a-v2.sndcdn.com/")) {
-      continue;
-    }
-
-    const scriptText = await fetch(scriptUrl).then((response) => response.text());
-    const scriptClientId = scriptText.match(/,client_id:"([A-Za-z0-9]{32})",/)?.[1];
-    if (scriptClientId) {
-      cachedClient.version = version ?? "";
-      cachedClient.id = scriptClientId;
-      return scriptClientId;
-    }
-  }
-
-  throw new Error("soundcloud.client_id");
-};
 
 const getCoverUrl = (artworkUrl: string | null | undefined) => {
   if (!artworkUrl) {
@@ -138,7 +97,7 @@ export default defineHandler(async (event) => {
     throw new Error("soundcloud.url_required");
   }
 
-  const clientId = await findClientId();
+  const clientId = await getSoundCloudClientId();
   const resolveUrl = new URL("https://api-v2.soundcloud.com/resolve");
   resolveUrl.searchParams.set("url", sourceUrl);
   resolveUrl.searchParams.set("client_id", clientId);

--- a/server/api/track-metadata.get.ts
+++ b/server/api/track-metadata.get.ts
@@ -1,0 +1,82 @@
+import { defineHandler } from "nitro";
+import { z } from "zod";
+import { getSoundCloudClientId } from "../utils/soundcloud";
+
+const oEmbedSchema = z.object({
+  title: z.string().min(1),
+  author_name: z.string().optional(),
+  thumbnail_url: z.string().url().optional(),
+});
+const soundCloudTrackSchema = z.object({
+  title: z.string().min(1),
+  artwork_url: z.string().url().nullable().optional(),
+  user: z.object({ username: z.string().optional() }).optional(),
+});
+
+const isSoundCloudUrl = (url: URL) =>
+  url.hostname === "soundcloud.com" || url.hostname.endsWith(".soundcloud.com");
+
+export const resolveSoundCloudTrackMetadata = async (
+  sourceUrl: string,
+  options: {
+    fetch?: typeof globalThis.fetch;
+    getClientId?: () => Promise<string>;
+    signal?: AbortSignal;
+  } = {},
+) => {
+  const fetch = options.fetch ?? globalThis.fetch;
+  const clientId = await (options.getClientId ?? getSoundCloudClientId)();
+  const resolveUrl = new URL("https://api-v2.soundcloud.com/resolve");
+  resolveUrl.searchParams.set("url", sourceUrl);
+  resolveUrl.searchParams.set("client_id", clientId);
+  const response = await fetch(resolveUrl, { signal: options.signal });
+  if (!response.ok) throw new Error(`track_metadata.fetch_failed (${response.status})`);
+  const metadata = soundCloudTrackSchema.parse(await response.json());
+  return {
+    title: metadata.title.trim(),
+    artist: metadata.user?.username?.trim() ?? "",
+    coverUrl: metadata.artwork_url?.replace(/-large/, "-t1080x1080") ?? undefined,
+  };
+};
+
+export const getTrackMetadataEndpoint = (sourceUrl: string) => {
+  const url = new URL(sourceUrl);
+  const isYouTube =
+    url.hostname === "youtu.be" ||
+    url.hostname === "youtube.com" ||
+    url.hostname.endsWith(".youtube.com");
+  if (isYouTube) {
+    const endpoint = new URL("https://www.youtube.com/oembed");
+    endpoint.searchParams.set("url", sourceUrl);
+    endpoint.searchParams.set("format", "json");
+    return endpoint;
+  }
+
+  return undefined;
+};
+
+export const normalizeTrackMetadataArtist = (artist: string, endpoint: URL) =>
+  endpoint.hostname.endsWith("youtube.com") ? artist.replace(/\s*-\s*Topic$/i, "").trim() : artist;
+
+export default defineHandler(async (event) => {
+  const requestUrl = new URL(event.req.url, "http://tagium.local");
+  const sourceUrl = requestUrl.searchParams.get("url");
+  if (!sourceUrl) throw new Error("track_metadata.url_required");
+
+  if (isSoundCloudUrl(new URL(sourceUrl))) {
+    return resolveSoundCloudTrackMetadata(sourceUrl, { signal: event.req.signal });
+  }
+
+  const endpoint = getTrackMetadataEndpoint(sourceUrl);
+  if (!endpoint) return new Response(null, { status: 204 });
+
+  const response = await fetch(endpoint, { signal: event.req.signal });
+  if (!response.ok) throw new Error(`track_metadata.fetch_failed (${response.status})`);
+  const metadata = oEmbedSchema.parse(await response.json());
+
+  return {
+    title: metadata.title.trim(),
+    artist: normalizeTrackMetadataArtist(metadata.author_name?.trim() ?? "", endpoint),
+    coverUrl: metadata.thumbnail_url,
+  };
+});

--- a/server/utils/soundcloud.ts
+++ b/server/utils/soundcloud.ts
@@ -1,0 +1,31 @@
+const cachedClient = { version: "", id: "" };
+
+export const getSoundCloudClientId = async (fetch: typeof globalThis.fetch = globalThis.fetch) => {
+  const html = await fetch("https://soundcloud.com/").then((response) => response.text());
+  const version = html
+    .match(/<script>window\.__sc_version="[0-9]{10}"<\/script>/)?.[0]
+    .match(/[0-9]{10}/)?.[0];
+  if (version && cachedClient.version === version) return cachedClient.id;
+
+  const hydratedClientId = html.match(
+    /"hydratable"\s*:\s*"apiClient"\s*,\s*"data"\s*:\s*\{\s*"id"\s*:\s*"([^"]+)"/,
+  )?.[1];
+  if (hydratedClientId) {
+    cachedClient.version = version ?? "";
+    cachedClient.id = hydratedClientId;
+    return hydratedClientId;
+  }
+
+  for (const script of html.matchAll(/<script.+src="(.+)">/g)) {
+    const scriptUrl = script[1];
+    if (!scriptUrl?.startsWith("https://a-v2.sndcdn.com/")) continue;
+    const scriptText = await fetch(scriptUrl).then((response) => response.text());
+    const scriptClientId = scriptText.match(/,client_id:"([A-Za-z0-9]{32})",/)?.[1];
+    if (!scriptClientId) continue;
+    cachedClient.version = version ?? "";
+    cachedClient.id = scriptClientId;
+    return scriptClientId;
+  }
+
+  throw new Error("soundcloud.client_id");
+};


### PR DESCRIPTION
## Summary

- resolve YouTube and SoundCloud oEmbed metadata before starting an individual-track download
- seed the pending track with its real title and artist instead of a URL-derived placeholder
- keep metadata enrichment optional so unsupported providers and lookup failures still download normally

## Why

Set and playlist imports already know their track names before the audio payloads finish. Individual YouTube and SoundCloud imports can provide the same editing experience by resolving their lightweight metadata first.

## Root cause

SoundCloud oEmbed exposes presentation metadata (and may append `by {author}` to titles), while Cobalt hydration uses SoundCloud's canonical track record. The pre-download path now uses the same canonical SoundCloud resolve API, so titles remain stable through hydration.

## Validation

- `vp fmt`
- `bun run typecheck`
- `bun run lint`
- `bun run test` — 255 tests passed in the full stack
- `bun run build`

This is the lower PR in the guided-cleanup stack. #89 is stacked above it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Single-URL imports can now automatically retrieve track titles, artists, and cover artwork from supported YouTube and SoundCloud links.
  - Download queues display resolved metadata before downloads begin.
  - SoundCloud artwork is normalized for improved quality where available.
- **Bug Fixes**
  - Metadata lookup failures no longer prevent imports; existing URL-based fallback information is retained.
  - YouTube artist names are cleaned up to remove unnecessary “- Topic” suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->