### PR TITLE
Fix dialog close transitions

### DIFF
--- a/components/audio/albumDialogState.test.ts
+++ b/components/audio/albumDialogState.test.ts
@@ -146,11 +146,11 @@ describe("albumDialogReducer", () => {
   });
 
   for (const finishType of ["closed", "saved", "deleted"] as const) {
-    it(`resets every dialog field when the dialog is ${finishType}`, () => {
-      const state = reduce([{ type: "edit-opened", album: album() }, { type: finishType }]);
+    it(`keeps edit content stable while the ${finishType} dialog exits`, () => {
+      const openState = reduce([{ type: "edit-opened", album: album() }]);
+      const state = albumDialogReducer(openState, { type: finishType });
 
-      expect(state).toEqual(createAlbumDialogState());
-      expect(state.draft).not.toBe(createAlbumDialogState().draft);
+      expect(state).toEqual({ ...openState, open: false });
     });
   }
 });

--- a/components/audio/albumDialogState.ts
+++ b/components/audio/albumDialogState.ts
@@ -115,7 +115,7 @@ export const albumDialogReducer = (
     case "closed":
     case "saved":
     case "deleted":
-      return createAlbumDialogState();
+      return { ...state, open: false };
   }
 };
 

--- a/components/audio/useAudioWorkspace.test.tsx
+++ b/components/audio/useAudioWorkspace.test.tsx
@@ -131,6 +131,9 @@ describe("audio workspace", () => {
 
     act(() => hook.result.workspace.sidebarProps.onRemoveFile(second.id));
     expect(hook.result.workspace.removalDialogProps).toMatchObject({ open: true, itemCount: 1 });
+    act(() => hook.result.workspace.removalDialogProps.onCancel());
+    expect(hook.result.workspace.removalDialogProps).toMatchObject({ open: false, itemCount: 1 });
+    act(() => hook.result.workspace.sidebarProps.onRemoveFile(second.id));
     act(() => hook.result.workspace.removalDialogProps.onConfirm());
     expect(removeDownloads).toHaveBeenCalledWith([second.id]);
     expect(hook.result.library.getSnapshot().files.map((file) => file.id)).toEqual([first.id]);

--- a/components/audio/useWorkspaceSelection.ts
+++ b/components/audio/useWorkspaceSelection.ts
@@ -47,7 +47,10 @@ export const useWorkspaceSelection = ({
   removalDialogProps: DestructiveActionDialogProps;
   sidebarProps: SelectionSidebarProps;
 } => {
-  const [pendingRemoval, setPendingRemoval] = useState<string[] | null>(null);
+  const [removalDialog, setRemovalDialog] = useState<{
+    open: boolean;
+    trackIds: string[];
+  }>({ open: false, trackIds: [] });
   const editorRef = useRef(editor);
   const settingsRef = useRef(settings);
   const removeDownloadsRef = useRef(removeDownloads);
@@ -104,7 +107,7 @@ export const useWorkspaceSelection = ({
   const requestRemoveSelected = useCallback(() => {
     const snapshot = library.getSnapshot();
     if (editorRef.current.isCoverProcessing || snapshot.selectedFileIds.size === 0) return;
-    setPendingRemoval(Array.from(snapshot.selectedFileIds));
+    setRemovalDialog({ open: true, trackIds: Array.from(snapshot.selectedFileIds) });
   }, [library]);
 
   const selectAll = useCallback(() => {
@@ -204,13 +207,13 @@ export const useWorkspaceSelection = ({
 
   return {
     removalDialogProps: {
-      open: pendingRemoval !== null,
-      itemCount: pendingRemoval?.length ?? 0,
-      onCancel: () => setPendingRemoval(null),
+      open: removalDialog.open,
+      itemCount: removalDialog.trackIds.length,
+      onCancel: () => setRemovalDialog((current) => ({ ...current, open: false })),
       onConfirm: () => {
-        const trackIds = pendingRemoval;
-        setPendingRemoval(null);
-        if (trackIds) removeFiles(trackIds);
+        const trackIds = removalDialog.trackIds;
+        setRemovalDialog((current) => ({ ...current, open: false }));
+        removeFiles(trackIds);
       },
     },
     sidebarProps: {
@@ -228,7 +231,9 @@ export const useWorkspaceSelection = ({
       onSelectFile: (albumId, fileId, event) => selectTrack(albumId, fileId, event),
       onSelectLooseTrack: (fileId, event) => selectTrack(null, fileId, event),
       onRemoveFile: (fileId) => {
-        if (!editorRef.current.isCoverProcessing) setPendingRemoval([fileId]);
+        if (!editorRef.current.isCoverProcessing) {
+          setRemovalDialog({ open: true, trackIds: [fileId] });
+        }
       },
       onMoveTrackToAlbum: (trackId, albumId, placement, referenceTrackId) =>
         moveTrack(trackId, { type: "album", albumId }, placement, referenceTrackId),


### PR DESCRIPTION
## What changed

- preserve album edit content while the album dialog closes
- preserve the selected track count while the remove-track dialog closes
- cover cancel, save, delete, and track-removal exit paths with regression tests
- keep subsequent dialog opens atomic, so retained exit content cannot leak into the next dialog

## Root cause

Both dialogs derived their visible content from state that was cleared in the same render used to close them. Radix keeps dialog content mounted during its exit animation, so:

- the album editor re-rendered as an empty create dialog
- the track-removal dialog re-rendered with an item count of zero

The close transitions now set visibility to false while preserving the current presentation state until the next open replaces it.

## Impact

Album and track-removal dialogs now retain accurate content throughout their exit animations instead of flashing reset values.

## Verification

- `bun run test` — 62 files, 376 tests passed
- `bun run typecheck`
- `bun run lint`
- `git diff --check`