### PR TITLE
feat: clean album titles from track names

### DIFF
--- a/components/audio/metadataCleanup.test.ts
+++ b/components/audio/metadataCleanup.test.ts
@@ -5,7 +5,7 @@ import {
   suggestTitleCleanup,
   undoMetadataCleanupSuggestions,
 } from "./metadataCleanup";
-import type { AudioMetadata, TagiumFile } from "./types";
+import type { AlbumGroup, AudioMetadata, TagiumFile } from "./types";
 
 const metadata = (title: string, artist = "Burial"): AudioMetadata => ({
   filename: title,
@@ -29,6 +29,14 @@ const file = (title: string): TagiumFile => ({
   metadata: metadata(title),
 });
 
+const album = (title: string, trackId = "track-1"): AlbumGroup => ({
+  id: "album-1",
+  title,
+  artist: "Burial",
+  genre: "Electronic",
+  trackIds: [trackId],
+});
+
 describe("metadata cleanup suggestions", () => {
   it("removes a matching artist prefix and known trailing video label", () => {
     expect(suggestTitleCleanup("Burial - Archangel (Official Audio)", ["Burial"])).toEqual({
@@ -40,6 +48,56 @@ describe("metadata cleanup suggestions", () => {
   it("keeps ambiguous labels and non-matching artist prefixes unchanged", () => {
     expect(suggestTitleCleanup("Audio", ["Burial"])).toBeNull();
     expect(suggestTitleCleanup("Four Tet - Audio (Live)", ["Burial"])).toBeNull();
+  });
+
+  it.each([
+    "Good Girls (XCX WORLD)",
+    "Good Girls [XCX WORLD]",
+    "Good Girls - XCX WORLD",
+    "Good Girls – XCX WORLD",
+    "Good Girls — XCX WORLD",
+  ])("removes a trailing album title from %s", (title) => {
+    expect(suggestTitleCleanup(title, [], "XCX WORLD")).toEqual({
+      afterTitle: "Good Girls",
+      reasons: ["album"],
+    });
+  });
+
+  it("matches album titles using NFKC, case, and whitespace normalization", () => {
+    expect(suggestTitleCleanup("Good Girls (ｘｃｘ   ｗｏｒｌｄ)", [], "XCX WORLD")).toEqual({
+      afterTitle: "Good Girls",
+      reasons: ["album"],
+    });
+  });
+
+  it("does not remove a title that only consists of the album title", () => {
+    expect(suggestTitleCleanup("THIS IS FOR", [], "THIS IS FOR")).toBeNull();
+  });
+
+  it("keeps tight dashes, missing album context, and non-matching suffixes unchanged", () => {
+    expect(suggestTitleCleanup("Good Girls-XCX WORLD", [], "XCX WORLD")).toBeNull();
+    expect(suggestTitleCleanup("Good Girls -XCX WORLD", [], "XCX WORLD")).toBeNull();
+    expect(suggestTitleCleanup("Good Girls- XCX WORLD", [], "XCX WORLD")).toBeNull();
+    expect(suggestTitleCleanup("Good Girls - XCX WORLD", [])).toBeNull();
+    expect(suggestTitleCleanup("Good Girls - BRAT", [], "XCX WORLD")).toBeNull();
+  });
+
+  it.each([
+    "Good Girls (XCX WORLD) (Official Audio)",
+    "Good Girls (Official Audio) (XCX WORLD)",
+    "Good Girls - XCX WORLD (Official Audio)",
+    "Good Girls (Official Audio) - XCX WORLD",
+  ])("composes album cleanup with recognized labels in %s", (title) => {
+    expect(suggestTitleCleanup(title, [], "XCX WORLD")).toEqual({
+      afterTitle: "Good Girls",
+      reasons: ["album", "label"],
+    });
+  });
+
+  it("uses the containing album group's title", () => {
+    expect(
+      findMetadataCleanupSuggestions([file("Good Girls (XCX WORLD)")], [album("XCX WORLD")]),
+    ).toEqual([expect.objectContaining({ afterTitle: "Good Girls", reasons: ["album"] })]);
   });
 
   it("uses album artist metadata as a confident prefix match", () => {

--- a/components/audio/metadataCleanup.ts
+++ b/components/audio/metadataCleanup.ts
@@ -16,7 +16,7 @@ export interface MetadataCleanupSuggestion {
   afterTitle: string;
   beforeFilename: string;
   afterFilename: string;
-  reasons: ("artist" | "label" | "spacing")[];
+  reasons: ("artist" | "album" | "label" | "spacing")[];
 }
 
 export interface MetadataCleanupUndoEntry {
@@ -62,23 +62,60 @@ const removeMatchingArtistPrefix = (title: string, artists: string[]) => {
   return normalizedTitle.slice(normalizedPrefix.length).trim();
 };
 
-const removeTrailingLabels = (title: string) => {
+const removeTrailingNoise = (title: string, albumTitle?: string) => {
   let nextTitle = title.trim();
-  let removed = false;
+  let removedAlbum = false;
+  let removedLabel = false;
+  const comparableAlbum = albumTitle ? normalizeComparable(albumTitle) : "";
 
   while (true) {
-    const match = nextTitle.match(/\s*[([]([^\])]+)[\])]\s*$/);
-    if (!match || !removableLabels.includes(normalizeComparable(match[1]) as never)) break;
-    nextTitle = nextTitle.slice(0, match.index).trim();
-    removed = true;
+    const annotation = nextTitle.match(/\(([^()]*)\)\s*$/) ?? nextTitle.match(/\[([^\]]*)\]\s*$/);
+    const annotationValue = annotation?.[1];
+    const annotationRemainder = annotation ? nextTitle.slice(0, annotation.index).trim() : "";
+
+    if (
+      annotationValue !== undefined &&
+      annotationRemainder &&
+      comparableAlbum &&
+      normalizeComparable(annotationValue) === comparableAlbum
+    ) {
+      nextTitle = annotationRemainder;
+      removedAlbum = true;
+      continue;
+    }
+    if (
+      annotation &&
+      annotationValue !== undefined &&
+      annotationRemainder &&
+      removableLabels.includes(normalizeComparable(annotationValue) as never)
+    ) {
+      nextTitle = annotationRemainder;
+      removedLabel = true;
+      continue;
+    }
+
+    let albumRemainder = "";
+    if (comparableAlbum) {
+      for (const separator of nextTitle.matchAll(/\s+[-–—]\s+/g)) {
+        const suffix = nextTitle.slice(separator.index + separator[0].length);
+        if (normalizeComparable(suffix) === comparableAlbum) {
+          albumRemainder = nextTitle.slice(0, separator.index).trim();
+          break;
+        }
+      }
+    }
+    if (!albumRemainder) break;
+    nextTitle = albumRemainder;
+    removedAlbum = true;
   }
 
-  return { title: nextTitle, removed };
+  return { title: nextTitle, removedAlbum, removedLabel };
 };
 
 export function suggestTitleCleanup(
   title: string,
   artists: string[],
+  albumTitle?: string,
 ): Pick<MetadataCleanupSuggestion, "afterTitle" | "reasons"> | null {
   const trimmedTitle = title.trim();
   if (!trimmedTitle) return null;
@@ -87,9 +124,10 @@ export function suggestTitleCleanup(
   let nextTitle = removeMatchingArtistPrefix(trimmedTitle, artists);
   if (nextTitle !== trimmedTitle) reasons.push("artist");
 
-  const withoutLabels = removeTrailingLabels(nextTitle);
-  if (withoutLabels.removed) reasons.push("label");
-  nextTitle = withoutLabels.title;
+  const withoutNoise = removeTrailingNoise(nextTitle, albumTitle);
+  if (withoutNoise.removedAlbum) reasons.push("album");
+  if (withoutNoise.removedLabel) reasons.push("label");
+  nextTitle = withoutNoise.title;
 
   const normalizedSpacing = nextTitle.replace(/\s+/g, " ").trim();
   if (normalizedSpacing !== nextTitle) reasons.push("spacing");
@@ -108,8 +146,12 @@ export function findMetadataCleanupSuggestions(
     if (candidateTrackIds && !candidateTrackIds.has(file.id)) return [];
     if (!file.metadata) return [];
 
-    const albumArtist = albums.find((album) => album.trackIds.includes(file.id))?.artist ?? "";
-    const cleanup = suggestTitleCleanup(file.metadata.title, [file.metadata.artist, albumArtist]);
+    const album = albums.find((candidate) => candidate.trackIds.includes(file.id));
+    const cleanup = suggestTitleCleanup(
+      file.metadata.title,
+      [file.metadata.artist, album?.artist ?? ""],
+      album?.title,
+    );
     if (!cleanup) return [];
 
     return [


### PR DESCRIPTION
## Summary

- remove redundant album-title suffixes from track titles
- support parenthesized, bracketed, hyphen, en dash, and em dash forms
- preserve title tracks and compose cleanup with existing media-label rules

## User impact

Tracks such as `Good Girls (XCX WORLD)` and `Good Girls - XCX WORLD` are suggested as `Good Girls`, while a track named exactly `XCX WORLD` remains unchanged.

## Validation

- `bun run test` — 389 tests passed
- `bun run test -- components/audio/metadataCleanup.test.ts` — 21 tests passed
- `bun run typecheck`
- `bun run lint -- components/audio/metadataCleanup.ts components/audio/metadataCleanup.test.ts`
- `git diff --check`

## Preview

- [Cloudflare preview](https://8fdaf7d2-tagium.oliver-boorstein.workers.dev) — verified HTTP 200
- Worker version: `8fdaf7d2-c0a2-4b55-95da-5613bee0ebb1`