### PR TITLE
fix: restore track selection transitions

### DIFF
--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -33,6 +33,7 @@ interface AlbumSidebarProps {
   onSelectAlbum: (albumId: string, event?: ReactMouseEvent) => void;
   onSelectFile: (albumId: string, fileId: string, event?: ReactMouseEvent) => void;
   onSelectLooseTrack: (fileId: string, event?: ReactMouseEvent) => void;
+  onClearSelection: () => void;
   onRemoveFile: (fileId: string) => void;
   onRetryDownload: (fileId: string) => void;
   onAddAlbum: () => void;
@@ -71,6 +72,7 @@ export default function AlbumSidebar({
   onSelectAlbum,
   onSelectFile,
   onSelectLooseTrack,
+  onClearSelection,
   onRemoveFile,
   onRetryDownload,
   onAddAlbum,
@@ -111,7 +113,7 @@ export default function AlbumSidebar({
   };
 
   if (albums.length === 0 && looseTracks.length === 0) {
-    return <AlbumSidebarEmptyState onAddAlbum={onAddAlbum} />;
+    return <AlbumSidebarEmptyState onAddAlbum={onAddAlbum} onClearSelection={onClearSelection} />;
   }
 
   return (
@@ -226,7 +228,15 @@ export default function AlbumSidebar({
             id={LOOSE_APPEND_CONTAINER_ID}
             data={{ type: "container", container: "loose" }}
             className="flex-1 min-h-16"
-          />
+          >
+            <button
+              type="button"
+              tabIndex={-1}
+              aria-label="clear track selection and return to editor"
+              className="min-h-16 flex-1 cursor-default"
+              onClick={onClearSelection}
+            />
+          </DroppableTrackContainer>
         </div>
         <DragOverlay dropAnimation={null}>
           {activeDrag ? (

--- a/components/audio/AlbumSidebarEmptyState.tsx
+++ b/components/audio/AlbumSidebarEmptyState.tsx
@@ -3,15 +3,36 @@
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-export function AlbumSidebarEmptyState({ onAddAlbum }: { onAddAlbum: () => void }) {
+export function AlbumSidebarEmptyState({
+  onAddAlbum,
+  onClearSelection,
+}: {
+  onAddAlbum: () => void;
+  onClearSelection: () => void;
+}) {
   return (
-    <div className="w-full flex-1 min-h-0 flex flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground px-4">
-      <p>no tracks yet</p>
-      <p className="text-xs">create an empty album or upload tracks</p>
-      <Button type="button" variant="outline" size="sm" onClick={onAddAlbum}>
-        <Plus className="h-4 w-4" />
-        add album
-      </Button>
+    <div className="relative w-full flex-1 min-h-0">
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-label="clear track selection and return to editor"
+        className="absolute inset-0 cursor-default"
+        onClick={onClearSelection}
+      />
+      <div className="pointer-events-none relative flex h-full flex-col items-center justify-center gap-3 px-4 text-center text-sm text-muted-foreground">
+        <p>no tracks yet</p>
+        <p className="text-xs">create an empty album or upload tracks</p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="pointer-events-auto"
+          onClick={onAddAlbum}
+        >
+          <Plus className="h-4 w-4" />
+          add album
+        </Button>
+      </div>
     </div>
   );
 }

--- a/components/audio/TagSidebarPanel.tsx
+++ b/components/audio/TagSidebarPanel.tsx
@@ -27,6 +27,7 @@ export interface TagSidebarPanelProps {
   onSelectAlbum: (albumId: string, event?: ReactMouseEvent) => void;
   onSelectFile: (albumId: string, fileId: string, event?: ReactMouseEvent) => void;
   onSelectLooseTrack: (fileId: string, event?: ReactMouseEvent) => void;
+  onClearSelection: () => void;
   onRemoveFile: (fileId: string) => void;
   onRetryDownload: (fileId: string) => void;
   onAddAlbum: () => void;
@@ -69,6 +70,7 @@ export default function TagSidebarPanel({
   onSelectAlbum,
   onSelectFile,
   onSelectLooseTrack,
+  onClearSelection,
   onRemoveFile,
   onRetryDownload,
   onAddAlbum,
@@ -163,6 +165,7 @@ export default function TagSidebarPanel({
         onSelectAlbum={onSelectAlbum}
         onSelectFile={onSelectFile}
         onSelectLooseTrack={onSelectLooseTrack}
+        onClearSelection={onClearSelection}
         onRemoveFile={onRemoveFile}
         onRetryDownload={onRetryDownload}
         onAddAlbum={onAddAlbum}

--- a/components/audio/TrackMetadataEditor.tsx
+++ b/components/audio/TrackMetadataEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useRef } from "react";
-import type { ChangeEvent, ReactNode, RefObject } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ChangeEvent, ReactNode, RefObject, TransitionEvent } from "react";
 import {
   Controller,
   useWatch,
@@ -459,22 +459,76 @@ function LoadedTrackMetadataEditor({
 
 export default function TrackMetadataEditor(props: TrackMetadataEditorProps) {
   const focusedTitleFileIdRef = useRef<string | null>(null);
+  const selectedFile = hasMetadata(props.selectedFile) ? props.selectedFile : null;
+  const currentSelection = selectedFile
+    ? { selectedFile, selectedFileAlbum: props.selectedFileAlbum }
+    : null;
+  const [retainedSelection, setRetainedSelection] = useState(currentSelection);
+  if (
+    currentSelection &&
+    (retainedSelection?.selectedFile !== currentSelection.selectedFile ||
+      retainedSelection.selectedFileAlbum !== currentSelection.selectedFileAlbum)
+  ) {
+    setRetainedSelection(currentSelection);
+  }
+  const displayedSelection = currentSelection ?? retainedSelection;
+  const trackIsSelected = currentSelection !== null;
+  useEffect(() => {
+    if (trackIsSelected || !retainedSelection) return;
 
-  if (!hasMetadata(props.selectedFile)) {
-    return (
-      <div className="flex-1 flex items-center justify-center bg-muted/5">
+    const reduceMotion =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    const timeoutId = globalThis.setTimeout(
+      () => setRetainedSelection(null),
+      reduceMotion ? 0 : 250,
+    );
+    return () => globalThis.clearTimeout(timeoutId);
+  }, [retainedSelection, trackIsSelected]);
+
+  const releaseExitedSelection = (event: TransitionEvent<HTMLDivElement>) => {
+    if (
+      !trackIsSelected &&
+      event.target === event.currentTarget &&
+      event.propertyName === "opacity"
+    ) {
+      setRetainedSelection(null);
+    }
+  };
+
+  return (
+    <div className="relative min-h-0 flex-1">
+      <div
+        data-editor-state="empty-selection"
+        aria-hidden={trackIsSelected}
+        inert={trackIsSelected}
+        className={`absolute inset-0 flex items-center justify-center bg-muted/5 transition-opacity duration-200 motion-reduce:transition-none ${
+          trackIsSelected ? "pointer-events-none opacity-0" : "opacity-100"
+        }`}
+      >
         <div className="text-center">
           <p className="text-muted-foreground">select a track to edit its tags</p>
         </div>
       </div>
-    );
-  }
-
-  return (
-    <LoadedTrackMetadataEditor
-      {...props}
-      selectedFile={props.selectedFile}
-      focusedTitleFileIdRef={focusedTitleFileIdRef}
-    />
+      <div
+        data-editor-state="loaded-track"
+        aria-hidden={!trackIsSelected}
+        inert={!trackIsSelected}
+        onTransitionEnd={releaseExitedSelection}
+        className={`absolute inset-0 flex min-h-0 flex-col transition-opacity duration-200 motion-reduce:transition-none ${
+          trackIsSelected ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+      >
+        {displayedSelection ? (
+          <LoadedTrackMetadataEditor
+            {...props}
+            selectedFile={displayedSelection.selectedFile}
+            selectedFileId={displayedSelection.selectedFile.id}
+            selectedFileAlbum={displayedSelection.selectedFileAlbum}
+            focusedTitleFileIdRef={focusedTitleFileIdRef}
+          />
+        ) : null}
+      </div>
+    </div>
   );
 }

--- a/components/audio/useAudioWorkspace.test.tsx
+++ b/components/audio/useAudioWorkspace.test.tsx
@@ -145,6 +145,13 @@ describe("audio workspace", () => {
     );
     expect(hook.result.settings.syncFilenames).toBe(true);
 
+    act(() => hook.result.workspace.sidebarProps.onClearSelection());
+    expect(hook.result.activeView).toBe("editor");
+    expect(hook.result.library.getSnapshot()).toMatchObject({
+      selectedAlbumId: null,
+      selectedFileId: null,
+    });
+
     act(() => {
       window.dispatchEvent(keyboardEvent("a", true));
     });

--- a/components/audio/useAudioWorkspace.ts
+++ b/components/audio/useAudioWorkspace.ts
@@ -25,6 +25,7 @@ type WorkspaceSidebarProps = Pick<
   | "onSelectAlbum"
   | "onSelectFile"
   | "onSelectLooseTrack"
+  | "onClearSelection"
   | "onRemoveFile"
   | "onAddAlbum"
   | "onEditAlbum"

--- a/components/audio/useWorkspaceSelection.ts
+++ b/components/audio/useWorkspaceSelection.ts
@@ -24,6 +24,7 @@ type SelectionSidebarProps = Pick<
   | "onSelectAlbum"
   | "onSelectFile"
   | "onSelectLooseTrack"
+  | "onClearSelection"
   | "onRemoveFile"
   | "onMoveTrackToAlbum"
   | "onMoveTrackToLoose"
@@ -213,6 +214,7 @@ export const useWorkspaceSelection = ({
       },
     },
     sidebarProps: {
+      onClearSelection: clearSelection,
       onSelectAlbum: (albumId, event) => {
         if (editorRef.current.isCoverProcessing) return;
         setActiveView("editor");

--- a/e2e/settings-transition.spec.ts
+++ b/e2e/settings-transition.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 import { Buffer } from "node:buffer";
 
 const uploadTrack = async (page: Page) => {
@@ -14,6 +14,87 @@ const uploadTrack = async (page: Page) => {
   });
   await expect(page.getByRole("button", { name: "remove track" })).toBeAttached();
 };
+
+const getPopulatedTrackList = (page: Page) => {
+  const libraryHeader = page.getByText("library (1)", { exact: true });
+  return libraryHeader.locator("..").locator("xpath=following-sibling::div[1]");
+};
+
+const clickBlankTrackList = async (page: Page) => {
+  const trackList = getPopulatedTrackList(page);
+  await expect(trackList).toBeVisible();
+
+  const bounds = await trackList.boundingBox();
+  if (!bounds) throw new Error("populated track list bounds were not found");
+
+  await trackList.click({
+    position: { x: bounds.width / 2, y: bounds.height - 8 },
+  });
+};
+
+const sampleEditorCrossfade = async (activationTarget?: unknown) => {
+  interface BrowserElement {
+    click: () => void;
+    parentElement: BrowserElement | null;
+  }
+  const browser = globalThis as unknown as {
+    document: { querySelector: (selector: string) => BrowserElement | null };
+    getComputedStyle: (element: BrowserElement) => { opacity: string };
+    performance: { now: () => number };
+    requestAnimationFrame: (callback: () => void) => number;
+  };
+  const effectiveOpacity = (element: BrowserElement) => {
+    let opacity = 1;
+    let current: BrowserElement | null = element;
+    while (current) {
+      opacity *= Number.parseFloat(browser.getComputedStyle(current).opacity);
+      current = current.parentElement;
+    }
+    return opacity;
+  };
+  const samples: Array<{
+    emptySelectionOpacity: number | null;
+    trackEditorOpacity: number | null;
+  }> = [];
+  const target = activationTarget as BrowserElement | undefined;
+  const startedAt = browser.performance.now();
+  target?.click();
+
+  await new Promise<void>((resolve) => {
+    const sample = () => {
+      const emptySelection = browser.document.querySelector(
+        '[data-editor-state="empty-selection"]',
+      );
+      const trackEditor = browser.document.querySelector('[data-editor-state="loaded-track"]');
+      samples.push({
+        emptySelectionOpacity: emptySelection ? effectiveOpacity(emptySelection) : null,
+        trackEditorOpacity: trackEditor ? effectiveOpacity(trackEditor) : null,
+      });
+      if (browser.performance.now() - startedAt >= 180) {
+        resolve();
+        return;
+      }
+      browser.requestAnimationFrame(sample);
+    };
+    browser.requestAnimationFrame(sample);
+  });
+
+  return samples;
+};
+
+const captureEditorCrossfade = (activationTarget: Locator) =>
+  activationTarget.evaluate(sampleEditorCrossfade);
+
+const includesCrossfadeMidpoint = (samples: Awaited<ReturnType<typeof captureEditorCrossfade>>) =>
+  samples.some(
+    ({ emptySelectionOpacity, trackEditorOpacity }) =>
+      emptySelectionOpacity !== null &&
+      emptySelectionOpacity > 0 &&
+      emptySelectionOpacity < 1 &&
+      trackEditorOpacity !== null &&
+      trackEditorOpacity > 0 &&
+      trackEditorOpacity < 1,
+  );
 
 test("keeps the media entry within its return transition endpoints", async ({ page }) => {
   await page.goto("/");
@@ -102,4 +183,83 @@ test("crossfades the metadata editor and settings without unmounting either pane
 
   await expect(editor).toHaveCSS("opacity", "0");
   await expect(settings).toHaveCSS("opacity", "1");
+});
+
+test("clicking blank space in the empty library closes settings", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "settings" }).click();
+  await expect(page.getByRole("button", { name: "back to editor" })).toBeVisible();
+
+  await page.getByRole("button", { name: "clear track selection and return to editor" }).click();
+
+  await expect(page.getByRole("button", { name: "back to editor" })).not.toBeAttached();
+  await expect(page.getByRole("button", { name: /drop your mp3s here/ })).toBeVisible();
+});
+
+test("clicking blank space in a populated track list closes settings and clears the track", async ({
+  page,
+}) => {
+  await uploadTrack(page);
+
+  const editor = page.locator('[data-view="metadata-editor"]');
+  const settings = page.locator('[data-view="settings"]');
+  await page.getByRole("button", { name: "settings" }).click();
+  await expect(settings).toHaveAttribute("aria-hidden", "false");
+
+  await clickBlankTrackList(page);
+
+  await expect(settings).toHaveAttribute("aria-hidden", "true");
+  await expect(editor).toHaveAttribute("aria-hidden", "false");
+  await expect(page.getByText("select a track to edit its tags", { exact: true })).toBeVisible();
+});
+
+test("crossfades between the empty selection and track editor in both directions", async ({
+  page,
+}) => {
+  await uploadTrack(page);
+  await page.getByRole("button", { name: "settings" }).focus();
+  await page.keyboard.press("Escape");
+  await expect(page.getByText("select a track to edit its tags", { exact: true })).toBeVisible();
+  await expect(page.locator('[data-editor-state="empty-selection"]')).toHaveCSS("opacity", "1");
+
+  const selectingTrack = await captureEditorCrossfade(
+    getPopulatedTrackList(page).getByRole("button").first(),
+  );
+  expect.soft(includesCrossfadeMidpoint(selectingTrack)).toBe(true);
+  await expect(page.getByRole("button", { name: "download track" })).toBeVisible();
+  await expect(page.locator('[data-editor-state="loaded-track"]')).toHaveCSS("opacity", "1");
+
+  const clearingTrack = await captureEditorCrossfade(
+    page.getByRole("button", { name: "clear track selection and return to editor" }),
+  );
+  expect.soft(includesCrossfadeMidpoint(clearingTrack)).toBe(true);
+  await expect(page.getByText("select a track to edit its tags", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "download track" })).not.toBeAttached();
+});
+
+test("keeps the loaded editor when a track is reselected during its exit", async ({ page }) => {
+  await uploadTrack(page);
+
+  await page.getByRole("button", { name: "clear track selection and return to editor" }).click();
+  await page.waitForTimeout(50);
+  await getPopulatedTrackList(page).getByRole("button").first().click();
+  await page.waitForTimeout(300);
+
+  await expect(page.locator('[data-editor-state="loaded-track"]')).toHaveAttribute(
+    "aria-hidden",
+    "false",
+  );
+  await expect(page.getByRole("button", { name: "download track" })).toBeVisible();
+});
+
+test("releases the loaded editor immediately when reduced motion is preferred", async ({
+  page,
+}) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await uploadTrack(page);
+
+  await page.getByRole("button", { name: "clear track selection and return to editor" }).click();
+
+  await expect(page.locator('[data-editor-state="empty-selection"]')).toHaveCSS("opacity", "1");
+  await expect(page.getByRole("button", { name: "download track" })).not.toBeAttached();
 });


### PR DESCRIPTION
## Summary

- restore click-to-clear behavior for the empty sidebar and the blank portion of a populated track list
- close settings and clear the selected track through the existing guarded workspace action
- crossfade the empty-selection prompt and loaded track editor in both directions
- dispose the retained editor after its exit transition, including reduced-motion and rapid-reselection handling

## Accessibility

Blank regions use dedicated semantic button surfaces without nesting interactive controls. The transition layers use aria-hidden, inert, pointer-event isolation, and reduced-motion support.

## Verification

- 376 unit tests
- 21 focused Playwright tests across Chromium, Firefox, and WebKit
- typecheck and lint (0 warnings, 0 errors)
- production build
- React Doctor 0.7.8 suppression audit: 100/100, no issues
- independent implementation review and lifecycle re-review