### PR TITLE
refactor: model album dialog state with a reducer

### DIFF
--- a/components/audio/albumDialogState.test.ts
+++ b/components/audio/albumDialogState.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  albumDialogReducer,
+  createAlbumDialogState,
+  createOpenAlbumDialogAction,
+  getAlbumDialogSubmission,
+  type AlbumDialogAction,
+  type AlbumDialogState,
+} from "./albumDialogState";
+import type { AlbumGroup, AudioMetadata, TagiumFile } from "./types";
+
+const picture = [
+  {
+    format: "image/jpeg",
+    data: new Uint8Array([1, 2, 3]),
+    type: 3,
+    description: "front cover",
+  },
+];
+
+const metadata = (overrides: Partial<AudioMetadata> = {}): AudioMetadata => ({
+  filename: "track",
+  title: "Track",
+  artist: "Seed Artist",
+  album: "",
+  genre: ["Ambient", "Electronic"],
+  year: 2025,
+  duration: 100,
+  bitrate: 320,
+  sampleRate: 44_100,
+  picture,
+  trackNumber: null,
+  ...overrides,
+});
+
+const file = (id: string, overrides: Partial<TagiumFile> = {}): TagiumFile => ({
+  id,
+  filename: `${id}.mp3`,
+  status: "saved",
+  downloadStatus: "ready",
+  metadata: metadata(),
+  ...overrides,
+});
+
+const album = (overrides: Partial<AlbumGroup> = {}): AlbumGroup => ({
+  id: "album-1",
+  title: "Existing Album",
+  artist: "Existing Artist",
+  genre: "Rock",
+  cover: picture,
+  year: 1999,
+  trackIds: ["one", "two"],
+  ...overrides,
+});
+
+const reduce = (actions: AlbumDialogAction[]) =>
+  actions.reduce<AlbumDialogState>(albumDialogReducer, createAlbumDialogState());
+
+describe("albumDialogReducer", () => {
+  it("opens an empty create dialog with a fresh placeholder seed", () => {
+    const action = createOpenAlbumDialogAction([], [], "generated-seed");
+    const state = albumDialogReducer(createAlbumDialogState(), action);
+
+    expect(state).toEqual({
+      open: true,
+      mode: "create",
+      draft: { title: "", artist: "", genre: "", cover: undefined, year: undefined },
+      placeholderSeed: "generated-seed",
+      editingAlbumId: null,
+      createSeedTrackIds: [],
+    });
+  });
+
+  it("deduplicates ordered create seeds and derives the draft and placeholder from the first", () => {
+    const files = [file("one"), file("two", { metadata: metadata({ artist: "Second" }) })];
+    const action = createOpenAlbumDialogAction(["one", "two", "one"], files, "unused");
+    const state = albumDialogReducer(createAlbumDialogState(), action);
+
+    expect(state.createSeedTrackIds).toEqual(["one", "two"]);
+    expect(state.placeholderSeed).toBe("one");
+    expect(state.draft).toEqual({
+      title: "",
+      artist: "Seed Artist",
+      genre: "Ambient, Electronic",
+      cover: picture,
+      year: 2025,
+    });
+  });
+
+  it("keeps seed membership but uses a blank draft when the first seed no longer exists", () => {
+    const state = albumDialogReducer(
+      createAlbumDialogState(),
+      createOpenAlbumDialogAction(["missing"], [file("other")], "unused"),
+    );
+
+    expect(state.createSeedTrackIds).toEqual(["missing"]);
+    expect(state.placeholderSeed).toBe("missing");
+    expect(state.draft).toEqual({
+      title: "",
+      artist: "",
+      genre: "",
+      cover: undefined,
+      year: undefined,
+    });
+  });
+
+  it("opens edit mode atomically and clears stale create seeds", () => {
+    const state = reduce([
+      createOpenAlbumDialogAction(["one"], [file("one")], "unused"),
+      { type: "edit-opened", album: album() },
+    ]);
+
+    expect(state).toEqual({
+      open: true,
+      mode: "edit",
+      draft: {
+        title: "Existing Album",
+        artist: "Existing Artist",
+        genre: "Rock",
+        cover: picture,
+        year: 1999,
+      },
+      placeholderSeed: "album-1",
+      editingAlbumId: "album-1",
+      createSeedTrackIds: [],
+    });
+  });
+
+  it("applies replacement and functional draft updates to the latest draft", () => {
+    const replacement = { title: "First", artist: "Artist", genre: "Jazz" };
+    const state = reduce([
+      { type: "edit-opened", album: album() },
+      { type: "draft-changed", update: replacement },
+      {
+        type: "draft-changed",
+        update: (draft) => ({ ...draft, artist: "Latest Artist", year: 2026 }),
+      },
+    ]);
+
+    expect(state.draft).toEqual({
+      title: "First",
+      artist: "Latest Artist",
+      genre: "Jazz",
+      year: 2026,
+    });
+  });
+
+  for (const finishType of ["closed", "saved", "deleted"] as const) {
+    it(`resets every dialog field when the dialog is ${finishType}`, () => {
+      const state = reduce([{ type: "edit-opened", album: album() }, { type: finishType }]);
+
+      expect(state).toEqual(createAlbumDialogState());
+      expect(state.draft).not.toBe(createAlbumDialogState().draft);
+    });
+  }
+});
+
+describe("getAlbumDialogSubmission", () => {
+  it("captures create seeds and trims submitted metadata", () => {
+    const state = reduce([
+      createOpenAlbumDialogAction(["one", "two"], [file("one"), file("two")], "unused"),
+      {
+        type: "draft-changed",
+        update: { title: "  New Album  ", artist: "  Artist  ", genre: "  Pop  ", year: 2026 },
+      },
+    ]);
+
+    expect(getAlbumDialogSubmission(state)).toEqual({
+      mode: "create",
+      seedTrackIds: ["one", "two"],
+      metadata: {
+        title: "New Album",
+        artist: "Artist",
+        genre: "Pop",
+        cover: undefined,
+        year: 2026,
+      },
+    });
+  });
+
+  it("captures the editing album and preserves its existing cover", () => {
+    const state = reduce([{ type: "edit-opened", album: album() }]);
+
+    expect(getAlbumDialogSubmission(state)).toEqual({
+      mode: "edit",
+      albumId: "album-1",
+      metadata: {
+        title: "Existing Album",
+        artist: "Existing Artist",
+        genre: "Rock",
+        cover: picture,
+        year: 1999,
+      },
+    });
+  });
+
+  it("does not submit closed state and retains the untitled fallback", () => {
+    expect(getAlbumDialogSubmission(createAlbumDialogState())).toBeNull();
+
+    const open = reduce([
+      createOpenAlbumDialogAction([], [], "placeholder"),
+      { type: "draft-changed", update: { title: "  ", artist: "Artist", genre: "" } },
+    ]);
+    expect(getAlbumDialogSubmission(open)?.metadata.title).toBe("untitled album");
+  });
+});

--- a/components/audio/albumDialogState.ts
+++ b/components/audio/albumDialogState.ts
@@ -1,0 +1,136 @@
+import type { SetStateAction } from "react";
+import type { AlbumMetadataDraft } from "./AlbumMetadataDialog";
+import { toGenreString } from "./mp3Utils";
+import type { AlbumGroup, TagiumFile } from "./types";
+
+export type AlbumDialogMode = "create" | "edit";
+
+export interface AlbumDialogState {
+  open: boolean;
+  mode: AlbumDialogMode;
+  draft: AlbumMetadataDraft;
+  placeholderSeed: string;
+  editingAlbumId: string | null;
+  createSeedTrackIds: string[];
+}
+
+export type AlbumDialogAction =
+  | {
+      type: "create-opened";
+      seedTrackIds: string[];
+      seedTrack?: TagiumFile;
+      placeholderSeed: string;
+    }
+  | { type: "edit-opened"; album: AlbumGroup }
+  | { type: "draft-changed"; update: SetStateAction<AlbumMetadataDraft> }
+  | { type: "closed" | "saved" | "deleted" };
+
+export type AlbumDialogSubmission =
+  | {
+      mode: "create";
+      seedTrackIds: string[];
+      metadata: Omit<AlbumGroup, "id" | "trackIds">;
+    }
+  | {
+      mode: "edit";
+      albumId: string;
+      metadata: Omit<AlbumGroup, "id" | "trackIds">;
+    };
+
+const emptyDraft = (): AlbumMetadataDraft => ({
+  title: "",
+  artist: "",
+  genre: "",
+  year: undefined,
+  cover: undefined,
+});
+
+export const createAlbumDialogState = (): AlbumDialogState => ({
+  open: false,
+  mode: "create",
+  draft: emptyDraft(),
+  placeholderSeed: "new-album",
+  editingAlbumId: null,
+  createSeedTrackIds: [],
+});
+
+export const createOpenAlbumDialogAction = (
+  seedTrackIds: string[],
+  files: TagiumFile[],
+  fallbackPlaceholderSeed: string,
+): AlbumDialogAction => {
+  const uniqueSeedTrackIds = [...new Set(seedTrackIds)];
+  const seedTrack = files.find((file) => file.id === uniqueSeedTrackIds[0]);
+  return {
+    type: "create-opened",
+    seedTrackIds: uniqueSeedTrackIds,
+    seedTrack,
+    placeholderSeed: uniqueSeedTrackIds[0] ?? fallbackPlaceholderSeed,
+  };
+};
+
+export const albumDialogReducer = (
+  state: AlbumDialogState,
+  action: AlbumDialogAction,
+): AlbumDialogState => {
+  switch (action.type) {
+    case "create-opened": {
+      const hasSeeds = action.seedTrackIds.length > 0;
+      const metadata = action.seedTrack?.metadata;
+      return {
+        open: true,
+        mode: "create",
+        draft: {
+          title: "",
+          artist: hasSeeds ? metadata?.artist || "" : "",
+          genre: hasSeeds ? toGenreString(metadata?.genre) : "",
+          cover: hasSeeds && metadata?.picture?.length ? metadata.picture : undefined,
+          year: hasSeeds ? (metadata?.year ?? undefined) : undefined,
+        },
+        placeholderSeed: action.placeholderSeed,
+        editingAlbumId: null,
+        createSeedTrackIds: action.seedTrackIds,
+      };
+    }
+    case "edit-opened":
+      return {
+        open: true,
+        mode: "edit",
+        draft: {
+          title: action.album.title,
+          artist: action.album.artist,
+          genre: action.album.genre,
+          cover: action.album.cover,
+          year: action.album.year,
+        },
+        placeholderSeed: action.album.id,
+        editingAlbumId: action.album.id,
+        createSeedTrackIds: [],
+      };
+    case "draft-changed":
+      return {
+        ...state,
+        draft: typeof action.update === "function" ? action.update(state.draft) : action.update,
+      };
+    case "closed":
+    case "saved":
+    case "deleted":
+      return createAlbumDialogState();
+  }
+};
+
+export const getAlbumDialogSubmission = (state: AlbumDialogState): AlbumDialogSubmission | null => {
+  if (!state.open) return null;
+
+  const metadata = {
+    title: state.draft.title.trim() || "untitled album",
+    artist: state.draft.artist.trim(),
+    genre: state.draft.genre.trim(),
+    cover: state.draft.cover,
+    year: state.draft.year,
+  };
+  if (state.mode === "edit") {
+    return state.editingAlbumId ? { mode: "edit", albumId: state.editingAlbumId, metadata } : null;
+  }
+  return { mode: "create", seedTrackIds: state.createSeedTrackIds, metadata };
+};

--- a/components/audio/albumMetadataDialog.test.tsx
+++ b/components/audio/albumMetadataDialog.test.tsx
@@ -165,4 +165,86 @@ describe("album metadata validation layout", () => {
       cover,
     });
   });
+
+  it("renders create placeholders and submits a valid create draft", () => {
+    const hooks = createHookHarness();
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+    const tree = hooks.render(() =>
+      AlbumMetadataDialog({
+        open: true,
+        mode: "create",
+        draft: { title: "New Album", artist: "Artist", genre: "" },
+        trackCount: 0,
+        onChange: vi.fn(),
+        onClose,
+        onSave,
+        placeholder: {
+          title: "Placeholder Album",
+          artist: "Placeholder Artist",
+          genre: "Placeholder Genre",
+          year: "2026",
+        },
+      }),
+    );
+
+    expect(
+      findElement(tree, (element) => element.props.id === "album-title").props.placeholder,
+    ).toBe("Placeholder Album");
+    expect(
+      findElement(tree, (element) => element.props.id === "album-artist").props.placeholder,
+    ).toBe("Placeholder Artist");
+    expect(textContent(tree)).toContain("create album");
+
+    const form = findElement(tree, (element) => element.type === "form");
+    (form.props.onSubmit as (event: { preventDefault: () => void }) => void)({
+      preventDefault: vi.fn(),
+    });
+    expect(onSave).toHaveBeenCalledOnce();
+
+    const cancel = findElement(
+      tree,
+      (element) => textContent(element) === "cancel" && typeof element.props.onClick === "function",
+    );
+    (cancel.props.onClick as () => void)();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("confirms deletion only in edit mode", () => {
+    const hooks = createHookHarness();
+    const onDelete = vi.fn();
+    const render = () =>
+      hooks.render(() =>
+        AlbumMetadataDialog({
+          open: true,
+          mode: "edit",
+          draft: { title: "Existing Album", artist: "Artist", genre: "Rock" },
+          trackCount: 2,
+          onChange: vi.fn(),
+          onClose: vi.fn(),
+          onSave: vi.fn(),
+          onDelete,
+          placeholder: { title: "Album", artist: "Artist", genre: "Genre", year: "2026" },
+        }),
+      );
+
+    let tree = render();
+    expect(textContent(tree)).toContain("edit album");
+    const requestDelete = findElement(
+      tree,
+      (element) =>
+        textContent(element) === "delete album" && typeof element.props.onClick === "function",
+    );
+    (requestDelete.props.onClick as () => void)();
+
+    tree = render();
+    expect(textContent(tree)).toContain("delete album and all 2 tracks?");
+    const confirmDelete = findElement(
+      tree,
+      (element) => textContent(element) === "delete" && typeof element.props.onClick === "function",
+    );
+    (confirmDelete.props.onClick as () => void)();
+
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
 });

--- a/components/audio/audioTagger.tsx
+++ b/components/audio/audioTagger.tsx
@@ -14,7 +14,7 @@ import { SubmitHandler, useForm } from "react-hook-form";
 import filenamify from "filenamify";
 import { toast } from "sonner";
 import { analytics } from "@/src/analytics";
-import AlbumMetadataDialog, { AlbumMetadataDraft } from "./AlbumMetadataDialog";
+import AlbumMetadataDialog from "./AlbumMetadataDialog";
 import DestructiveActionDialog from "./DestructiveActionDialog";
 import {
   downloadFromCobalt,
@@ -75,11 +75,7 @@ import {
   undoMetadataCleanupSuggestions,
   type MetadataCleanupSuggestion,
 } from "./metadataCleanup";
-import {
-  sortTrackIdsByTrackNumber,
-  sortUploadedTracksByTrackNumber,
-  toGenreString,
-} from "./mp3Utils";
+import { sortTrackIdsByTrackNumber, sortUploadedTracksByTrackNumber } from "./mp3Utils";
 import {
   createDirtyMetadataPatch,
   getAcceptedUploadParseResult,
@@ -104,6 +100,12 @@ import { isValidFilenameBase } from "./filename";
 import { writeExportMetadata } from "./exportMetadataWrites";
 import { createLibraryState, libraryReducer, type LibraryAction } from "./libraryState";
 import {
+  albumDialogReducer,
+  createAlbumDialogState,
+  createOpenAlbumDialogAction,
+  getAlbumDialogSubmission,
+} from "./albumDialogState";
+import {
   subscribeToEditorKeyboardShortcuts,
   type EditorKeyboardShortcutActions,
 } from "./editorKeyboardShortcuts";
@@ -120,13 +122,6 @@ type ActiveView = "editor" | "settings";
 type ManagedDownloadTrack = QueuedDownloadTrack & { importOperationId?: string };
 type PlaylistDownloadQueueState = PlaylistDownloadControllerSnapshot;
 
-const EMPTY_ALBUM_DRAFT: AlbumMetadataDraft = {
-  title: "",
-  artist: "",
-  genre: "",
-  year: undefined,
-  cover: undefined,
-};
 const asUniqueTrackIds = (trackIds: string[]) => [...new Set(trackIds)];
 const getManagedDownloadTrackTitle = (file: TagiumFile) => {
   if (file.metadata?.title) return file.metadata.title;
@@ -219,14 +214,13 @@ export default function AudioTagger() {
   } = library;
   const [loading, setLoading] = useState(false);
   const [urlImporting, setUrlImporting] = useState(false);
-  const [albumDialogOpen, setAlbumDialogOpen] = useState(false);
-  const [albumDialogMode, setAlbumDialogMode] = useState<"create" | "edit">("create");
+  const [albumDialog, dispatchAlbumDialog] = useReducer(
+    albumDialogReducer,
+    undefined,
+    createAlbumDialogState,
+  );
   const [pendingTrackRemoval, setPendingTrackRemoval] = useState<string[] | null>(null);
   const [isTrackCoverProcessing, setIsTrackCoverProcessing] = useState(false);
-  const [albumDraft, setAlbumDraft] = useState<AlbumMetadataDraft>(EMPTY_ALBUM_DRAFT);
-  const [albumPlaceholderSeed, setAlbumPlaceholderSeed] = useState("new-album");
-  const [editingAlbumId, setEditingAlbumId] = useState<string | null>(null);
-  const [createSeedTrackIds, setCreateSeedTrackIds] = useState<string[]>([]);
   const [activeView, setActiveView] = useState<ActiveView>("editor");
   const [settings, setSettings] = useState<AppSettings>(loadAppSettings);
   const [metadataCleanupSuggestions, setMetadataCleanupSuggestions] = useState<
@@ -1314,9 +1308,6 @@ export default function AudioTagger() {
     if (!albumToRemove) return;
     playlistDownloadControllerRef.current?.remove(albumToRemove.trackIds);
     dispatchLibrary({ type: "album-removed", albumId });
-    if (editingAlbumId === albumId) {
-      closeAlbumDialog();
-    }
   };
   const handleSelectAlbum = (albumId: string, event?: ReactMouseEvent) => {
     if (isTrackCoverProcessing) return;
@@ -1412,25 +1403,13 @@ export default function AudioTagger() {
   );
 
   const openCreateAlbumDialog = (seedTrackIds: string[]) => {
-    const uniqueSeedTrackIds = asUniqueTrackIds(seedTrackIds);
-    const seedTrack = filesRef.current.find((file) => file.id === uniqueSeedTrackIds[0]);
-    setAlbumDialogMode("create");
-    setEditingAlbumId(null);
-    setCreateSeedTrackIds(uniqueSeedTrackIds);
-    setAlbumPlaceholderSeed(uniqueSeedTrackIds[0] ?? crypto.randomUUID());
-    setAlbumDraft({
-      title: "",
-      artist: uniqueSeedTrackIds.length > 0 ? seedTrack?.metadata?.artist || "" : "",
-      genre: uniqueSeedTrackIds.length > 0 ? toGenreString(seedTrack?.metadata?.genre) : "",
-      cover:
-        uniqueSeedTrackIds.length > 0 &&
-        seedTrack?.metadata?.picture &&
-        seedTrack.metadata.picture.length > 0
-          ? seedTrack.metadata.picture
-          : undefined,
-      year: uniqueSeedTrackIds.length > 0 ? (seedTrack?.metadata?.year ?? undefined) : undefined,
-    });
-    setAlbumDialogOpen(true);
+    dispatchAlbumDialog(
+      createOpenAlbumDialogAction(
+        seedTrackIds,
+        filesRef.current,
+        seedTrackIds[0] ?? crypto.randomUUID(),
+      ),
+    );
   };
   const handleOpenCreateAlbumDialog = () => {
     bufferCurrentFormMetadata();
@@ -1447,34 +1426,29 @@ export default function AudioTagger() {
   const handleOpenEditAlbumDialog = (albumId: string) => {
     const album = albums.find((entry) => entry.id === albumId);
     if (!album) return;
-    setAlbumDialogMode("edit");
-    setEditingAlbumId(albumId);
-    setAlbumPlaceholderSeed(albumId);
-    setCreateSeedTrackIds([]);
-    setAlbumDraft({
-      title: album.title,
-      artist: album.artist,
-      genre: album.genre,
-      cover: album.cover,
-      year: album.year,
-    });
-    setAlbumDialogOpen(true);
+    dispatchAlbumDialog({ type: "edit-opened", album });
   };
   const closeAlbumDialog = () => {
-    setAlbumDialogOpen(false);
+    dispatchAlbumDialog({ type: "closed" });
+  };
+  const deleteEditingAlbum = () => {
+    if (!albumDialog.editingAlbumId) return;
+    handleRemoveAlbum(albumDialog.editingAlbumId);
+    dispatchAlbumDialog({ type: "deleted" });
   };
   const syncAlbumDraftCoverToTracks = () => {
-    if (albumDialogMode !== "edit" || !editingAlbumId || !albumDraft.cover) return;
-    if (albumDraft.cover.length === 0) return;
+    if (albumDialog.mode !== "edit" || !albumDialog.editingAlbumId || !albumDialog.draft.cover)
+      return;
+    if (albumDialog.draft.cover.length === 0) return;
 
-    const album = albumsRef.current.find((entry) => entry.id === editingAlbumId);
+    const album = albumsRef.current.find((entry) => entry.id === albumDialog.editingAlbumId);
     if (!album) return;
 
     const bufferedFiles = applyCurrentFormMetadataToFiles(filesRef.current, album.trackIds);
     const covered = applyAlbumCoverToFilesWithSelectedMetadata(
       bufferedFiles,
       album.trackIds,
-      albumDraft.cover,
+      albumDialog.draft.cover,
       selectedFileIdRef.current,
     );
     const coveredFiles = covered.files;
@@ -1484,20 +1458,16 @@ export default function AudioTagger() {
     }
   };
   const saveAlbumDialog = () => {
-    const title = albumDraft.title.trim() || "untitled album";
-    const artist = albumDraft.artist.trim();
-    const genre = albumDraft.genre.trim();
-    const metadata = {
-      title,
-      artist,
-      genre,
-      cover: albumDraft.cover,
-      year: albumDraft.year,
-    };
-    if (albumDialogMode === "edit" && editingAlbumId) {
-      const currentAlbum = albumsRef.current.find((album) => album.id === editingAlbumId);
-      const updatedAlbums = updateAlbumMetadata(albumsRef.current, editingAlbumId, metadata);
-      const updatedAlbum = updatedAlbums.find((album) => album.id === editingAlbumId) ?? null;
+    const submission = getAlbumDialogSubmission(albumDialog);
+    if (!submission) return;
+    if (submission.mode === "edit") {
+      const currentAlbum = albumsRef.current.find((album) => album.id === submission.albumId);
+      const updatedAlbums = updateAlbumMetadata(
+        albumsRef.current,
+        submission.albumId,
+        submission.metadata,
+      );
+      const updatedAlbum = updatedAlbums.find((album) => album.id === submission.albumId) ?? null;
       let finalFiles = filesRef.current;
       if (updatedAlbum) {
         const bufferedFiles = applyCurrentFormMetadataToFiles(
@@ -1538,51 +1508,49 @@ export default function AudioTagger() {
         files: finalFiles,
         albums: updatedAlbums,
       });
-      closeAlbumDialog();
+      dispatchAlbumDialog({ type: "saved" });
       return;
     }
-    if (albumDialogMode === "create") {
-      const created = createAlbumFromTracks(
-        albumsRef.current,
-        libraryRef.current.looseTrackIds,
-        createSeedTrackIds,
-        metadata,
-        settings,
-      );
-      let finalFiles = filesRef.current;
-      if (created.syncAlbums.length > 0) {
-        finalFiles = applyTrackOrderNumbersToFiles(finalFiles, created.albums, created.syncAlbums);
-      }
-      if (created.newAlbumId) {
-        const createdAlbum = created.albums.find((album) => album.id === created.newAlbumId);
-        if (createdAlbum) {
-          const taggedFiles = applyAlbumSharedTagsToFiles(finalFiles, createdAlbum);
-          finalFiles = settings.syncFilenames
-            ? applySyncedFilenamesToFiles(taggedFiles, createdAlbum.trackIds)
-            : taggedFiles;
-          analytics.capture({
-            type: "album_created",
-            trackCount: createdAlbum.trackIds.length,
-            hasCover: Boolean(createdAlbum.cover?.length),
-          });
-        }
-      }
-      dispatchLibrary({
-        type: "content-replaced",
-        files: finalFiles,
-        albums: created.albums,
-        looseTrackIds: created.looseTrackIds,
-        ...(created.newAlbumId
-          ? {
-              selection: {
-                selectedAlbumId: created.newAlbumId,
-                selectedFileId: createSeedTrackIds[0] ?? null,
-              },
-            }
-          : {}),
-      });
+    const created = createAlbumFromTracks(
+      albumsRef.current,
+      libraryRef.current.looseTrackIds,
+      submission.seedTrackIds,
+      submission.metadata,
+      settings,
+    );
+    let finalFiles = filesRef.current;
+    if (created.syncAlbums.length > 0) {
+      finalFiles = applyTrackOrderNumbersToFiles(finalFiles, created.albums, created.syncAlbums);
     }
-    closeAlbumDialog();
+    if (created.newAlbumId) {
+      const createdAlbum = created.albums.find((album) => album.id === created.newAlbumId);
+      if (createdAlbum) {
+        const taggedFiles = applyAlbumSharedTagsToFiles(finalFiles, createdAlbum);
+        finalFiles = settings.syncFilenames
+          ? applySyncedFilenamesToFiles(taggedFiles, createdAlbum.trackIds)
+          : taggedFiles;
+        analytics.capture({
+          type: "album_created",
+          trackCount: createdAlbum.trackIds.length,
+          hasCover: Boolean(createdAlbum.cover?.length),
+        });
+      }
+    }
+    dispatchLibrary({
+      type: "content-replaced",
+      files: finalFiles,
+      albums: created.albums,
+      looseTrackIds: created.looseTrackIds,
+      ...(created.newAlbumId
+        ? {
+            selection: {
+              selectedAlbumId: created.newAlbumId,
+              selectedFileId: submission.seedTrackIds[0] ?? null,
+            },
+          }
+        : {}),
+    });
+    dispatchAlbumDialog({ type: "saved" });
   };
   const handleMoveTrackToAlbum = (
     trackId: string,
@@ -1779,26 +1747,21 @@ export default function AudioTagger() {
         }}
       />
       <AlbumMetadataDialog
-        open={albumDialogOpen}
-        mode={albumDialogMode}
-        draft={albumDraft}
-        placeholder={getSampleAlbum(albumPlaceholderSeed)}
+        open={albumDialog.open}
+        mode={albumDialog.mode}
+        draft={albumDialog.draft}
+        placeholder={getSampleAlbum(albumDialog.placeholderSeed)}
         trackCount={
-          albumDialogMode === "edit" && editingAlbumId
-            ? (albums.find((a) => a.id === editingAlbumId)?.trackIds.length ?? 0)
+          albumDialog.mode === "edit" && albumDialog.editingAlbumId
+            ? (albums.find((a) => a.id === albumDialog.editingAlbumId)?.trackIds.length ?? 0)
             : 0
         }
-        onChange={setAlbumDraft}
+        onChange={(update) => dispatchAlbumDialog({ type: "draft-changed", update })}
         onClose={closeAlbumDialog}
         onSave={saveAlbumDialog}
         onSyncCoverToTracks={syncAlbumDraftCoverToTracks}
         onDelete={
-          albumDialogMode === "edit" && editingAlbumId
-            ? () => {
-                handleRemoveAlbum(editingAlbumId);
-                closeAlbumDialog();
-              }
-            : undefined
+          albumDialog.mode === "edit" && albumDialog.editingAlbumId ? deleteEditingAlbum : undefined
         }
       />
       <div className="min-h-svh flex flex-col bg-background md:h-svh md:flex-row md:overflow-hidden">


### PR DESCRIPTION
## Summary

- model album dialog create/edit state with a focused reducer
- make open, draft, seed, placeholder, save, delete, and reset transitions atomic
- preserve seeded cover metadata and delete confirmation behavior

## Why

Six related state values and a handler-only seed list changed together but were managed independently. A reducer now owns the dialog transaction as one coherent state machine.

## Verification

- 359 tests, including 16 focused dialog tests
- typecheck and lint
- React Doctor: the final two state findings removed

