### PR TITLE
fix: stabilize empty settings transition

### DIFF
--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -77,7 +77,7 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
         }
       >
         {active && (
-          <>
+          <div className="flex w-full flex-col items-center gap-10 animate-in fade-in motion-reduce:animate-none max-lg:[@media(max-height:700px)]:gap-6">
             <div className="text-center select-none">
               <h1 className="text-7xl font-bold tracking-tighter text-foreground">tagium</h1>
               <p className="text-muted-foreground mt-3 text-base">tag your music</p>
@@ -109,7 +109,7 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
                 </p>
               </div>
             </button>
-          </>
+          </div>
         )}
         {children}
       </div>

--- a/components/audio/MediaUrlEntry.tsx
+++ b/components/audio/MediaUrlEntry.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { ArrowRight, Link2, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { getMediaUrlEntryMotionKeyframes } from "./mediaUrlEntryMotion";
 import { getSystemFailurePresentation, reportSystemFailure } from "./systemFailure";
 
 interface MediaUrlEntryProps {
   layout: "landing" | "editor";
   hidden: boolean;
+  docked?: boolean;
   onUrlImport: (sourceUrl: string) => void | Promise<void>;
 }
 
@@ -24,52 +26,105 @@ const validateMediaUrl = (value: string) => {
   return "enter a complete http or https url";
 };
 
-export default function MediaUrlEntry({ layout, hidden, onUrlImport }: MediaUrlEntryProps) {
+const prefersReducedMotion = () =>
+  window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+
+export default function MediaUrlEntry({
+  layout,
+  hidden,
+  docked = false,
+  onUrlImport,
+}: MediaUrlEntryProps) {
   const [sourceUrl, setSourceUrl] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
-  const formRef = useRef<HTMLFormElement>(null);
-  const feedbackRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const motionRef = useRef<HTMLDivElement>(null);
   const previousRectRef = useRef<DOMRect | null>(null);
   const previousLayoutRef = useRef(layout);
+  const animationRef = useRef<Animation | null>(null);
+
+  const clearMotionStyles = () => {
+    const anchor = anchorRef.current;
+    const motion = motionRef.current;
+    if (anchor) anchor.style.height = "";
+    if (!motion) return;
+
+    motion.style.position = "";
+    motion.style.left = "";
+    motion.style.top = "";
+    motion.style.width = "";
+    motion.style.zIndex = "";
+  };
 
   useLayoutEffect(() => {
-    const form = formRef.current;
-    if (!form || hidden) {
+    const anchor = anchorRef.current;
+    const motion = motionRef.current;
+    if (!anchor || !motion || hidden) {
+      animationRef.current?.cancel();
+      animationRef.current = null;
+      clearMotionStyles();
       previousRectRef.current = null;
       previousLayoutRef.current = layout;
       return;
     }
 
-    const nextRect = form.getBoundingClientRect();
-    const previousRect = previousRectRef.current;
+    const runningAnimation = animationRef.current;
+    const previousRect = runningAnimation
+      ? motion.getBoundingClientRect()
+      : previousRectRef.current;
     const layoutChanged = previousLayoutRef.current !== layout;
-    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    runningAnimation?.cancel();
+    animationRef.current = null;
+    clearMotionStyles();
 
-    if (previousRect && layoutChanged && !reducedMotion) {
-      const deltaX = previousRect.left - nextRect.left;
-      const deltaY = previousRect.top - nextRect.top;
-      const scaleX = previousRect.width / Math.max(1, nextRect.width);
-      form.animate(
-        [
-          {
-            transform: `translate(${deltaX}px, ${deltaY}px) scaleX(${scaleX})`,
-            transformOrigin: "top left",
-          },
-          { transform: "translate(0, 0) scaleX(1)", transformOrigin: "top left" },
-        ],
-        { duration: 420, easing: "cubic-bezier(0.22, 1, 0.36, 1)" },
-      );
+    const nextRect = motion.getBoundingClientRect();
+    const reducedMotion = prefersReducedMotion();
+
+    if (previousRect && layoutChanged && !reducedMotion && typeof motion.animate === "function") {
+      anchor.style.height = `${nextRect.height}px`;
+      motion.style.position = "fixed";
+      motion.style.left = `${previousRect.left}px`;
+      motion.style.top = `${previousRect.top}px`;
+      motion.style.width = `${previousRect.width}px`;
+      motion.style.zIndex = "30";
+
+      const animation = motion.animate(getMediaUrlEntryMotionKeyframes(previousRect, nextRect), {
+        duration: 420,
+        easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+      });
+      animationRef.current = animation;
+      animation.onfinish = () => {
+        if (animationRef.current !== animation) return;
+        animationRef.current = null;
+        clearMotionStyles();
+        previousRectRef.current = motion.getBoundingClientRect();
+      };
     }
 
     previousRectRef.current = nextRect;
     previousLayoutRef.current = layout;
-  }, [hidden, layout]);
+  }, [docked, hidden, layout]);
+
+  useEffect(() => {
+    const settleMotion = () => {
+      animationRef.current?.cancel();
+      animationRef.current = null;
+      clearMotionStyles();
+      previousRectRef.current = motionRef.current?.getBoundingClientRect() ?? null;
+    };
+
+    window.addEventListener("resize", settleMotion);
+    return () => {
+      window.removeEventListener("resize", settleMotion);
+      settleMotion();
+    };
+  }, []);
 
   const showValidationError = (message: string) => {
     setValidationError(message);
-    const feedback = feedbackRef.current;
-    if (!feedback || window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const feedback = motionRef.current;
+    if (!feedback || prefersReducedMotion() || typeof feedback.animate !== "function") return;
     feedback.animate(
       [
         { transform: "translateX(0)" },
@@ -122,72 +177,66 @@ export default function MediaUrlEntry({ layout, hidden, onUrlImport }: MediaUrlE
       inert={hidden || undefined}
       className={cn(
         hidden && "hidden",
-        layout === "landing" && "flex w-full justify-center",
+        layout === "landing" &&
+          "flex w-full flex-col gap-10 max-lg:[@media(max-height:700px)]:gap-6",
         layout === "editor" &&
           "flex-shrink-0 border-t bg-background/95 p-3 lg:pointer-events-none lg:absolute lg:inset-x-0 lg:bottom-4 lg:z-10 lg:flex lg:justify-center lg:border-t-0 lg:bg-transparent lg:px-4 lg:p-0",
+        docked &&
+          "pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center lg:bottom-4",
       )}
     >
-      <div
-        ref={feedbackRef}
-        className={cn(
-          "pointer-events-auto flex w-full flex-col",
-          layout === "landing"
-            ? "max-w-md gap-10 max-lg:[@media(max-height:700px)]:gap-6"
-            : "max-w-3xl gap-1",
-        )}
-      >
-        {layout === "landing" && (
-          <div className="flex items-center gap-4 text-sm text-muted-foreground">
-            <div className="h-px flex-1 bg-border" />
-            <span>or import from a url</span>
-            <div className="h-px flex-1 bg-border" />
-          </div>
-        )}
-        <form ref={formRef} noValidate onSubmit={handleSubmit} className="flex items-start gap-2">
-          <div className="min-w-0 flex-1">
-            <div className="relative">
-              <Link2 className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                type="url"
-                name="media-url"
-                autoComplete="url"
-                value={sourceUrl}
-                aria-label="media url"
-                aria-invalid={Boolean(validationError)}
-                aria-describedby={validationError ? "media-url-error" : undefined}
-                onChange={(event) => {
-                  setSourceUrl(event.target.value);
-                  setValidationError(null);
-                }}
-                placeholder="soundcloud or youtube url"
-                disabled={submitting}
+      {layout === "landing" && (
+        <div className="flex items-center gap-4 text-sm text-muted-foreground">
+          <div className="h-px flex-1 bg-border" />
+          <span>or import from a url</span>
+          <div className="h-px flex-1 bg-border" />
+        </div>
+      )}
+      <div ref={anchorRef} className={cn("w-full", layout === "editor" && "max-w-3xl")}>
+        <div ref={motionRef} className="pointer-events-auto w-full bg-background">
+          <form noValidate onSubmit={handleSubmit} className="flex items-start gap-2">
+            <div className="min-w-0 flex-1">
+              <div className="relative">
+                <Link2 className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  type="url"
+                  name="media-url"
+                  autoComplete="url"
+                  value={sourceUrl}
+                  aria-label="media url"
+                  aria-invalid={Boolean(validationError)}
+                  aria-describedby={validationError ? "media-url-error" : undefined}
+                  onChange={(event) => {
+                    setSourceUrl(event.target.value);
+                    setValidationError(null);
+                  }}
+                  placeholder="soundcloud or youtube url"
+                  disabled={submitting}
+                  className="h-10 rounded-lg pl-9 placeholder:text-muted-foreground/45"
+                />
+              </div>
+              <p
+                id="media-url-error"
                 className={cn(
-                  "pl-9 placeholder:text-muted-foreground/45",
-                  layout === "landing" && "h-10 rounded-lg",
+                  "h-4 pt-0.5 text-xs leading-4 text-destructive",
+                  layout === "landing" && "text-center",
                 )}
-              />
+                aria-live="polite"
+              >
+                {validationError ?? ""}
+              </p>
             </div>
-            <p
-              id="media-url-error"
-              className={cn(
-                "h-4 pt-0.5 text-xs leading-4 text-destructive",
-                layout === "landing" && "text-center",
-              )}
-              aria-live="polite"
+            <Button
+              type="submit"
+              size="icon"
+              disabled={!canSubmit}
+              aria-label="start media import"
+              className="size-10 rounded-lg"
             >
-              {validationError ?? ""}
-            </p>
-          </div>
-          <Button
-            type="submit"
-            size="icon"
-            disabled={!canSubmit}
-            aria-label="start media import"
-            className={cn(layout === "landing" && "size-10 rounded-lg")}
-          >
-            {submitting ? <Loader2 className="animate-spin" /> : <ArrowRight />}
-          </Button>
-        </form>
+              {submitting ? <Loader2 className="animate-spin" /> : <ArrowRight />}
+            </Button>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/components/audio/SettingsPage.tsx
+++ b/components/audio/SettingsPage.tsx
@@ -19,7 +19,7 @@ export default function SettingsPage({ settings, onChange, onBack }: SettingsPag
   const [bitrateOpen, setBitrateOpen] = useState(false);
 
   return (
-    <div className="min-h-0 flex-1 flex flex-col overflow-hidden animate-in fade-in duration-200 motion-reduce:animate-none">
+    <div className="min-h-0 flex-1 flex flex-col overflow-hidden">
       <div className="p-6 h-[104px] border-b flex-shrink-0 flex flex-col justify-center gap-1">
         <div className="flex min-w-0 items-center gap-2">
           <button

--- a/components/audio/SettingsPage.tsx
+++ b/components/audio/SettingsPage.tsx
@@ -19,7 +19,7 @@ export default function SettingsPage({ settings, onChange, onBack }: SettingsPag
   const [bitrateOpen, setBitrateOpen] = useState(false);
 
   return (
-    <div className="min-h-0 flex-1 flex flex-col overflow-hidden">
+    <div className="min-h-0 flex-1 flex flex-col overflow-hidden animate-in fade-in duration-200 motion-reduce:animate-none">
       <div className="p-6 h-[104px] border-b flex-shrink-0 flex flex-col justify-center gap-1">
         <div className="flex min-w-0 items-center gap-2">
           <button

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -59,6 +59,7 @@ import LandingScreen from "./LandingScreen";
 import TrackMetadataEditor from "./TrackMetadataEditor";
 import SettingsPage from "./SettingsPage";
 import MediaUrlEntry from "./MediaUrlEntry";
+import { getMediaUrlEntryPresentation } from "./mediaUrlEntryPresentation";
 import MetadataCleanupDialog from "./MetadataCleanupDialog";
 import {
   applyMetadataCleanupSuggestions,
@@ -1845,6 +1846,10 @@ export default function AudioTagger() {
 
   const libraryIsEmpty = files.length === 0 && albums.length === 0 && looseTrackIds.length === 0;
   const landingIsActive = libraryIsEmpty && activeView === "editor";
+  const mediaUrlEntryPresentation = getMediaUrlEntryPresentation(
+    libraryIsEmpty,
+    activeView === "settings",
+  );
   const playlistQueueDownloaded = playlistDownloadQueue ? playlistDownloadQueue.completed : 0;
   const playlistQueueEta = playlistDownloadQueue
     ? formatPlaylistQueueEta(playlistDownloadQueue.etaMs)
@@ -1936,6 +1941,11 @@ export default function AudioTagger() {
     });
   };
 
+  const toggleSettings = () => {
+    if (isTrackCoverProcessing) return;
+    setActiveView((currentView) => (currentView === "settings" ? "editor" : "settings"));
+  };
+
   return (
     <>
       <MetadataCleanupDialog
@@ -2004,10 +2014,7 @@ export default function AudioTagger() {
           onReorderAlbums={handleReorderAlbums}
           playlistDownloadQueue={playlistSidebarQueue}
           onDownloadAll={handleDownloadAll}
-          onOpenSettings={() => {
-            if (isTrackCoverProcessing) return;
-            setActiveView((currentView) => (currentView === "settings" ? "editor" : "settings"));
-          }}
+          onOpenSettings={toggleSettings}
           onCancelPlaylistDownloadQueue={handleCancelPlaylistDownloads}
           onRetryPlaylistDownloadQueue={handleRetryPlaylistDownloads}
         />
@@ -2023,7 +2030,7 @@ export default function AudioTagger() {
               <SettingsPage
                 settings={settings}
                 onChange={handleSettingsChange}
-                onBack={() => setActiveView("editor")}
+                onBack={toggleSettings}
               />
             ) : !libraryIsEmpty ? (
               <TrackMetadataEditor
@@ -2047,8 +2054,9 @@ export default function AudioTagger() {
           </div>
           <LandingScreen active={landingIsActive} onAudioUpload={handleAudioUpload}>
             <MediaUrlEntry
-              layout={libraryIsEmpty ? "landing" : "editor"}
-              hidden={activeView !== "editor"}
+              layout={mediaUrlEntryPresentation.layout}
+              hidden={mediaUrlEntryPresentation.hidden}
+              docked={mediaUrlEntryPresentation.docked}
               onUrlImport={handleUrlImport}
             />
           </LandingScreen>

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -2026,29 +2026,58 @@ export default function AudioTagger() {
                 : "h-svh min-h-0 flex flex-col overflow-hidden md:h-auto md:min-h-0 md:flex-1"
             }
           >
-            {activeView === "settings" ? (
+            {!libraryIsEmpty ? (
+              <div className="relative min-h-0 flex-1">
+                <div
+                  data-view="metadata-editor"
+                  aria-hidden={activeView !== "editor"}
+                  inert={activeView !== "editor"}
+                  className={`absolute inset-0 flex min-h-0 flex-col bg-background transition-opacity duration-200 motion-reduce:transition-none ${
+                    activeView === "editor"
+                      ? "z-10 opacity-100"
+                      : "pointer-events-none z-0 opacity-0"
+                  }`}
+                >
+                  <TrackMetadataEditor
+                    selectedFile={selectedFile}
+                    selectedFileId={selectedFileId}
+                    register={register}
+                    control={control}
+                    handleSubmit={handleSubmit}
+                    onTrackCoverUpload={handleTrackCoverUpload}
+                    onTrackCoverProcessingChange={setIsTrackCoverProcessing}
+                    isTrackCoverProcessing={isTrackCoverProcessing}
+                    onDownloadUpdatedFile={handleDownloadUpdatedFile}
+                    selectedFileAlbum={selectedFileAlbum}
+                    syncFilenames={settings.syncFilenames}
+                    syncTrackNumbers={settings.syncTrackNumbers}
+                    onPreviewMetadataChange={(field, event) =>
+                      handlePreviewMetadataChange(field, event.target.value)
+                    }
+                  />
+                </div>
+                <div
+                  data-view="settings"
+                  aria-hidden={activeView !== "settings"}
+                  inert={activeView !== "settings"}
+                  className={`absolute inset-0 flex min-h-0 flex-col bg-background transition-opacity duration-200 motion-reduce:transition-none ${
+                    activeView === "settings"
+                      ? "z-10 opacity-100"
+                      : "pointer-events-none z-0 opacity-0"
+                  }`}
+                >
+                  <SettingsPage
+                    settings={settings}
+                    onChange={handleSettingsChange}
+                    onBack={toggleSettings}
+                  />
+                </div>
+              </div>
+            ) : activeView === "settings" ? (
               <SettingsPage
                 settings={settings}
                 onChange={handleSettingsChange}
                 onBack={toggleSettings}
-              />
-            ) : !libraryIsEmpty ? (
-              <TrackMetadataEditor
-                selectedFile={selectedFile}
-                selectedFileId={selectedFileId}
-                register={register}
-                control={control}
-                handleSubmit={handleSubmit}
-                onTrackCoverUpload={handleTrackCoverUpload}
-                onTrackCoverProcessingChange={setIsTrackCoverProcessing}
-                isTrackCoverProcessing={isTrackCoverProcessing}
-                onDownloadUpdatedFile={handleDownloadUpdatedFile}
-                selectedFileAlbum={selectedFileAlbum}
-                syncFilenames={settings.syncFilenames}
-                syncTrackNumbers={settings.syncTrackNumbers}
-                onPreviewMetadataChange={(field, event) =>
-                  handlePreviewMetadataChange(field, event.target.value)
-                }
               />
             ) : null}
           </div>

--- a/components/audio/mediaUrlEntryMotion.test.ts
+++ b/components/audio/mediaUrlEntryMotion.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vite-plus/test";
+import { getMediaUrlEntryMotionKeyframes } from "./mediaUrlEntryMotion";
+import { getMediaUrlEntryPresentation } from "./mediaUrlEntryPresentation";
+
+describe("media URL entry presentation", () => {
+  it("docks the persistent entry in empty-library settings", () => {
+    expect(getMediaUrlEntryPresentation(true, false)).toEqual({
+      layout: "landing",
+      hidden: false,
+      docked: false,
+    });
+    expect(getMediaUrlEntryPresentation(true, true)).toEqual({
+      layout: "editor",
+      hidden: false,
+      docked: true,
+    });
+  });
+
+  it("preserves non-empty-library visibility behavior", () => {
+    expect(getMediaUrlEntryPresentation(false, false)).toEqual({
+      layout: "editor",
+      hidden: false,
+      docked: false,
+    });
+    expect(getMediaUrlEntryPresentation(false, true)).toEqual({
+      layout: "editor",
+      hidden: true,
+      docked: false,
+    });
+  });
+
+  it("animates position and real width without a transform", () => {
+    const keyframes = getMediaUrlEntryMotionKeyframes(
+      { left: 100, top: 500, width: 448 },
+      { left: 300, top: 700, width: 768 },
+    );
+
+    expect(keyframes).toEqual([
+      { left: "100px", top: "500px", width: "448px" },
+      { left: "300px", top: "700px", width: "768px" },
+    ]);
+    expect(keyframes.every((keyframe) => keyframe.transform === undefined)).toBe(true);
+  });
+});

--- a/components/audio/mediaUrlEntryMotion.ts
+++ b/components/audio/mediaUrlEntryMotion.ts
@@ -1,0 +1,18 @@
+interface MotionRect {
+  left: number;
+  top: number;
+  width: number;
+}
+
+export const getMediaUrlEntryMotionKeyframes = (from: MotionRect, to: MotionRect): Keyframe[] => [
+  {
+    left: `${from.left}px`,
+    top: `${from.top}px`,
+    width: `${from.width}px`,
+  },
+  {
+    left: `${to.left}px`,
+    top: `${to.top}px`,
+    width: `${to.width}px`,
+  },
+];

--- a/components/audio/mediaUrlEntryPresentation.ts
+++ b/components/audio/mediaUrlEntryPresentation.ts
@@ -1,0 +1,16 @@
+export type MediaUrlEntryLayout = "landing" | "editor";
+
+interface MediaUrlEntryPresentation {
+  layout: MediaUrlEntryLayout;
+  hidden: boolean;
+  docked: boolean;
+}
+
+export const getMediaUrlEntryPresentation = (
+  libraryIsEmpty: boolean,
+  settingsOpen: boolean,
+): MediaUrlEntryPresentation => ({
+  layout: libraryIsEmpty && !settingsOpen ? "landing" : "editor",
+  hidden: settingsOpen && !libraryIsEmpty,
+  docked: libraryIsEmpty && settingsOpen,
+});

--- a/components/audio/urlImportGateway.test.tsx
+++ b/components/audio/urlImportGateway.test.tsx
@@ -6,6 +6,7 @@ import mediaUrlEntrySource from "./MediaUrlEntry.tsx?raw";
 import MediaUrlEntry from "./MediaUrlEntry";
 
 const reactHookMocks = vi.hoisted(() => ({
+  useEffect: vi.fn(),
   useLayoutEffect: vi.fn(),
   useRef: vi.fn(),
   useState: vi.fn(),
@@ -17,6 +18,7 @@ vi.mock("react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react")>();
   return {
     ...actual,
+    useEffect: reactHookMocks.useEffect,
     useLayoutEffect: reactHookMocks.useLayoutEffect,
     useRef: reactHookMocks.useRef,
     useState: reactHookMocks.useState,
@@ -71,6 +73,7 @@ const createHookHarness = () => {
   let refCursor = 0;
 
   reactHookMocks.useLayoutEffect.mockImplementation(() => undefined);
+  reactHookMocks.useEffect.mockImplementation(() => undefined);
   reactHookMocks.useRef.mockImplementation((initial: unknown) => {
     const index = refCursor++;
     refs[index] ??= { current: initial };
@@ -135,10 +138,6 @@ describe("media URL entry", () => {
     });
 
     expect(onUrlImport).toHaveBeenCalledWith("https://soundcloud.com/user/track");
-  });
-
-  it("anchors width-changing layout motion to the measured left edge", () => {
-    expect(mediaUrlEntrySource.match(/transformOrigin: "top left"/g)).toHaveLength(2);
   });
 
   it("keeps malformed URL feedback local to the input", async () => {

--- a/e2e/settings-transition.spec.ts
+++ b/e2e/settings-transition.spec.ts
@@ -1,4 +1,19 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+import { Buffer } from "node:buffer";
+
+const uploadTrack = async (page: Page) => {
+  const mp3Bytes = new Uint8Array(834);
+  mp3Bytes.set([0xff, 0xfb, 0x90, 0x00], 0);
+  mp3Bytes.set([0xff, 0xfb, 0x90, 0x00], 417);
+
+  await page.goto("/");
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "crossfade-track.mp3",
+    mimeType: "audio/mpeg",
+    buffer: Buffer.from(mp3Bytes),
+  });
+  await expect(page.getByRole("button", { name: "remove track" })).toBeAttached();
+};
 
 test("keeps the media entry within its return transition endpoints", async ({ page }) => {
   await page.goto("/");
@@ -51,4 +66,40 @@ test("keeps the media entry within its return transition endpoints", async ({ pa
   const minimumLeft = Math.min(transition.startLeft, transition.endLeft) - 2;
   const maximumLeft = Math.max(transition.startLeft, transition.endLeft) + 2;
   expect(transition.samples.every((left) => left >= minimumLeft && left <= maximumLeft)).toBe(true);
+});
+
+test("crossfades the metadata editor and settings without unmounting either panel", async ({
+  page,
+}) => {
+  await uploadTrack(page);
+
+  const editor = page.locator('[data-view="metadata-editor"]');
+  const settings = page.locator('[data-view="settings"]');
+  await expect(editor).toHaveAttribute("aria-hidden", "false");
+  await expect(settings).toHaveAttribute("aria-hidden", "true");
+
+  await page.getByRole("button", { name: "settings" }).click();
+  await expect(editor).toHaveAttribute("aria-hidden", "true");
+  await expect(settings).toHaveAttribute("aria-hidden", "false");
+  await page.waitForTimeout(100);
+
+  const midpoint = await Promise.all([
+    editor.evaluate((element) =>
+      Number.parseFloat(
+        element.ownerDocument.defaultView?.getComputedStyle(element).opacity ?? "0",
+      ),
+    ),
+    settings.evaluate((element) =>
+      Number.parseFloat(
+        element.ownerDocument.defaultView?.getComputedStyle(element).opacity ?? "0",
+      ),
+    ),
+  ]);
+  expect(midpoint[0]).toBeGreaterThan(0);
+  expect(midpoint[0]).toBeLessThan(1);
+  expect(midpoint[1]).toBeGreaterThan(0);
+  expect(midpoint[1]).toBeLessThan(1);
+
+  await expect(editor).toHaveCSS("opacity", "0");
+  await expect(settings).toHaveCSS("opacity", "1");
 });

--- a/e2e/settings-transition.spec.ts
+++ b/e2e/settings-transition.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+test("keeps the media entry within its return transition endpoints", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "settings" }).click();
+  await page.waitForTimeout(500);
+
+  const transition = await page.evaluate(async () => {
+    interface BrowserElement {
+      click: () => void;
+      closest: (selector: string) => BrowserElement | null;
+      getBoundingClientRect: () => { left: number };
+      parentElement: BrowserElement | null;
+    }
+
+    const browser = globalThis as unknown as {
+      document: { querySelector: (selector: string) => BrowserElement | null };
+      performance: { now: () => number };
+      requestAnimationFrame: (callback: () => void) => number;
+    };
+    const input = browser.document.querySelector('input[name="media-url"]');
+    const motion = input?.closest("form")?.parentElement;
+    const back = browser.document.querySelector('button[aria-label="back to editor"]');
+    if (!motion || !back) {
+      throw new Error("media entry transition elements were not found");
+    }
+
+    const startLeft = motion.getBoundingClientRect().left;
+    back.click();
+    const samples: number[] = [];
+    const startedAt = browser.performance.now();
+    await new Promise<void>((resolve) => {
+      const sample = () => {
+        samples.push(motion.getBoundingClientRect().left);
+        if (browser.performance.now() - startedAt >= 550) {
+          resolve();
+          return;
+        }
+        browser.requestAnimationFrame(sample);
+      };
+      browser.requestAnimationFrame(sample);
+    });
+
+    return {
+      startLeft,
+      endLeft: motion.getBoundingClientRect().left,
+      samples,
+    };
+  });
+
+  const minimumLeft = Math.min(transition.startLeft, transition.endLeft) - 2;
+  const maximumLeft = Math.max(transition.startLeft, transition.endLeft) + 2;
+  expect(transition.samples.every((left) => left >= minimumLeft && left <= maximumLeft)).toBe(true);
+});


### PR DESCRIPTION
## What changed

- keeps the media URL entry mounted while moving between the empty landing view and Settings
- animates the live control with real viewport `left`, `top`, and `width` values instead of transform scaling or snapshots
- preserves the narrow landing width and wider docked Settings width without stretching text or controls
- gives the sidebar toggle and Settings back button one guarded transition path
- handles rapid reversals, resize, reduced motion, and missing Web Animations support
- fades landing and Settings content independently from the persistent media entry
- adds presentation and motion unit coverage plus a browser geometry regression

## Why

The previous implementation combined layout movement with view-transition snapshots and transform-based animation, which produced scaling and flicker. During the fresh implementation, the landing fade also briefly transformed the media entry's ancestor. That made the fixed-position form use the landing panel as its containing block, adding the 288px sidebar offset on the return transition and visibly teleporting the form to the right.

The landing fade now applies only to landing-specific content, keeping the persistent form in viewport coordinates throughout the animation.

Supersedes #92.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run test` (45 files, 285 tests)
- `bun run test:e2e -- e2e/settings-transition.spec.ts --project=chromium`
- `git diff --check`
- Computer Use verification at desktop and 390x844 mobile sizes
- rapid 100ms reversal and reduced-motion emulation
- frame-by-frame geometry probe confirming the return path remains within `left=360` to `left=520` with no escaped frames