### PR TITLE
fix: harden cover and dev panel state lifecycles

### DIFF
--- a/components/audio/coverArt.tsx
+++ b/components/audio/coverArt.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useId, useRef } from "react";
+import { useEffect, useId, useReducer, useRef, useState } from "react";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
@@ -8,6 +8,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import ImageCropper from "../ui/image-cropper";
 import { Crop, Upload } from "lucide-react";
 import { runCoverArtUploadTransaction } from "./coverArtProcessing";
+import { coverArtReducer, initialCoverArtState, type CropSource } from "./coverArtState";
 import type { AudioMetadata } from "./types";
 
 interface CoverArtProps {
@@ -37,12 +38,15 @@ export default function CoverArt({
   resetKey,
   className,
 }: CoverArtProps) {
-  const [uploadedCover, setUploadedCover] = useState<File | null>(null);
-  const [tempImageForCropping, setTempImageForCropping] = useState<string | null>(null);
-  const [showCropper, setShowCropper] = useState(false);
-  const [isProcessing, setIsProcessing] = useState(false);
-  const [coverError, setCoverError] = useState<string | null>(null);
-  const [coverErrorOpen, setCoverErrorOpen] = useState(false);
+  const [state, dispatch] = useReducer(coverArtReducer, initialCoverArtState);
+  const {
+    uploadedCover,
+    cropSource,
+    isCropperOpen,
+    isProcessing,
+    error: coverError,
+    isErrorOpen: coverErrorOpen,
+  } = state;
   const coverErrorId = useId();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const coverUploadIdRef = useRef(0);
@@ -51,13 +55,9 @@ export default function CoverArt({
     processingChangeRef.current = onProcessingChange;
   }, [onProcessingChange]);
 
-  const reportProcessing = (processing: boolean) => {
-    setIsProcessing(processing);
-    processingChangeRef.current?.(processing);
-  };
-
-  const processCover = async (file: File, uploadId: number) => {
-    reportProcessing(true);
+  const processCover = async (file: File, uploadId: number, closeCropper = false) => {
+    dispatch({ type: "uploadStarted", uploadId, closeCropper });
+    processingChangeRef.current?.(true);
 
     try {
       const optimizedFile = await runCoverArtUploadTransaction(file, {
@@ -65,15 +65,16 @@ export default function CoverArt({
         commit: (picture) => onCoverUpload?.(picture, resetKey),
       });
       if (!optimizedFile || uploadId !== coverUploadIdRef.current) return;
-      setUploadedCover(optimizedFile);
-      setCoverError(null);
-      setCoverErrorOpen(false);
+      dispatch({ type: "uploadSucceeded", uploadId, file: optimizedFile });
     } catch (error) {
       if (uploadId !== coverUploadIdRef.current) return;
-      setCoverError(error instanceof Error ? error.message : "could not load cover art.");
-      setCoverErrorOpen(true);
+      dispatch({
+        type: "uploadFailed",
+        uploadId,
+        message: error instanceof Error ? error.message : "could not load cover art.",
+      });
     } finally {
-      if (uploadId === coverUploadIdRef.current) reportProcessing(false);
+      if (uploadId === coverUploadIdRef.current) processingChangeRef.current?.(false);
     }
   };
 
@@ -90,20 +91,11 @@ export default function CoverArt({
       type: "image/jpeg",
     });
     const uploadId = ++coverUploadIdRef.current;
-    void processCover(croppedFile, uploadId);
-    setShowCropper(false);
-    if (tempImageForCropping) {
-      URL.revokeObjectURL(tempImageForCropping);
-      setTempImageForCropping(null);
-    }
+    void processCover(croppedFile, uploadId, true);
   };
 
   const handleCropCancel = () => {
-    setShowCropper(false);
-    if (tempImageForCropping) {
-      URL.revokeObjectURL(tempImageForCropping);
-      setTempImageForCropping(null);
-    }
+    dispatch({ type: "cropClosed" });
   };
 
   const [coverSrc, setCoverSrc] = useState<string | null>(null);
@@ -113,19 +105,15 @@ export default function CoverArt({
     : "flex-shrink-0 flex flex-col items-center gap-2 lg:grid lg:grid-rows-2 lg:items-start";
 
   useEffect(() => {
-    coverUploadIdRef.current += 1;
-    reportProcessing(false);
-    setUploadedCover(null);
-    setCoverError(null);
-    setCoverErrorOpen(false);
-    setShowCropper(false);
-    setTempImageForCropping((previous) => {
-      if (previous) {
-        URL.revokeObjectURL(previous);
-      }
-      return null;
-    });
+    const uploadId = ++coverUploadIdRef.current;
+    dispatch({ type: "reset", uploadId });
+    processingChangeRef.current?.(false);
   }, [resetKey]);
+
+  useEffect(() => {
+    if (!cropSource?.owned) return;
+    return () => URL.revokeObjectURL(cropSource.url);
+  }, [cropSource]);
 
   useEffect(
     () => () => {
@@ -183,7 +171,19 @@ export default function CoverArt({
           </div>
         )}
         {coverSrc && (
-          <Popover open={showCropper} onOpenChange={setShowCropper}>
+          <Popover
+            open={isCropperOpen}
+            onOpenChange={(open) => {
+              if (!open) {
+                dispatch({ type: "cropClosed" });
+                return;
+              }
+              const source: CropSource = uploadedCover
+                ? { url: URL.createObjectURL(uploadedCover), owned: true }
+                : { url: coverSrc, owned: false };
+              dispatch({ type: "cropOpened", source });
+            }}
+          >
             <Tooltip>
               <PopoverTrigger asChild>
                 <TooltipTrigger asChild>
@@ -194,16 +194,6 @@ export default function CoverArt({
                     aria-label="crop cover art"
                     disabled={isProcessing}
                     className="absolute top-2 right-2 size-10 p-0 max-lg:[@media(max-height:700px)]:top-1.5 max-lg:[@media(max-height:700px)]:right-1.5"
-                    onClick={() => {
-                      if (tempImageForCropping) {
-                        URL.revokeObjectURL(tempImageForCropping);
-                      }
-                      // Use uploaded cover first, then fall back to original picture
-                      const imageUrl = uploadedCover
-                        ? URL.createObjectURL(uploadedCover)
-                        : coverSrc;
-                      setTempImageForCropping(imageUrl);
-                    }}
                   >
                     <Crop className="h-4 w-4" />
                   </Button>
@@ -216,9 +206,9 @@ export default function CoverArt({
               side="bottom"
               align="start"
             >
-              {tempImageForCropping && (
+              {cropSource && (
                 <ImageCropper
-                  src={tempImageForCropping}
+                  src={cropSource.url}
                   onCrop={handleCropComplete}
                   onCancel={handleCropCancel}
                 />
@@ -242,7 +232,10 @@ export default function CoverArt({
           className="hidden"
           ref={fileInputRef}
         />
-        <Tooltip open={Boolean(coverError) && coverErrorOpen} onOpenChange={setCoverErrorOpen}>
+        <Tooltip
+          open={Boolean(coverError) && coverErrorOpen}
+          onOpenChange={(open) => dispatch({ type: "errorOpenChanged", open })}
+        >
           <TooltipTrigger asChild>
             <Button
               type="button"

--- a/components/audio/coverArtState.test.ts
+++ b/components/audio/coverArtState.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vite-plus/test";
+import { coverArtReducer, initialCoverArtState } from "./coverArtState";
+
+const cover = (name: string) => new File([name], name, { type: "image/jpeg" });
+
+describe("cover art state", () => {
+  it("commits a successful upload as one cohesive transition", () => {
+    const previousCover = cover("previous.jpg");
+    const cropSource = { url: "blob:crop", owned: true };
+    const editing = {
+      ...initialCoverArtState,
+      uploadedCover: previousCover,
+      cropSource,
+      isCropperOpen: true,
+      error: "previous error",
+      isErrorOpen: true,
+    };
+
+    const processing = coverArtReducer(editing, {
+      type: "uploadStarted",
+      uploadId: 4,
+      closeCropper: true,
+    });
+    expect(processing).toMatchObject({
+      activeUploadId: 4,
+      uploadedCover: previousCover,
+      cropSource: null,
+      isCropperOpen: false,
+      isProcessing: true,
+      error: "previous error",
+      isErrorOpen: true,
+    });
+
+    const uploadedCover = cover("latest.jpg");
+    expect(
+      coverArtReducer(processing, { type: "uploadSucceeded", uploadId: 4, file: uploadedCover }),
+    ).toMatchObject({
+      activeUploadId: 4,
+      uploadedCover,
+      isProcessing: false,
+      error: null,
+      isErrorOpen: false,
+    });
+  });
+
+  it("keeps the previous cover and exposes a current upload error", () => {
+    const uploadedCover = cover("previous.jpg");
+    const processing = coverArtReducer(
+      { ...initialCoverArtState, uploadedCover },
+      { type: "uploadStarted", uploadId: 2 },
+    );
+
+    expect(
+      coverArtReducer(processing, {
+        type: "uploadFailed",
+        uploadId: 2,
+        message: "could not optimize cover art.",
+      }),
+    ).toMatchObject({
+      uploadedCover,
+      isProcessing: false,
+      error: "could not optimize cover art.",
+      isErrorOpen: true,
+    });
+  });
+
+  it("ignores stale success and error completions after a newer upload starts", () => {
+    const latest = coverArtReducer(initialCoverArtState, {
+      type: "uploadStarted",
+      uploadId: 8,
+    });
+
+    expect(
+      coverArtReducer(latest, {
+        type: "uploadSucceeded",
+        uploadId: 7,
+        file: cover("stale.jpg"),
+      }),
+    ).toBe(latest);
+    expect(
+      coverArtReducer(latest, { type: "uploadFailed", uploadId: 7, message: "stale error" }),
+    ).toBe(latest);
+  });
+
+  it("opens and closes the crop resource as one editing transition", () => {
+    const source = { url: "blob:crop", owned: true };
+    const open = coverArtReducer(initialCoverArtState, { type: "cropOpened", source });
+
+    expect(open).toMatchObject({ cropSource: source, isCropperOpen: true });
+    expect(coverArtReducer(open, { type: "cropClosed" })).toMatchObject({
+      cropSource: null,
+      isCropperOpen: false,
+    });
+  });
+
+  it("closes the error tooltip without clearing the validation error", () => {
+    const failed = {
+      ...initialCoverArtState,
+      error: "bad image",
+      isErrorOpen: true,
+    };
+
+    expect(coverArtReducer(failed, { type: "errorOpenChanged", open: false })).toMatchObject({
+      error: "bad image",
+      isErrorOpen: false,
+    });
+  });
+
+  it("resets every editing surface while invalidating pending uploads", () => {
+    const editing = {
+      ...initialCoverArtState,
+      activeUploadId: 3,
+      uploadedCover: cover("uploaded.jpg"),
+      cropSource: { url: "blob:crop", owned: true },
+      isCropperOpen: true,
+      isProcessing: true,
+      error: "bad image",
+      isErrorOpen: true,
+    };
+
+    expect(coverArtReducer(editing, { type: "reset", uploadId: 4 })).toEqual({
+      ...initialCoverArtState,
+      activeUploadId: 4,
+    });
+  });
+});

--- a/components/audio/coverArtState.ts
+++ b/components/audio/coverArtState.ts
@@ -1,0 +1,70 @@
+export interface CropSource {
+  url: string;
+  owned: boolean;
+}
+
+export interface CoverArtState {
+  activeUploadId: number;
+  uploadedCover: File | null;
+  cropSource: CropSource | null;
+  isCropperOpen: boolean;
+  isProcessing: boolean;
+  error: string | null;
+  isErrorOpen: boolean;
+}
+
+export const initialCoverArtState: CoverArtState = {
+  activeUploadId: 0,
+  uploadedCover: null,
+  cropSource: null,
+  isCropperOpen: false,
+  isProcessing: false,
+  error: null,
+  isErrorOpen: false,
+};
+
+export type CoverArtAction =
+  | { type: "uploadStarted"; uploadId: number; closeCropper?: boolean }
+  | { type: "uploadSucceeded"; uploadId: number; file: File }
+  | { type: "uploadFailed"; uploadId: number; message: string }
+  | { type: "cropOpened"; source: CropSource }
+  | { type: "cropClosed" }
+  | { type: "errorOpenChanged"; open: boolean }
+  | { type: "reset"; uploadId: number };
+
+export const coverArtReducer = (state: CoverArtState, action: CoverArtAction): CoverArtState => {
+  switch (action.type) {
+    case "uploadStarted":
+      return {
+        ...state,
+        activeUploadId: action.uploadId,
+        isProcessing: true,
+        ...(action.closeCropper ? { cropSource: null, isCropperOpen: false } : {}),
+      };
+    case "uploadSucceeded":
+      if (action.uploadId !== state.activeUploadId) return state;
+      return {
+        ...state,
+        uploadedCover: action.file,
+        isProcessing: false,
+        error: null,
+        isErrorOpen: false,
+      };
+    case "uploadFailed":
+      if (action.uploadId !== state.activeUploadId) return state;
+      return {
+        ...state,
+        isProcessing: false,
+        error: action.message,
+        isErrorOpen: true,
+      };
+    case "cropOpened":
+      return { ...state, cropSource: action.source, isCropperOpen: true };
+    case "cropClosed":
+      return { ...state, cropSource: null, isCropperOpen: false };
+    case "errorOpenChanged":
+      return { ...state, isErrorOpen: action.open };
+    case "reset":
+      return { ...initialCoverArtState, activeUploadId: action.uploadId };
+  }
+};

--- a/components/audio/errorPresentation.test.ts
+++ b/components/audio/errorPresentation.test.ts
@@ -37,8 +37,9 @@ describe("local error presentation", () => {
   });
 
   it("keeps cover validation state separate from tooltip visibility", () => {
-    expect(coverArtSource).toContain("onOpenChange={setCoverErrorOpen}");
+    expect(coverArtSource).toContain(
+      'onOpenChange={(open) => dispatch({ type: "errorOpenChanged", open })}',
+    );
     expect(coverArtSource).toContain("aria-describedby={coverError ? coverErrorId : undefined}");
-    expect(coverArtSource).not.toContain("if (!open) setCoverError(null)");
   });
 });

--- a/components/dev/DevPanel.test.tsx
+++ b/components/dev/DevPanel.test.tsx
@@ -1,0 +1,240 @@
+import type { ReactElement, ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { DevPanel } from "./DevPanel";
+
+const reactHookMocks = vi.hoisted(() => ({
+  useCallback: vi.fn(),
+  useEffect: vi.fn(),
+  useRef: vi.fn(),
+  useState: vi.fn(),
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useCallback: reactHookMocks.useCallback,
+    useEffect: reactHookMocks.useEffect,
+    useRef: reactHookMocks.useRef,
+    useState: reactHookMocks.useState,
+  };
+});
+
+type TestElement = ReactElement<Record<string, unknown> & { children?: ReactNode }>;
+type EffectSetup = () => void | (() => void);
+
+const isElement = (node: ReactNode): node is TestElement =>
+  typeof node === "object" && node !== null && "props" in node;
+
+const childrenOf = (node: TestElement): ReactNode[] => {
+  const children = node.props.children;
+  if (children === undefined || children === null || typeof children === "boolean") return [];
+  return Array.isArray(children) ? children : [children];
+};
+
+const findElement = (
+  node: ReactNode,
+  predicate: (element: TestElement) => boolean,
+): TestElement => {
+  if (isElement(node)) {
+    if (predicate(node)) return node;
+    for (const child of childrenOf(node)) {
+      try {
+        return findElement(child, predicate);
+      } catch {
+        // Continue through the remaining children.
+      }
+    }
+  }
+  throw new Error("element not found");
+};
+
+const createHookHarness = () => {
+  const states: unknown[] = [];
+  const refs: Array<{ current: unknown }> = [];
+  let stateCursor = 0;
+  let refCursor = 0;
+  let effect: EffectSetup | undefined;
+
+  reactHookMocks.useCallback.mockImplementation((callback: unknown) => callback);
+  reactHookMocks.useEffect.mockImplementation((setup: EffectSetup) => {
+    effect = setup;
+  });
+  reactHookMocks.useRef.mockImplementation((initial: unknown) => {
+    const index = refCursor++;
+    refs[index] ??= { current: initial };
+    return refs[index];
+  });
+  reactHookMocks.useState.mockImplementation((initial: unknown) => {
+    const index = stateCursor++;
+    if (!(index in states)) states[index] = typeof initial === "function" ? initial() : initial;
+    return [
+      states[index],
+      (next: unknown) => {
+        states[index] = typeof next === "function" ? next(states[index]) : next;
+      },
+    ];
+  });
+
+  return {
+    render() {
+      stateCursor = 0;
+      refCursor = 0;
+      return DevPanel();
+    },
+    runEffect() {
+      if (!effect) throw new Error("effect not registered");
+      return effect();
+    },
+  };
+};
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+const config = (windowMs: number) => ({
+  enabled: true,
+  deployEnv: "local",
+  detectedFrom: "test",
+  productionBranch: "main",
+  rateLimit: {
+    windowMs,
+    maxRequests: 60,
+    bucketCount: 0,
+    client: { key: "test", count: 0, remaining: 60 },
+  },
+  faults: {},
+});
+
+const response = (body: unknown, ok = true) =>
+  ({ ok, json: vi.fn(async () => body) }) as unknown as Response;
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const refreshButton = (tree: ReactNode) =>
+  findElement(tree, (element) => element.props["aria-label"] === "refresh dev config");
+
+const windowInput = (tree: ReactNode) =>
+  findElement(tree, (element) => element.props.type === "number" && element.props.step === 1000);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("DevPanel config loading", () => {
+  it("aborts the discarded StrictMode request and ignores its stale result", async () => {
+    const first = createDeferred<Response>();
+    const second = createDeferred<Response>();
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise);
+    vi.stubGlobal("fetch", fetchMock);
+    const hooks = createHookHarness();
+
+    expect(hooks.render()).toBeNull();
+    const cleanup = hooks.runEffect();
+    expect(typeof cleanup).toBe("function");
+    cleanup?.();
+    hooks.runEffect();
+
+    const firstSignal = (fetchMock.mock.calls[0][1] as RequestInit).signal;
+    expect(firstSignal?.aborted).toBe(true);
+
+    second.resolve(response(config(2_000)));
+    await flushPromises();
+    first.resolve(response(config(1_000)));
+    await flushPromises();
+
+    expect(windowInput(hooks.render()).props.value).toBe("2000");
+  });
+
+  it("makes the latest manual refresh win and aborts the superseded request", async () => {
+    const firstRefresh = createDeferred<Response>();
+    const latestRefresh = createDeferred<Response>();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(config(1_000)))
+      .mockImplementationOnce(() => firstRefresh.promise)
+      .mockImplementationOnce(() => latestRefresh.promise);
+    vi.stubGlobal("fetch", fetchMock);
+    const hooks = createHookHarness();
+
+    hooks.render();
+    hooks.runEffect();
+    await flushPromises();
+    const button = refreshButton(hooks.render());
+
+    (button.props.onClick as () => void)();
+    (button.props.onClick as () => void)();
+
+    const firstRefreshSignal = (fetchMock.mock.calls[1][1] as RequestInit).signal;
+    expect(firstRefreshSignal?.aborted).toBe(true);
+
+    latestRefresh.resolve(response(config(3_000)));
+    await flushPromises();
+    firstRefresh.resolve(response(config(2_000)));
+    await flushPromises();
+
+    expect(windowInput(hooks.render()).props.value).toBe("3000");
+  });
+
+  it("does not update after cleanup even when fetch ignores abort", async () => {
+    const pending = createDeferred<Response>();
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) => pending.promise);
+    vi.stubGlobal("fetch", fetchMock);
+    const hooks = createHookHarness();
+
+    hooks.render();
+    const cleanup = hooks.runEffect();
+    cleanup?.();
+    pending.resolve(response(config(1_000)));
+    await flushPromises();
+
+    expect((fetchMock.mock.calls[0][1] as RequestInit).signal?.aborted).toBe(true);
+    expect(hooks.render()).toBeNull();
+  });
+
+  it("keeps the last successful config when a manual refresh rejects", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(config(1_000)))
+      .mockRejectedValueOnce(new TypeError("network unavailable"));
+    vi.stubGlobal("fetch", fetchMock);
+    const hooks = createHookHarness();
+
+    hooks.render();
+    hooks.runEffect();
+    await flushPromises();
+    const button = refreshButton(hooks.render());
+    (button.props.onClick as () => void)();
+    await flushPromises();
+
+    expect(windowInput(hooks.render()).props.value).toBe("1000");
+  });
+
+  it("keeps non-OK dev config responses as a hidden null panel", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => response(undefined, false)),
+    );
+    const hooks = createHookHarness();
+
+    hooks.render();
+    hooks.runEffect();
+    await flushPromises();
+
+    expect(hooks.render()).toBeNull();
+  });
+});

--- a/components/dev/DevPanel.tsx
+++ b/components/dev/DevPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AlertTriangle, BellRing, RotateCcw, SlidersHorizontal, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -47,8 +47,8 @@ const tunnelFaults: Array<{ value: TunnelFault; label: string }> = [
   { value: "empty-body", label: "empty" },
 ];
 
-const readDevConfig = async () => {
-  const response = await fetch("/api/dev/config");
+const readDevConfig = async (signal: AbortSignal) => {
+  const response = await fetch("/api/dev/config", { signal });
   if (!response.ok) return null;
   return (await response.json()) as DevConfig;
 };
@@ -65,19 +65,36 @@ export function DevPanel() {
   const [windowMs, setWindowMs] = useState("60000");
   const [maxRequests, setMaxRequests] = useState("60");
   const [busy, setBusy] = useState(false);
+  const activeConfigRequest = useRef<AbortController | null>(null);
 
-  const refresh = async () => {
-    const nextConfig = await readDevConfig();
-    setConfig(nextConfig);
-    if (nextConfig) {
-      setWindowMs(String(nextConfig.rateLimit.windowMs));
-      setMaxRequests(String(nextConfig.rateLimit.maxRequests));
+  const refresh = useCallback(async () => {
+    activeConfigRequest.current?.abort();
+    const request = new AbortController();
+    activeConfigRequest.current = request;
+
+    try {
+      const nextConfig = await readDevConfig(request.signal);
+      if (request.signal.aborted || activeConfigRequest.current !== request) return;
+
+      setConfig(nextConfig);
+      if (nextConfig) {
+        setWindowMs(String(nextConfig.rateLimit.windowMs));
+        setMaxRequests(String(nextConfig.rateLimit.maxRequests));
+      }
+    } catch {
+      // This panel is optional; retain the last config if its dev-only endpoint is unavailable.
+    } finally {
+      if (activeConfigRequest.current === request) activeConfigRequest.current = null;
     }
-  };
+  }, []);
 
   useEffect(() => {
     void refresh();
-  }, []);
+    return () => {
+      activeConfigRequest.current?.abort();
+      activeConfigRequest.current = null;
+    };
+  }, [refresh]);
 
   if (!config?.enabled) return null;
 


### PR DESCRIPTION
## Summary

- model cover upload, crop, processing, and error transitions with a reducer
- preserve latest-upload-wins and object URL ownership
- harden DevPanel config loading with abort and latest-request ownership
- add StrictMode, overlap, stale completion, and reducer transition coverage

## Why

Related cover state previously changed through multiple setters, while DevPanel requests could race during StrictMode or manual refreshes. Both workflows now have explicit lifecycle ownership.

## Verification

- 300 tests
- typecheck and lint
- full React Doctor: both scoped findings removed

