### PR TITLE
fix: improve editor accessibility and refresh boundaries

### DIFF
--- a/components/audio/AlbumMetadataDialog.tsx
+++ b/components/audio/AlbumMetadataDialog.tsx
@@ -116,8 +116,11 @@ export default function AlbumMetadataDialog({
               <div className="order-2 min-w-0 h-full flex flex-col justify-between gap-3 md:order-2">
                 <div className="flex flex-col gap-0">
                   <div>
-                    <label className="block text-sm font-medium mb-1">album title:</label>
+                    <label htmlFor="album-title" className="block text-sm font-medium mb-1">
+                      album title:
+                    </label>
                     <Input
+                      id="album-title"
                       value={draft.title}
                       onChange={(event) =>
                         onChange({
@@ -139,8 +142,11 @@ export default function AlbumMetadataDialog({
                     </p>
                   </div>
                   <div>
-                    <label className="block text-sm font-medium mb-1">artist:</label>
+                    <label htmlFor="album-artist" className="block text-sm font-medium mb-1">
+                      artist:
+                    </label>
                     <Input
+                      id="album-artist"
                       value={draft.artist}
                       onChange={(event) =>
                         onChange({
@@ -162,8 +168,11 @@ export default function AlbumMetadataDialog({
                     </p>
                   </div>
                   <div className="mb-3">
-                    <label className="block text-sm font-medium mb-1">genre:</label>
+                    <label htmlFor="album-genre" className="block text-sm font-medium mb-1">
+                      genre:
+                    </label>
                     <Input
+                      id="album-genre"
                       value={draft.genre}
                       onChange={(event) =>
                         onChange({
@@ -176,8 +185,11 @@ export default function AlbumMetadataDialog({
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium mb-1">year:</label>
+                    <label htmlFor="album-year" className="block text-sm font-medium mb-1">
+                      year:
+                    </label>
                     <Input
+                      id="album-year"
                       type="number"
                       value={draft.year ?? ""}
                       onChange={(event) =>

--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -23,23 +23,25 @@ import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AlbumSidebarEmptyState } from "./AlbumSidebarEmptyState";
 import {
+  DroppableTrackContainer,
+  SidebarDragPreview,
+  SortableAlbumCard,
+  SortableTrackRow,
+} from "./AlbumSidebarDnd";
+import {
   albumIdFromDrop,
   albumContainerId,
   albumItemId,
   dragStartY,
-  DroppableTrackContainer,
   isCenteredLooseDrop,
   LOOSE_APPEND_CONTAINER_ID,
   LOOSE_CONTAINER_ID,
   rowPlacement,
   sidebarCollisionDetection,
-  SidebarDragPreview,
-  SortableAlbumCard,
-  SortableTrackRow,
   trackItemId,
   type SidebarDragData,
   type SidebarDropData,
-} from "./AlbumSidebarDnd";
+} from "./sidebarDnd";
 import type { AlbumGroup, TagiumFile } from "./types";
 import { isTrackReadyForDownload } from "./downloadLibrary";
 
@@ -53,7 +55,6 @@ interface AlbumSidebarProps {
   onSelectAlbum: (albumId: string, event?: ReactMouseEvent) => void;
   onSelectFile: (albumId: string, fileId: string, event?: ReactMouseEvent) => void;
   onSelectLooseTrack: (fileId: string, event?: ReactMouseEvent) => void;
-  onClearSelection: () => void;
   onRemoveFile: (fileId: string) => void;
   onRetryDownload: (fileId: string) => void;
   onAddAlbum: () => void;
@@ -78,6 +79,21 @@ interface AlbumSidebarProps {
 
 const isFileDrag = (event: React.DragEvent) => event.dataTransfer.types.includes("Files");
 
+const isRetryableError = (track: TagiumFile) =>
+  Boolean(track.downloadRequest) &&
+  (track.downloadStatus === "error" ||
+    track.downloadStatus === "canceled" ||
+    track.status === "error");
+
+const handleFileDrop = (event: React.DragEvent, onUpload: (files: File[]) => void) => {
+  const droppedFiles = Array.from(event.dataTransfer.files);
+  if (droppedFiles.length === 0) return;
+
+  event.preventDefault();
+  event.stopPropagation();
+  onUpload(droppedFiles);
+};
+
 export default function AlbumSidebar({
   albums,
   looseTrackIds,
@@ -88,7 +104,6 @@ export default function AlbumSidebar({
   onSelectAlbum,
   onSelectFile,
   onSelectLooseTrack,
-  onClearSelection,
   onRemoveFile,
   onRetryDownload,
   onAddAlbum,
@@ -119,11 +134,6 @@ export default function AlbumSidebar({
     .map((trackId) => filesById.get(trackId))
     .filter((track): track is TagiumFile => Boolean(track));
 
-  const isRetryableError = (track: TagiumFile) =>
-    Boolean(track.downloadRequest) &&
-    (track.downloadStatus === "error" ||
-      track.downloadStatus === "canceled" ||
-      track.status === "error");
   const selectedTone = (trackId: string) => {
     if (selectedFileIds.has(trackId)) return "primary";
     if (selectedFileId === trackId) return "secondary";
@@ -236,17 +246,8 @@ export default function AlbumSidebar({
     setActiveDrag(null);
   };
 
-  const handleFileDrop = (event: React.DragEvent, onUpload: (files: File[]) => void) => {
-    const droppedFiles = Array.from(event.dataTransfer.files);
-    if (droppedFiles.length === 0) return;
-
-    event.preventDefault();
-    event.stopPropagation();
-    onUpload(droppedFiles);
-  };
-
   if (albums.length === 0 && looseTracks.length === 0) {
-    return <AlbumSidebarEmptyState onAddAlbum={onAddAlbum} onClearSelection={onClearSelection} />;
+    return <AlbumSidebarEmptyState onAddAlbum={onAddAlbum} />;
   }
 
   return (
@@ -274,9 +275,6 @@ export default function AlbumSidebar({
       >
         <div
           className="flex-1 overflow-y-auto overflow-x-hidden flex flex-col"
-          onClick={(event) => {
-            if (event.target === event.currentTarget) onClearSelection();
-          }}
           onDragOver={(event) => {
             if (!isFileDrag(event)) return;
             event.preventDefault();
@@ -352,10 +350,7 @@ export default function AlbumSidebar({
                       data={{ type: "container", container: "album", albumId: album.id }}
                     >
                       {album.trackIds.length === 0 ? (
-                        <div
-                          className="text-xs text-muted-foreground px-4 py-3 text-center"
-                          onClick={onClearSelection}
-                        >
+                        <div className="text-xs text-muted-foreground px-4 py-3 text-center">
                           drag tracks here
                         </div>
                       ) : (

--- a/components/audio/AlbumSidebarDnd.tsx
+++ b/components/audio/AlbumSidebarDnd.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
-import {
-  closestCorners,
-  type CollisionDetection,
-  type DragEndEvent,
-  pointerWithin,
-  rectIntersection,
-  useDroppable,
-} from "@dnd-kit/core";
+import { useDroppable } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import {
   AlertCircle,
@@ -25,83 +18,8 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { AlbumCoverThumb } from "./AlbumCoverThumb";
+import { albumItemId, trackItemId, type SidebarDragData, type SidebarDropData } from "./sidebarDnd";
 import type { AlbumGroup, TagiumFile } from "./types";
-
-export const LOOSE_CONTAINER_ID = "container:loose";
-export const LOOSE_APPEND_CONTAINER_ID = "container:loose:append";
-
-export type SidebarDragData =
-  | { type: "album"; albumId: string }
-  | { type: "track"; trackId: string; container: "album"; albumId: string }
-  | { type: "track"; trackId: string; container: "loose" };
-
-export type SidebarDropData =
-  | SidebarDragData
-  | { type: "container"; container: "loose" }
-  | { type: "container"; container: "album"; albumId: string };
-
-export const albumItemId = (albumId: string) => `album:${albumId}`;
-export const albumContainerId = (albumId: string) => `container:album:${albumId}`;
-export const trackItemId = (trackId: string) => `track:${trackId}`;
-
-export const sidebarCollisionDetection: CollisionDetection = (args) => {
-  const pointerCollisions = pointerWithin(args);
-  if (pointerCollisions.length > 0) return pointerCollisions;
-
-  const intersections = rectIntersection(args);
-  if (intersections.length > 0) return intersections;
-
-  return closestCorners(args);
-};
-
-export const dragStartY = (event: Event) => {
-  const sourceEvent = event as Event & {
-    changedTouches?: TouchList;
-    clientY?: number;
-    touches?: TouchList;
-  };
-  if (sourceEvent.clientY !== undefined) return sourceEvent.clientY;
-  if (sourceEvent.touches?.[0]) return sourceEvent.touches[0].clientY;
-  if (sourceEvent.changedTouches?.[0]) return sourceEvent.changedTouches[0].clientY;
-  return null;
-};
-
-export const albumIdFromDrop = (drop: SidebarDropData) => {
-  if (drop.type === "album") return drop.albumId;
-  if (drop.type === "track" && drop.container === "album") return drop.albumId;
-  if (drop.type === "container" && drop.container === "album") return drop.albumId;
-  return null;
-};
-
-export const rowPlacement = (
-  event: DragEndEvent,
-  sourceTrackId: string,
-  targetTrackId: string,
-  trackIds: string[],
-  initialY: number | null,
-) => {
-  const rect = event.over?.rect;
-  if (!rect) return "after";
-  if (initialY === null) {
-    const sourceIndex = trackIds.indexOf(sourceTrackId);
-    const targetIndex = trackIds.indexOf(targetTrackId);
-    if (sourceIndex >= 0 && targetIndex >= 0 && sourceIndex > targetIndex) return "before";
-    if (sourceIndex < 0) return "before";
-    return "after";
-  }
-
-  const y = initialY + event.delta.y;
-  return y > rect.top + rect.height / 2 ? "after" : "before";
-};
-
-export const isCenteredLooseDrop = (event: DragEndEvent, initialY: number | null) => {
-  const rect = event.over?.rect;
-  if (!rect) return false;
-  if (initialY === null) return false;
-  const y = initialY + event.delta.y;
-  const position = (y - rect.top) / rect.height;
-  return position > 0.3 && position < 0.7;
-};
 
 const artistLabel = (artist: string) => (artist ? artist : "unknown");
 

--- a/components/audio/AlbumSidebarEmptyState.tsx
+++ b/components/audio/AlbumSidebarEmptyState.tsx
@@ -3,29 +3,12 @@
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-export function AlbumSidebarEmptyState({
-  onAddAlbum,
-  onClearSelection,
-}: {
-  onAddAlbum: () => void;
-  onClearSelection: () => void;
-}) {
+export function AlbumSidebarEmptyState({ onAddAlbum }: { onAddAlbum: () => void }) {
   return (
-    <div
-      className="w-full flex-1 min-h-0 flex flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground px-4"
-      onClick={onClearSelection}
-    >
+    <div className="w-full flex-1 min-h-0 flex flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground px-4">
       <p>no tracks yet</p>
       <p className="text-xs">create an empty album or upload tracks</p>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={(event) => {
-          event.stopPropagation();
-          onAddAlbum();
-        }}
-      >
+      <Button type="button" variant="outline" size="sm" onClick={onAddAlbum}>
         <Plus className="h-4 w-4" />
         add album
       </Button>

--- a/components/audio/LandingScreen.tsx
+++ b/components/audio/LandingScreen.tsx
@@ -10,6 +10,11 @@ interface LandingScreenProps {
   onAudioUpload: (files: File[]) => void | Promise<void>;
 }
 
+const handleDragOver = (e: React.DragEvent) => {
+  e.preventDefault();
+  e.dataTransfer.dropEffect = "copy";
+};
+
 export default function LandingScreen({ active, children, onAudioUpload }: LandingScreenProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragCounterRef = useRef(0);
@@ -24,11 +29,6 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
   const handleDragLeave = () => {
     dragCounterRef.current--;
     if (dragCounterRef.current === 0) setIsDragging(false);
-  };
-
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = "copy";
   };
 
   const handleDrop = (e: React.DragEvent) => {

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -27,7 +27,6 @@ interface TagSidebarPanelProps {
   onSelectAlbum: (albumId: string, event?: ReactMouseEvent) => void;
   onSelectFile: (albumId: string, fileId: string, event?: ReactMouseEvent) => void;
   onSelectLooseTrack: (fileId: string, event?: ReactMouseEvent) => void;
-  onClearSelection: () => void;
   onRemoveFile: (fileId: string) => void;
   onRetryDownload: (fileId: string) => void;
   onAddAlbum: () => void;
@@ -54,6 +53,9 @@ interface TagSidebarPanelProps {
   onRetryPlaylistDownloadQueue?: () => void;
 }
 
+const isFileDrag = (event: React.DragEvent<HTMLDivElement>) =>
+  event.dataTransfer.types.includes("Files");
+
 export default function TagSidebarPanel({
   loading,
   files,
@@ -67,7 +69,6 @@ export default function TagSidebarPanel({
   onSelectAlbum,
   onSelectFile,
   onSelectLooseTrack,
-  onClearSelection,
   onRemoveFile,
   onRetryDownload,
   onAddAlbum,
@@ -97,9 +98,6 @@ export default function TagSidebarPanel({
       : hasInvalidFilename
         ? "every track needs a filename"
         : "tracks need files and metadata";
-
-  const isFileDrag = (event: React.DragEvent<HTMLDivElement>) =>
-    event.dataTransfer.types.includes("Files");
 
   const handleSidebarDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
     if (!isFileDrag(event)) return;
@@ -165,7 +163,6 @@ export default function TagSidebarPanel({
         onSelectAlbum={onSelectAlbum}
         onSelectFile={onSelectFile}
         onSelectLooseTrack={onSelectLooseTrack}
-        onClearSelection={onClearSelection}
         onRemoveFile={onRemoveFile}
         onRetryDownload={onRetryDownload}
         onAddAlbum={onAddAlbum}

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -41,6 +41,8 @@ interface TrackMetadataEditorProps {
   ) => void;
 }
 
+const fieldLabelClassName = "mb-1 block text-xs font-medium md:text-sm";
+
 function DisabledReason({
   disabled,
   reason,
@@ -226,9 +228,12 @@ export default function TrackMetadataEditor({
             />
             <div className="flex flex-1 flex-col gap-2 max-lg:[@media(max-height:700px)]:gap-1.5 lg:gap-3">
               <div>
-                <label className="mb-1 block text-xs font-medium md:text-sm">title:</label>
+                <label htmlFor="track-title" className={fieldLabelClassName}>
+                  title:
+                </label>
                 <Input
                   {...titleInputRegistration}
+                  id="track-title"
                   ref={titleInputRef}
                   aria-invalid={syncFilenames && filenameInvalid}
                   aria-describedby={
@@ -239,10 +244,13 @@ export default function TrackMetadataEditor({
                 />
               </div>
               <div>
-                <label className="mb-1 block text-xs font-medium md:text-sm">artist:</label>
+                <label htmlFor="track-artist" className={fieldLabelClassName}>
+                  artist:
+                </label>
                 <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
                   <Input
                     {...artistRegistration}
+                    id="track-artist"
                     placeholder={placeholder.artist}
                     disabled={inAlbum}
                     className={`${placeholderClassName} ${syncedInputClassName}`}
@@ -250,10 +258,13 @@ export default function TrackMetadataEditor({
                 </DisabledReason>
               </div>
               <div>
-                <label className="mb-1 block text-xs font-medium md:text-sm">album:</label>
+                <label htmlFor="track-album" className={fieldLabelClassName}>
+                  album:
+                </label>
                 <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
                   <Input
                     {...register("album")}
+                    id="track-album"
                     placeholder={placeholder.album}
                     disabled={inAlbum}
                     className={`${placeholderClassName} ${syncedInputClassName}`}
@@ -262,11 +273,14 @@ export default function TrackMetadataEditor({
               </div>
               <div className="grid grid-cols-[minmax(4.5rem,0.8fr)_minmax(0,1.4fr)_minmax(4.5rem,0.8fr)] gap-2">
                 <div>
-                  <label className="mb-1 block text-xs font-medium md:text-sm">year:</label>
+                  <label htmlFor="track-year" className={fieldLabelClassName}>
+                    year:
+                  </label>
                   <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
                     <Input
                       type="number"
                       {...register("year", { valueAsNumber: true })}
+                      id="track-year"
                       placeholder={placeholder.year}
                       disabled={inAlbum}
                       className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
@@ -274,10 +288,13 @@ export default function TrackMetadataEditor({
                   </DisabledReason>
                 </div>
                 <div>
-                  <label className="mb-1 block text-xs font-medium md:text-sm">genre:</label>
+                  <label htmlFor="track-genre" className={fieldLabelClassName}>
+                    genre:
+                  </label>
                   <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
                     <Input
                       {...register("genre")}
+                      id="track-genre"
                       placeholder={placeholder.genre}
                       disabled={inAlbum}
                       className={`${placeholderClassName} ${syncedInputClassName}`}
@@ -285,7 +302,9 @@ export default function TrackMetadataEditor({
                   </DisabledReason>
                 </div>
                 <div>
-                  <label className="mb-1 block text-xs font-medium md:text-sm">track:</label>
+                  <label htmlFor="track-number" className={fieldLabelClassName}>
+                    track:
+                  </label>
                   <DisabledReason
                     disabled={inAlbum && syncTrackNumbers}
                     reason="follows album order"
@@ -293,6 +312,7 @@ export default function TrackMetadataEditor({
                     <Input
                       type="number"
                       {...register("trackNumber", { valueAsNumber: true })}
+                      id="track-number"
                       placeholder={placeholder.trackNumber}
                       disabled={inAlbum && syncTrackNumbers}
                       className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}

--- a/components/audio/albumMetadataDialog.test.tsx
+++ b/components/audio/albumMetadataDialog.test.tsx
@@ -108,6 +108,30 @@ describe("album metadata validation layout", () => {
     ).toBe("artist is required");
   });
 
+  it("associates every field label with its input", () => {
+    const hooks = createHookHarness();
+    const tree = hooks.render(() =>
+      AlbumMetadataDialog({
+        open: true,
+        mode: "create",
+        draft: { title: "", artist: "", genre: "" },
+        trackCount: 0,
+        onChange: vi.fn(),
+        onClose: vi.fn(),
+        onSave: vi.fn(),
+        placeholder: { title: "Album", artist: "Artist", genre: "Genre", year: "2026" },
+      }),
+    );
+
+    for (const id of ["album-title", "album-artist", "album-genre", "album-year"]) {
+      findElement(tree, (element) => element.type === "label" && element.props.htmlFor === id);
+      findElement(tree, (element) => element.props.id === id);
+    }
+
+    const titleInput = findElement(tree, (element) => element.props.id === "album-title");
+    expect(titleInput.props["aria-describedby"]).toBe("album-title-error");
+  });
+
   it("adds an uploaded cover to the latest draft", () => {
     const hooks = createHookHarness();
     const onChange = vi.fn();

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -1905,7 +1905,6 @@ export default function AudioTagger() {
           onSelectAlbum={handleSelectAlbum}
           onSelectFile={handleSelectFile}
           onSelectLooseTrack={handleSelectLooseTrack}
-          onClearSelection={handleClearSelection}
           onRemoveFile={requestRemoveFile}
           onRetryDownload={handleRetryDownload}
           onAddAlbum={handleOpenCreateAlbumDialog}

--- a/components/audio/errorPresentation.test.ts
+++ b/components/audio/errorPresentation.test.ts
@@ -3,6 +3,24 @@ import coverArtSource from "./coverArt.tsx?raw";
 import trackMetadataEditorSource from "./TrackMetadataEditor.tsx?raw";
 
 describe("local error presentation", () => {
+  it("associates every track field label with its input", () => {
+    for (const id of [
+      "track-title",
+      "track-artist",
+      "track-album",
+      "track-year",
+      "track-genre",
+      "track-number",
+    ]) {
+      expect(trackMetadataEditorSource).toContain(`<label htmlFor="${id}"`);
+      expect(trackMetadataEditorSource).toContain(`id="${id}"`);
+    }
+
+    expect(trackMetadataEditorSource).toContain(
+      'syncFilenames && filenameInvalid ? "track-filename-error" : undefined',
+    );
+  });
+
   it("keeps an empty filename visible when a durable track failure also exists", () => {
     expect(trackMetadataEditorSource).toContain("{filenameInvalid ? (");
     expect(trackMetadataEditorSource).toContain("track error");

--- a/components/audio/sidebarDnd.ts
+++ b/components/audio/sidebarDnd.ts
@@ -1,0 +1,83 @@
+import {
+  closestCorners,
+  type CollisionDetection,
+  type DragEndEvent,
+  pointerWithin,
+  rectIntersection,
+} from "@dnd-kit/core";
+
+export const LOOSE_CONTAINER_ID = "container:loose";
+export const LOOSE_APPEND_CONTAINER_ID = "container:loose:append";
+
+export type SidebarDragData =
+  | { type: "album"; albumId: string }
+  | { type: "track"; trackId: string; container: "album"; albumId: string }
+  | { type: "track"; trackId: string; container: "loose" };
+
+export type SidebarDropData =
+  | SidebarDragData
+  | { type: "container"; container: "loose" }
+  | { type: "container"; container: "album"; albumId: string };
+
+export const albumItemId = (albumId: string) => `album:${albumId}`;
+export const albumContainerId = (albumId: string) => `container:album:${albumId}`;
+export const trackItemId = (trackId: string) => `track:${trackId}`;
+
+export const sidebarCollisionDetection: CollisionDetection = (args) => {
+  const pointerCollisions = pointerWithin(args);
+  if (pointerCollisions.length > 0) return pointerCollisions;
+
+  const intersections = rectIntersection(args);
+  if (intersections.length > 0) return intersections;
+
+  return closestCorners(args);
+};
+
+export const dragStartY = (event: Event) => {
+  const sourceEvent = event as Event & {
+    changedTouches?: TouchList;
+    clientY?: number;
+    touches?: TouchList;
+  };
+  if (sourceEvent.clientY !== undefined) return sourceEvent.clientY;
+  if (sourceEvent.touches?.[0]) return sourceEvent.touches[0].clientY;
+  if (sourceEvent.changedTouches?.[0]) return sourceEvent.changedTouches[0].clientY;
+  return null;
+};
+
+export const albumIdFromDrop = (drop: SidebarDropData) => {
+  if (drop.type === "album") return drop.albumId;
+  if (drop.type === "track" && drop.container === "album") return drop.albumId;
+  if (drop.type === "container" && drop.container === "album") return drop.albumId;
+  return null;
+};
+
+export const rowPlacement = (
+  event: DragEndEvent,
+  sourceTrackId: string,
+  targetTrackId: string,
+  trackIds: string[],
+  initialY: number | null,
+) => {
+  const rect = event.over?.rect;
+  if (!rect) return "after";
+  if (initialY === null) {
+    const sourceIndex = trackIds.indexOf(sourceTrackId);
+    const targetIndex = trackIds.indexOf(targetTrackId);
+    if (sourceIndex >= 0 && targetIndex >= 0 && sourceIndex > targetIndex) return "before";
+    if (sourceIndex < 0) return "before";
+    return "after";
+  }
+
+  const y = initialY + event.delta.y;
+  return y > rect.top + rect.height / 2 ? "after" : "before";
+};
+
+export const isCenteredLooseDrop = (event: DragEndEvent, initialY: number | null) => {
+  const rect = event.over?.rect;
+  if (!rect) return false;
+  if (initialY === null) return false;
+  const y = initialY + event.delta.y;
+  const position = (y - rect.top) / rect.height;
+  return position > 0.3 && position < 0.7;
+};

--- a/components/dev/DevPanel.tsx
+++ b/components/dev/DevPanel.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
 import { AlertTriangle, BellRing, RotateCcw, SlidersHorizontal, Zap } from "lucide-react";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { devToastKinds, spawnDevToast } from "./devToast";
 
 type DevConfig = {
   enabled: boolean;
@@ -31,21 +31,6 @@ type DevConfig = {
 
 type AudioFault = "rate-limit" | "capacity" | "timeout" | "unreachable" | "malformed";
 type TunnelFault = "rate-limit" | "capacity" | "timeout" | "empty-body";
-export type DevToastKind = "neutral" | "success" | "error" | "info" | "warning";
-
-const devToastKinds: DevToastKind[] = ["neutral", "success", "error", "info", "warning"];
-
-export const spawnDevToast = (kind: DevToastKind) => {
-  const title = `${kind} toast`;
-  const options = { description: "previewing Tagium's notification styling" };
-
-  if (kind === "neutral") {
-    toast(title, options);
-    return;
-  }
-
-  toast[kind](title, options);
-};
 
 const audioFaults: Array<{ value: AudioFault; label: string }> = [
   { value: "rate-limit", label: "429" },

--- a/components/dev/devToast.test.ts
+++ b/components/dev/devToast.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import { spawnDevToast, type DevToastKind } from "./DevPanel";
+import { spawnDevToast, type DevToastKind } from "./devToast";
 
 const toastMocks = vi.hoisted(() => {
   const neutral = vi.fn();

--- a/components/dev/devToast.ts
+++ b/components/dev/devToast.ts
@@ -1,0 +1,17 @@
+import { toast } from "sonner";
+
+export type DevToastKind = "neutral" | "success" | "error" | "info" | "warning";
+
+export const devToastKinds: DevToastKind[] = ["neutral", "success", "error", "info", "warning"];
+
+export const spawnDevToast = (kind: DevToastKind) => {
+  const title = `${kind} toast`;
+  const options = { description: "previewing Tagium's notification styling" };
+
+  if (kind === "neutral") {
+    toast(title, options);
+    return;
+  }
+
+  toast[kind](title, options);
+};

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -53,4 +53,4 @@ function Button({
   );
 }
 
-export { Button, buttonVariants };
+export { Button };


### PR DESCRIPTION
## Summary

- associate all metadata labels with stable control IDs
- remove decorative click-to-clear behavior from static regions
- split Fast Refresh-incompatible non-component exports
- move closure-free helpers to module scope

## Why

This fixes keyboard and screen-reader semantics while preserving Escape clearing and drag-and-drop behavior. Module splits let Fast Refresh retain component state safely.

## Verification

- 294 tests, including focused label and behavior coverage
- typecheck and lint
- React Doctor: 28 scoped findings removed, no new findings

