### PR TITLE
refactor: replace Zod with Effect Schema

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,8 +27,6 @@
         "react-image-crop": "^11.0.10",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
-        "zod": "^4.1.5",
-        "zod-validation-error": "^4.0.1",
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/components/audio/settings.ts
+++ b/components/audio/settings.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { Effect, Option, Schema } from "effect";
 import type { AudioDownloadBitrate } from "./cobaltAudio";
 import type { AppSettings } from "./types";
 
@@ -19,16 +19,25 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
 
 export const APP_SETTINGS_STORAGE_KEY = "tagium:app-settings";
 
-const storedAppSettingsSchema = z
-  .object({
-    syncTrackNumbers: z.boolean().catch(DEFAULT_APP_SETTINGS.syncTrackNumbers),
-    syncFilenames: z.boolean().catch(DEFAULT_APP_SETTINGS.syncFilenames),
-    audioBitrate: z.enum(AUDIO_BITRATE_OPTIONS).catch(DEFAULT_APP_SETTINGS.audioBitrate),
-    applySoundCloudAlbumCoverToTracks: z
-      .boolean()
-      .catch(DEFAULT_APP_SETTINGS.applySoundCloudAlbumCoverToTracks),
-  })
-  .catch(DEFAULT_APP_SETTINGS);
+const booleanWithDefault = (value: boolean) =>
+  Schema.Boolean.pipe(
+    Schema.catchDecoding(() => Effect.succeed(Option.some(value))),
+    Schema.withDecodingDefaultKey(Effect.succeed(value)),
+  );
+
+const storedAppSettingsSchema = Schema.Struct({
+  syncTrackNumbers: booleanWithDefault(DEFAULT_APP_SETTINGS.syncTrackNumbers),
+  syncFilenames: booleanWithDefault(DEFAULT_APP_SETTINGS.syncFilenames),
+  audioBitrate: Schema.Literals(AUDIO_BITRATE_OPTIONS).pipe(
+    Schema.catchDecoding(() => Effect.succeed(Option.some(DEFAULT_APP_SETTINGS.audioBitrate))),
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_APP_SETTINGS.audioBitrate)),
+  ),
+  applySoundCloudAlbumCoverToTracks: booleanWithDefault(
+    DEFAULT_APP_SETTINGS.applySoundCloudAlbumCoverToTracks,
+  ),
+});
+
+const decodeStoredAppSettings = Schema.decodeUnknownSync(storedAppSettingsSchema);
 
 export const loadAppSettings = (storage?: Pick<Storage, "getItem">): AppSettings => {
   try {
@@ -38,7 +47,7 @@ export const loadAppSettings = (storage?: Pick<Storage, "getItem">): AppSettings
 
     return {
       ...DEFAULT_APP_SETTINGS,
-      ...storedAppSettingsSchema.parse(JSON.parse(storedSettings)),
+      ...decodeStoredAppSettings(JSON.parse(storedSettings)),
     };
   } catch {
     return DEFAULT_APP_SETTINGS;

--- a/package.json
+++ b/package.json
@@ -42,9 +42,7 @@
     "react-hook-form": "^7.62.0",
     "react-image-crop": "^11.0.10",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.3.1",
-    "zod": "^4.1.5",
-    "zod-validation-error": "^4.0.1"
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/server-tests/cobalt/audio.post.test.ts
+++ b/server-tests/cobalt/audio.post.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { HTTPError } from "nitro";
 import handler from "../../server/api/cobalt/audio.post";
 
 type RuntimeRequest = Request & {
@@ -69,6 +70,26 @@ describe("cobalt audio endpoint", () => {
     vi.unstubAllGlobals();
   });
 
+  it("maps invalid request bodies to HTTP 400 errors", async () => {
+    const request = makeAudioRequest();
+    const invalidRequest = new Request(request.url, {
+      method: "POST",
+      headers: request.headers,
+      body: JSON.stringify({
+        url: "not a URL",
+        audioBitrate: "lossless",
+        year: 99,
+      }),
+    }) as RuntimeRequest;
+    invalidRequest.runtime = request.runtime;
+
+    const error = await handler(makeEvent(invalidRequest)).catch((cause) => cause);
+
+    expect(HTTPError.isError(error)).toBe(true);
+    expect(error).toMatchObject({ status: 400 });
+    expect(error.message).toContain('["url"]');
+  });
+
   it("requests non-HLS Cobalt audio", async () => {
     const cobaltBodies: unknown[] = [];
     const audioTunnel =
@@ -95,7 +116,9 @@ describe("cobalt audio endpoint", () => {
           format: "mp3",
           bitrate: "128",
           cover: true,
+          futureAudioField: "ignored",
         },
+        futureResponseField: { nested: true },
       });
     });
 
@@ -119,6 +142,18 @@ describe("cobalt audio endpoint", () => {
         },
       },
     });
+  });
+
+  it("classifies malformed upstream payloads as gateway failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ status: "a-future-cobalt-status" })),
+    );
+
+    const response = await handler(makeEvent(makeAudioRequest()));
+
+    expect(response.status).toBe(502);
+    expect(await response.text()).toContain("a-future-cobalt-status");
   });
 
   it("infers direct YouTube track year from its upload date", async () => {

--- a/server-tests/soundcloud-set.get.test.ts
+++ b/server-tests/soundcloud-set.get.test.ts
@@ -36,6 +36,7 @@ describe("soundcloud set endpoint", () => {
         return Response.json({
           kind: "playlist",
           title: " Album ",
+          future_playlist_field: { is: "ignored" },
           genre: " Electronic ",
           display_date: "2024-05-01T00:00:00Z",
           release_date: "2023-09-15T00:00:00Z",
@@ -52,6 +53,7 @@ describe("soundcloud set endpoint", () => {
               title: " Track ",
               permalink_url: "https://soundcloud.com/artist/track",
               duration: 123,
+              future_track_field: true,
             },
           ],
         });

--- a/server/api/cobalt/audio.post.ts
+++ b/server/api/cobalt/audio.post.ts
@@ -6,9 +6,9 @@
  * Changes: runs server-side in Tagium, uses server env for Cobalt URL/auth,
  * and returns a browser-executable download plan without exposing auth.
  */
-import { defineHandler } from "nitro";
+import { Effect, Schema } from "effect";
+import { defineHandler, HTTPError } from "nitro";
 import { env as processEnv } from "node:process";
-import { z } from "zod";
 import { parseCobaltMachineId, signCobaltMachine } from "../../utils/cobalt-machine-affinity";
 import {
   createCloudflareCobaltRequestAdmission,
@@ -22,6 +22,7 @@ import {
   getDeployEnv,
   type CobaltRuntimeEnv as DevControlRuntimeEnv,
 } from "../../utils/dev-controls";
+import { decodeRequestBody, urlStringSchema } from "../../utils/schema";
 import { getYouTubeVideoId, resolveYouTubeUploadYear } from "../../utils/youtube";
 
 enum CobaltResponseType {
@@ -32,59 +33,61 @@ enum CobaltResponseType {
   LocalProcessing = "local-processing",
 }
 
-const audioRequestSchema = z.object({
-  url: z.string().url(),
-  audioBitrate: z.enum(["320", "256", "128", "96", "64"]),
-  year: z.number().int().min(1000).max(9999).optional(),
+const audioRequestSchema = Schema.Struct({
+  url: urlStringSchema,
+  audioBitrate: Schema.Literals(["320", "256", "128", "96", "64"]),
+  year: Schema.optionalKey(
+    Schema.Number.check(Schema.isInt(), Schema.isBetween({ minimum: 1_000, maximum: 9_999 })),
+  ),
 });
 
-const cobaltResponseSchema = z.discriminatedUnion("status", [
-  z.object({
-    status: z.literal(CobaltResponseType.Error),
-    error: z.object({
-      code: z.string(),
+const cobaltResponseSchema = Schema.Union([
+  Schema.Struct({
+    status: Schema.Literal(CobaltResponseType.Error),
+    error: Schema.Struct({
+      code: Schema.String,
     }),
   }),
-  z.object({
-    status: z.literal(CobaltResponseType.Picker),
-    audio: z.string().url().optional(),
-    audioFilename: z.string().optional(),
+  Schema.Struct({
+    status: Schema.Literal(CobaltResponseType.Picker),
+    audio: Schema.optionalKey(urlStringSchema),
+    audioFilename: Schema.optionalKey(Schema.String),
   }),
-  z.object({
-    status: z.literal(CobaltResponseType.Redirect),
-    url: z.string().url(),
-    filename: z.string(),
+  Schema.Struct({
+    status: Schema.Literal(CobaltResponseType.Redirect),
+    url: urlStringSchema,
+    filename: Schema.String,
   }),
-  z.object({
-    status: z.literal(CobaltResponseType.Tunnel),
-    url: z.string().url(),
-    filename: z.string(),
+  Schema.Struct({
+    status: Schema.Literal(CobaltResponseType.Tunnel),
+    url: urlStringSchema,
+    filename: Schema.String,
   }),
-  z.object({
-    status: z.literal(CobaltResponseType.LocalProcessing),
-    type: z.enum(["merge", "mute", "audio", "gif", "remux", "proxy"]),
-    service: z.string(),
-    tunnel: z.array(z.string().url()),
-    output: z.object({
-      type: z.string(),
-      filename: z.string(),
-      metadata: z.record(z.string(), z.string().optional()).optional(),
-      subtitles: z.boolean().optional(),
+  Schema.Struct({
+    status: Schema.Literal(CobaltResponseType.LocalProcessing),
+    type: Schema.Literals(["merge", "mute", "audio", "gif", "remux", "proxy"]),
+    service: Schema.String,
+    tunnel: Schema.Array(urlStringSchema),
+    output: Schema.Struct({
+      type: Schema.String,
+      filename: Schema.String,
+      metadata: Schema.optionalKey(Schema.Record(Schema.String, Schema.UndefinedOr(Schema.String))),
+      subtitles: Schema.optionalKey(Schema.Boolean),
     }),
-    audio: z
-      .object({
-        copy: z.boolean(),
-        format: z.string(),
-        bitrate: z.string(),
-        cover: z.boolean().optional(),
-        cropCover: z.boolean().optional(),
-      })
-      .optional(),
-    isHLS: z.boolean().optional(),
+    audio: Schema.optionalKey(
+      Schema.Struct({
+        copy: Schema.Boolean,
+        format: Schema.String,
+        bitrate: Schema.String,
+        cover: Schema.optionalKey(Schema.Boolean),
+        cropCover: Schema.optionalKey(Schema.Boolean),
+      }),
+    ),
+    isHLS: Schema.optionalKey(Schema.Boolean),
   }),
 ]);
 
-type CobaltResponse = z.infer<typeof cobaltResponseSchema>;
+type CobaltResponse = Schema.Schema.Type<typeof cobaltResponseSchema>;
 type CobaltAudioResult = {
   response: CobaltResponse;
   machineId: string | undefined;
@@ -177,7 +180,7 @@ const parseCobaltJson = async (response: Response) => {
     throw new Error(`Cobalt API returned non-JSON (${response.status}).`);
   }
 
-  return cobaltResponseSchema.parse(await response.json());
+  return Effect.runPromise(Schema.decodeUnknownEffect(cobaltResponseSchema)(await response.json()));
 };
 
 const isCobaltCapacityError = (response: CobaltResponse) =>
@@ -359,14 +362,6 @@ const withYearMetadata = (
   };
 };
 
-const parseAudioRequest = async (request: Request) => {
-  try {
-    return audioRequestSchema.parse(await request.json());
-  } catch {
-    return undefined;
-  }
-};
-
 const getCobaltRequestAdmission = (
   request: Request,
   runtimeEnv: CobaltRuntimeEnv,
@@ -416,10 +411,7 @@ export default defineHandler(async (event) => {
       return devFaultResponse;
     }
 
-    const body = await parseAudioRequest(event.req);
-    if (!body) {
-      return new Response("Invalid audio download request.", { status: 400 });
-    }
+    const body = await decodeRequestBody(event.req, audioRequestSchema);
 
     const admission = getCobaltRequestAdmission(event.req, runtimeEnv);
     if (!admission) return admissionUnavailableResponse();
@@ -488,6 +480,8 @@ export default defineHandler(async (event) => {
       proxiedTunnelResponse(event.req, runtimeEnv, cobaltResponse, cobaltResult.machineId),
     );
   } catch (error) {
+    if (HTTPError.isError(error)) throw error;
+
     if (error instanceof Error) {
       return cobaltErrorResponse(error.message);
     }

--- a/server/api/dev/config.post.ts
+++ b/server/api/dev/config.post.ts
@@ -7,6 +7,7 @@ import {
   updateDevConfig,
   type CobaltRuntimeEnv,
 } from "../../utils/dev-controls";
+import { decodeRequestBody } from "../../utils/schema";
 
 type CloudflareRequest = Request & {
   runtime?: {
@@ -27,7 +28,7 @@ export default defineHandler(async (event) => {
     return new Response("Not found.", { status: 404 });
   }
 
-  const body = devConfigUpdateSchema.parse(await event.req.json());
+  const body = await decodeRequestBody(event.req, devConfigUpdateSchema);
   updateDevConfig(body);
   return Response.json(getDevControlSnapshot(event.req, runtimeEnv));
 });

--- a/server/api/dev/fault.post.ts
+++ b/server/api/dev/fault.post.ts
@@ -7,6 +7,7 @@ import {
   setDevFault,
   type CobaltRuntimeEnv,
 } from "../../utils/dev-controls";
+import { decodeRequestBody } from "../../utils/schema";
 
 type CloudflareRequest = Request & {
   runtime?: {
@@ -27,7 +28,7 @@ export default defineHandler(async (event) => {
     return new Response("Not found.", { status: 404 });
   }
 
-  const body = devFaultUpdateSchema.parse(await event.req.json());
+  const body = await decodeRequestBody(event.req, devFaultUpdateSchema);
   setDevFault(body);
   return Response.json(getDevControlSnapshot(event.req, runtimeEnv));
 });

--- a/server/api/soundcloud-set.get.ts
+++ b/server/api/soundcloud-set.get.ts
@@ -2,43 +2,44 @@
  * SoundCloud client id discovery adapted from imputnet/cobalt:
  * api/src/processing/services/soundcloud.js
  */
+import { Effect, Option, Schema } from "effect";
 import { defineHandler } from "nitro";
-import { z } from "zod";
 import { getSoundCloudClientId } from "../utils/soundcloud";
+import { urlStringSchema } from "../utils/schema";
 
 const TRACK_RESOLVE_CONCURRENCY = 4;
 
-const soundCloudTrackSchema = z.object({
-  id: z.number(),
-  kind: z.literal("track"),
-  title: z.string().optional(),
-  permalink_url: z.string().url().optional(),
-  duration: z.number().optional(),
+const soundCloudTrackSchema = Schema.Struct({
+  id: Schema.Finite,
+  kind: Schema.Literal("track"),
+  title: Schema.optionalKey(Schema.String),
+  permalink_url: Schema.optionalKey(urlStringSchema),
+  duration: Schema.optionalKey(Schema.Finite),
 });
-const soundCloudTrackListEntrySchema = z.unknown().transform((entry) => {
-  const parsedEntry = soundCloudTrackSchema.safeParse(entry);
-  return parsedEntry.success ? parsedEntry.data : undefined;
-});
+const decodeSoundCloudTrackOption = Schema.decodeUnknownOption(soundCloudTrackSchema);
 
-const soundCloudPlaylistSchema = z.object({
-  kind: z.literal("playlist"),
-  title: z.string(),
-  genre: z.string().optional(),
-  display_date: z.string().optional(),
-  release_date: z.string().nullable().optional(),
-  is_album: z.boolean().optional(),
-  set_type: z.string().optional(),
-  artwork_url: z.string().nullable().optional(),
-  user: z
-    .object({
-      username: z.string().optional(),
-    })
-    .optional(),
-  tracks: z.array(soundCloudTrackListEntrySchema),
+const soundCloudPlaylistSchema = Schema.Struct({
+  kind: Schema.Literal("playlist"),
+  title: Schema.String,
+  genre: Schema.optionalKey(Schema.String),
+  display_date: Schema.optionalKey(Schema.String),
+  release_date: Schema.optionalKey(Schema.NullOr(Schema.String)),
+  is_album: Schema.optionalKey(Schema.Boolean),
+  set_type: Schema.optionalKey(Schema.String),
+  artwork_url: Schema.optionalKey(Schema.NullOr(Schema.String)),
+  user: Schema.optionalKey(
+    Schema.Struct({
+      username: Schema.optionalKey(Schema.String),
+    }),
+  ),
+  tracks: Schema.Array(Schema.Unknown),
 });
-const soundCloudResolvedTrackSchema = soundCloudTrackSchema.extend({
-  title: z.string(),
-  permalink_url: z.string().url(),
+const soundCloudResolvedTrackSchema = Schema.Struct({
+  id: Schema.Finite,
+  kind: Schema.Literal("track"),
+  title: Schema.String,
+  permalink_url: urlStringSchema,
+  duration: Schema.optionalKey(Schema.Finite),
 });
 
 const getCoverUrl = (artworkUrl: string | null | undefined) => {
@@ -54,20 +55,28 @@ const getYear = (displayDate: string | undefined) => {
   return Number.isNaN(year) ? undefined : year;
 };
 
-const resolveTrack = async (clientId: string, track: z.infer<typeof soundCloudTrackSchema>) => {
+const resolveTrack = async (
+  clientId: string,
+  track: Schema.Schema.Type<typeof soundCloudTrackSchema>,
+) => {
   if (track.title && track.permalink_url) {
-    return soundCloudResolvedTrackSchema.parse(track);
+    return Effect.runPromise(Schema.decodeUnknownEffect(soundCloudResolvedTrackSchema)(track));
   }
 
   const trackUrl = new URL(`https://api-v2.soundcloud.com/tracks/${track.id}`);
   trackUrl.searchParams.set("client_id", clientId);
-  return soundCloudResolvedTrackSchema.parse(
-    await fetch(trackUrl).then((response) => response.json()),
+  return Effect.runPromise(
+    Schema.decodeUnknownEffect(soundCloudResolvedTrackSchema)(
+      await fetch(trackUrl).then((response) => response.json()),
+    ),
   );
 };
 
-const resolveTracks = async (clientId: string, tracks: z.infer<typeof soundCloudTrackSchema>[]) => {
-  const resolvedTracks: z.infer<typeof soundCloudResolvedTrackSchema>[] = [];
+const resolveTracks = async (
+  clientId: string,
+  tracks: ReadonlyArray<Schema.Schema.Type<typeof soundCloudTrackSchema>>,
+) => {
+  const resolvedTracks: Array<Schema.Schema.Type<typeof soundCloudResolvedTrackSchema>> = [];
 
   for (let index = 0; index < tracks.length; index += TRACK_RESOLVE_CONCURRENCY) {
     const chunk = tracks.slice(index, index + TRACK_RESOLVE_CONCURRENCY);
@@ -102,10 +111,15 @@ export default defineHandler(async (event) => {
   resolveUrl.searchParams.set("url", sourceUrl);
   resolveUrl.searchParams.set("client_id", clientId);
 
-  const playlist = soundCloudPlaylistSchema.parse(
-    await fetch(resolveUrl).then((response) => response.json()),
+  const playlist = await Effect.runPromise(
+    Schema.decodeUnknownEffect(soundCloudPlaylistSchema)(
+      await fetch(resolveUrl).then((response) => response.json()),
+    ),
   );
-  const trackEntries = playlist.tracks.filter((track) => track !== undefined);
+  const trackEntries = playlist.tracks.flatMap((entry) => {
+    const track = decodeSoundCloudTrackOption(entry);
+    return Option.isSome(track) ? [track.value] : [];
+  });
   const tracks = await resolveTracks(clientId, trackEntries);
   const isAlbum = [playlist.is_album, playlist.set_type === "album"].includes(true);
   let yearDate = playlist.display_date;

--- a/server/api/track-metadata.get.ts
+++ b/server/api/track-metadata.get.ts
@@ -1,16 +1,19 @@
+import { Effect, Schema } from "effect";
 import { defineHandler } from "nitro";
-import { z } from "zod";
 import { getSoundCloudClientId } from "../utils/soundcloud";
+import { urlStringSchema } from "../utils/schema";
 
-const oEmbedSchema = z.object({
-  title: z.string().min(1),
-  author_name: z.string().optional(),
-  thumbnail_url: z.string().url().optional(),
+const nonEmptyStringSchema = Schema.String.check(Schema.isNonEmpty());
+
+const oEmbedSchema = Schema.Struct({
+  title: nonEmptyStringSchema,
+  author_name: Schema.optionalKey(Schema.String),
+  thumbnail_url: Schema.optionalKey(urlStringSchema),
 });
-const soundCloudTrackSchema = z.object({
-  title: z.string().min(1),
-  artwork_url: z.string().url().nullable().optional(),
-  user: z.object({ username: z.string().optional() }).optional(),
+const soundCloudTrackSchema = Schema.Struct({
+  title: nonEmptyStringSchema,
+  artwork_url: Schema.optionalKey(Schema.NullOr(urlStringSchema)),
+  user: Schema.optionalKey(Schema.Struct({ username: Schema.optionalKey(Schema.String) })),
 });
 
 const isSoundCloudUrl = (url: URL) =>
@@ -31,7 +34,9 @@ export const resolveSoundCloudTrackMetadata = async (
   resolveUrl.searchParams.set("client_id", clientId);
   const response = await fetch(resolveUrl, { signal: options.signal });
   if (!response.ok) throw new Error(`track_metadata.fetch_failed (${response.status})`);
-  const metadata = soundCloudTrackSchema.parse(await response.json());
+  const metadata = await Effect.runPromise(
+    Schema.decodeUnknownEffect(soundCloudTrackSchema)(await response.json()),
+  );
   return {
     title: metadata.title.trim(),
     artist: metadata.user?.username?.trim() ?? "",
@@ -72,7 +77,9 @@ export default defineHandler(async (event) => {
 
   const response = await fetch(endpoint, { signal: event.req.signal });
   if (!response.ok) throw new Error(`track_metadata.fetch_failed (${response.status})`);
-  const metadata = oEmbedSchema.parse(await response.json());
+  const metadata = await Effect.runPromise(
+    Schema.decodeUnknownEffect(oEmbedSchema)(await response.json()),
+  );
 
   return {
     title: metadata.title.trim(),

--- a/server/api/youtube-playlist.get.ts
+++ b/server/api/youtube-playlist.get.ts
@@ -1,5 +1,5 @@
+import { Option, Schema } from "effect";
 import { defineHandler } from "nitro";
-import { z } from "zod";
 import {
   extractYouTubeJsonObject,
   fetchYouTubeWithRetry,
@@ -8,59 +8,51 @@ import {
   YOUTUBE_ORIGIN,
   YOUTUBE_USER_AGENT,
 } from "../utils/youtube";
+import { urlStringSchema } from "../utils/schema";
 
 const MAX_CONTINUATION_REQUESTS = 100;
 
-const textSchema = z
-  .object({
-    simpleText: z.string().optional(),
-    content: z.string().optional(),
-    runs: z.array(z.object({ text: z.string() }).passthrough()).optional(),
-  })
-  .passthrough();
+const textSchema = Schema.Struct({
+  simpleText: Schema.optionalKey(Schema.String),
+  content: Schema.optionalKey(Schema.String),
+  runs: Schema.optionalKey(Schema.Array(Schema.Struct({ text: Schema.String }))),
+});
 
-const legacyVideoSchema = z
-  .object({
-    videoId: z.string().min(1),
-    title: textSchema,
-    lengthSeconds: z.string().optional(),
-    lengthText: textSchema.optional(),
-  })
-  .passthrough();
+const nonEmptyStringSchema = Schema.String.check(Schema.isNonEmpty());
 
-const lockupVideoSchema = z
-  .object({
-    contentId: z.string().min(1),
-    contentType: z.string().optional(),
-    metadata: z
-      .object({
-        lockupMetadataViewModel: z
-          .object({
-            title: textSchema,
-          })
-          .passthrough(),
-      })
-      .passthrough(),
-  })
-  .passthrough();
+const legacyVideoSchema = Schema.Struct({
+  videoId: nonEmptyStringSchema,
+  title: textSchema,
+  lengthSeconds: Schema.optionalKey(Schema.String),
+  lengthText: Schema.optionalKey(textSchema),
+});
 
-const thumbnailSchema = z
-  .object({
-    thumbnail: z
-      .object({
-        thumbnails: z.array(
-          z
-            .object({
-              url: z.string().url(),
-              width: z.number().optional(),
-              height: z.number().optional(),
-            })
-            .passthrough(),
-        ),
-      })
-      .passthrough(),
-  })
-  .passthrough();
+const lockupVideoSchema = Schema.Struct({
+  contentId: nonEmptyStringSchema,
+  contentType: Schema.optionalKey(Schema.String),
+  metadata: Schema.Struct({
+    lockupMetadataViewModel: Schema.Struct({
+      title: textSchema,
+    }),
+  }),
+});
+
+const thumbnailSchema = Schema.Struct({
+  thumbnail: Schema.Struct({
+    thumbnails: Schema.Array(
+      Schema.Struct({
+        url: urlStringSchema,
+        width: Schema.optionalKey(Schema.Finite),
+        height: Schema.optionalKey(Schema.Finite),
+      }),
+    ),
+  }),
+});
+
+const decodeTextOption = Schema.decodeUnknownOption(textSchema);
+const decodeLegacyVideoOption = Schema.decodeUnknownOption(legacyVideoSchema);
+const decodeLockupVideoOption = Schema.decodeUnknownOption(lockupVideoSchema);
+const decodeThumbnailOption = Schema.decodeUnknownOption(thumbnailSchema);
 
 type JsonRecord = Record<string, unknown>;
 
@@ -75,11 +67,11 @@ const isRecord = (value: unknown): value is JsonRecord =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
 const getText = (value: unknown) => {
-  const parsed = textSchema.safeParse(value);
-  if (!parsed.success) return undefined;
-  if (parsed.data.simpleText) return parsed.data.simpleText;
-  if (parsed.data.content) return parsed.data.content;
-  const runs = parsed.data.runs?.map((run) => run.text).join("");
+  const parsed = decodeTextOption(value);
+  if (Option.isNone(parsed)) return undefined;
+  if (parsed.value.simpleText) return parsed.value.simpleText;
+  if (parsed.value.content) return parsed.value.content;
+  const runs = parsed.value.runs?.map((run) => run.text).join("");
   return runs || undefined;
 };
 
@@ -136,37 +128,37 @@ const collectTracks = (value: unknown, seenVideoIds: Set<string>, tracks: YouTub
   }
   if (!isRecord(value)) return;
 
-  const legacyVideo = legacyVideoSchema.safeParse(value.playlistVideoRenderer);
-  if (legacyVideo.success && !seenVideoIds.has(legacyVideo.data.videoId)) {
-    const title = getText(legacyVideo.data.title)?.trim();
+  const legacyVideo = decodeLegacyVideoOption(value.playlistVideoRenderer);
+  if (Option.isSome(legacyVideo) && !seenVideoIds.has(legacyVideo.value.videoId)) {
+    const title = getText(legacyVideo.value.title)?.trim();
     if (title) {
-      const durationFromSeconds = Number(legacyVideo.data.lengthSeconds);
-      seenVideoIds.add(legacyVideo.data.videoId);
+      const durationFromSeconds = Number(legacyVideo.value.lengthSeconds);
+      seenVideoIds.add(legacyVideo.value.videoId);
       tracks.push({
         title,
-        url: `${YOUTUBE_ORIGIN}/watch?v=${encodeURIComponent(legacyVideo.data.videoId)}`,
+        url: `${YOUTUBE_ORIGIN}/watch?v=${encodeURIComponent(legacyVideo.value.videoId)}`,
         duration: Number.isFinite(durationFromSeconds)
           ? durationFromSeconds
-          : parseDuration(getText(legacyVideo.data.lengthText)),
+          : parseDuration(getText(legacyVideo.value.lengthText)),
         trackNumber: tracks.length + 1,
       });
     }
   }
 
-  const lockupVideo = lockupVideoSchema.safeParse(value.lockupViewModel);
+  const lockupVideo = decodeLockupVideoOption(value.lockupViewModel);
   if (
-    lockupVideo.success &&
-    (!lockupVideo.data.contentType ||
-      lockupVideo.data.contentType === "LOCKUP_CONTENT_TYPE_VIDEO") &&
-    !seenVideoIds.has(lockupVideo.data.contentId)
+    Option.isSome(lockupVideo) &&
+    (!lockupVideo.value.contentType ||
+      lockupVideo.value.contentType === "LOCKUP_CONTENT_TYPE_VIDEO") &&
+    !seenVideoIds.has(lockupVideo.value.contentId)
   ) {
-    const title = getText(lockupVideo.data.metadata.lockupMetadataViewModel.title)?.trim();
+    const title = getText(lockupVideo.value.metadata.lockupMetadataViewModel.title)?.trim();
     if (title) {
-      seenVideoIds.add(lockupVideo.data.contentId);
+      seenVideoIds.add(lockupVideo.value.contentId);
       tracks.push({
         title,
-        url: `${YOUTUBE_ORIGIN}/watch?v=${encodeURIComponent(lockupVideo.data.contentId)}`,
-        duration: findDuration(lockupVideo.data),
+        url: `${YOUTUBE_ORIGIN}/watch?v=${encodeURIComponent(lockupVideo.value.contentId)}`,
+        duration: findDuration(value.lockupViewModel),
         trackNumber: tracks.length + 1,
       });
     }
@@ -201,11 +193,11 @@ const getPlaylistArtist = (initialData: unknown) => {
 };
 
 const getPlaylistCover = (initialData: unknown) => {
-  const parsed = thumbnailSchema.safeParse(
+  const parsed = decodeThumbnailOption(
     findFirstValue(initialData, "playlistVideoThumbnailRenderer"),
   );
-  if (!parsed.success || parsed.data.thumbnail.thumbnails.length === 0) return undefined;
-  const coverUrl = parsed.data.thumbnail.thumbnails.reduce((largest, thumbnail) => {
+  if (Option.isNone(parsed) || parsed.value.thumbnail.thumbnails.length === 0) return undefined;
+  const coverUrl = parsed.value.thumbnail.thumbnails.reduce((largest, thumbnail) => {
     const largestArea = (largest.width ?? 0) * (largest.height ?? 0);
     const thumbnailArea = (thumbnail.width ?? 0) * (thumbnail.height ?? 0);
     return thumbnailArea >= largestArea ? thumbnail : largest;

--- a/server/utils/dev-controls.ts
+++ b/server/utils/dev-controls.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { Schema } from "effect";
 
 export type CobaltRuntimeEnv = {
   CF_PAGES?: string;
@@ -35,24 +35,32 @@ const devState: DevState = {
   nextTunnelFault: undefined,
 };
 
-export const devConfigUpdateSchema = z.object({
-  rateLimit: z
-    .object({
-      windowMs: z.number().int().min(1_000).max(600_000),
-      maxRequests: z.number().int().min(1).max(500),
-    })
-    .optional(),
-  resetRateLimitBuckets: z.boolean().optional(),
+export const devConfigUpdateSchema = Schema.Struct({
+  rateLimit: Schema.optionalKey(
+    Schema.Struct({
+      windowMs: Schema.Number.check(
+        Schema.isInt(),
+        Schema.isBetween({ minimum: 1_000, maximum: 600_000 }),
+      ),
+      maxRequests: Schema.Number.check(
+        Schema.isInt(),
+        Schema.isBetween({ minimum: 1, maximum: 500 }),
+      ),
+    }),
+  ),
+  resetRateLimitBuckets: Schema.optionalKey(Schema.Boolean),
 });
 
-export const devFaultUpdateSchema = z.discriminatedUnion("target", [
-  z.object({
-    target: z.literal("audio"),
-    fault: z.enum(["rate-limit", "capacity", "timeout", "unreachable", "malformed"]).nullable(),
+export const devFaultUpdateSchema = Schema.Union([
+  Schema.Struct({
+    target: Schema.Literal("audio"),
+    fault: Schema.NullOr(
+      Schema.Literals(["rate-limit", "capacity", "timeout", "unreachable", "malformed"]),
+    ),
   }),
-  z.object({
-    target: z.literal("tunnel"),
-    fault: z.enum(["rate-limit", "capacity", "timeout", "empty-body"]).nullable(),
+  Schema.Struct({
+    target: Schema.Literal("tunnel"),
+    fault: Schema.NullOr(Schema.Literals(["rate-limit", "capacity", "timeout", "empty-body"])),
   }),
 ]);
 
@@ -109,7 +117,7 @@ export const resetRateLimitBuckets = () => {
   rateLimitBuckets.clear();
 };
 
-export const updateDevConfig = (input: z.infer<typeof devConfigUpdateSchema>) => {
+export const updateDevConfig = (input: Schema.Schema.Type<typeof devConfigUpdateSchema>) => {
   if (input.rateLimit) {
     devState.rateLimitWindowMs = input.rateLimit.windowMs;
     devState.rateLimitMaxRequests = input.rateLimit.maxRequests;
@@ -120,7 +128,7 @@ export const updateDevConfig = (input: z.infer<typeof devConfigUpdateSchema>) =>
   }
 };
 
-export const setDevFault = (input: z.infer<typeof devFaultUpdateSchema>) => {
+export const setDevFault = (input: Schema.Schema.Type<typeof devFaultUpdateSchema>) => {
   if (input.target === "audio") {
     devState.nextAudioFault = input.fault ?? undefined;
     return;

--- a/server/utils/schema.test.ts
+++ b/server/utils/schema.test.ts
@@ -1,0 +1,63 @@
+import { Schema } from "effect";
+import { HTTPError } from "nitro";
+import { describe, expect, it } from "vite-plus/test";
+import { decodeRequestBody, urlStringSchema } from "./schema";
+
+const exampleBodySchema = Schema.Struct({
+  name: Schema.String,
+  count: Schema.Number.check(Schema.isInt(), Schema.isBetween({ minimum: 1, maximum: 3 })),
+});
+
+describe("request body decoding", () => {
+  it("decodes valid JSON bodies and ignores unknown fields", async () => {
+    const request = new Request("https://tagium.test/example", {
+      method: "POST",
+      body: JSON.stringify({ name: "Tagium", count: 2, futureField: true }),
+    });
+
+    await expect(decodeRequestBody(request, exampleBodySchema)).resolves.toEqual({
+      name: "Tagium",
+      count: 2,
+    });
+  });
+
+  it("maps schema failures to HTTP 400 errors with validation context", async () => {
+    const request = new Request("https://tagium.test/example", {
+      method: "POST",
+      body: JSON.stringify({ name: "Tagium", count: 4 }),
+    });
+
+    const error = await decodeRequestBody(request, exampleBodySchema).catch((cause) => cause);
+
+    expect(HTTPError.isError(error)).toBe(true);
+    expect(error).toMatchObject({ status: 400 });
+    expect(error.message).toContain("count");
+    expect(error.message).toContain("between 1 and 3");
+  });
+
+  it("maps malformed JSON to an HTTP 400 error", async () => {
+    const request = new Request("https://tagium.test/example", {
+      method: "POST",
+      body: "not json",
+    });
+
+    await expect(decodeRequestBody(request, exampleBodySchema)).rejects.toMatchObject({
+      status: 400,
+      message: "Invalid request body: expected valid JSON.",
+    });
+  });
+});
+
+describe("URL string decoding", () => {
+  it("preserves the string type while trimming a valid URL", () => {
+    expect(Schema.decodeUnknownSync(urlStringSchema)(" https://tagium.app/track ")).toBe(
+      "https://tagium.app/track",
+    );
+  });
+
+  it("rejects invalid URLs", () => {
+    expect(() => Schema.decodeUnknownSync(urlStringSchema)("not a URL")).toThrow(
+      "Expected a valid URL",
+    );
+  });
+});

--- a/server/utils/schema.ts
+++ b/server/utils/schema.ts
@@ -1,0 +1,43 @@
+import { Effect, Schema } from "effect";
+import { HTTPError } from "nitro";
+
+export const urlStringSchema = Schema.Trim.check(
+  Schema.makeFilter((value) => {
+    try {
+      new URL(value);
+      return true;
+    } catch {
+      return "Expected a valid URL";
+    }
+  }),
+);
+
+export const decodeRequestBody = async <S extends Schema.ConstraintDecoder<unknown, never>>(
+  request: Request,
+  schema: S,
+): Promise<S["Type"]> => {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch (cause) {
+    throw new HTTPError({
+      status: 400,
+      message: "Invalid request body: expected valid JSON.",
+      cause,
+    });
+  }
+
+  return Effect.runPromise(
+    Schema.decodeUnknownEffect(schema)(body).pipe(
+      Effect.mapError(
+        (cause) =>
+          new HTTPError({
+            status: 400,
+            message: `Invalid request body: ${cause.message}`,
+            cause,
+          }),
+      ),
+    ),
+  );
+};


### PR DESCRIPTION
## Summary

- replace every project Zod schema with Effect 4 Schema
- add one request-decoding seam that maps client schema failures to useful Nitro HTTP 400 responses
- keep upstream decoding failures classified as server/upstream failures
- preserve permissive YouTube and SoundCloud payload handling, settings recovery, URL string output, and finite-number validation
- remove direct `zod` and `zod-validation-error` dependencies

## Why

Tagium already uses Effect Schema for its audio domain and Effect for backend workflows. Keeping Zod in routes and settings created a second schema and error model without adding a useful seam.

The independent migration review caught and fixed two parity gaps before publication: Effect's bare number schema accepts non-finite numbers, and URL decoding initially did not match Zod's trimming behavior.

## Verification

- PR scope: 299 tests
- complete stack: 376 tests
- typecheck and lint with zero findings
- production build
- frozen lockfile install
- no project-source Zod usage or direct dependency
- React Doctor changed scope and suppression audit: zero diagnostics
