### PR TITLE
perf: simplify audio collection work

### DIFF
--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -118,6 +118,15 @@ const getManagedDownloadTrackTitle = (file: TagiumFile) => {
   if (file.metadata?.title) return file.metadata.title;
   return file.filename;
 };
+const managedDownloadTrackFromFile = (file: TagiumFile): ManagedDownloadTrack | null => {
+  if (!file.downloadRequest) return null;
+
+  return {
+    fileId: file.id,
+    title: getManagedDownloadTrackTitle(file),
+    downloadRequest: file.downloadRequest,
+  };
+};
 const formatPlaylistQueueEta = (etaMs?: number) => {
   if (etaMs === undefined) return null;
 
@@ -220,7 +229,7 @@ export default function AudioTagger() {
   const selectedFileIdRef = useRef<string | null>(selectedFileId);
   const lastResetFileIdRef = useRef<string | null>(null);
   const formDirtyRef = useRef(false);
-  const importQueueRef = useRef(Promise.resolve());
+  const importQueueRef = useRef<Promise<void> | null>(null);
   const pendingImportKeysRef = useRef(new Set<string>());
   const offeredCleanupKeysRef = useRef(new Set<string>());
   const playlistDownloadQueueRef = useRef<PlaylistDownloadQueueState | null>(null);
@@ -504,8 +513,9 @@ export default function AudioTagger() {
   );
 
   const prepareFilesForExport = (albumIds?: string[]) => {
-    const albumsToSync = albumIds
-      ? albumsRef.current.filter((album) => albumIds.includes(album.id))
+    const albumIdSet = albumIds && new Set(albumIds);
+    const albumsToSync = albumIdSet
+      ? albumsRef.current.filter((album) => albumIdSet.has(album.id))
       : albumsRef.current;
     const trackIds = albumIds ? albumsToSync.flatMap((album) => album.trackIds) : undefined;
     let syncedFiles = applyCurrentFormMetadataToFiles(filesRef.current, trackIds);
@@ -725,7 +735,7 @@ export default function AudioTagger() {
       }
     };
 
-    const queuedImport = importQueueRef.current.then(runImport, runImport);
+    const queuedImport = (importQueueRef.current ?? Promise.resolve()).then(runImport, runImport);
     importQueueRef.current = queuedImport.catch(() => undefined);
     await queuedImport;
   };
@@ -892,8 +902,13 @@ export default function AudioTagger() {
       hydrateTrack: (track, downloadedFile) =>
         provideAudioBackend(hydrateDownloadedTrack(track.fileId, downloadedFile)),
       hasTrack: (trackId) => filesRef.current.some((file) => file.id === trackId),
-      getFileErrorTrackIds: () =>
-        new Set(filesRef.current.filter((file) => file.status === "error").map((file) => file.id)),
+      getFileErrorTrackIds: () => {
+        const errorTrackIds = new Set<string>();
+        for (const file of filesRef.current) {
+          if (file.status === "error") errorTrackIds.add(file.id);
+        }
+        return errorTrackIds;
+      },
       markQueued: markDownloadsQueued,
       markCanceled: markDownloadsCanceled,
       markFailed: markDownloadError,
@@ -935,15 +950,6 @@ export default function AudioTagger() {
   const queueDownloadTracks = (tracks: ManagedDownloadTrack[]) => {
     if (tracks.length === 0) return;
     getPlaylistDownloadController().enqueue(tracks);
-  };
-  const managedDownloadTrackFromFile = (file: TagiumFile): ManagedDownloadTrack | null => {
-    if (!file.downloadRequest) return null;
-
-    return {
-      fileId: file.id,
-      title: getManagedDownloadTrackTitle(file),
-      downloadRequest: file.downloadRequest,
-    };
   };
   const handleAudioDownload = (
     sourceUrl: string,
@@ -1022,18 +1028,21 @@ export default function AudioTagger() {
             reset(selectedMetadata);
           }
           const trackIdSet = new Set(coverImport.trackIds);
-          await Promise.all(
-            coveredFiles
-              .filter((file) => trackIdSet.has(file.id) && Boolean(file.file) && file.metadata)
-              .map(async (file) => {
-                if (!file.metadata) return;
+          const coverWriteJobs: Promise<void>[] = [];
+          for (const file of coveredFiles) {
+            const metadata = file.metadata;
+            if (!trackIdSet.has(file.id) || !file.file || !metadata) continue;
+            coverWriteJobs.push(
+              (async () => {
                 try {
-                  await handleTagUpdate(file, file.metadata);
+                  await handleTagUpdate(file, metadata);
                 } catch {
                   // handleTagUpdate records the per-track error state.
                 }
-              }),
-          );
+              })(),
+            );
+          }
+          await Promise.all(coverWriteJobs);
         } catch (error) {
           reportSystemFailure(error, "cover-import");
         }
@@ -1105,10 +1114,12 @@ export default function AudioTagger() {
     if (currentQueue.active.length > 0) return;
 
     const trackIdSet = new Set(currentQueue.trackIds);
-    const tracksToRetry = filesRef.current
-      .filter((file) => trackIdSet.has(file.id) && !file.file)
-      .map((file) => managedDownloadTrackFromFile(file))
-      .filter((track): track is ManagedDownloadTrack => Boolean(track));
+    const tracksToRetry: ManagedDownloadTrack[] = [];
+    for (const file of filesRef.current) {
+      if (!trackIdSet.has(file.id) || file.file) continue;
+      const track = managedDownloadTrackFromFile(file);
+      if (track) tracksToRetry.push(track);
+    }
     getPlaylistDownloadController().retry(tracksToRetry);
   };
   const handleDownloadAll = async () => {
@@ -1269,9 +1280,12 @@ export default function AudioTagger() {
       const idSet = new Set(idsToRemove);
       const removedFiles = filesRef.current.filter((file) => idSet.has(file.id));
       playlistDownloadControllerRef.current?.remove(idsToRemove);
-      const affectedAlbumIds = albumsRef.current
-        .filter((album) => album.trackIds.some((trackId) => idSet.has(trackId)))
-        .map((album) => album.id);
+      const affectedAlbumIds: string[] = [];
+      for (const album of albumsRef.current) {
+        if (album.trackIds.some((trackId) => idSet.has(trackId))) {
+          affectedAlbumIds.push(album.id);
+        }
+      }
       const nextAlbums = idsToRemove.reduce(
         (currentAlbums, fileId) => removeTrackFromAlbums(currentAlbums, fileId),
         albumsRef.current,

--- a/components/audio/cobaltLocalProcessingWorker.js
+++ b/components/audio/cobaltLocalProcessingWorker.js
@@ -8,7 +8,7 @@ import EncodeLibAV from "@imput/libav.js-encode-cli";
 const inputName = "tagium-audio-input";
 const outputName = (format) => `tagium-output.${format}`;
 const progressName = "tagium-progress.txt";
-const cobaltFileMetadataKeys = [
+const cobaltFileMetadataKeys = new Set([
   "album",
   "composer",
   "genre",
@@ -19,7 +19,7 @@ const cobaltFileMetadataKeys = [
   "track",
   "date",
   "sublanguage",
-];
+]);
 
 const postLocalProcessingMessage = (message) => {
   globalThis.self.postMessage({
@@ -98,7 +98,7 @@ const makeMetadataArgs = (metadata) => {
   }
 
   return Object.entries(metadata).flatMap(([name, value]) => {
-    if (!cobaltFileMetadataKeys.includes(name) || !value) {
+    if (!cobaltFileMetadataKeys.has(name) || !value) {
       return [];
     }
 

--- a/components/audio/coverArtProcessing.ts
+++ b/components/audio/coverArtProcessing.ts
@@ -6,9 +6,19 @@ export const MAX_COVER_ART_UPLOAD_BYTES = 25 * 1024 * 1024;
 const COVER_ART_REENCODE_THRESHOLD_BYTES = 2 * 1024 * 1024;
 const COVER_ART_HEADER_BYTES = 1024 * 1024;
 const supportedCoverArtTypes = new Set(["image/jpeg", "image/jpg", "image/png"]);
+const pngSignature = [137, 80, 78, 71, 13, 10, 26, 10] as const;
 const jpegStartOfFrameMarkers = new Set([
   0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf,
 ]);
+
+const startsWithBytes = (bytes: Uint8Array, prefix: readonly number[]) => {
+  if (bytes.length < prefix.length) return false;
+
+  for (let index = 0; index < prefix.length; index += 1) {
+    if (bytes[index] !== prefix[index]) return false;
+  }
+  return true;
+};
 
 export const getCoverArtTargetSize = (
   width: number,
@@ -46,8 +56,7 @@ export const validateCoverArtDimensions = (width: number, height: number) => {
 };
 
 const readPngDimensions = (bytes: Uint8Array) => {
-  const pngSignature = [137, 80, 78, 71, 13, 10, 26, 10];
-  if (bytes.length < 24 || !pngSignature.every((byte, index) => bytes[index] === byte)) {
+  if (bytes.length < 24 || !startsWithBytes(bytes, pngSignature)) {
     return undefined;
   }
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);

--- a/components/audio/downloadAdmissionWindow.ts
+++ b/components/audio/downloadAdmissionWindow.ts
@@ -43,7 +43,7 @@ export const createDownloadAdmissionWindow = ({
       }
 
       let releasedCost = 0;
-      const orderedReservations = [...reservations].sort(
+      const orderedReservations = reservations.toSorted(
         (left, right) => left.reservedAtMs - right.reservedAtMs,
       );
       for (const reservation of orderedReservations) {

--- a/components/audio/fileMetadataOps.ts
+++ b/components/audio/fileMetadataOps.ts
@@ -195,10 +195,11 @@ export function applyTrackOrderNumbersToFiles(
   albums: AlbumGroup[],
   albumIdsToSync: string[],
 ) {
+  const albumsById = new Map(albums.map((album) => [album.id, album]));
   const numbersByTrackId = new Map<string, number>();
 
   for (const albumId of albumIdsToSync) {
-    const album = albums.find((entry) => entry.id === albumId);
+    const album = albumsById.get(albumId);
     if (!album) continue;
     album.trackIds.forEach((trackId, index) => {
       numbersByTrackId.set(trackId, index + 1);

--- a/components/audio/metadataCleanup.ts
+++ b/components/audio/metadataCleanup.ts
@@ -37,14 +37,19 @@ const normalizeComparable = (value: string) =>
 
 const removeMatchingArtistPrefix = (title: string, artists: string[]) => {
   const comparableTitle = normalizeComparable(title);
-  const matchingArtist = artists
-    .map((artist) => artist.trim())
-    .filter(Boolean)
-    .find((artist) =>
+  let matchingArtist: string | undefined;
+  for (const artist of artists) {
+    const trimmedArtist = artist.trim();
+    if (
+      trimmedArtist &&
       artistSeparators.some((separator) =>
-        comparableTitle.startsWith(`${normalizeComparable(artist)}${separator}`),
-      ),
-    );
+        comparableTitle.startsWith(`${normalizeComparable(trimmedArtist)}${separator}`),
+      )
+    ) {
+      matchingArtist = trimmedArtist;
+      break;
+    }
+  }
   if (!matchingArtist) return title;
 
   const separator = artistSeparators.find((candidate) =>

--- a/components/audio/mp3Utils.ts
+++ b/components/audio/mp3Utils.ts
@@ -48,13 +48,13 @@ const compareTrackNumbers = (
 };
 
 export const sortUploadedTracksByTrackNumber = (uploads: UploadedTrack[]) =>
-  [...uploads].sort((left, right) => {
+  uploads.toSorted((left, right) => {
     return compareTrackNumbers(left.file.metadata?.trackNumber, right.file.metadata?.trackNumber);
   });
 
 export const sortTrackIdsByTrackNumber = (trackIds: string[], files: TagiumFile[]) => {
   const filesById = new Map(files.map((file) => [file.id, file]));
-  return [...trackIds].sort((leftId, rightId) => {
+  return trackIds.toSorted((leftId, rightId) => {
     return compareTrackNumbers(
       filesById.get(leftId)?.metadata?.trackNumber,
       filesById.get(rightId)?.metadata?.trackNumber,

--- a/components/audio/playlistDownloadQueueRuntime.ts
+++ b/components/audio/playlistDownloadQueueRuntime.ts
@@ -134,9 +134,10 @@ export const removePlaylistDownloadTracks = <Track extends PlaylistDownloadRunti
 
   const removedTrackIds = new Set(removedItems.map((item) => item.id));
   const pendingTracks = run.pending.filter((track) => removedTrackIds.has(track.fileId));
-  const activeTrackIds = run.active
-    .filter((track) => removedTrackIds.has(track.fileId))
-    .map((track) => track.fileId);
+  const activeTrackIds: string[] = [];
+  for (const track of run.active) {
+    if (removedTrackIds.has(track.fileId)) activeTrackIds.push(track.fileId);
+  }
 
   run.pending = run.pending.filter((track) => !removedTrackIds.has(track.fileId));
   run.trackIds = run.trackIds.filter((trackId) => !removedTrackIds.has(trackId));

--- a/components/audio/soundcloudSetImport.ts
+++ b/components/audio/soundcloudSetImport.ts
@@ -63,18 +63,21 @@ const startSoundCloudSetCoverImport = (
       }
 
       const trackIdSet = new Set(coverImport.trackIds);
-      await Promise.all(
-        coveredFiles
-          .filter((file) => trackIdSet.has(file.id) && Boolean(file.file) && file.metadata)
-          .map(async (file) => {
-            if (!file.metadata) return;
+      const tagUpdates: Promise<void>[] = [];
+      for (const file of coveredFiles) {
+        if (!trackIdSet.has(file.id) || !file.file || !file.metadata) continue;
+        const metadata = file.metadata;
+        tagUpdates.push(
+          (async () => {
             try {
-              await deps.updateTags(file, file.metadata);
+              await deps.updateTags(file, metadata);
             } catch {
               // updateTags records the per-track error state.
             }
-          }),
-      );
+          })(),
+        );
+      }
+      await Promise.all(tagUpdates);
     } catch (error) {
       deps.warn("failed to import album cover:", error);
     }


### PR DESCRIPTION
## Summary

- replace repeated collection scans with Maps and Sets
- use immutable sorting and one-pass collection transforms
- simplify AudioTagger collection work without changing ordering or concurrency
- preserve PNG validation and worker metadata behavior

## Why

React Doctor identified avoidable repeated scans and chained iterations across audio utilities and AudioTagger. The rewrites keep behavior stable while reducing unnecessary work.

## Verification

- 294 tests plus 70 focused utility tests
- typecheck, lint, and production build
- 16 performance/maintainability findings removed

