### PR TITLE
fix: stabilize export and keyboard behavior

### DIFF
--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -93,6 +93,11 @@ import { resolveTrackMetadata, type TrackMetadata } from "./trackMetadata";
 import { isYouTubePlaylistUrl, resolveYouTubePlaylist } from "./youtubePlaylist";
 import { getSystemFailurePresentation, reportSystemFailure } from "./systemFailure";
 import { isValidFilenameBase } from "./filename";
+import { writeExportMetadata } from "./exportMetadataWrites";
+import {
+  subscribeToEditorKeyboardShortcuts,
+  type EditorKeyboardShortcutActions,
+} from "./editorKeyboardShortcuts";
 import {
   AlbumGroup,
   AppSettings,
@@ -538,13 +543,8 @@ export default function AudioTagger() {
     return syncedFiles;
   };
 
-  const writeFilesForExport = async (filesToExport: TagiumFile[]) => {
-    for (const file of filesToExport) {
-      if (!file.file) continue;
-      if (!file.metadata) continue;
-      await handleTagUpdate(file, file.metadata);
-    }
-  };
+  const writeFilesForExport = (filesToExport: TagiumFile[]) =>
+    writeExportMetadata(filesToExport, handleTagUpdate);
 
   const handleAudioUpload = async (
     uploadedFiles: File[],
@@ -1490,40 +1490,32 @@ export default function AudioTagger() {
     setAlbums((prevAlbums) => reorderAlbums(prevAlbums, albumId, targetIndex));
   };
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const isModifierPressed = event.ctrlKey || event.metaKey;
-      const target = event.target as HTMLElement;
-      const isInputFocused =
-        target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable;
-
-      if (isInputFocused) {
-        return;
-      }
-
-      if (isModifierPressed && event.key === "a") {
-        event.preventDefault();
-        handleSelectAllFiles();
-        return;
-      }
-
-      if (event.key === "Delete" || event.key === "Backspace") {
-        if (selectedFileIds.size > 0) {
-          event.preventDefault();
-          requestRemoveSelectedFiles();
-          return;
-        }
-      }
-
-      if (event.key === "Escape") {
-        handleClearSelection();
-        return;
-      }
+  const keyboardShortcutActionsRef = useRef<EditorKeyboardShortcutActions>({
+    selectedFileCount: selectedFileIds.size,
+    isTrackCoverProcessing,
+    selectAllFiles: handleSelectAllFiles,
+    requestRemoveSelectedFiles,
+    clearSelection: handleClearSelection,
+  });
+  useLayoutEffect(() => {
+    keyboardShortcutActionsRef.current = {
+      selectedFileCount: selectedFileIds.size,
+      isTrackCoverProcessing,
+      selectAllFiles: handleSelectAllFiles,
+      requestRemoveSelectedFiles,
+      clearSelection: handleClearSelection,
     };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedFileIds, handleSelectAllFiles, requestRemoveSelectedFiles, handleClearSelection]);
+  }, [
+    handleClearSelection,
+    handleSelectAllFiles,
+    isTrackCoverProcessing,
+    requestRemoveSelectedFiles,
+    selectedFileIds.size,
+  ]);
+  useEffect(
+    () => subscribeToEditorKeyboardShortcuts(window, () => keyboardShortcutActionsRef.current),
+    [],
+  );
 
   const openCreateAlbumDialog = (seedTrackIds: string[]) => {
     const uniqueSeedTrackIds = asUniqueTrackIds(seedTrackIds);

--- a/components/audio/editorKeyboardShortcuts.test.ts
+++ b/components/audio/editorKeyboardShortcuts.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  subscribeToEditorKeyboardShortcuts,
+  type EditorKeyboardShortcutActions,
+} from "./editorKeyboardShortcuts";
+
+type KeyDownListener = (event: KeyboardEvent) => void;
+
+const createKeyboardTarget = () => {
+  let listener: KeyDownListener | undefined;
+  return {
+    addEventListener: vi.fn((_type: "keydown", nextListener: KeyDownListener) => {
+      listener = nextListener;
+    }),
+    removeEventListener: vi.fn((_type: "keydown", currentListener: KeyDownListener) => {
+      if (listener === currentListener) listener = undefined;
+    }),
+    dispatch(event: KeyboardEvent) {
+      listener?.(event);
+    },
+  };
+};
+
+const preventDefaultMocks = new WeakMap<KeyboardEvent, ReturnType<typeof vi.fn>>();
+const keyboardEvent = (
+  key: string,
+  options: Omit<Partial<KeyboardEvent>, "target"> & {
+    target?: Pick<HTMLElement, "tagName" | "isContentEditable">;
+  } = {},
+) => {
+  const preventDefault = vi.fn();
+  const event = {
+    key,
+    ctrlKey: false,
+    metaKey: false,
+    target: null,
+    preventDefault,
+    ...options,
+  } as unknown as KeyboardEvent;
+  preventDefaultMocks.set(event, preventDefault);
+  return event;
+};
+const preventDefaultFor = (event: KeyboardEvent) => preventDefaultMocks.get(event);
+
+const actions = (
+  overrides: Partial<EditorKeyboardShortcutActions> = {},
+): EditorKeyboardShortcutActions => ({
+  selectedFileCount: 0,
+  isTrackCoverProcessing: false,
+  selectAllFiles: vi.fn(),
+  requestRemoveSelectedFiles: vi.fn(),
+  clearSelection: vi.fn(),
+  ...overrides,
+});
+
+describe("editor keyboard shortcuts", () => {
+  it("subscribes once and delegates to the latest actions", () => {
+    const target = createKeyboardTarget();
+    const initialActions = actions();
+    const latestActions = actions();
+    let currentActions = initialActions;
+
+    const unsubscribe = subscribeToEditorKeyboardShortcuts(target, () => currentActions);
+    const subscribedListener = target.addEventListener.mock.calls[0][1];
+
+    currentActions = latestActions;
+    target.dispatch(keyboardEvent("Escape"));
+    unsubscribe();
+
+    expect(target.addEventListener).toHaveBeenCalledOnce();
+    expect(initialActions.clearSelection).not.toHaveBeenCalled();
+    expect(latestActions.clearSelection).toHaveBeenCalledOnce();
+    expect(target.removeEventListener).toHaveBeenCalledWith("keydown", subscribedListener);
+  });
+
+  it("uses the latest selection when deciding whether Delete is handled", () => {
+    const target = createKeyboardTarget();
+    const initialActions = actions();
+    const latestActions = actions({ selectedFileCount: 1 });
+    let currentActions = initialActions;
+    subscribeToEditorKeyboardShortcuts(target, () => currentActions);
+    const event = keyboardEvent("Delete");
+
+    currentActions = latestActions;
+    target.dispatch(event);
+
+    expect(preventDefaultFor(event)).toHaveBeenCalledOnce();
+    expect(initialActions.requestRemoveSelectedFiles).not.toHaveBeenCalled();
+    expect(latestActions.requestRemoveSelectedFiles).toHaveBeenCalledOnce();
+    expect(target.addEventListener).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { modifier: { ctrlKey: true }, label: "Ctrl" },
+    { modifier: { metaKey: true }, label: "Cmd" },
+  ])("handles $label+A", ({ modifier }) => {
+    const target = createKeyboardTarget();
+    const currentActions = actions();
+    const event = keyboardEvent("a", modifier);
+    subscribeToEditorKeyboardShortcuts(target, () => currentActions);
+
+    target.dispatch(event);
+
+    expect(preventDefaultFor(event)).toHaveBeenCalledOnce();
+    expect(currentActions.selectAllFiles).toHaveBeenCalledOnce();
+  });
+
+  it.each(["Delete", "Backspace"])("handles %s when tracks are selected", (key) => {
+    const target = createKeyboardTarget();
+    const currentActions = actions({ selectedFileCount: 2 });
+    const event = keyboardEvent(key);
+    subscribeToEditorKeyboardShortcuts(target, () => currentActions);
+
+    target.dispatch(event);
+
+    expect(preventDefaultFor(event)).toHaveBeenCalledOnce();
+    expect(currentActions.requestRemoveSelectedFiles).toHaveBeenCalledOnce();
+  });
+
+  it("does not claim Delete when no tracks are selected", () => {
+    const target = createKeyboardTarget();
+    const currentActions = actions();
+    const event = keyboardEvent("Delete");
+    subscribeToEditorKeyboardShortcuts(target, () => currentActions);
+
+    target.dispatch(event);
+
+    expect(preventDefaultFor(event)).not.toHaveBeenCalled();
+    expect(currentActions.requestRemoveSelectedFiles).not.toHaveBeenCalled();
+  });
+
+  it("clears the selection on Escape", () => {
+    const target = createKeyboardTarget();
+    const currentActions = actions({ selectedFileCount: 1 });
+    subscribeToEditorKeyboardShortcuts(target, () => currentActions);
+
+    target.dispatch(keyboardEvent("Escape"));
+
+    expect(currentActions.clearSelection).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { tagName: "INPUT", isContentEditable: false },
+    { tagName: "TEXTAREA", isContentEditable: false },
+    { tagName: "DIV", isContentEditable: true },
+  ])("ignores shortcuts from editable targets: $tagName", (targetElement) => {
+    const target = createKeyboardTarget();
+    const currentActions = actions({ selectedFileCount: 1 });
+    const event = keyboardEvent("Delete", { target: targetElement });
+    subscribeToEditorKeyboardShortcuts(target, () => currentActions);
+
+    target.dispatch(event);
+
+    expect(preventDefaultFor(event)).not.toHaveBeenCalled();
+    expect(currentActions.requestRemoveSelectedFiles).not.toHaveBeenCalled();
+  });
+
+  it("keeps shortcuts inert while track cover processing is active", () => {
+    const target = createKeyboardTarget();
+    const currentActions = actions({ selectedFileCount: 1, isTrackCoverProcessing: true });
+    subscribeToEditorKeyboardShortcuts(target, () => currentActions);
+
+    const selectAllEvent = keyboardEvent("a", { ctrlKey: true });
+    const deleteEvent = keyboardEvent("Delete");
+    target.dispatch(selectAllEvent);
+    target.dispatch(deleteEvent);
+    target.dispatch(keyboardEvent("Escape"));
+
+    expect(preventDefaultFor(selectAllEvent)).toHaveBeenCalledOnce();
+    expect(preventDefaultFor(deleteEvent)).toHaveBeenCalledOnce();
+    expect(currentActions.selectAllFiles).not.toHaveBeenCalled();
+    expect(currentActions.requestRemoveSelectedFiles).not.toHaveBeenCalled();
+    expect(currentActions.clearSelection).not.toHaveBeenCalled();
+  });
+});

--- a/components/audio/editorKeyboardShortcuts.ts
+++ b/components/audio/editorKeyboardShortcuts.ts
@@ -1,0 +1,55 @@
+export type EditorKeyboardShortcutActions = {
+  selectedFileCount: number;
+  isTrackCoverProcessing: boolean;
+  selectAllFiles: () => void;
+  requestRemoveSelectedFiles: () => void;
+  clearSelection: () => void;
+};
+
+type KeyboardTarget = {
+  addEventListener: (type: "keydown", listener: (event: KeyboardEvent) => void) => void;
+  removeEventListener: (type: "keydown", listener: (event: KeyboardEvent) => void) => void;
+};
+
+const isEditableTarget = (target: EventTarget | null) => {
+  const element = target as Pick<HTMLElement, "tagName" | "isContentEditable"> | null;
+  return (
+    element?.tagName === "INPUT" ||
+    element?.tagName === "TEXTAREA" ||
+    element?.isContentEditable === true
+  );
+};
+
+const handleEditorKeyboardShortcut = (
+  event: KeyboardEvent,
+  actions: EditorKeyboardShortcutActions,
+) => {
+  if (isEditableTarget(event.target)) return;
+
+  if ((event.ctrlKey || event.metaKey) && event.key === "a") {
+    event.preventDefault();
+    if (!actions.isTrackCoverProcessing) actions.selectAllFiles();
+    return;
+  }
+
+  if (event.key === "Delete" || event.key === "Backspace") {
+    if (actions.selectedFileCount > 0) {
+      event.preventDefault();
+      if (!actions.isTrackCoverProcessing) actions.requestRemoveSelectedFiles();
+    }
+    return;
+  }
+
+  if (event.key === "Escape" && !actions.isTrackCoverProcessing) {
+    actions.clearSelection();
+  }
+};
+
+export const subscribeToEditorKeyboardShortcuts = (
+  target: KeyboardTarget,
+  getActions: () => EditorKeyboardShortcutActions,
+) => {
+  const listener = (event: KeyboardEvent) => handleEditorKeyboardShortcut(event, getActions());
+  target.addEventListener("keydown", listener);
+  return () => target.removeEventListener("keydown", listener);
+};

--- a/components/audio/exportMetadataWrites.test.ts
+++ b/components/audio/exportMetadataWrites.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vite-plus/test";
+import { writeExportMetadata } from "./exportMetadataWrites";
+import type { AudioMetadata, TagiumFile } from "./types";
+
+const metadata = (title: string): AudioMetadata => ({
+  filename: title,
+  title,
+  artist: "Artist",
+  album: "Album",
+  year: 2024,
+  genre: "",
+  duration: 0,
+  bitrate: 0,
+  sampleRate: 0,
+  picture: [],
+  trackNumber: null,
+});
+
+const readyFile = (id: string): TagiumFile => ({
+  id,
+  file: new File([id], `${id}.mp3`, { type: "audio/mpeg" }),
+  filename: `${id}.mp3`,
+  status: "pending",
+  downloadStatus: "ready",
+  metadata: metadata(id),
+});
+
+const deferred = () => {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+};
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("writeExportMetadata", () => {
+  it("writes at most two files concurrently and completes every write before returning", async () => {
+    const pendingWrites = new Map<string, ReturnType<typeof deferred>>();
+    const started: string[] = [];
+    let active = 0;
+    let peakActive = 0;
+    const writeFile = async (file: TagiumFile) => {
+      started.push(file.id);
+      active += 1;
+      peakActive = Math.max(peakActive, active);
+      const pendingWrite = deferred();
+      pendingWrites.set(file.id, pendingWrite);
+      await pendingWrite.promise;
+      active -= 1;
+    };
+
+    let completed = false;
+    const writeAll = writeExportMetadata(
+      [readyFile("track-1"), readyFile("track-2"), readyFile("track-3"), readyFile("track-4")],
+      writeFile,
+    ).then(() => {
+      completed = true;
+    });
+    await flushMicrotasks();
+
+    expect(started).toEqual(["track-1", "track-2"]);
+    expect(peakActive).toBe(2);
+    expect(completed).toBe(false);
+
+    pendingWrites.get("track-2")?.resolve();
+    await flushMicrotasks();
+    expect(started).toEqual(["track-1", "track-2", "track-3"]);
+
+    pendingWrites.get("track-1")?.resolve();
+    await flushMicrotasks();
+    expect(started).toEqual(["track-1", "track-2", "track-3", "track-4"]);
+
+    pendingWrites.get("track-3")?.resolve();
+    pendingWrites.get("track-4")?.resolve();
+    await writeAll;
+
+    expect(peakActive).toBe(2);
+    expect(completed).toBe(true);
+  });
+
+  it("waits for in-flight work, stops scheduling, and propagates a write rejection", async () => {
+    const pendingWrites = new Map<string, ReturnType<typeof deferred>>();
+    const started: string[] = [];
+    const writeError = new Error("metadata write failed");
+    const writeAll = writeExportMetadata(
+      [readyFile("track-1"), readyFile("track-2"), readyFile("track-3")],
+      (file) => {
+        started.push(file.id);
+        const pendingWrite = deferred();
+        pendingWrites.set(file.id, pendingWrite);
+        return pendingWrite.promise;
+      },
+    );
+    let settled = false;
+    const outcome = writeAll.then(
+      () => {
+        settled = true;
+        return undefined;
+      },
+      (error: unknown) => {
+        settled = true;
+        return error;
+      },
+    );
+    await flushMicrotasks();
+
+    pendingWrites.get("track-2")?.reject(writeError);
+    await flushMicrotasks();
+
+    expect(settled).toBe(false);
+    expect(started).toEqual(["track-1", "track-2"]);
+
+    pendingWrites.get("track-1")?.resolve();
+
+    expect(await outcome).toBe(writeError);
+    expect(started).toEqual(["track-1", "track-2"]);
+  });
+
+  it("reports the earliest-started failure after all in-flight writes settle", async () => {
+    const pendingWrites = new Map<string, ReturnType<typeof deferred>>();
+    const started: string[] = [];
+    const firstError = new Error("first write failed");
+    const secondError = new Error("second write failed");
+    const outcome = writeExportMetadata(
+      [readyFile("track-1"), readyFile("track-2"), readyFile("track-3")],
+      (file) => {
+        started.push(file.id);
+        const pendingWrite = deferred();
+        pendingWrites.set(file.id, pendingWrite);
+        return pendingWrite.promise;
+      },
+    ).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    await flushMicrotasks();
+
+    pendingWrites.get("track-2")?.reject(secondError);
+    await flushMicrotasks();
+    expect(started).toEqual(["track-1", "track-2"]);
+
+    pendingWrites.get("track-1")?.reject(firstError);
+
+    expect(await outcome).toBe(firstError);
+    expect(started).toEqual(["track-1", "track-2"]);
+  });
+
+  it("skips files without both audio and metadata, including an empty selection", async () => {
+    const noAudio: TagiumFile = { ...readyFile("no-audio"), file: undefined };
+    const noMetadata: TagiumFile = { ...readyFile("no-metadata"), metadata: undefined };
+    const eligible = readyFile("eligible");
+    const writes: Array<{ id: string; metadata: AudioMetadata }> = [];
+
+    await writeExportMetadata([noAudio, noMetadata, eligible], async (file, fileMetadata) => {
+      writes.push({ id: file.id, metadata: fileMetadata });
+    });
+    await writeExportMetadata([], async () => {
+      throw new Error("empty exports must not invoke the writer");
+    });
+
+    expect(writes).toEqual([{ id: "eligible", metadata: eligible.metadata }]);
+  });
+});

--- a/components/audio/exportMetadataWrites.ts
+++ b/components/audio/exportMetadataWrites.ts
@@ -1,0 +1,53 @@
+import type { AudioMetadata, TagiumFile } from "./types";
+
+type WritableExportFile = TagiumFile & {
+  file: File;
+  metadata: AudioMetadata;
+};
+
+type ExportMetadataWriter = (file: WritableExportFile, metadata: AudioMetadata) => Promise<void>;
+
+const EXPORT_METADATA_WRITE_CONCURRENCY = 2;
+
+const isWritableExportFile = (file: TagiumFile): file is WritableExportFile =>
+  Boolean(file.file && file.metadata);
+
+export async function writeExportMetadata(
+  files: TagiumFile[],
+  writeFile: ExportMetadataWriter,
+): Promise<void> {
+  const writableFiles = files.filter(isWritableExportFile);
+  let nextIndex = 0;
+  const failures: Array<{ index: number; error: unknown }> = [];
+
+  const writeNext = async (): Promise<void> => {
+    if (failures.length > 0) return;
+
+    const index = nextIndex;
+    const file = writableFiles[index];
+    nextIndex += 1;
+    if (!file) return;
+
+    try {
+      await writeFile(file, file.metadata);
+    } catch (error) {
+      failures.push({ index, error });
+      return;
+    }
+    return writeNext();
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(EXPORT_METADATA_WRITE_CONCURRENCY, writableFiles.length) },
+      writeNext,
+    ),
+  );
+
+  const failure = failures.reduce<(typeof failures)[number] | undefined>(
+    (firstFailure, nextFailure) =>
+      !firstFailure || nextFailure.index < firstFailure.index ? nextFailure : firstFailure,
+    undefined,
+  );
+  if (failure) throw failure.error;
+}


### PR DESCRIPTION
## Summary

- bound export metadata writes to two concurrent jobs
- drain in-flight writes and propagate deterministic failures
- use one stable keyboard listener with layout-synchronized latest actions
- preserve every editor shortcut and editable-target exclusion

## Why

Serial export writes were slow, but unbounded parallelism would risk large audio memory spikes. Keyboard callbacks also caused listener re-subscription and stale-state risk.

## Verification

- 306 tests
- scheduler failure-order and concurrency tests
- keyboard identity, cleanup, latest-state, and shortcut tests
- React Doctor: four scoped findings removed

