### PR TITLE
fix: harden YouTube playlist resolution

### DIFF
--- a/server-tests/youtube-playlist.get.test.ts
+++ b/server-tests/youtube-playlist.get.test.ts
@@ -35,6 +35,7 @@ const lockupVideo = (videoId: string, title: string, duration: string) => ({
 
 describe("youtube playlist endpoint", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -163,6 +164,58 @@ describe("youtube playlist endpoint", () => {
       ],
     });
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("recovers when YouTube transiently rejects the playlist request", async () => {
+    const initialData = {
+      metadata: { playlistMetadataRenderer: { title: "Recovered Playlist" } },
+      contents: [lockupVideo("first-video", "First Track", "4:14")],
+    };
+    const html = `<script>var ytInitialData = ${JSON.stringify(initialData)};</script>`;
+    const fetchMock = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(new Response("temporarily unavailable", { status: 503 }))
+      .mockResolvedValueOnce(new Response(html));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const playlist = await handler(makeEvent());
+
+    expect(playlist).toMatchObject({
+      title: "Recovered Playlist",
+      tracks: [{ title: "First Track" }],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns playable tracks when optional upload-year enrichment fails", async () => {
+    const initialData = {
+      metadata: { playlistMetadataRenderer: { title: "Playlist Without Year" } },
+      contents: [lockupVideo("first-video", "First Track", "4:14")],
+    };
+    const html = [
+      `<script>var ytInitialData = ${JSON.stringify(initialData)};</script>`,
+      `<script>ytcfg.set(${JSON.stringify({
+        INNERTUBE_API_KEY: "api-key",
+        INNERTUBE_CLIENT_VERSION: "2.20260708.00.00",
+        INNERTUBE_CONTEXT: { client: { clientName: "WEB" } },
+      })});</script>`,
+    ].join("");
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = input instanceof Request ? input.url : new URL(input).toString();
+      if (url.startsWith("https://www.youtube.com/playlist?")) return new Response(html);
+      return new Response("temporarily unavailable", { status: 503 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const playlist = await handler(makeEvent());
+
+    expect(playlist).toMatchObject({
+      title: "Playlist Without Year",
+      tracks: [{ title: "First Track" }],
+    });
+    expect(playlist).not.toHaveProperty("year");
   });
 
   it("rejects non-playlist YouTube URLs without fetching them", async () => {

--- a/server/api/youtube-playlist.get.ts
+++ b/server/api/youtube-playlist.get.ts
@@ -2,6 +2,7 @@ import { defineHandler } from "nitro";
 import { z } from "zod";
 import {
   extractYouTubeJsonObject,
+  fetchYouTubeWithRetry,
   getYouTubeConfig,
   resolveYouTubeUploadYear,
   YOUTUBE_ORIGIN,
@@ -226,7 +227,7 @@ const getDeclaredTrackCount = (initialData: unknown) => {
   return undefined;
 };
 
-const fetchContinuation = async (token: string, config: JsonRecord) => {
+const fetchContinuation = async (token: string, config: JsonRecord, signal: AbortSignal) => {
   const apiKey = config.INNERTUBE_API_KEY;
   const context = config.INNERTUBE_CONTEXT;
   const clientVersion = config.INNERTUBE_CLIENT_VERSION;
@@ -236,16 +237,21 @@ const fetchContinuation = async (token: string, config: JsonRecord) => {
 
   const endpoint = new URL("/youtubei/v1/browse", YOUTUBE_ORIGIN);
   endpoint.searchParams.set("key", apiKey);
-  const response = await fetch(endpoint, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "user-agent": YOUTUBE_USER_AGENT,
-      "x-youtube-client-name": "1",
-      "x-youtube-client-version": clientVersion,
+  const response = await fetchYouTubeWithRetry(
+    endpoint,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "user-agent": YOUTUBE_USER_AGENT,
+        "x-youtube-client-name": "1",
+        "x-youtube-client-version": clientVersion,
+      },
+      body: JSON.stringify({ context, continuation: token }),
+      signal,
     },
-    body: JSON.stringify({ context, continuation: token }),
-  });
+    { stage: "continuation" },
+  );
   if (!response.ok) throw new Error(`youtube.continuation_failed (${response.status})`);
   return response.json() as Promise<unknown>;
 };
@@ -271,12 +277,17 @@ export default defineHandler(async (event) => {
   playlistUrl.searchParams.set("list", playlistId);
   playlistUrl.searchParams.set("hl", "en");
 
-  const response = await fetch(playlistUrl, {
-    headers: {
-      "accept-language": "en-US,en;q=0.9",
-      "user-agent": YOUTUBE_USER_AGENT,
+  const response = await fetchYouTubeWithRetry(
+    playlistUrl,
+    {
+      headers: {
+        "accept-language": "en-US,en;q=0.9",
+        "user-agent": YOUTUBE_USER_AGENT,
+      },
+      signal: event.req.signal,
     },
-  });
+    { stage: "playlist" },
+  );
   if (!response.ok) throw new Error(`youtube.playlist_failed (${response.status})`);
   const html = await response.text();
   const initialData = extractYouTubeJsonObject(html, "var ytInitialData =")?.value;
@@ -300,7 +311,7 @@ export default defineHandler(async (event) => {
       if (!token || visitedTokens.has(token)) continue;
       visitedTokens.add(token);
 
-      const continuation = await fetchContinuation(token, config);
+      const continuation = await fetchContinuation(token, config, event.req.signal);
       if (!continuation) break;
       collectTracks(continuation, seenVideoIds, tracks);
       if (declaredTrackCount !== undefined && tracks.length >= declaredTrackCount) break;
@@ -309,10 +320,21 @@ export default defineHandler(async (event) => {
   }
 
   if (tracks.length === 0) throw new Error("youtube.no_resolvable_tracks");
-  const year = await resolveYouTubeUploadYear(tracks[0]!.url, {
-    config,
-    signal: event.req.signal,
-  });
+  let year: number | undefined;
+  try {
+    year = await resolveYouTubeUploadYear(tracks[0]!.url, {
+      config,
+      signal: event.req.signal,
+    });
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: "youtube_playlist_enrichment_skipped",
+        stage: "upload_year",
+        errorType: error instanceof Error ? error.name : "UnknownError",
+      }),
+    );
+  }
 
   return {
     title,

--- a/server/utils/youtube.ts
+++ b/server/utils/youtube.ts
@@ -5,8 +5,71 @@ export const YOUTUBE_USER_AGENT =
 
 type JsonRecord = Record<string, unknown>;
 
+type YouTubeRequestStage = "config" | "continuation" | "playlist" | "upload_year";
+
+const MAX_YOUTUBE_FETCH_ATTEMPTS = 2;
+const YOUTUBE_RETRY_DELAY_MS = 100;
+const TRANSIENT_YOUTUBE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
 const isRecord = (value: unknown): value is JsonRecord =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+const wait = (milliseconds: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+
+const isAbortError = (error: unknown) => error instanceof Error && error.name === "AbortError";
+
+const logYouTubeUpstreamFailure = (
+  stage: YouTubeRequestStage,
+  attempt: number,
+  retrying: boolean,
+  details: { errorType?: string; status?: number },
+) => {
+  console.warn(
+    JSON.stringify({
+      event: "youtube_upstream_failure",
+      stage,
+      attempt,
+      retrying,
+      ...details,
+    }),
+  );
+};
+
+export const fetchYouTubeWithRetry = async (
+  input: string | URL | Request,
+  init: RequestInit,
+  options: {
+    stage: YouTubeRequestStage;
+    fetch?: typeof globalThis.fetch;
+  },
+) => {
+  const fetch = options.fetch ?? globalThis.fetch;
+
+  for (let attempt = 1; attempt <= MAX_YOUTUBE_FETCH_ATTEMPTS; attempt++) {
+    try {
+      const response = await fetch(input, init);
+      if (response.ok) return response;
+
+      const retrying =
+        attempt < MAX_YOUTUBE_FETCH_ATTEMPTS && TRANSIENT_YOUTUBE_STATUSES.has(response.status);
+      logYouTubeUpstreamFailure(options.stage, attempt, retrying, { status: response.status });
+      if (!retrying) return response;
+
+      await response.body?.cancel().catch(() => undefined);
+    } catch (error) {
+      const retrying = attempt < MAX_YOUTUBE_FETCH_ATTEMPTS && !isAbortError(error);
+      logYouTubeUpstreamFailure(options.stage, attempt, retrying, {
+        errorType: error instanceof Error ? error.name : "UnknownError",
+      });
+      if (!retrying) throw error;
+    }
+
+    await wait(YOUTUBE_RETRY_DELAY_MS);
+  }
+
+  throw new Error("youtube.retry_exhausted");
+};
 
 const videoIdPattern = /^[A-Za-z0-9_-]{11}$/;
 
@@ -118,10 +181,14 @@ export const resolveYouTubeUploadYear = async (
 
   let config = options.config;
   if (!config) {
-    const homepageResponse = await fetch(YOUTUBE_ORIGIN, {
-      headers: { "user-agent": YOUTUBE_USER_AGENT },
-      signal: options.signal,
-    });
+    const homepageResponse = await fetchYouTubeWithRetry(
+      YOUTUBE_ORIGIN,
+      {
+        headers: { "user-agent": YOUTUBE_USER_AGENT },
+        signal: options.signal,
+      },
+      { fetch, stage: "config" },
+    );
     if (!homepageResponse.ok) {
       throw new Error(`youtube.config_failed (${homepageResponse.status})`);
     }
@@ -138,17 +205,21 @@ export const resolveYouTubeUploadYear = async (
   const nextUrl = new URL("/youtubei/v1/next", YOUTUBE_ORIGIN);
   nextUrl.searchParams.set("prettyPrint", "false");
   nextUrl.searchParams.set("key", apiKey);
-  const response = await fetch(nextUrl, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "user-agent": YOUTUBE_USER_AGENT,
-      "x-youtube-client-name": "1",
-      "x-youtube-client-version": clientVersion,
+  const response = await fetchYouTubeWithRetry(
+    nextUrl,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "user-agent": YOUTUBE_USER_AGENT,
+        "x-youtube-client-name": "1",
+        "x-youtube-client-version": clientVersion,
+      },
+      body: JSON.stringify({ videoId, context }),
+      signal: options.signal,
     },
-    body: JSON.stringify({ videoId, context }),
-    signal: options.signal,
-  });
+    { fetch, stage: "upload_year" },
+  );
   if (!response.ok) throw new Error(`youtube.video_failed (${response.status})`);
 
   const data = await response.json();


### PR DESCRIPTION
## Summary

- retry transient YouTube playlist, continuation, config, and upload-year requests once after a short bounded delay
- emit structured, stage-specific upstream failure logs without request URLs, API keys, or continuation tokens
- treat upload-year lookup as optional enrichment so playable tracks still import when that request fails

## Root cause

The playlist resolver depended on several outbound YouTube requests, and a single transient response or network error failed the whole import. The upload-year request was also awaited as if it were required even though it only enriches optional metadata.

## User impact

Transient YouTube failures now get one bounded retry. If upload-year enrichment still fails, Tagium returns the resolved playlist without a year instead of showing the generic import error. Existing filtering of removed or unlisted entries is unchanged.

## Validation

- `bun run test` — 45 files, 287 tests passed
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- called the resolver handler against `PLco9ZX1KZNVdaWJKCxnkk6bA-O-nsPMWa`; it returned all 12 playable tracks and year 2025
