### PR TITLE
Fix missing cover art for SoundCloud playlists

### DIFF
--- a/server-tests/soundcloud-set.get.test.ts
+++ b/server-tests/soundcloud-set.get.test.ts
@@ -138,4 +138,48 @@ describe("soundcloud set endpoint", () => {
       ],
     });
   });
+
+  it("falls back to track artwork when the playlist artwork is null", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        let url = "";
+        if (input instanceof Request) {
+          url = input.url;
+        } else {
+          url = new URL(input).toString();
+        }
+
+        if (url === "https://soundcloud.com/") {
+          return new Response(
+            '<script>window.__sc_version="1234567890"</script>{"hydratable":"apiClient","data":{"id":"client-id"}}',
+          );
+        }
+
+        expect(url).toContain("https://api-v2.soundcloud.com/resolve");
+
+        return Response.json({
+          kind: "playlist",
+          title: "XCX WORLD",
+          artwork_url: null,
+          user: {
+            username: "twvnkxcx",
+          },
+          tracks: [
+            {
+              id: 686556559,
+              kind: "track",
+              title: "Good Girls (XCX WORLD)",
+              permalink_url: "https://soundcloud.com/siafan/good-girls-xcx-world",
+              artwork_url: "https://i1.sndcdn.com/artworks-000603058507-5buc5j-large.jpg",
+            },
+          ],
+        });
+      }),
+    );
+
+    await expect(handler(makeEvent())).resolves.toMatchObject({
+      coverUrl: "https://i1.sndcdn.com/artworks-000603058507-5buc5j-t1080x1080.jpg",
+    });
+  });
 });

--- a/server/api/soundcloud-set.get.ts
+++ b/server/api/soundcloud-set.get.ts
@@ -15,6 +15,7 @@ const soundCloudTrackSchema = Schema.Struct({
   title: Schema.optionalKey(Schema.String),
   permalink_url: Schema.optionalKey(urlStringSchema),
   duration: Schema.optionalKey(Schema.Finite),
+  artwork_url: Schema.optionalKey(Schema.NullOr(urlStringSchema)),
 });
 const decodeSoundCloudTrackOption = Schema.decodeUnknownOption(soundCloudTrackSchema);
 
@@ -40,6 +41,7 @@ const soundCloudResolvedTrackSchema = Schema.Struct({
   title: Schema.String,
   permalink_url: urlStringSchema,
   duration: Schema.optionalKey(Schema.Finite),
+  artwork_url: Schema.optionalKey(Schema.NullOr(urlStringSchema)),
 });
 
 const getCoverUrl = (artworkUrl: string | null | undefined) => {
@@ -126,6 +128,7 @@ export default defineHandler(async (event) => {
   if (isAlbum && playlist.release_date) {
     yearDate = playlist.release_date;
   }
+  const artworkUrl = playlist.artwork_url ?? tracks.find((track) => track.artwork_url)?.artwork_url;
 
   return {
     title: playlist.title.trim(),
@@ -133,7 +136,7 @@ export default defineHandler(async (event) => {
     genre: playlist.genre?.trim() ?? "",
     year: getYear(yearDate),
     isAlbum,
-    coverUrl: getCoverUrl(playlist.artwork_url),
+    coverUrl: getCoverUrl(artworkUrl),
     tracks: tracks.map((track, index) => ({
       title: track.title.trim(),
       url: track.permalink_url,


### PR DESCRIPTION
## Summary

- preserve track artwork URLs while resolving SoundCloud sets
- use the first available track artwork when the playlist-level artwork is missing
- add a regression test based on the XCX WORLD playlist payload

## Why

Some SoundCloud playlists expose `artwork_url: null` at the playlist level while SoundCloud displays the first track's artwork as the set cover. Tagium only read the playlist-level field, so the imported album object had no cover.

This fallback only supplies the Tagium album cover. Existing playlist behavior remains unchanged: cover art is not applied to individual track metadata.

## Validation

- `bun run test server-tests/soundcloud-set.get.test.ts components/audio/soundcloudSet.test.ts`
- `bun run typecheck`
- `bun run lint`
- verified the exact XCX WORLD URL against SoundCloud