### PR TITLE
fix(e2e): use valid mp3 fixture

### DIFF
--- a/e2e/session-safety.spec.ts
+++ b/e2e/session-safety.spec.ts
@@ -2,11 +2,15 @@ import { expect, test, type Page } from "@playwright/test";
 import { Buffer } from "node:buffer";
 
 const uploadTrack = async (page: Page) => {
+  const mp3Bytes = new Uint8Array(834);
+  mp3Bytes.set([0xff, 0xfb, 0x90, 0x00], 0);
+  mp3Bytes.set([0xff, 0xfb, 0x90, 0x00], 417);
+
   await page.goto("/");
   await page.locator('input[type="file"]').setInputFiles({
     name: "walk-away-track.mp3",
     mimeType: "audio/mpeg",
-    buffer: Buffer.from("ID3\u0004\u0000\u0000\u0000\u0000\u0000\u0000", "binary"),
+    buffer: Buffer.from(mp3Bytes),
   });
   await expect(page.getByRole("button", { name: "remove track" })).toBeAttached();
 };


### PR DESCRIPTION
## What changed

Updated the session-safety Playwright upload fixture to include two valid MP3 frame headers.

## Why

MP3 admission validation now correctly rejects the previous ID3-only fixture. That left the test without an imported track, causing eight cross-browser E2E failures and skipping the production deployment.

## Validation

- `vp exec playwright test e2e/session-safety.spec.ts` — 11 passed, 1 expected skip
- `vp check`
- `vp test run` — 283 passed
- `vp build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end session safety test reliability by updating how MP3 upload fixtures are prepared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->