### PR TITLE
refactor: split editor and sidebar controllers

### DIFF
--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -1,24 +1,8 @@
 "use client";
 
 import type { MouseEvent as ReactMouseEvent } from "react";
-import { useRef, useState } from "react";
-import {
-  DndContext,
-  DragOverlay,
-  type DragEndEvent,
-  type DragOverEvent,
-  type DragStartEvent,
-  KeyboardSensor,
-  MouseSensor,
-  useSensor,
-  useSensors,
-  TouchSensor,
-} from "@dnd-kit/core";
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
+import { DndContext, DragOverlay } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AlbumSidebarEmptyState } from "./AlbumSidebarEmptyState";
@@ -29,21 +13,15 @@ import {
   SortableTrackRow,
 } from "./AlbumSidebarDnd";
 import {
-  albumIdFromDrop,
   albumContainerId,
   albumItemId,
-  dragStartY,
-  isCenteredLooseDrop,
   LOOSE_APPEND_CONTAINER_ID,
   LOOSE_CONTAINER_ID,
-  rowPlacement,
-  sidebarCollisionDetection,
   trackItemId,
-  type SidebarDragData,
-  type SidebarDropData,
 } from "./sidebarDnd";
 import type { AlbumGroup, TagiumFile } from "./types";
 import { isTrackReadyForDownload } from "./downloadLibrary";
+import { useAlbumSidebarDragController } from "./useAlbumSidebarDragController";
 
 interface AlbumSidebarProps {
   albums: AlbumGroup[];
@@ -77,22 +55,11 @@ interface AlbumSidebarProps {
   onAudioUpload: (files: File[]) => void;
 }
 
-const isFileDrag = (event: React.DragEvent) => event.dataTransfer.types.includes("Files");
-
 const isRetryableError = (track: TagiumFile) =>
   Boolean(track.downloadRequest) &&
   (track.downloadStatus === "error" ||
     track.downloadStatus === "canceled" ||
     track.status === "error");
-
-const handleFileDrop = (event: React.DragEvent, onUpload: (files: File[]) => void) => {
-  const droppedFiles = Array.from(event.dataTransfer.files);
-  if (droppedFiles.length === 0) return;
-
-  event.preventDefault();
-  event.stopPropagation();
-  onUpload(droppedFiles);
-};
 
 export default function AlbumSidebar({
   albums,
@@ -116,134 +83,31 @@ export default function AlbumSidebar({
   onReorderAlbums,
   onAudioUpload,
 }: AlbumSidebarProps) {
-  const [activeDrag, setActiveDrag] = useState<SidebarDragData | null>(null);
-  const dragStartYRef = useRef<number | null>(null);
-  const recentLooseTargetRef = useRef<{ trackId: string; expiresAt: number } | null>(null);
-  const sensors = useSensors(
-    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
-    useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 6 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  );
   const filesById = new Map(files.map((file) => [file.id, file]));
+  const looseTracks = looseTrackIds
+    .map((trackId) => filesById.get(trackId))
+    .filter((track): track is TagiumFile => Boolean(track));
+  const { activeDrag, dndContextProps, libraryFileDropProps, albumFileDropProps } =
+    useAlbumSidebarDragController({
+      albums,
+      looseTrackIds,
+      onMoveTrackToAlbum,
+      onMoveTrackToLoose,
+      onPromptCreateAlbumFromLooseTracks,
+      onReorderAlbums,
+      onAudioUpload,
+      onUploadToAlbum,
+    });
   const activeTrack = activeDrag?.type === "track" ? filesById.get(activeDrag.trackId) : undefined;
   const activeAlbum =
     activeDrag?.type === "album"
       ? albums.find((album) => album.id === activeDrag.albumId)
       : undefined;
-  const looseTracks = looseTrackIds
-    .map((trackId) => filesById.get(trackId))
-    .filter((track): track is TagiumFile => Boolean(track));
 
   const selectedTone = (trackId: string) => {
     if (selectedFileIds.has(trackId)) return "primary";
     if (selectedFileId === trackId) return "secondary";
     return null;
-  };
-
-  const handleDragStart = (event: DragStartEvent) => {
-    setActiveDrag((event.active.data.current as SidebarDragData | undefined) ?? null);
-    recentLooseTargetRef.current = null;
-    dragStartYRef.current = dragStartY(event.activatorEvent);
-  };
-
-  const handleDragOver = (event: DragOverEvent) => {
-    const active = event.active.data.current as SidebarDragData | undefined;
-    const over = event.over?.data.current as SidebarDropData | undefined;
-    if (active?.type !== "track") return;
-    if (active.container !== "loose") return;
-    if (over?.type !== "track") return;
-    if (over.container !== "loose") return;
-    if (over.trackId === active.trackId) return;
-    recentLooseTargetRef.current = { trackId: over.trackId, expiresAt: Date.now() + 700 };
-  };
-
-  const trackIdsForDrop = (drop: Extract<SidebarDropData, { type: "track" }>) => {
-    if (drop.container === "loose") return looseTrackIds;
-
-    const album = albums.find((entry) => entry.id === drop.albumId);
-    if (album) return album.trackIds;
-    return [];
-  };
-
-  const handleAlbumDragEnd = (active: SidebarDragData, over: SidebarDropData) => {
-    if (active.type !== "album") return;
-
-    const targetAlbumId = albumIdFromDrop(over);
-
-    if (targetAlbumId && targetAlbumId !== active.albumId) {
-      const sourceIndex = albums.findIndex((album) => album.id === active.albumId);
-      const targetIndex = albums.findIndex((album) => album.id === targetAlbumId);
-      if (sourceIndex < 0 || targetIndex < 0) return;
-      onReorderAlbums(active.albumId, targetIndex);
-    }
-  };
-
-  const handleTrackDragEnd = (
-    event: DragEndEvent,
-    active: SidebarDragData,
-    over: SidebarDropData,
-  ) => {
-    if (active.type !== "track") return;
-
-    if (over.type === "track") {
-      if (over.trackId === active.trackId) return;
-
-      const placement = rowPlacement(
-        event,
-        active.trackId,
-        over.trackId,
-        trackIdsForDrop(over),
-        dragStartYRef.current,
-      );
-      if (over.container === "loose") {
-        if (active.container === "loose" && isCenteredLooseDrop(event, dragStartYRef.current)) {
-          onPromptCreateAlbumFromLooseTracks(active.trackId, over.trackId);
-          return;
-        }
-        onMoveTrackToLoose(active.trackId, placement, over.trackId);
-        return;
-      }
-
-      onMoveTrackToAlbum(active.trackId, over.albumId, placement, over.trackId);
-      return;
-    }
-
-    if (over.type === "album") {
-      onMoveTrackToAlbum(active.trackId, over.albumId, "append");
-      return;
-    }
-
-    if (over.type === "container" && over.container === "album") {
-      onMoveTrackToAlbum(active.trackId, over.albumId, "append");
-      return;
-    }
-
-    if (over.type === "container" && over.container === "loose") {
-      const recentLooseTarget = recentLooseTargetRef.current;
-      if (
-        active.container === "loose" &&
-        event.over?.id !== LOOSE_APPEND_CONTAINER_ID &&
-        recentLooseTarget &&
-        recentLooseTarget.expiresAt > Date.now()
-      ) {
-        onPromptCreateAlbumFromLooseTracks(active.trackId, recentLooseTarget.trackId);
-        return;
-      }
-      onMoveTrackToLoose(active.trackId, "append");
-    }
-  };
-
-  const handleDragEnd = (event: DragEndEvent) => {
-    const active = event.active.data.current as SidebarDragData | undefined;
-    const over = event.over?.data.current as SidebarDropData | undefined;
-
-    if (active && over) {
-      handleAlbumDragEnd(active, over);
-      handleTrackDragEnd(event, active, over);
-    }
-    dragStartYRef.current = null;
-    recentLooseTargetRef.current = null;
-    setActiveDrag(null);
   };
 
   if (albums.length === 0 && looseTracks.length === 0) {
@@ -261,26 +125,10 @@ export default function AlbumSidebar({
         </Button>
       </div>
 
-      <DndContext
-        sensors={sensors}
-        collisionDetection={sidebarCollisionDetection}
-        onDragStart={handleDragStart}
-        onDragOver={handleDragOver}
-        onDragCancel={() => {
-          dragStartYRef.current = null;
-          recentLooseTargetRef.current = null;
-          setActiveDrag(null);
-        }}
-        onDragEnd={handleDragEnd}
-      >
+      <DndContext {...dndContextProps}>
         <div
           className="flex-1 overflow-y-auto overflow-x-hidden flex flex-col"
-          onDragOver={(event) => {
-            if (!isFileDrag(event)) return;
-            event.preventDefault();
-            event.dataTransfer.dropEffect = "copy";
-          }}
-          onDrop={(event) => handleFileDrop(event, onAudioUpload)}
+          {...libraryFileDropProps}
         >
           <SortableContext
             items={looseTracks.map((track) => trackItemId(track.id))}
@@ -322,6 +170,7 @@ export default function AlbumSidebar({
                   const file = filesById.get(trackId);
                   return file ? isTrackReadyForDownload(file) : false;
                 });
+              const fileDropProps = albumFileDropProps(album.id);
               return (
                 <SortableAlbumCard
                   key={album.id}
@@ -331,15 +180,7 @@ export default function AlbumSidebar({
                   onSelect={(event) => onSelectAlbum(album.id, event)}
                   onEdit={() => onEditAlbum(album.id)}
                   onDownload={() => onDownloadAlbum(album.id)}
-                  onFileDragOver={(event) => {
-                    if (!isFileDrag(event)) return;
-                    event.preventDefault();
-                    event.stopPropagation();
-                    event.dataTransfer.dropEffect = "copy";
-                  }}
-                  onFileDrop={(event) =>
-                    handleFileDrop(event, (audioFiles) => onUploadToAlbum(album.id, audioFiles))
-                  }
+                  {...fileDropProps}
                 >
                   <SortableContext
                     items={album.trackIds.map((trackId) => trackItemId(trackId))}

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -1,23 +1,26 @@
 "use client";
 
 import { useCallback, useRef } from "react";
-import type { ChangeEvent, ReactNode } from "react";
+import type { ChangeEvent, ReactNode, RefObject } from "react";
 import {
-  Control,
   Controller,
-  SubmitHandler,
-  UseFormHandleSubmit,
-  UseFormRegister,
   useWatch,
+  type Control,
+  type SubmitHandler,
+  type UseFormHandleSubmit,
+  type UseFormRegister,
+  type UseFormRegisterReturn,
 } from "react-hook-form";
-import CoverArt from "./coverArt";
-import { AlbumGroup, AudioMetadata, TagiumFile } from "./types";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
-import { getTrackFailureDisplay } from "./systemFailure";
-import { getSampleTrack } from "./sampleMetadata";
+import CoverArt from "./coverArt";
 import { isValidFilenameBase, sanitizeFilenameBase } from "./filename";
+import { getSampleTrack, type SampleTrackMetadata } from "./sampleMetadata";
+import { getTrackFailureDisplay } from "./systemFailure";
+import type { AlbumGroup, AudioMetadata, TagiumFile } from "./types";
+
+type LoadedTrack = TagiumFile & { metadata: AudioMetadata };
 
 interface TrackMetadataEditorProps {
   selectedFile: TagiumFile | null;
@@ -41,7 +44,18 @@ interface TrackMetadataEditorProps {
   ) => void;
 }
 
+interface LoadedTrackMetadataEditorProps extends Omit<TrackMetadataEditorProps, "selectedFile"> {
+  selectedFile: LoadedTrack;
+  focusedTitleFileIdRef: RefObject<string | null>;
+}
+
+const hasMetadata = (selectedFile: TagiumFile | null): selectedFile is LoadedTrack =>
+  Boolean(selectedFile?.metadata);
+
 const fieldLabelClassName = "mb-1 block text-xs font-medium md:text-sm";
+const placeholderClassName = "placeholder:text-muted-foreground/45";
+const syncedInputClassName =
+  "disabled:pointer-events-auto disabled:cursor-not-allowed disabled:border-dashed disabled:bg-muted/10 disabled:text-muted-foreground disabled:opacity-100 dark:disabled:bg-muted/10";
 
 function DisabledReason({
   disabled,
@@ -64,9 +78,291 @@ function DisabledReason({
   );
 }
 
-export default function TrackMetadataEditor({
+interface TrackFailure {
+  title: string;
+  description: string;
+}
+
+function TrackFilenameHeader({
+  syncFilenames,
+  watchedFilename,
+  sanitizedFilename,
+  filenamePlaceholder,
+  filenameInvalid,
+  filenameRegistration,
+  failure,
+}: {
+  syncFilenames: boolean;
+  watchedFilename: string;
+  sanitizedFilename: string;
+  filenamePlaceholder: string;
+  filenameInvalid: boolean;
+  filenameRegistration: UseFormRegisterReturn<"filename">;
+  failure: TrackFailure | null;
+}) {
+  return (
+    <div className="relative h-16 border-b flex-shrink-0 px-4 max-lg:[@media(max-height:700px)]:h-14 max-lg:[@media(max-height:700px)]:px-3 lg:h-[104px] lg:px-6">
+      <div className="flex h-full min-w-0 items-center">
+        {syncFilenames ? (
+          <h2 className="inline-flex min-w-0 max-w-full items-center text-base font-semibold text-muted-foreground max-lg:[@media(max-height:700px)]:text-sm lg:text-lg">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="min-w-0 cursor-not-allowed truncate">
+                  {sanitizedFilename || filenamePlaceholder}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>filename follows the title</TooltipContent>
+            </Tooltip>
+            <span className="shrink-0 select-none text-muted-foreground/70">.mp3</span>
+          </h2>
+        ) : (
+          <label className="inline-flex min-w-0 max-w-full items-center text-base font-semibold max-lg:[@media(max-height:700px)]:text-sm lg:text-lg">
+            <span className="grid w-fit max-w-[calc(100%-2.25rem)] overflow-hidden">
+              <span className="invisible col-start-1 row-start-1 whitespace-pre" aria-hidden>
+                {watchedFilename || filenamePlaceholder}
+              </span>
+              <input
+                {...filenameRegistration}
+                aria-label="filename"
+                aria-invalid={filenameInvalid}
+                aria-describedby={filenameInvalid ? "track-filename-error" : undefined}
+                size={1}
+                className="col-start-1 row-start-1 min-w-0 truncate bg-transparent outline-none placeholder:text-muted-foreground/45"
+                placeholder={filenamePlaceholder}
+              />
+            </span>
+            <span className="shrink-0 select-none text-muted-foreground/70">.mp3</span>
+          </label>
+        )}
+      </div>
+      <div className="absolute inset-x-4 bottom-1 h-4 min-w-0 overflow-hidden text-xs leading-4 text-destructive max-lg:[@media(max-height:700px)]:inset-x-3 max-lg:[@media(max-height:700px)]:bottom-0 lg:inset-x-6 lg:h-8">
+        {filenameInvalid ? (
+          <div className="flex min-w-0 items-center gap-2">
+            <p
+              id="track-filename-error"
+              className="min-w-0 truncate font-medium"
+              aria-live="polite"
+            >
+              filename is required
+            </p>
+            {failure && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="shrink-0 underline decoration-dotted underline-offset-2"
+                    aria-label={`${failure.title}: ${failure.description}`}
+                  >
+                    track error
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="font-medium">{failure.title}</p>
+                  <p>{failure.description}</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        ) : failure ? (
+          <div className="min-w-0 text-xs text-destructive" aria-live="polite">
+            <p className="truncate font-medium">{failure.title}</p>
+            <p className="sr-only truncate lg:not-sr-only">{failure.description}</p>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function TrackDetailsFields({
+  selectedFileId,
+  focusedTitleFileIdRef,
+  register,
+  placeholder,
+  inAlbum,
+  syncFilenames,
+  syncTrackNumbers,
+  filenameInvalid,
+  onPreviewMetadataChange,
+}: {
+  selectedFileId: string | null;
+  focusedTitleFileIdRef: RefObject<string | null>;
+  register: UseFormRegister<AudioMetadata>;
+  placeholder: SampleTrackMetadata;
+  inAlbum: boolean;
+  syncFilenames: boolean;
+  syncTrackNumbers: boolean;
+  filenameInvalid: boolean;
+  onPreviewMetadataChange: TrackMetadataEditorProps["onPreviewMetadataChange"];
+}) {
+  const titleRegistration = register("title", {
+    onChange: (event) => onPreviewMetadataChange("title", event),
+  });
+  const artistRegistration = register("artist", {
+    onChange: (event) => onPreviewMetadataChange("artist", event),
+  });
+  const { ref: titleRegistrationRef, ...titleInputRegistration } = titleRegistration;
+  const titleInputRef = useCallback(
+    (node: HTMLInputElement | null) => {
+      titleRegistrationRef(node);
+      if (!node || !selectedFileId) return;
+      if (focusedTitleFileIdRef.current === selectedFileId) return;
+
+      focusedTitleFileIdRef.current = selectedFileId;
+      node.focus({ preventScroll: true });
+    },
+    [focusedTitleFileIdRef, selectedFileId, titleRegistrationRef],
+  );
+  const albumFieldReason = "controlled by the album";
+
+  return (
+    <>
+      <div>
+        <label htmlFor="track-title" className={fieldLabelClassName}>
+          title:
+        </label>
+        <Input
+          {...titleInputRegistration}
+          id="track-title"
+          ref={titleInputRef}
+          aria-invalid={syncFilenames && filenameInvalid}
+          aria-describedby={syncFilenames && filenameInvalid ? "track-filename-error" : undefined}
+          placeholder={placeholder.title}
+          className={placeholderClassName}
+        />
+      </div>
+      <div>
+        <label htmlFor="track-artist" className={fieldLabelClassName}>
+          artist:
+        </label>
+        <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
+          <Input
+            {...artistRegistration}
+            id="track-artist"
+            placeholder={placeholder.artist}
+            disabled={inAlbum}
+            className={`${placeholderClassName} ${syncedInputClassName}`}
+          />
+        </DisabledReason>
+      </div>
+      <div>
+        <label htmlFor="track-album" className={fieldLabelClassName}>
+          album:
+        </label>
+        <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
+          <Input
+            {...register("album")}
+            id="track-album"
+            placeholder={placeholder.album}
+            disabled={inAlbum}
+            className={`${placeholderClassName} ${syncedInputClassName}`}
+          />
+        </DisabledReason>
+      </div>
+      <div className="grid grid-cols-[minmax(4.5rem,0.8fr)_minmax(0,1.4fr)_minmax(4.5rem,0.8fr)] gap-2">
+        <div>
+          <label htmlFor="track-year" className={fieldLabelClassName}>
+            year:
+          </label>
+          <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
+            <Input
+              type="number"
+              {...register("year", { valueAsNumber: true })}
+              id="track-year"
+              placeholder={placeholder.year}
+              disabled={inAlbum}
+              className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
+            />
+          </DisabledReason>
+        </div>
+        <div>
+          <label htmlFor="track-genre" className={fieldLabelClassName}>
+            genre:
+          </label>
+          <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
+            <Input
+              {...register("genre")}
+              id="track-genre"
+              placeholder={placeholder.genre}
+              disabled={inAlbum}
+              className={`${placeholderClassName} ${syncedInputClassName}`}
+            />
+          </DisabledReason>
+        </div>
+        <div>
+          <label htmlFor="track-number" className={fieldLabelClassName}>
+            track:
+          </label>
+          <DisabledReason disabled={inAlbum && syncTrackNumbers} reason="follows album order">
+            <Input
+              type="number"
+              {...register("trackNumber", { valueAsNumber: true })}
+              id="track-number"
+              placeholder={placeholder.trackNumber}
+              disabled={inAlbum && syncTrackNumbers}
+              className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
+            />
+          </DisabledReason>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function TrackFileSummary({ selectedFile }: { selectedFile: LoadedTrack }) {
+  return (
+    <div className="grid grid-cols-2 gap-2 text-xs md:text-sm">
+      <div>
+        <span className="font-medium">duration: </span>
+        {`${Math.floor(selectedFile.metadata.duration / 60)}:${String(Math.round(selectedFile.metadata.duration % 60)).padStart(2, "0")}`}
+      </div>
+      <div className="justify-self-end text-right">
+        <span className="font-medium">size: </span>
+        {selectedFile.file &&
+          selectedFile.status !== "error" &&
+          `${(selectedFile.file.size / (1024 * 1024)).toFixed(2)} MB`}
+        {selectedFile.file &&
+          selectedFile.status === "error" &&
+          `${(selectedFile.file.size / (1024 * 1024)).toFixed(2)} MB (metadata failed)`}
+        {!selectedFile.file && selectedFile.downloadStatus === "downloading" && "downloading"}
+        {!selectedFile.file && selectedFile.downloadStatus === "error" && "download failed"}
+        {!selectedFile.file && selectedFile.downloadStatus === "canceled" && "download canceled"}
+      </div>
+    </div>
+  );
+}
+
+function DownloadTrackButton({
+  handleSubmit,
+  onDownloadUpdatedFile,
+  disabled,
+  disabledReason,
+}: {
+  handleSubmit: UseFormHandleSubmit<AudioMetadata>;
+  onDownloadUpdatedFile: SubmitHandler<AudioMetadata>;
+  disabled: boolean;
+  disabledReason: string;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-end gap-2 pt-1 max-lg:[@media(max-height:700px)]:flex-none max-lg:[@media(max-height:700px)]:pt-0 lg:flex-none lg:pt-2">
+      <DisabledReason disabled={disabled} reason={disabledReason}>
+        <Button
+          type="button"
+          onClick={handleSubmit(onDownloadUpdatedFile)}
+          disabled={disabled}
+          className="min-w-36 max-lg:[@media(max-height:700px)]:h-10 max-lg:[@media(max-height:700px)]:text-xs"
+        >
+          download track
+        </Button>
+      </DisabledReason>
+    </div>
+  );
+}
+
+function LoadedTrackMetadataEditor({
   selectedFile,
   selectedFileId,
+  focusedTitleFileIdRef,
   register,
   control,
   handleSubmit,
@@ -78,59 +374,30 @@ export default function TrackMetadataEditor({
   syncFilenames,
   syncTrackNumbers,
   onPreviewMetadataChange,
-}: TrackMetadataEditorProps) {
+}: LoadedTrackMetadataEditorProps) {
   const watchedTitle = useWatch({ control, name: "title", defaultValue: "" });
   const watchedFilename = useWatch({ control, name: "filename", defaultValue: "" });
-  const inAlbum = !!selectedFileAlbum;
-  const audioReady = Boolean(selectedFile?.file);
-  const sanitizedFilename = sanitizeFilenameBase(syncFilenames ? watchedTitle : watchedFilename);
-  const filenameInvalid = !isValidFilenameBase(syncFilenames ? watchedTitle : watchedFilename);
-  const canDownloadTrack = audioReady && !isTrackCoverProcessing && !filenameInvalid;
-  const albumFieldReason = "controlled by the album";
-  const filenameRegistration = register("filename", {
-    onChange: (event) => onPreviewMetadataChange("filename", event),
-  });
-  const titleRegistration = register("title", {
-    onChange: (event) => onPreviewMetadataChange("title", event),
-  });
-  const artistRegistration = register("artist", {
-    onChange: (event) => onPreviewMetadataChange("artist", event),
-  });
-  const { ref: titleRegistrationRef, ...titleInputRegistration } = titleRegistration;
-  const placeholderClassName = "placeholder:text-muted-foreground/45";
-  const syncedInputClassName =
-    "disabled:pointer-events-auto disabled:cursor-not-allowed disabled:border-dashed disabled:bg-muted/10 disabled:text-muted-foreground disabled:opacity-100 dark:disabled:bg-muted/10";
-  const focusedTitleFileIdRef = useRef<string | null>(null);
-  const titleInputRef = useCallback(
-    (node: HTMLInputElement | null) => {
-      titleRegistrationRef(node);
-      if (!node || !selectedFileId) return;
-      if (focusedTitleFileIdRef.current === selectedFileId) return;
-
-      focusedTitleFileIdRef.current = selectedFileId;
-      node.focus({ preventScroll: true });
-    },
-    [selectedFileId, titleRegistrationRef],
-  );
-
-  if (!selectedFile || !selectedFile.metadata) {
-    return (
-      <div className="flex-1 flex items-center justify-center bg-muted/5">
-        <div className="text-center">
-          <p className="text-muted-foreground">select a track to edit its tags</p>
-        </div>
-      </div>
-    );
-  }
-
+  const filenameValue = syncFilenames ? watchedTitle : watchedFilename;
+  const filenameInvalid = !isValidFilenameBase(filenameValue);
+  const canDownloadTrack =
+    Boolean(selectedFile.file) && !isTrackCoverProcessing && !filenameInvalid;
   const placeholder = getSampleTrack(selectedFile.id);
-  const filenamePlaceholder = placeholder.filename;
   const downloadErrorDisplay = selectedFile.downloadError
     ? getTrackFailureDisplay(selectedFile.downloadError)
     : null;
-  const hasTrackFailure =
+  const failure =
     (selectedFile.downloadStatus === "error" || selectedFile.status === "error") &&
-    downloadErrorDisplay;
+    downloadErrorDisplay
+      ? downloadErrorDisplay
+      : null;
+  const filenameRegistration = register("filename", {
+    onChange: (event) => onPreviewMetadataChange("filename", event),
+  });
+  const downloadDisabledReason = isTrackCoverProcessing
+    ? "cover art is still processing"
+    : filenameInvalid
+      ? "filename is required"
+      : "track file is not ready";
 
   return (
     <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
@@ -140,78 +407,15 @@ export default function TrackMetadataEditor({
         }}
         className="flex min-h-0 flex-col h-full"
       >
-        <div className="relative h-16 border-b flex-shrink-0 px-4 max-lg:[@media(max-height:700px)]:h-14 max-lg:[@media(max-height:700px)]:px-3 lg:h-[104px] lg:px-6">
-          <div className="flex h-full min-w-0 items-center">
-            {syncFilenames ? (
-              <h2 className="inline-flex min-w-0 max-w-full items-center text-base font-semibold text-muted-foreground max-lg:[@media(max-height:700px)]:text-sm lg:text-lg">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="min-w-0 cursor-not-allowed truncate">
-                      {sanitizedFilename || filenamePlaceholder}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>filename follows the title</TooltipContent>
-                </Tooltip>
-                <span className="shrink-0 select-none text-muted-foreground/70">.mp3</span>
-              </h2>
-            ) : (
-              <label className="inline-flex min-w-0 max-w-full items-center text-base font-semibold max-lg:[@media(max-height:700px)]:text-sm lg:text-lg">
-                <span className="grid w-fit max-w-[calc(100%-2.25rem)] overflow-hidden">
-                  <span className="invisible col-start-1 row-start-1 whitespace-pre" aria-hidden>
-                    {watchedFilename || filenamePlaceholder}
-                  </span>
-                  <input
-                    {...filenameRegistration}
-                    aria-label="filename"
-                    aria-invalid={filenameInvalid}
-                    aria-describedby={filenameInvalid ? "track-filename-error" : undefined}
-                    size={1}
-                    className="col-start-1 row-start-1 min-w-0 truncate bg-transparent outline-none placeholder:text-muted-foreground/45"
-                    placeholder={filenamePlaceholder}
-                  />
-                </span>
-                <span className="shrink-0 select-none text-muted-foreground/70">.mp3</span>
-              </label>
-            )}
-          </div>
-          <div className="absolute inset-x-4 bottom-1 h-4 min-w-0 overflow-hidden text-xs leading-4 text-destructive max-lg:[@media(max-height:700px)]:inset-x-3 max-lg:[@media(max-height:700px)]:bottom-0 lg:inset-x-6 lg:h-8">
-            {filenameInvalid ? (
-              <div className="flex min-w-0 items-center gap-2">
-                <p
-                  id="track-filename-error"
-                  className="min-w-0 truncate font-medium"
-                  aria-live="polite"
-                >
-                  filename is required
-                </p>
-                {hasTrackFailure && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="shrink-0 underline decoration-dotted underline-offset-2"
-                        aria-label={`${downloadErrorDisplay.title}: ${downloadErrorDisplay.description}`}
-                      >
-                        track error
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p className="font-medium">{downloadErrorDisplay.title}</p>
-                      <p>{downloadErrorDisplay.description}</p>
-                    </TooltipContent>
-                  </Tooltip>
-                )}
-              </div>
-            ) : hasTrackFailure ? (
-              <div className="min-w-0 text-xs text-destructive" aria-live="polite">
-                <p className="truncate font-medium">{downloadErrorDisplay.title}</p>
-                <p className="sr-only truncate lg:not-sr-only">
-                  {downloadErrorDisplay.description}
-                </p>
-              </div>
-            ) : null}
-          </div>
-        </div>
+        <TrackFilenameHeader
+          syncFilenames={syncFilenames}
+          watchedFilename={watchedFilename}
+          sanitizedFilename={sanitizeFilenameBase(filenameValue)}
+          filenamePlaceholder={placeholder.filename}
+          filenameInvalid={filenameInvalid}
+          filenameRegistration={filenameRegistration}
+          failure={failure}
+        />
         <div className="flex-1 min-h-0 overflow-y-auto p-3 pb-3 max-lg:[@media(max-height:700px)]:p-2 lg:p-6 lg:pb-28">
           <div className="flex min-h-full flex-col gap-3 max-lg:[@media(max-height:700px)]:gap-2 lg:min-h-0 lg:flex-row lg:gap-4">
             <Controller
@@ -227,148 +431,50 @@ export default function TrackMetadataEditor({
               )}
             />
             <div className="flex flex-1 flex-col gap-2 max-lg:[@media(max-height:700px)]:gap-1.5 lg:gap-3">
-              <div>
-                <label htmlFor="track-title" className={fieldLabelClassName}>
-                  title:
-                </label>
-                <Input
-                  {...titleInputRegistration}
-                  id="track-title"
-                  ref={titleInputRef}
-                  aria-invalid={syncFilenames && filenameInvalid}
-                  aria-describedby={
-                    syncFilenames && filenameInvalid ? "track-filename-error" : undefined
-                  }
-                  placeholder={placeholder.title}
-                  className={placeholderClassName}
-                />
-              </div>
-              <div>
-                <label htmlFor="track-artist" className={fieldLabelClassName}>
-                  artist:
-                </label>
-                <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
-                  <Input
-                    {...artistRegistration}
-                    id="track-artist"
-                    placeholder={placeholder.artist}
-                    disabled={inAlbum}
-                    className={`${placeholderClassName} ${syncedInputClassName}`}
-                  />
-                </DisabledReason>
-              </div>
-              <div>
-                <label htmlFor="track-album" className={fieldLabelClassName}>
-                  album:
-                </label>
-                <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
-                  <Input
-                    {...register("album")}
-                    id="track-album"
-                    placeholder={placeholder.album}
-                    disabled={inAlbum}
-                    className={`${placeholderClassName} ${syncedInputClassName}`}
-                  />
-                </DisabledReason>
-              </div>
-              <div className="grid grid-cols-[minmax(4.5rem,0.8fr)_minmax(0,1.4fr)_minmax(4.5rem,0.8fr)] gap-2">
-                <div>
-                  <label htmlFor="track-year" className={fieldLabelClassName}>
-                    year:
-                  </label>
-                  <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
-                    <Input
-                      type="number"
-                      {...register("year", { valueAsNumber: true })}
-                      id="track-year"
-                      placeholder={placeholder.year}
-                      disabled={inAlbum}
-                      className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
-                    />
-                  </DisabledReason>
-                </div>
-                <div>
-                  <label htmlFor="track-genre" className={fieldLabelClassName}>
-                    genre:
-                  </label>
-                  <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
-                    <Input
-                      {...register("genre")}
-                      id="track-genre"
-                      placeholder={placeholder.genre}
-                      disabled={inAlbum}
-                      className={`${placeholderClassName} ${syncedInputClassName}`}
-                    />
-                  </DisabledReason>
-                </div>
-                <div>
-                  <label htmlFor="track-number" className={fieldLabelClassName}>
-                    track:
-                  </label>
-                  <DisabledReason
-                    disabled={inAlbum && syncTrackNumbers}
-                    reason="follows album order"
-                  >
-                    <Input
-                      type="number"
-                      {...register("trackNumber", { valueAsNumber: true })}
-                      id="track-number"
-                      placeholder={placeholder.trackNumber}
-                      disabled={inAlbum && syncTrackNumbers}
-                      className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
-                    />
-                  </DisabledReason>
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-2 text-xs md:text-sm">
-                <div>
-                  <span className="font-medium">duration: </span>
-                  {`${Math.floor(selectedFile.metadata.duration / 60)}:${String(Math.round(selectedFile.metadata.duration % 60)).padStart(2, "0")}`}
-                </div>
-                <div className="justify-self-end text-right">
-                  <span className="font-medium">size: </span>
-                  {selectedFile.file &&
-                    selectedFile.status !== "error" &&
-                    `${(selectedFile.file.size / (1024 * 1024)).toFixed(2)} MB`}
-                  {selectedFile.file &&
-                    selectedFile.status === "error" &&
-                    `${(selectedFile.file.size / (1024 * 1024)).toFixed(2)} MB (metadata failed)`}
-                  {!selectedFile.file &&
-                    selectedFile.downloadStatus === "downloading" &&
-                    "downloading"}
-                  {!selectedFile.file &&
-                    selectedFile.downloadStatus === "error" &&
-                    "download failed"}
-                  {!selectedFile.file &&
-                    selectedFile.downloadStatus === "canceled" &&
-                    "download canceled"}
-                </div>
-              </div>
-              <div className="flex min-h-0 flex-1 items-center justify-end gap-2 pt-1 max-lg:[@media(max-height:700px)]:flex-none max-lg:[@media(max-height:700px)]:pt-0 lg:flex-none lg:pt-2">
-                <DisabledReason
-                  disabled={!canDownloadTrack}
-                  reason={
-                    isTrackCoverProcessing
-                      ? "cover art is still processing"
-                      : filenameInvalid
-                        ? "filename is required"
-                        : "track file is not ready"
-                  }
-                >
-                  <Button
-                    type="button"
-                    onClick={handleSubmit(onDownloadUpdatedFile)}
-                    disabled={!canDownloadTrack}
-                    className="min-w-36 max-lg:[@media(max-height:700px)]:h-10 max-lg:[@media(max-height:700px)]:text-xs"
-                  >
-                    download track
-                  </Button>
-                </DisabledReason>
-              </div>
+              <TrackDetailsFields
+                selectedFileId={selectedFileId}
+                focusedTitleFileIdRef={focusedTitleFileIdRef}
+                register={register}
+                placeholder={placeholder}
+                inAlbum={Boolean(selectedFileAlbum)}
+                syncFilenames={syncFilenames}
+                syncTrackNumbers={syncTrackNumbers}
+                filenameInvalid={filenameInvalid}
+                onPreviewMetadataChange={onPreviewMetadataChange}
+              />
+              <TrackFileSummary selectedFile={selectedFile} />
+              <DownloadTrackButton
+                handleSubmit={handleSubmit}
+                onDownloadUpdatedFile={onDownloadUpdatedFile}
+                disabled={!canDownloadTrack}
+                disabledReason={downloadDisabledReason}
+              />
             </div>
           </div>
         </div>
       </form>
     </div>
+  );
+}
+
+export default function TrackMetadataEditor(props: TrackMetadataEditorProps) {
+  const focusedTitleFileIdRef = useRef<string | null>(null);
+
+  if (!hasMetadata(props.selectedFile)) {
+    return (
+      <div className="flex-1 flex items-center justify-center bg-muted/5">
+        <div className="text-center">
+          <p className="text-muted-foreground">select a track to edit its tags</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <LoadedTrackMetadataEditor
+      {...props}
+      selectedFile={props.selectedFile}
+      focusedTitleFileIdRef={focusedTitleFileIdRef}
+    />
   );
 }

--- a/components/audio/sidebarDnd.ts
+++ b/components/audio/sidebarDnd.ts
@@ -1,7 +1,6 @@
 import {
   closestCorners,
   type CollisionDetection,
-  type DragEndEvent,
   pointerWithin,
   rectIntersection,
 } from "@dnd-kit/core";
@@ -33,51 +32,9 @@ export const sidebarCollisionDetection: CollisionDetection = (args) => {
   return closestCorners(args);
 };
 
-export const dragStartY = (event: Event) => {
-  const sourceEvent = event as Event & {
-    changedTouches?: TouchList;
-    clientY?: number;
-    touches?: TouchList;
-  };
-  if (sourceEvent.clientY !== undefined) return sourceEvent.clientY;
-  if (sourceEvent.touches?.[0]) return sourceEvent.touches[0].clientY;
-  if (sourceEvent.changedTouches?.[0]) return sourceEvent.changedTouches[0].clientY;
-  return null;
-};
-
 export const albumIdFromDrop = (drop: SidebarDropData) => {
   if (drop.type === "album") return drop.albumId;
   if (drop.type === "track" && drop.container === "album") return drop.albumId;
   if (drop.type === "container" && drop.container === "album") return drop.albumId;
   return null;
-};
-
-export const rowPlacement = (
-  event: DragEndEvent,
-  sourceTrackId: string,
-  targetTrackId: string,
-  trackIds: string[],
-  initialY: number | null,
-) => {
-  const rect = event.over?.rect;
-  if (!rect) return "after";
-  if (initialY === null) {
-    const sourceIndex = trackIds.indexOf(sourceTrackId);
-    const targetIndex = trackIds.indexOf(targetTrackId);
-    if (sourceIndex >= 0 && targetIndex >= 0 && sourceIndex > targetIndex) return "before";
-    if (sourceIndex < 0) return "before";
-    return "after";
-  }
-
-  const y = initialY + event.delta.y;
-  return y > rect.top + rect.height / 2 ? "after" : "before";
-};
-
-export const isCenteredLooseDrop = (event: DragEndEvent, initialY: number | null) => {
-  const rect = event.over?.rect;
-  if (!rect) return false;
-  if (initialY === null) return false;
-  const y = initialY + event.delta.y;
-  const position = (y - rect.top) / rect.height;
-  return position > 0.3 && position < 0.7;
 };

--- a/components/audio/sidebarDragController.test.ts
+++ b/components/audio/sidebarDragController.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vite-plus/test";
+import { resolveSidebarDragCommand, type SidebarDropPosition } from "./sidebarDragController";
+import { LOOSE_APPEND_CONTAINER_ID, LOOSE_CONTAINER_ID } from "./sidebarDnd";
+
+const albums = [
+  { id: "album-a", trackIds: ["a-1", "a-2"] },
+  { id: "album-b", trackIds: ["b-1", "b-2"] },
+];
+
+const pointerPosition = (overrides: Partial<SidebarDropPosition> = {}): SidebarDropPosition => ({
+  deltaY: 0,
+  overId: "track:target",
+  overRect: { top: 100, height: 40 },
+  ...overrides,
+});
+
+const resolve = (overrides: Partial<Parameters<typeof resolveSidebarDragCommand>[0]> = {}) =>
+  resolveSidebarDragCommand({
+    active: { type: "track", trackId: "a-1", container: "album", albumId: "album-a" },
+    over: { type: "track", trackId: "b-1", container: "album", albumId: "album-b" },
+    position: pointerPosition(),
+    albums,
+    looseTrackIds: ["loose-1", "loose-2"],
+    dragStartY: 100,
+    recentLooseTarget: null,
+    now: 1_000,
+    ...overrides,
+  });
+
+describe("sidebar drag controller", () => {
+  it("reorders albums by the album containing the drop target", () => {
+    expect(
+      resolve({
+        active: { type: "album", albumId: "album-a" },
+        over: { type: "track", trackId: "b-1", container: "album", albumId: "album-b" },
+      }),
+    ).toEqual({ type: "reorder-album", albumId: "album-a", targetIndex: 1 });
+  });
+
+  it("places pointer-driven cross-album moves relative to the target midpoint", () => {
+    expect(
+      resolve({
+        dragStartY: 90,
+        position: pointerPosition({ deltaY: 35 }),
+      }),
+    ).toEqual({
+      type: "move-track-to-album",
+      trackId: "a-1",
+      albumId: "album-b",
+      placement: "after",
+      referenceTrackId: "b-1",
+    });
+  });
+
+  it("uses list order for keyboard reordering", () => {
+    expect(
+      resolve({
+        active: { type: "track", trackId: "loose-2", container: "loose" },
+        over: { type: "track", trackId: "loose-1", container: "loose" },
+        dragStartY: null,
+      }),
+    ).toEqual({
+      type: "move-track-to-loose",
+      trackId: "loose-2",
+      placement: "before",
+      referenceTrackId: "loose-1",
+    });
+  });
+
+  it("turns a centered loose-track drop into the create-album gesture", () => {
+    expect(
+      resolve({
+        active: { type: "track", trackId: "loose-1", container: "loose" },
+        over: { type: "track", trackId: "loose-2", container: "loose" },
+        dragStartY: 100,
+        position: pointerPosition({ overRect: { top: 50, height: 100 } }),
+      }),
+    ).toEqual({
+      type: "create-album-from-loose-tracks",
+      sourceTrackId: "loose-1",
+      targetTrackId: "loose-2",
+    });
+  });
+
+  it("preserves a recently crossed loose target when collision falls back to its container", () => {
+    expect(
+      resolve({
+        active: { type: "track", trackId: "loose-1", container: "loose" },
+        over: { type: "container", container: "loose" },
+        position: pointerPosition({ overId: LOOSE_CONTAINER_ID }),
+        recentLooseTarget: { trackId: "loose-2", expiresAt: 1_001 },
+      }),
+    ).toEqual({
+      type: "create-album-from-loose-tracks",
+      sourceTrackId: "loose-1",
+      targetTrackId: "loose-2",
+    });
+  });
+
+  it("expires the recent loose target and treats the append zone as an ordinary move", () => {
+    expect(
+      resolve({
+        active: { type: "track", trackId: "loose-1", container: "loose" },
+        over: { type: "container", container: "loose" },
+        position: pointerPosition({ overId: LOOSE_APPEND_CONTAINER_ID }),
+        recentLooseTarget: { trackId: "loose-2", expiresAt: 2_000 },
+      }),
+    ).toEqual({
+      type: "move-track-to-loose",
+      trackId: "loose-1",
+      placement: "append",
+    });
+
+    expect(
+      resolve({
+        active: { type: "track", trackId: "loose-1", container: "loose" },
+        over: { type: "container", container: "loose" },
+        position: pointerPosition({ overId: LOOSE_CONTAINER_ID }),
+        recentLooseTarget: { trackId: "loose-2", expiresAt: 1_000 },
+      }),
+    ).toEqual({
+      type: "move-track-to-loose",
+      trackId: "loose-1",
+      placement: "append",
+    });
+  });
+
+  it("appends tracks dropped on an album card or empty album container", () => {
+    expect(resolve({ over: { type: "album", albumId: "album-b" } })).toEqual({
+      type: "move-track-to-album",
+      trackId: "a-1",
+      albumId: "album-b",
+      placement: "append",
+    });
+
+    expect(
+      resolve({ over: { type: "container", container: "album", albumId: "album-b" } }),
+    ).toEqual({
+      type: "move-track-to-album",
+      trackId: "a-1",
+      albumId: "album-b",
+      placement: "append",
+    });
+  });
+});

--- a/components/audio/sidebarDragController.ts
+++ b/components/audio/sidebarDragController.ts
@@ -1,0 +1,161 @@
+import type { UniqueIdentifier } from "@dnd-kit/core";
+import { albumIdFromDrop, LOOSE_APPEND_CONTAINER_ID } from "./sidebarDnd";
+import type { SidebarDragData, SidebarDropData } from "./sidebarDnd";
+import type { AlbumGroup } from "./types";
+
+export type TrackPlacement = "before" | "after" | "append";
+
+export type SidebarDragCommand =
+  | { type: "reorder-album"; albumId: string; targetIndex: number }
+  | {
+      type: "move-track-to-album";
+      trackId: string;
+      albumId: string;
+      placement: TrackPlacement;
+      referenceTrackId?: string;
+    }
+  | {
+      type: "move-track-to-loose";
+      trackId: string;
+      placement: TrackPlacement;
+      referenceTrackId?: string;
+    }
+  | { type: "create-album-from-loose-tracks"; sourceTrackId: string; targetTrackId: string };
+
+export interface SidebarDropPosition {
+  deltaY: number;
+  overId: UniqueIdentifier;
+  overRect: { top: number; height: number } | null;
+}
+
+export interface RecentLooseTarget {
+  trackId: string;
+  expiresAt: number;
+}
+
+interface ResolveSidebarDragCommandOptions {
+  active: SidebarDragData;
+  over: SidebarDropData;
+  position: SidebarDropPosition;
+  albums: Pick<AlbumGroup, "id" | "trackIds">[];
+  looseTrackIds: string[];
+  dragStartY: number | null;
+  recentLooseTarget: RecentLooseTarget | null;
+  now: number;
+}
+
+const rowPlacement = (
+  position: SidebarDropPosition,
+  sourceTrackId: string,
+  targetTrackId: string,
+  trackIds: string[],
+  initialY: number | null,
+): Exclude<TrackPlacement, "append"> => {
+  if (!position.overRect) return "after";
+  if (initialY === null) {
+    const sourceIndex = trackIds.indexOf(sourceTrackId);
+    const targetIndex = trackIds.indexOf(targetTrackId);
+    if (sourceIndex >= 0 && targetIndex >= 0 && sourceIndex > targetIndex) return "before";
+    if (sourceIndex < 0) return "before";
+    return "after";
+  }
+
+  const y = initialY + position.deltaY;
+  return y > position.overRect.top + position.overRect.height / 2 ? "after" : "before";
+};
+
+const isCenteredLooseDrop = (position: SidebarDropPosition, initialY: number | null) => {
+  if (!position.overRect || initialY === null) return false;
+  const y = initialY + position.deltaY;
+  const relativePosition = (y - position.overRect.top) / position.overRect.height;
+  return relativePosition > 0.3 && relativePosition < 0.7;
+};
+
+const trackIdsForDrop = (
+  drop: Extract<SidebarDropData, { type: "track" }>,
+  albums: Pick<AlbumGroup, "id" | "trackIds">[],
+  looseTrackIds: string[],
+) => {
+  if (drop.container === "loose") return looseTrackIds;
+  return albums.find((album) => album.id === drop.albumId)?.trackIds ?? [];
+};
+
+export const resolveSidebarDragCommand = ({
+  active,
+  over,
+  position,
+  albums,
+  looseTrackIds,
+  dragStartY,
+  recentLooseTarget,
+  now,
+}: ResolveSidebarDragCommandOptions): SidebarDragCommand | null => {
+  if (active.type === "album") {
+    const targetAlbumId = albumIdFromDrop(over);
+    if (!targetAlbumId || targetAlbumId === active.albumId) return null;
+
+    const sourceIndex = albums.findIndex((album) => album.id === active.albumId);
+    const targetIndex = albums.findIndex((album) => album.id === targetAlbumId);
+    if (sourceIndex < 0 || targetIndex < 0) return null;
+    return { type: "reorder-album", albumId: active.albumId, targetIndex };
+  }
+
+  if (over.type === "track") {
+    if (over.trackId === active.trackId) return null;
+
+    const placement = rowPlacement(
+      position,
+      active.trackId,
+      over.trackId,
+      trackIdsForDrop(over, albums, looseTrackIds),
+      dragStartY,
+    );
+    if (over.container === "loose") {
+      if (active.container === "loose" && isCenteredLooseDrop(position, dragStartY)) {
+        return {
+          type: "create-album-from-loose-tracks",
+          sourceTrackId: active.trackId,
+          targetTrackId: over.trackId,
+        };
+      }
+      return {
+        type: "move-track-to-loose",
+        trackId: active.trackId,
+        placement,
+        referenceTrackId: over.trackId,
+      };
+    }
+
+    return {
+      type: "move-track-to-album",
+      trackId: active.trackId,
+      albumId: over.albumId,
+      placement,
+      referenceTrackId: over.trackId,
+    };
+  }
+
+  if (over.type === "album" || (over.type === "container" && over.container === "album")) {
+    return {
+      type: "move-track-to-album",
+      trackId: active.trackId,
+      albumId: over.albumId,
+      placement: "append",
+    };
+  }
+
+  if (
+    active.container === "loose" &&
+    position.overId !== LOOSE_APPEND_CONTAINER_ID &&
+    recentLooseTarget &&
+    recentLooseTarget.expiresAt > now
+  ) {
+    return {
+      type: "create-album-from-loose-tracks",
+      sourceTrackId: active.trackId,
+      targetTrackId: recentLooseTarget.trackId,
+    };
+  }
+
+  return { type: "move-track-to-loose", trackId: active.trackId, placement: "append" };
+};

--- a/components/audio/trackMetadataEditor.test.tsx
+++ b/components/audio/trackMetadataEditor.test.tsx
@@ -1,0 +1,104 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { TooltipProvider } from "../ui/tooltip";
+import TrackMetadataEditor from "./TrackMetadataEditor";
+import type { AudioMetadata, TagiumFile } from "./types";
+
+const metadata: AudioMetadata = {
+  filename: "",
+  title: "",
+  artist: "",
+  album: "",
+  year: null,
+  genre: "",
+  duration: 125,
+  bitrate: 320,
+  sampleRate: 44_100,
+  picture: [],
+  trackNumber: null,
+};
+
+const loadedTrack: TagiumFile = {
+  id: "track-1",
+  filename: "track-1.mp3",
+  status: "saved",
+  downloadStatus: "ready",
+  metadata,
+};
+
+function EditorHarness({
+  selectedFile = loadedTrack,
+  syncFilenames = true,
+}: {
+  selectedFile?: TagiumFile | null;
+  syncFilenames?: boolean;
+}) {
+  const { register, control, handleSubmit } = useForm<AudioMetadata>({
+    defaultValues: metadata,
+  });
+
+  return (
+    <TooltipProvider>
+      <TrackMetadataEditor
+        selectedFile={selectedFile}
+        selectedFileId={selectedFile?.id ?? null}
+        register={register}
+        control={control}
+        handleSubmit={handleSubmit}
+        onTrackCoverUpload={vi.fn()}
+        onTrackCoverProcessingChange={vi.fn()}
+        isTrackCoverProcessing={false}
+        onDownloadUpdatedFile={vi.fn()}
+        selectedFileAlbum={undefined}
+        syncFilenames={syncFilenames}
+        syncTrackNumbers
+        onPreviewMetadataChange={vi.fn()}
+      />
+    </TooltipProvider>
+  );
+}
+
+describe("track metadata editor form seam", () => {
+  it("routes an unavailable track to the empty editor state", () => {
+    const markup = renderToStaticMarkup(<EditorHarness selectedFile={null} />);
+
+    expect(markup).toContain("select a track to edit its tags");
+    expect(markup).not.toContain('id="track-title"');
+  });
+
+  it("associates every metadata label with its input", () => {
+    const markup = renderToStaticMarkup(<EditorHarness />);
+
+    for (const id of [
+      "track-title",
+      "track-artist",
+      "track-album",
+      "track-year",
+      "track-genre",
+      "track-number",
+    ]) {
+      expect(markup).toContain(`for="${id}"`);
+      expect(markup).toContain(`id="${id}"`);
+    }
+  });
+
+  it("describes a synced filename error from the title field", () => {
+    const markup = renderToStaticMarkup(<EditorHarness />);
+
+    expect(markup).toContain('id="track-filename-error"');
+    expect(markup).toContain("filename is required");
+    expect(markup).toMatch(
+      /id="track-title"[^>]*aria-invalid="true"[^>]*aria-describedby="track-filename-error"/,
+    );
+  });
+
+  it("describes an independent filename error from the filename input", () => {
+    const markup = renderToStaticMarkup(<EditorHarness syncFilenames={false} />);
+
+    expect(markup).toMatch(
+      /aria-label="filename"[^>]*aria-invalid="true"[^>]*aria-describedby="track-filename-error"/,
+    );
+    expect(markup).not.toMatch(/id="track-title"[^>]*aria-describedby=/);
+  });
+});

--- a/components/audio/useAlbumSidebarDragController.ts
+++ b/components/audio/useAlbumSidebarDragController.ts
@@ -1,0 +1,178 @@
+"use client";
+
+import type { DragEvent as ReactDragEvent } from "react";
+import { useRef, useState } from "react";
+import {
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import {
+  resolveSidebarDragCommand,
+  type RecentLooseTarget,
+  type SidebarDragCommand,
+  type TrackPlacement,
+} from "./sidebarDragController";
+import { sidebarCollisionDetection } from "./sidebarDnd";
+import type { SidebarDragData, SidebarDropData } from "./sidebarDnd";
+import type { AlbumGroup } from "./types";
+
+interface AlbumSidebarDragActions {
+  onMoveTrackToAlbum: (
+    trackId: string,
+    targetAlbumId: string,
+    placement: TrackPlacement,
+    referenceTrackId?: string,
+  ) => void;
+  onMoveTrackToLoose: (
+    trackId: string,
+    placement: TrackPlacement,
+    referenceTrackId?: string,
+  ) => void;
+  onPromptCreateAlbumFromLooseTracks: (sourceTrackId: string, targetTrackId: string) => void;
+  onReorderAlbums: (albumId: string, targetIndex: number) => void;
+  onAudioUpload: (files: File[]) => void;
+  onUploadToAlbum: (albumId: string, files: File[]) => void;
+}
+
+interface UseAlbumSidebarDragControllerOptions extends AlbumSidebarDragActions {
+  albums: AlbumGroup[];
+  looseTrackIds: string[];
+}
+
+const dragStartY = (event: Event) => {
+  const sourceEvent = event as Event & {
+    changedTouches?: TouchList;
+    clientY?: number;
+    touches?: TouchList;
+  };
+  if (sourceEvent.clientY !== undefined) return sourceEvent.clientY;
+  if (sourceEvent.touches?.[0]) return sourceEvent.touches[0].clientY;
+  if (sourceEvent.changedTouches?.[0]) return sourceEvent.changedTouches[0].clientY;
+  return null;
+};
+
+const isFileDrag = (event: ReactDragEvent) => event.dataTransfer.types.includes("Files");
+
+const acceptFileDrag = (event: ReactDragEvent, nested: boolean) => {
+  if (!isFileDrag(event)) return;
+  event.preventDefault();
+  if (nested) event.stopPropagation();
+  event.dataTransfer.dropEffect = "copy";
+};
+
+const acceptFileDrop = (event: ReactDragEvent, onUpload: (files: File[]) => void) => {
+  const files = Array.from(event.dataTransfer.files);
+  if (files.length === 0) return;
+  event.preventDefault();
+  event.stopPropagation();
+  onUpload(files);
+};
+
+const runCommand = (command: SidebarDragCommand | null, actions: AlbumSidebarDragActions) => {
+  if (!command) return;
+  switch (command.type) {
+    case "reorder-album":
+      actions.onReorderAlbums(command.albumId, command.targetIndex);
+      break;
+    case "move-track-to-album":
+      actions.onMoveTrackToAlbum(
+        command.trackId,
+        command.albumId,
+        command.placement,
+        command.referenceTrackId,
+      );
+      break;
+    case "move-track-to-loose":
+      actions.onMoveTrackToLoose(command.trackId, command.placement, command.referenceTrackId);
+      break;
+    case "create-album-from-loose-tracks":
+      actions.onPromptCreateAlbumFromLooseTracks(command.sourceTrackId, command.targetTrackId);
+      break;
+  }
+};
+
+export function useAlbumSidebarDragController(options: UseAlbumSidebarDragControllerOptions) {
+  const [activeDrag, setActiveDrag] = useState<SidebarDragData | null>(null);
+  const dragStartYRef = useRef<number | null>(null);
+  const recentLooseTargetRef = useRef<RecentLooseTarget | null>(null);
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const resetDrag = () => {
+    dragStartYRef.current = null;
+    recentLooseTargetRef.current = null;
+    setActiveDrag(null);
+  };
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveDrag((event.active.data.current as SidebarDragData | undefined) ?? null);
+    recentLooseTargetRef.current = null;
+    dragStartYRef.current = dragStartY(event.activatorEvent);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    const active = event.active.data.current as SidebarDragData | undefined;
+    const over = event.over?.data.current as SidebarDropData | undefined;
+    if (active?.type !== "track" || active.container !== "loose") return;
+    if (over?.type !== "track" || over.container !== "loose") return;
+    if (over.trackId === active.trackId) return;
+    recentLooseTargetRef.current = { trackId: over.trackId, expiresAt: Date.now() + 700 };
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const active = event.active.data.current as SidebarDragData | undefined;
+    const over = event.over?.data.current as SidebarDropData | undefined;
+    if (active && over && event.over) {
+      runCommand(
+        resolveSidebarDragCommand({
+          active,
+          over,
+          albums: options.albums,
+          looseTrackIds: options.looseTrackIds,
+          dragStartY: dragStartYRef.current,
+          recentLooseTarget: recentLooseTargetRef.current,
+          now: Date.now(),
+          position: {
+            deltaY: event.delta.y,
+            overId: event.over.id,
+            overRect: event.over.rect,
+          },
+        }),
+        options,
+      );
+    }
+    resetDrag();
+  };
+
+  return {
+    activeDrag,
+    dndContextProps: {
+      sensors,
+      collisionDetection: sidebarCollisionDetection,
+      onDragStart: handleDragStart,
+      onDragOver: handleDragOver,
+      onDragCancel: resetDrag,
+      onDragEnd: handleDragEnd,
+    },
+    libraryFileDropProps: {
+      onDragOver: (event: ReactDragEvent<HTMLDivElement>) => acceptFileDrag(event, false),
+      onDrop: (event: ReactDragEvent<HTMLDivElement>) =>
+        acceptFileDrop(event, options.onAudioUpload),
+    },
+    albumFileDropProps: (albumId: string) => ({
+      onFileDragOver: (event: ReactDragEvent<HTMLDivElement>) => acceptFileDrag(event, true),
+      onFileDrop: (event: ReactDragEvent<HTMLDivElement>) =>
+        acceptFileDrop(event, (files) => options.onUploadToAlbum(albumId, files)),
+    }),
+  };
+}


### PR DESCRIPTION
## Summary

- extract AlbumSidebar drag lifecycle into a tested controller
- preserve mouse, touch, keyboard, cross-container, and native-file drop behavior
- split TrackMetadataEditor into cohesive private sections without prop pass-through modules

## Why

Both components mixed unrelated interaction and rendering concerns. The new seams keep the composition roots readable while preserving existing interfaces and exact form/accessibility behavior.

## Verification

- 328 tests
- controller and editor parity tests
- typecheck and lint
- React Doctor: both giant-component findings removed

