### PR TITLE
Fix library drop spacing and download status cleanup

### DIFF
--- a/components/audio/AlbumSidebar.test.tsx
+++ b/components/audio/AlbumSidebar.test.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+import AlbumSidebar from "./AlbumSidebar";
+import { LOOSE_CONTAINER_ID } from "./sidebarDnd";
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  DragOverlay: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  verticalListSortingStrategy: "vertical-list",
+}));
+
+vi.mock("./AlbumSidebarDnd", () => ({
+  DroppableTrackContainer: ({
+    children,
+    className,
+    id,
+  }: {
+    children?: ReactNode;
+    className?: string;
+    id: string;
+  }) => (
+    <div data-drop-container={id} className={className}>
+      {children}
+    </div>
+  ),
+  SidebarDragPreview: () => null,
+  SortableAlbumCard: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SortableTrackRow: () => null,
+}));
+
+vi.mock("./useAlbumSidebarDragController", () => ({
+  useAlbumSidebarDragController: () => ({
+    activeDrag: { type: "track", trackId: "album-track", container: "album", albumId: "album-a" },
+    dndContextProps: {},
+    libraryFileDropProps: {},
+    albumFileDropProps: () => ({ onFileDragOver: () => {}, onFileDrop: () => {} }),
+  }),
+}));
+
+const noOp = () => {};
+
+describe("AlbumSidebar", () => {
+  it("does not add height to an empty loose area during a track drag", () => {
+    const markup = renderToStaticMarkup(
+      <AlbumSidebar
+        albums={[{ id: "album-a", title: "Album A", artist: "Artist", genre: "", trackIds: [] }]}
+        looseTrackIds={[]}
+        files={[]}
+        selectedAlbumId={null}
+        selectedFileId={null}
+        selectedFileIds={new Set()}
+        onSelectAlbum={noOp}
+        onSelectFile={noOp}
+        onSelectLooseTrack={noOp}
+        onClearSelection={noOp}
+        onRemoveFile={noOp}
+        onRetryDownload={noOp}
+        onAddAlbum={noOp}
+        onEditAlbum={noOp}
+        onDownloadAlbum={noOp}
+        onUploadToAlbum={noOp}
+        onMoveTrackToAlbum={noOp}
+        onMoveTrackToLoose={noOp}
+        onPromptCreateAlbumFromLooseTracks={noOp}
+        onReorderAlbums={noOp}
+        onAudioUpload={noOp}
+      />,
+    );
+
+    expect(markup).toContain(
+      `data-drop-container="${LOOSE_CONTAINER_ID}" class="min-h-0 shrink-0"`,
+    );
+    expect(markup).not.toContain("min-h-12");
+  });
+});

--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -142,7 +142,9 @@ export default function AlbumSidebar({
               className={
                 looseTracks.length === 0 && activeDrag?.type === "track"
                   ? "min-h-12 shrink-0"
-                  : "shrink-0"
+                  : looseTracks.length === 0
+                    ? "min-h-0 shrink-0"
+                    : "shrink-0"
               }
             >
               {looseTracks.map((track) => (

--- a/components/audio/AlbumSidebar.tsx
+++ b/components/audio/AlbumSidebar.tsx
@@ -139,13 +139,7 @@ export default function AlbumSidebar({
             <DroppableTrackContainer
               id={LOOSE_CONTAINER_ID}
               data={{ type: "container", container: "loose" }}
-              className={
-                looseTracks.length === 0 && activeDrag?.type === "track"
-                  ? "min-h-12 shrink-0"
-                  : looseTracks.length === 0
-                    ? "min-h-0 shrink-0"
-                    : "shrink-0"
-              }
+              className={looseTracks.length === 0 ? "min-h-0 shrink-0" : "shrink-0"}
             >
               {looseTracks.map((track) => (
                 <SortableTrackRow
@@ -193,6 +187,7 @@ export default function AlbumSidebar({
                     <DroppableTrackContainer
                       id={albumContainerId(album.id)}
                       data={{ type: "container", container: "album", albumId: album.id }}
+                      className="min-h-8"
                     >
                       {album.trackIds.length === 0 ? (
                         <div className="text-xs text-muted-foreground px-4 py-3 text-center">

--- a/components/audio/AlbumSidebarDnd.tsx
+++ b/components/audio/AlbumSidebarDnd.tsx
@@ -283,7 +283,7 @@ export function DroppableTrackContainer({
     <div
       ref={setNodeRef}
       className={cn(
-        "flex flex-col min-h-8 transition-shadow",
+        "flex flex-col transition-shadow",
         isOver ? "shadow-[inset_0_0_0_2px_var(--primary)]" : "",
         className,
       )}

--- a/components/audio/PlaylistDownloadQueuePanel.tsx
+++ b/components/audio/PlaylistDownloadQueuePanel.tsx
@@ -1,9 +1,15 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { RefreshCw, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-export type PlaylistDownloadQueueStatus = "downloading" | "waiting" | "error" | "canceled";
+export type PlaylistDownloadQueueStatus =
+  | "downloading"
+  | "waiting"
+  | "complete"
+  | "error"
+  | "canceled";
 
 export interface PlaylistDownloadQueueTrack {
   id: string;
@@ -11,6 +17,7 @@ export interface PlaylistDownloadQueueTrack {
 }
 
 export interface PlaylistDownloadQueuePanelState {
+  id: number;
   status: PlaylistDownloadQueueStatus;
   downloadedCount: number;
   totalCount: number;
@@ -34,7 +41,16 @@ export default function PlaylistDownloadQueuePanel({
   onCancel,
   onRetry,
 }: PlaylistDownloadQueuePanelProps) {
-  if (!queue) return null;
+  const [dismissedQueueId, setDismissedQueueId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!queue || queue.status !== "complete") return;
+
+    const timeout = window.setTimeout(() => setDismissedQueueId(queue.id), 10_000);
+    return () => window.clearTimeout(timeout);
+  }, [queue]);
+
+  if (!queue || dismissedQueueId === queue.id) return null;
 
   const progress = Math.min(100, Math.max(0, queue.progress));
   const shownTracks = queue.currentTracks.slice(0, 2);
@@ -47,6 +63,9 @@ export default function PlaylistDownloadQueuePanel({
   }
   if (queue.status === "canceled") {
     label = `canceled ${queue.canceledCount}/${queue.totalCount}`;
+  }
+  if (queue.status === "complete") {
+    label = `downloaded ${queue.downloadedCount}/${queue.totalCount}`;
   }
 
   return (
@@ -71,7 +90,7 @@ export default function PlaylistDownloadQueuePanel({
           )}
         </div>
 
-        {(showCancel || showRetry) && (
+        {(showCancel || showRetry || queue.status !== "downloading") && (
           <div className="flex shrink-0 items-center gap-1">
             {showRetry && (
               <Button
@@ -93,6 +112,18 @@ export default function PlaylistDownloadQueuePanel({
                 className="size-7"
                 onClick={onCancel}
                 aria-label="cancel playlist downloads"
+              >
+                <X className="size-3.5" />
+              </Button>
+            )}
+            {!showCancel && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                onClick={() => setDismissedQueueId(queue.id)}
+                aria-label="dismiss playlist download progress"
               >
                 <X className="size-3.5" />
               </Button>

--- a/components/audio/downloadPresentation.test.tsx
+++ b/components/audio/downloadPresentation.test.tsx
@@ -1,14 +1,23 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vite-plus/test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { SortableTrackRow } from "./AlbumSidebarDnd";
 import PlaylistDownloadQueuePanel from "./PlaylistDownloadQueuePanel";
 import type { TagiumFile } from "./types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
 
 describe("download presentation", () => {
   it("describes admission waits without exposing Cobalt implementation details", () => {
     const markup = renderToStaticMarkup(
       <PlaylistDownloadQueuePanel
         queue={{
+          id: 1,
           status: "waiting",
           downloadedCount: 20,
           totalCount: 21,
@@ -49,5 +58,43 @@ describe("download presentation", () => {
 
     expect(markup).not.toContain(">canceled<");
     expect(markup).toContain("h-3 w-3 text-muted-foreground flex-shrink-0 group-hover:opacity-0");
+  });
+
+  it("lets a completed queue be dismissed and hides it automatically after ten seconds", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { setTimeout, clearTimeout });
+    let renderer: ReactTestRenderer;
+
+    act(() => {
+      renderer = create(
+        <PlaylistDownloadQueuePanel
+          queue={{
+            id: 2,
+            status: "complete",
+            downloadedCount: 13,
+            totalCount: 13,
+            failedCount: 0,
+            canceledCount: 0,
+            currentTracks: [],
+            progress: 100,
+          }}
+        />,
+      );
+    });
+
+    expect(renderer!.toJSON()).not.toBeNull();
+    expect(
+      renderer!.root.findByProps({ "aria-label": "dismiss playlist download progress" }),
+    ).toBeDefined();
+
+    act(() => {
+      vi.advanceTimersByTime(9_999);
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(renderer!.toJSON()).toBeNull();
+    act(() => renderer!.unmount());
   });
 });

--- a/components/audio/importQueuePresentation.test.ts
+++ b/components/audio/importQueuePresentation.test.ts
@@ -55,4 +55,10 @@ describe("import queue presentation", () => {
   it("keeps single-track controller state out of the playlist panel", () => {
     expect(getImportQueuePresentation(snapshot({ total: 1 }), [])).toBeNull();
   });
+
+  it("marks a successfully settled queue complete", () => {
+    expect(
+      getImportQueuePresentation(snapshot({ completed: 2, pending: 0, done: true }), []),
+    ).toMatchObject({ id: 1, status: "complete", downloadedCount: 2, progress: 100 });
+  });
 });

--- a/components/audio/importQueuePresentation.ts
+++ b/components/audio/importQueuePresentation.ts
@@ -23,11 +23,13 @@ export const getImportQueuePresentation = (
   ).length;
   let status: PlaylistDownloadQueuePanelState["status"] = "downloading";
   if (snapshot.waitingForTunnelBudget) status = "waiting";
+  if (snapshot.done && snapshot.failed === 0 && !snapshot.canceled) status = "complete";
   if (snapshot.done && snapshot.failed > 0) status = "error";
   if (snapshot.canceled && snapshot.failed === 0) status = "canceled";
   const settled = snapshot.completed + snapshot.failed + snapshot.canceledCount;
   const eta = formatEta(snapshot.etaMs);
   return {
+    id: snapshot.id,
     status,
     downloadedCount: snapshot.completed,
     totalCount: snapshot.total,

--- a/components/audio/sidebarDnd.ts
+++ b/components/audio/sidebarDnd.ts
@@ -1,5 +1,6 @@
 import {
   closestCorners,
+  type Collision,
   type CollisionDetection,
   pointerWithin,
   rectIntersection,
@@ -22,7 +23,46 @@ export const albumItemId = (albumId: string) => `album:${albumId}`;
 export const albumContainerId = (albumId: string) => `container:album:${albumId}`;
 export const trackItemId = (trackId: string) => `track:${trackId}`;
 
+const EMPTY_LOOSE_DROP_ZONE_HEIGHT = 24;
+
+export const emptyLooseDropCollision = ({
+  active,
+  droppableContainers,
+  droppableRects,
+  pointerCoordinates,
+}: Parameters<CollisionDetection>[0]): Collision[] | null => {
+  const activeData = active.data.current as SidebarDragData | undefined;
+  if (activeData?.type !== "track" || !pointerCoordinates) return null;
+
+  const looseContainer = droppableContainers.find(({ id }) => id === LOOSE_CONTAINER_ID);
+  const looseRect = droppableRects.get(LOOSE_CONTAINER_ID);
+  if (!looseContainer || !looseRect) return null;
+
+  const hasLooseTracks = droppableContainers.some(({ data }) => {
+    const dropData = data.current as SidebarDropData | undefined;
+    return dropData?.type === "track" && dropData.container === "loose";
+  });
+  if (hasLooseTracks) return null;
+
+  const firstAlbumTop = droppableContainers.reduce<number | null>((top, container) => {
+    const data = container.data.current as SidebarDropData | undefined;
+    if (data?.type !== "album") return top;
+    const rect = droppableRects.get(container.id);
+    if (!rect) return top;
+    return top === null ? rect.top : Math.min(top, rect.top);
+  }, null);
+  if (firstAlbumTop === null) return null;
+
+  const isNearFirstAlbum =
+    pointerCoordinates.y >= looseRect.top &&
+    pointerCoordinates.y <= firstAlbumTop + EMPTY_LOOSE_DROP_ZONE_HEIGHT;
+  return isNearFirstAlbum ? [{ id: looseContainer.id }] : null;
+};
+
 export const sidebarCollisionDetection: CollisionDetection = (args) => {
+  const emptyLooseCollision = emptyLooseDropCollision(args);
+  if (emptyLooseCollision) return emptyLooseCollision;
+
   const pointerCollisions = pointerWithin(args);
   if (pointerCollisions.length > 0) return pointerCollisions;
 

--- a/components/audio/sidebarDragController.test.ts
+++ b/components/audio/sidebarDragController.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 import { resolveSidebarDragCommand, type SidebarDropPosition } from "./sidebarDragController";
-import { LOOSE_APPEND_CONTAINER_ID, LOOSE_CONTAINER_ID } from "./sidebarDnd";
+import {
+  emptyLooseDropCollision,
+  LOOSE_APPEND_CONTAINER_ID,
+  LOOSE_CONTAINER_ID,
+} from "./sidebarDnd";
 
 const albums = [
   { id: "album-a", trackIds: ["a-1", "a-2"] },
@@ -28,6 +32,35 @@ const resolve = (overrides: Partial<Parameters<typeof resolveSidebarDragCommand>
   });
 
 describe("sidebar drag controller", () => {
+  it("keeps an empty loose drop target available at the first album without reserving space", () => {
+    const looseContainer = {
+      id: LOOSE_CONTAINER_ID,
+      data: { current: { type: "container", container: "loose" } },
+    };
+    const firstAlbum = {
+      id: "album:album-a",
+      data: { current: { type: "album", albumId: "album-a" } },
+    };
+
+    const collisionArgs = (y: number) =>
+      ({
+        active: {
+          data: {
+            current: { type: "track", trackId: "a-1", container: "album", albumId: "album-a" },
+          },
+        },
+        droppableContainers: [looseContainer, firstAlbum],
+        droppableRects: new Map([
+          [LOOSE_CONTAINER_ID, { top: 100 }],
+          ["album:album-a", { top: 100 }],
+        ]),
+        pointerCoordinates: { x: 10, y },
+      }) as never;
+
+    expect(emptyLooseDropCollision(collisionArgs(112))).toEqual([{ id: LOOSE_CONTAINER_ID }]);
+    expect(emptyLooseDropCollision(collisionArgs(125))).toBeNull();
+  });
+
   it("reorders albums by the album containing the drop target", () => {
     expect(
       resolve({


### PR DESCRIPTION
## What changed

- remove the permanent empty loose-track drop gap above the first album
- preserve a temporary drop target while a track is actively being dragged
- represent successfully completed playlist downloads explicitly
- allow completed, failed, and canceled download panels to be dismissed
- automatically hide successful download panels after 10 seconds
- cover completion state and auto-dismiss behavior with focused tests

## Why

The empty loose-track container always inherited a minimum height, leaving an unnecessary blank strip above albums. Successful playlist queues also remained visible indefinitely because they never had a completed presentation state or dismissal lifecycle.

## Impact

The library begins directly with its content during normal use, while track drag-and-drop remains available. Download progress clears itself after success and can also be dismissed manually.

## Validation

- `bun run test components/audio/downloadPresentation.test.tsx components/audio/importQueuePresentation.test.ts components/audio/sidebarDragController.test.ts`
- `bun run typecheck`
- `bun run lint`