### PR TITLE
Establish tagium.app as the canonical production domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 mp3tag editing for music fans who want to save their favorite tracks locally.
 
+[Open Tagium](https://tagium.app)
+
 ## Docs
 
 see `./docs`.

--- a/docs/cobalt-audio-downloads.md
+++ b/docs/cobalt-audio-downloads.md
@@ -50,8 +50,11 @@ If Cobalt emits `X-Cobalt-Machine-Id`, Tagium signs machine-bound tunnel URLs. S
 wrangler secret put COBALT_MACHINE_AFFINITY_SECRET
 ```
 
-Preview deployments should leave `COBALT_ALLOWED_ORIGIN` unset so each preview URL can use the same-origin fallback.
-Production can set `COBALT_ALLOWED_ORIGIN` to the final public Tagium origin once the domain is fixed.
+The canonical production origin is `https://tagium.app`. `nitro.config.ts` manages its Cloudflare
+custom domain along with permanent redirects from `https://www.tagium.app` and
+`https://tagium.oli.boo`. Keep `COBALT_ALLOWED_ORIGIN` unset: production requests are already
+same-origin, and the request-origin fallback lets isolated preview URLs use Cobalt without
+masquerading as production.
 
 ## Fly scaling
 

--- a/index.html
+++ b/index.html
@@ -14,12 +14,14 @@
       content="save your favorite music and edit mp3 tags all on the web."
     />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tagium.app/" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="tagium" />
     <meta
       name="twitter:description"
       content="save your favorite music and edit mp3 tags all on the web."
     />
+    <link rel="canonical" href="https://tagium.app/" />
     <link rel="icon" href="/favicon.ico" />
     <script>
       (() => {

--- a/nitro.config.ts
+++ b/nitro.config.ts
@@ -2,6 +2,13 @@ import { defineNitroConfig } from "nitro/config";
 
 const wrangler = {
   keep_vars: true,
+  workers_dev: false,
+  preview_urls: true,
+  routes: [
+    { pattern: "tagium.app", custom_domain: true },
+    { pattern: "www.tagium.app", custom_domain: true },
+    { pattern: "tagium.oli.boo", custom_domain: true },
+  ],
   vars: {
     COBALT_API_URL: "https://tagium-cobalt.fly.dev/",
     TAGIUM_DEPLOY_ENV: "production",

--- a/server/middleware/01-canonical-origin.ts
+++ b/server/middleware/01-canonical-origin.ts
@@ -1,0 +1,12 @@
+import { defineHandler } from "nitro";
+import { getCanonicalRedirectUrl } from "../utils/canonical-origin";
+
+export default defineHandler((event) => {
+  const redirectUrl = getCanonicalRedirectUrl(event.req.url);
+  if (!redirectUrl) return;
+
+  return new Response(null, {
+    status: 308,
+    headers: { Location: redirectUrl },
+  });
+});

--- a/server/utils/canonical-origin.test.ts
+++ b/server/utils/canonical-origin.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { getCanonicalRedirectUrl } from "./canonical-origin";
+
+describe("getCanonicalRedirectUrl", () => {
+  it("redirects the previous domain while preserving the path and query", () => {
+    expect(getCanonicalRedirectUrl("https://tagium.oli.boo/album/edit?track=2")).toBe(
+      "https://tagium.app/album/edit?track=2",
+    );
+  });
+
+  it("redirects the www hostname to the apex domain", () => {
+    expect(getCanonicalRedirectUrl("https://www.tagium.app/settings")).toBe(
+      "https://tagium.app/settings",
+    );
+  });
+
+  it.each(["https://tagium.app/", "https://tagium-preview.workers.dev/"])(
+    "does not redirect %s",
+    (url) => {
+      expect(getCanonicalRedirectUrl(url)).toBeUndefined();
+    },
+  );
+});

--- a/server/utils/canonical-origin.ts
+++ b/server/utils/canonical-origin.ts
@@ -1,0 +1,15 @@
+export const CANONICAL_ORIGIN = "https://tagium.app";
+
+const redirectHostnames = new Set(["tagium.oli.boo", "www.tagium.app"]);
+
+export const getCanonicalRedirectUrl = (requestUrl: string) => {
+  const url = new URL(requestUrl);
+  if (!redirectHostnames.has(url.hostname.toLowerCase())) return undefined;
+
+  const canonicalUrl = new URL(url);
+  canonicalUrl.protocol = "https:";
+  canonicalUrl.hostname = "tagium.app";
+  canonicalUrl.port = "";
+  canonicalUrl.hash = "";
+  return canonicalUrl.toString();
+};


### PR DESCRIPTION
## Summary

- configure `tagium.app`, `www.tagium.app`, and `tagium.oli.boo` as Cloudflare Worker custom domains
- make `https://tagium.app` canonical in page metadata and repository documentation
- permanently redirect the `www` and legacy production hostnames while preserving paths and query strings
- keep production `workers.dev` disabled while retaining isolated per-version preview URLs
- document why `COBALT_ALLOWED_ORIGIN` remains unset for same-origin production and previews

The Cloudflare configuration is already deployed and the canonical domain is live.

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run test` — 46 files, 289 tests
- `bun run build`
- `https://tagium.app/` returns `200` over HTTPS
- `https://www.tagium.app/*` and `https://tagium.oli.boo/*` return `308` to the canonical origin
- canonical and Open Graph URL metadata resolve to `https://tagium.app/`

Closes #82