### PR TITLE
Fix YouTube playlist cover art imports

### DIFF
--- a/server-tests/youtube-cover.get.test.ts
+++ b/server-tests/youtube-cover.get.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import handler from "../server/api/youtube-cover.get";
+
+const makeEvent = (coverUrl: string) => {
+  const request = new Request(
+    `https://tagium.test/api/youtube-cover?url=${encodeURIComponent(coverUrl)}`,
+  );
+  return { req: request } as unknown as Parameters<typeof handler>[0];
+};
+
+describe("youtube cover endpoint", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("proxies a bounded YouTube JPEG for browser cover imports", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(Uint8Array.of(0xff, 0xd8, 0xff), {
+          headers: { "content-type": "image/jpeg", "content-length": "3" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handler(
+      makeEvent("https://i.ytimg.com/pl_c/playlist/studio_square_thumbnail.jpg?sig=test"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(Uint8Array.of(0xff, 0xd8, 0xff));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://i.ytimg.com/pl_c/playlist/studio_square_thumbnail.jpg?sig=test",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it.each([
+    "http://i.ytimg.com/cover.jpg",
+    "https://example.com/cover.jpg",
+    "https://i.ytimg.com.evil.test/cover.jpg",
+  ])("rejects non-YouTube image URLs: %s", async (coverUrl) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handler(makeEvent(coverUrl));
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-image upstream responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { headers: { "content-type": "text/html" } })),
+    );
+
+    const response = await handler(makeEvent("https://i.ytimg.com/cover.jpg"));
+
+    expect(response.status).toBe(502);
+  });
+});

--- a/server-tests/youtube-playlist.get.test.ts
+++ b/server-tests/youtube-playlist.get.test.ts
@@ -140,7 +140,7 @@ describe("youtube playlist endpoint", () => {
       genre: "",
       isAlbum: false,
       year: 2022,
-      coverUrl: "https://i.ytimg.com/large.jpg",
+      coverUrl: "/api/youtube-cover?url=https%3A%2F%2Fi.ytimg.com%2Flarge.jpg",
       tracks: [
         {
           title: "First Track",

--- a/server/api/youtube-cover.get.ts
+++ b/server/api/youtube-cover.get.ts
@@ -1,0 +1,58 @@
+import { defineHandler } from "nitro";
+
+const MAX_COVER_BYTES = 25 * 1024 * 1024;
+const YOUTUBE_COVER_TIMEOUT_MS = 15_000;
+const supportedTypes = new Set(["image/jpeg", "image/jpg", "image/png"]);
+
+const parseYouTubeCoverUrl = (request: Request) => {
+  const requestUrl = new URL(request.url, "http://tagium.local");
+  const coverUrlParam = requestUrl.searchParams.get("url");
+  if (!coverUrlParam) return undefined;
+
+  try {
+    const coverUrl = new URL(coverUrlParam);
+    if (coverUrl.protocol !== "https:" || coverUrl.hostname !== "i.ytimg.com") return undefined;
+    return coverUrl;
+  } catch {
+    return undefined;
+  }
+};
+
+export default defineHandler(async (event) => {
+  const coverUrl = parseYouTubeCoverUrl(event.req);
+  if (!coverUrl) return new Response("Invalid YouTube cover URL.", { status: 400 });
+
+  try {
+    const response = await fetch(coverUrl.toString(), {
+      signal: AbortSignal.any([event.req.signal, AbortSignal.timeout(YOUTUBE_COVER_TIMEOUT_MS)]),
+    });
+    if (!response.ok) {
+      return new Response(`YouTube cover request failed (${response.status}).`, { status: 502 });
+    }
+
+    const contentTypeHeader = response.headers.get("content-type") ?? "";
+    const contentType = contentTypeHeader.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+    if (!supportedTypes.has(contentType)) {
+      return new Response("YouTube cover response was not a JPEG or PNG.", { status: 502 });
+    }
+
+    const declaredLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_COVER_BYTES) {
+      return new Response("YouTube cover response was too large.", { status: 502 });
+    }
+
+    const body = await response.arrayBuffer();
+    if (body.byteLength === 0 || body.byteLength > MAX_COVER_BYTES) {
+      return new Response("YouTube cover response had an invalid size.", { status: 502 });
+    }
+
+    return new Response(body, {
+      headers: {
+        "Cache-Control": "public, max-age=21600",
+        "Content-Type": contentType === "image/jpg" ? "image/jpeg" : contentType,
+      },
+    });
+  } catch {
+    return new Response("YouTube cover request failed.", { status: 502 });
+  }
+});

--- a/server/api/youtube-playlist.get.ts
+++ b/server/api/youtube-playlist.get.ts
@@ -204,11 +204,14 @@ const getPlaylistCover = (initialData: unknown) => {
     findFirstValue(initialData, "playlistVideoThumbnailRenderer"),
   );
   if (!parsed.success || parsed.data.thumbnail.thumbnails.length === 0) return undefined;
-  return parsed.data.thumbnail.thumbnails.reduce((largest, thumbnail) => {
+  const coverUrl = parsed.data.thumbnail.thumbnails.reduce((largest, thumbnail) => {
     const largestArea = (largest.width ?? 0) * (largest.height ?? 0);
     const thumbnailArea = (thumbnail.width ?? 0) * (thumbnail.height ?? 0);
     return thumbnailArea >= largestArea ? thumbnail : largest;
   }).url;
+  const proxyUrl = new URL("/api/youtube-cover", "http://tagium.local");
+  proxyUrl.searchParams.set("url", coverUrl);
+  return `${proxyUrl.pathname}${proxyUrl.search}`;
 };
 
 const getDeclaredTrackCount = (initialData: unknown) => {


### PR DESCRIPTION
## Summary

- proxy YouTube playlist cover images through a restricted Tagium endpoint
- validate the upstream host, protocol, media type, size, timeout, and status
- return the local proxy URL from YouTube playlist resolution
- add endpoint and playlist regression coverage

## Root cause

Custom YouTube playlist images use the `i.ytimg.com/pl_c/...` endpoint, which does not return `Access-Control-Allow-Origin`. Tagium previously fetched the image directly in the browser, so CORS blocked otherwise valid JPEG artwork.

## Impact

Playlists with custom artwork now import their album cover while regular YouTube playlist imports continue through the same bounded image-processing path.

## Validation

- `bun run test server-tests/youtube-playlist.get.test.ts server-tests/youtube-cover.get.test.ts`
- `bun run typecheck`
- `bun run lint -- server/api/youtube-playlist.get.ts server/api/youtube-cover.get.ts server-tests/youtube-playlist.get.test.ts server-tests/youtube-cover.get.test.ts`
- live local request against `PLESiES1i-ThqUjxot6jWLDu90fxtkcpA0` returned a 1280×720 JPEG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure proxying for YouTube cover images.
  * Added validation for supported image formats, URL domains, response status, and maximum file size.
  * Added caching headers and normalized image content types for proxied covers.

* **Bug Fixes**
  * YouTube playlist covers now load through the application proxy instead of direct thumbnail URLs.
  * Invalid or unsupported cover requests return appropriate error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->