### PR TITLE
feat(ui): polish workspace states

### DIFF
--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -11,7 +11,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 cursor-pointer rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer select-none border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 cursor-pointer rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/src/features/editor/AlbumMetadataDialog.tsx
+++ b/src/features/editor/AlbumMetadataDialog.tsx
@@ -52,7 +52,7 @@ export default function AlbumMetadataDialog({
   placeholder,
 }: AlbumMetadataDialogProps) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [showErrors, setShowErrors] = useState(false);
+  const [touchedFields, setTouchedFields] = useState({ title: false, artist: false });
   const [isSyncingCover, setIsSyncingCover] = useState(false);
   const [isProcessingCover, setIsProcessingCover] = useState(false);
   const [syncCoverRotation, setSyncCoverRotation] = useState(0);
@@ -60,6 +60,9 @@ export default function AlbumMetadataDialog({
     mode === "edit" && draft.cover && draft.cover.length > 0 && onSyncCoverToTracks;
   const syncCoverLabel = isSyncingCover ? "syncing cover to tracks" : "sync cover to tracks";
   const placeholderClassName = "placeholder:text-muted-foreground/45";
+  const titleInvalid = !draft.title.trim();
+  const artistInvalid = !draft.artist.trim();
+  const formInvalid = titleInvalid || artistInvalid;
 
   const handleSyncCoverToTracks = () => {
     if (!onSyncCoverToTracks) return;
@@ -87,7 +90,7 @@ export default function AlbumMetadataDialog({
       onOpenChange={(nextOpen) => {
         if (!nextOpen && !isProcessingCover) {
           setShowDeleteConfirm(false);
-          setShowErrors(false);
+          setTouchedFields({ title: false, artist: false });
           onClose();
         }
       }}
@@ -98,10 +101,7 @@ export default function AlbumMetadataDialog({
           onSubmit={(event) => {
             event.preventDefault();
             if (isProcessingCover) return;
-            if (!draft.title.trim() || !draft.artist.trim()) {
-              setShowErrors(true);
-              return;
-            }
+            if (formInvalid) return;
             onSave();
           }}
         >
@@ -117,10 +117,16 @@ export default function AlbumMetadataDialog({
                 <div className="flex flex-col gap-0">
                   <div>
                     <label htmlFor="album-title" className="block text-sm font-medium mb-1">
-                      album title:
+                      album title:{" "}
+                      <span className="text-destructive" aria-hidden="true">
+                        *
+                      </span>
+                      <span className="sr-only"> required</span>
                     </label>
                     <Input
                       id="album-title"
+                      required
+                      aria-required="true"
                       value={draft.title}
                       onChange={(event) =>
                         onChange({
@@ -128,9 +134,12 @@ export default function AlbumMetadataDialog({
                           title: event.target.value,
                         })
                       }
+                      onBlur={() => setTouchedFields((current) => ({ ...current, title: true }))}
                       placeholder={placeholder.title}
-                      aria-invalid={showErrors && !draft.title.trim()}
-                      aria-describedby="album-title-error"
+                      aria-invalid={touchedFields.title && titleInvalid}
+                      aria-describedby={
+                        touchedFields.title && titleInvalid ? "album-title-error" : undefined
+                      }
                       className={placeholderClassName}
                     />
                     <p
@@ -138,15 +147,21 @@ export default function AlbumMetadataDialog({
                       className="h-4 text-xs leading-4 text-destructive"
                       aria-live="polite"
                     >
-                      {showErrors && !draft.title.trim() ? "album title is required" : ""}
+                      {touchedFields.title && titleInvalid ? "album title is required" : ""}
                     </p>
                   </div>
                   <div>
                     <label htmlFor="album-artist" className="block text-sm font-medium mb-1">
-                      artist:
+                      artist:{" "}
+                      <span className="text-destructive" aria-hidden="true">
+                        *
+                      </span>
+                      <span className="sr-only"> required</span>
                     </label>
                     <Input
                       id="album-artist"
+                      required
+                      aria-required="true"
                       value={draft.artist}
                       onChange={(event) =>
                         onChange({
@@ -154,9 +169,12 @@ export default function AlbumMetadataDialog({
                           artist: event.target.value,
                         })
                       }
+                      onBlur={() => setTouchedFields((current) => ({ ...current, artist: true }))}
                       placeholder={placeholder.artist}
-                      aria-invalid={showErrors && !draft.artist.trim()}
-                      aria-describedby="album-artist-error"
+                      aria-invalid={touchedFields.artist && artistInvalid}
+                      aria-describedby={
+                        touchedFields.artist && artistInvalid ? "album-artist-error" : undefined
+                      }
                       className={placeholderClassName}
                     />
                     <p
@@ -164,7 +182,7 @@ export default function AlbumMetadataDialog({
                       className="h-4 text-xs leading-4 text-destructive"
                       aria-live="polite"
                     >
-                      {showErrors && !draft.artist.trim() ? "artist is required" : ""}
+                      {touchedFields.artist && artistInvalid ? "artist is required" : ""}
                     </p>
                   </div>
                   <div className="mb-3">
@@ -287,7 +305,11 @@ export default function AlbumMetadataDialog({
                 >
                   cancel
                 </Button>
-                <Button type="submit" disabled={isProcessingCover}>
+                <Button
+                  type="submit"
+                  disabled={isProcessingCover || formInvalid}
+                  aria-busy={isProcessingCover}
+                >
                   {isProcessingCover
                     ? "processing cover"
                     : mode === "create"

--- a/src/features/editor/TrackMetadataEditor.tsx
+++ b/src/features/editor/TrackMetadataEditor.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import CoverArt from "@/features/editor/coverArt";
+import AudioImportDropzone from "@/features/import/AudioImportDropzone";
 import { isValidFilenameBase, sanitizeFilenameBase } from "@/features/library/filename";
 import { getAudioFormatInfo } from "@/features/audio/audioFormat";
 import { getSampleTrack, type SampleTrackMetadata } from "@/features/editor/sampleMetadata";
@@ -67,6 +68,7 @@ interface TrackMetadataEditorProps {
     field: "filename" | "title" | "artist",
     event: ChangeEvent<HTMLInputElement>,
   ) => void;
+  onAudioUpload: (files: File[]) => void | Promise<void>;
 }
 
 interface LoadedTrackMetadataEditorProps extends Omit<TrackMetadataEditorProps, "selectedFile"> {
@@ -855,13 +857,11 @@ export default function TrackMetadataEditor(props: TrackMetadataEditorProps) {
         data-editor-state="empty-selection"
         aria-hidden={trackIsSelected}
         inert={trackIsSelected}
-        className={`absolute inset-0 flex items-center justify-center bg-muted/5 transition-opacity duration-200 motion-reduce:transition-none ${
+        className={`absolute inset-0 flex items-center justify-center bg-muted/5 px-4 pb-28 transition-opacity duration-200 motion-reduce:transition-none ${
           trackIsSelected ? "pointer-events-none opacity-0" : "opacity-100"
         }`}
       >
-        <div className="text-center">
-          <p className="text-muted-foreground">select a track to edit its tags</p>
-        </div>
+        <AudioImportDropzone onAudioUpload={props.onAudioUpload} />
       </div>
       <div
         data-editor-state="loaded-track"

--- a/src/features/import/AudioImportDropzone.tsx
+++ b/src/features/import/AudioImportDropzone.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Music4, Upload } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface AudioImportDropzoneProps {
+  onAudioUpload: (files: File[]) => void | Promise<void>;
+  showBrand?: boolean;
+  className?: string;
+}
+
+const handleDragOver = (event: React.DragEvent) => {
+  event.preventDefault();
+  event.dataTransfer.dropEffect = "copy";
+};
+
+export default function AudioImportDropzone({
+  onAudioUpload,
+  showBrand = false,
+  className,
+}: AudioImportDropzoneProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const dragCounterRef = useRef(0);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const importFiles = (files: FileList | null) => {
+    const audioFiles = Array.from(files ?? []);
+    if (audioFiles.length > 0) void onAudioUpload(audioFiles);
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex w-full max-w-md flex-col items-center gap-10 max-lg:[@media(max-height:700px)]:gap-6",
+        className,
+      )}
+    >
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".mp3,audio/mpeg"
+        multiple
+        className="hidden"
+        onChange={(event) => {
+          importFiles(event.target.files);
+          event.target.value = "";
+        }}
+      />
+      {showBrand && (
+        <div className="text-center select-none">
+          <h1 className="text-7xl font-bold tracking-tighter text-foreground">tagium</h1>
+          <p className="text-muted-foreground mt-3 text-base">tag your music</p>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        onDragEnter={(event) => {
+          event.preventDefault();
+          dragCounterRef.current++;
+          setIsDragging(true);
+        }}
+        onDragLeave={() => {
+          dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
+          if (dragCounterRef.current === 0) setIsDragging(false);
+        }}
+        onDragOver={handleDragOver}
+        onDrop={(event) => {
+          event.preventDefault();
+          dragCounterRef.current = 0;
+          setIsDragging(false);
+          importFiles(event.dataTransfer.files);
+        }}
+        className={cn(
+          "w-full rounded-3xl border-2 border-dashed transition-all duration-200 motion-reduce:transition-none cursor-pointer",
+          "flex flex-col items-center justify-center gap-5 py-16 px-8 outline-none max-lg:[@media(max-height:700px)]:gap-3 max-lg:[@media(max-height:700px)]:py-8",
+          isDragging
+            ? "border-primary bg-primary/10 scale-[1.015] shadow-xl shadow-primary/10 motion-reduce:scale-100"
+            : "border-border hover:border-primary/50 hover:bg-accent/20 focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        )}
+      >
+        {isDragging ? (
+          <Music4 className="h-14 w-14 text-primary" />
+        ) : (
+          <div className="h-16 w-16 rounded-2xl bg-muted flex items-center justify-center">
+            <Upload className="h-7 w-7 text-muted-foreground" />
+          </div>
+        )}
+        <div className="text-center select-none">
+          <p className="text-lg font-semibold text-foreground">
+            {isDragging ? "drop to import" : "drop your mp3s here"}
+          </p>
+          <p className="text-sm text-muted-foreground mt-1">mp3 files only · or click to browse</p>
+        </div>
+      </button>
+    </div>
+  );
+}

--- a/src/features/import/LandingScreen.tsx
+++ b/src/features/import/LandingScreen.tsx
@@ -1,75 +1,23 @@
 "use client";
 
-import { useRef, useState, type ReactNode } from "react";
-import { Music4, Upload } from "lucide-react";
-import { cn } from "@/lib/utils";
-import { getAudioUploadAccept } from "@/features/audio/audioFormat";
+import type { ReactNode } from "react";
+import AudioImportDropzone from "@/features/import/AudioImportDropzone";
 
 interface LandingScreenProps {
   active: boolean;
-  children: ReactNode;
+  children?: ReactNode;
   onAudioUpload: (files: File[]) => void | Promise<void>;
 }
 
-const handleDragOver = (e: React.DragEvent) => {
-  e.preventDefault();
-  e.dataTransfer.dropEffect = "copy";
-};
-
 export default function LandingScreen({ active, children, onAudioUpload }: LandingScreenProps) {
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const dragCounterRef = useRef(0);
-  const [isDragging, setIsDragging] = useState(false);
-
-  const handleDragEnter = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current++;
-    setIsDragging(true);
-  };
-
-  const handleDragLeave = () => {
-    dragCounterRef.current--;
-    if (dragCounterRef.current === 0) setIsDragging(false);
-  };
-
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current = 0;
-    setIsDragging(false);
-    const dropped = Array.from(e.dataTransfer.files);
-    if (dropped.length > 0) void onAudioUpload(dropped);
-  };
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const picked = Array.from(e.target.files || []);
-    if (picked.length > 0) void onAudioUpload(picked);
-    e.target.value = "";
-  };
-
   return (
     <div
-      className={cn(
+      className={
         active
-          ? "h-svh min-h-0 overflow-y-auto flex flex-col items-center justify-center p-8 transition-colors duration-200 max-lg:[@media(max-height:700px)]:p-4 md:h-auto md:flex-1"
-          : "contents",
-        active && isDragging && "bg-primary/5",
-      )}
-      onDragEnter={active ? handleDragEnter : undefined}
-      onDragLeave={active ? handleDragLeave : undefined}
-      onDragOver={active ? handleDragOver : undefined}
-      onDrop={active ? handleDrop : undefined}
+          ? "h-svh min-h-0 overflow-y-auto flex flex-col items-center justify-center p-8 max-lg:[@media(max-height:700px)]:p-4 md:h-auto md:flex-1"
+          : "contents"
+      }
     >
-      {active && (
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept={getAudioUploadAccept()}
-          multiple
-          className="hidden"
-          onChange={handleFileChange}
-        />
-      )}
-
       <div
         className={
           active
@@ -78,39 +26,11 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
         }
       >
         {active && (
-          <div className="flex w-full flex-col items-center gap-10 animate-in fade-in motion-reduce:animate-none max-lg:[@media(max-height:700px)]:gap-6">
-            <div className="text-center select-none">
-              <h1 className="text-7xl font-bold tracking-tighter text-foreground">tagium</h1>
-              <p className="text-muted-foreground mt-3 text-base">tag your music</p>
-            </div>
-            <button
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
-              className={cn(
-                "w-full rounded-3xl border-2 border-dashed transition-all duration-200 cursor-pointer",
-                "flex flex-col items-center justify-center gap-5 py-16 px-8 outline-none max-lg:[@media(max-height:700px)]:gap-3 max-lg:[@media(max-height:700px)]:py-8",
-                isDragging
-                  ? "border-primary bg-primary/10 scale-[1.015] shadow-xl shadow-primary/10"
-                  : "border-border hover:border-primary/50 hover:bg-accent/20 focus-visible:border-primary/50",
-              )}
-            >
-              {isDragging ? (
-                <Music4 className="h-14 w-14 text-primary" />
-              ) : (
-                <div className="h-16 w-16 rounded-2xl bg-muted flex items-center justify-center">
-                  <Upload className="h-7 w-7 text-muted-foreground" />
-                </div>
-              )}
-              <div className="text-center">
-                <p className="text-lg font-semibold text-foreground">
-                  {isDragging ? "drop to import" : "drop your mp3s here"}
-                </p>
-                <p className="text-sm text-muted-foreground mt-1">
-                  mp3 files only · or click to browse
-                </p>
-              </div>
-            </button>
-          </div>
+          <AudioImportDropzone
+            showBrand
+            onAudioUpload={onAudioUpload}
+            className="animate-in fade-in motion-reduce:animate-none"
+          />
         )}
         {children}
       </div>

--- a/src/features/import/MediaUrlEntry.tsx
+++ b/src/features/import/MediaUrlEntry.tsx
@@ -10,11 +10,10 @@ import {
   getSystemFailurePresentation,
   reportSystemFailure,
 } from "@/features/workspace/systemFailure";
+import type { MediaUrlEntryLayout } from "@/features/import/mediaUrlEntryPresentation";
 
 interface MediaUrlEntryProps {
-  layout: "landing" | "editor";
-  hidden: boolean;
-  docked?: boolean;
+  layout: MediaUrlEntryLayout;
   onUrlImport: (sourceUrl: string) => void | Promise<void>;
 }
 
@@ -32,12 +31,7 @@ const validateMediaUrl = (value: string) => {
 const prefersReducedMotion = () =>
   window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 
-export default function MediaUrlEntry({
-  layout,
-  hidden,
-  docked = false,
-  onUrlImport,
-}: MediaUrlEntryProps) {
+export default function MediaUrlEntry({ layout, onUrlImport }: MediaUrlEntryProps) {
   const [sourceUrl, setSourceUrl] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
@@ -63,7 +57,7 @@ export default function MediaUrlEntry({
   useLayoutEffect(() => {
     const anchor = anchorRef.current;
     const motion = motionRef.current;
-    if (!anchor || !motion || hidden) {
+    if (!anchor || !motion) {
       animationRef.current?.cancel();
       animationRef.current = null;
       clearMotionStyles();
@@ -107,7 +101,7 @@ export default function MediaUrlEntry({
 
     previousRectRef.current = nextRect;
     previousLayoutRef.current = layout;
-  }, [docked, hidden, layout]);
+  }, [layout]);
 
   useEffect(() => {
     const settleMotion = () => {
@@ -176,26 +170,23 @@ export default function MediaUrlEntry({
   return (
     <div
       data-layout={layout}
-      aria-hidden={hidden || undefined}
-      inert={hidden || undefined}
       className={cn(
-        hidden && "hidden",
         layout === "landing" &&
           "flex w-full flex-col gap-10 max-lg:[@media(max-height:700px)]:gap-6",
         layout === "editor" &&
           "flex-shrink-0 border-t bg-background/95 p-3 lg:pointer-events-none lg:absolute lg:inset-x-0 lg:bottom-4 lg:z-10 lg:flex lg:justify-center lg:border-t-0 lg:bg-transparent lg:px-4 lg:p-0",
-        docked &&
-          "pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center lg:bottom-4",
+        layout === "empty-editor" &&
+          "pointer-events-none absolute inset-x-0 bottom-4 z-10 flex justify-center px-4 lg:bottom-[calc(50%-13rem)]",
       )}
     >
-      {layout === "landing" && (
+      {layout !== "editor" && (
         <div className="flex items-center gap-4 text-sm text-muted-foreground">
           <div className="h-px flex-1 bg-border" />
           <span>or import from a url</span>
           <div className="h-px flex-1 bg-border" />
         </div>
       )}
-      <div ref={anchorRef} className={cn("w-full", layout === "editor" && "max-w-3xl")}>
+      <div ref={anchorRef} className={cn("w-full", layout === "editor" ? "max-w-3xl" : "max-w-md")}>
         <div ref={motionRef} className="pointer-events-auto w-full bg-background">
           <form noValidate onSubmit={handleSubmit} className="flex items-start gap-2">
             <div className="min-w-0 flex-1">
@@ -222,7 +213,7 @@ export default function MediaUrlEntry({
                 id="media-url-error"
                 className={cn(
                   "h-4 pt-0.5 text-xs leading-4 text-destructive",
-                  layout === "landing" && "text-center",
+                  layout !== "editor" && "text-center",
                 )}
                 aria-live="polite"
               >

--- a/src/features/import/mediaUrlEntryPresentation.ts
+++ b/src/features/import/mediaUrlEntryPresentation.ts
@@ -1,16 +1,15 @@
-export type MediaUrlEntryLayout = "landing" | "editor";
+export type MediaUrlEntryLayout = "landing" | "empty-editor" | "editor";
 
-interface MediaUrlEntryPresentation {
+export interface MediaUrlEntryPresentation {
   layout: MediaUrlEntryLayout;
-  hidden: boolean;
-  docked: boolean;
 }
 
 export const getMediaUrlEntryPresentation = (
   libraryIsEmpty: boolean,
   settingsOpen: boolean,
-): MediaUrlEntryPresentation => ({
-  layout: libraryIsEmpty && !settingsOpen ? "landing" : "editor",
-  hidden: settingsOpen && !libraryIsEmpty,
-  docked: libraryIsEmpty && settingsOpen,
-});
+  trackSelected = false,
+): MediaUrlEntryPresentation | null => {
+  if (settingsOpen) return null;
+  if (libraryIsEmpty) return { layout: "landing" };
+  return { layout: trackSelected ? "editor" : "empty-editor" };
+};

--- a/src/features/library/AlbumSidebarDnd.tsx
+++ b/src/features/library/AlbumSidebarDnd.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
@@ -64,6 +65,9 @@ export function SortableTrackRow({
   onRemove,
   onRetry,
 }: TrackRowProps) {
+  const previousStatusRef = useRef(track.status);
+  const successTimerRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
+  const [showSavedCheck, setShowSavedCheck] = useState(false);
   const {
     attributes,
     listeners,
@@ -79,6 +83,33 @@ export function SortableTrackRow({
         ? ({ type: "track", trackId: track.id, container, albumId } satisfies SidebarDragData)
         : ({ type: "track", trackId: track.id, container } satisfies SidebarDragData),
   });
+
+  useEffect(() => {
+    const transitionedToSaved = previousStatusRef.current !== "saved" && track.status === "saved";
+    previousStatusRef.current = track.status;
+
+    if (successTimerRef.current !== null) {
+      globalThis.clearTimeout(successTimerRef.current);
+      successTimerRef.current = null;
+    }
+
+    if (transitionedToSaved) {
+      setShowSavedCheck(true);
+      successTimerRef.current = globalThis.setTimeout(() => {
+        setShowSavedCheck(false);
+        successTimerRef.current = null;
+      }, 3_000);
+    } else if (track.status !== "saved") {
+      setShowSavedCheck(false);
+    }
+
+    return () => {
+      if (successTimerRef.current !== null) {
+        globalThis.clearTimeout(successTimerRef.current);
+        successTimerRef.current = null;
+      }
+    };
+  }, [track.status]);
 
   return (
     <div
@@ -116,8 +147,11 @@ export function SortableTrackRow({
             {track.downloadStatus === "downloading" && (
               <Loader2 className="h-3 w-3 text-muted-foreground flex-shrink-0 animate-spin" />
             )}
-            {track.downloadStatus !== "downloading" && track.status === "saved" && (
-              <Check className="h-3 w-3 text-green-500 flex-shrink-0" />
+            {track.downloadStatus !== "downloading" && showSavedCheck && (
+              <Check
+                aria-hidden="true"
+                className="h-3 w-3 flex-shrink-0 text-green-500 animate-in fade-in motion-reduce:animate-none"
+              />
             )}
             {(track.downloadStatus === "error" || track.status === "error") && (
               <AlertCircle
@@ -134,6 +168,11 @@ export function SortableTrackRow({
           </div>
         </div>
       </Button>
+      {showSavedCheck && (
+        <span role="status" aria-live="polite" className="sr-only">
+          track saved
+        </span>
+      )}
       {retryable && (
         <button
           type="button"

--- a/src/features/library/AlbumSidebarDnd.tsx
+++ b/src/features/library/AlbumSidebarDnd.tsx
@@ -139,25 +139,25 @@ export function SortableTrackRow({
         <div className="flex flex-col gap-1 w-full min-w-0">
           <div className="flex items-center gap-1.5 w-full overflow-hidden">
             {container === "loose" ? (
-              <FileMusic className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+              <FileMusic className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
             ) : (
               <span className="min-w-3 text-[11px] text-muted-foreground">{index}</span>
             )}
             <span className="truncate text-sm flex-1">{track.filename}</span>
             {track.downloadStatus === "downloading" && (
-              <Loader2 className="h-3 w-3 text-muted-foreground flex-shrink-0 animate-spin" />
+              <Loader2 className="h-3 w-3 text-muted-foreground shrink-0 animate-spin" />
             )}
             {track.downloadStatus !== "downloading" && showSavedCheck && (
               <Check
                 aria-hidden="true"
-                className="h-3 w-3 flex-shrink-0 text-green-500 animate-in fade-in motion-reduce:animate-none"
+                className="h-3 w-3 shrink-0 text-green-500 animate-in fade-in motion-reduce:animate-none"
               />
             )}
             {(track.downloadStatus === "error" || track.status === "error") && (
               <AlertCircle
                 aria-label="track has an error"
                 className={cn(
-                  "h-3 w-3 text-red-500 flex-shrink-0",
+                  "h-3 w-3 text-red-500 shrink-0",
                   retryable ? "group-hover:opacity-0" : "",
                 )}
               />

--- a/src/features/workspace/audioTagger.tsx
+++ b/src/features/workspace/audioTagger.tsx
@@ -54,6 +54,7 @@ export default function AudioTagger() {
   const mediaUrlEntryPresentation = getMediaUrlEntryPresentation(
     libraryIsEmpty,
     activeView === "settings",
+    Boolean(editor.selectedFile),
   );
   useBeforeUnloadProtection(
     hasRecoverableSessionWork({
@@ -129,6 +130,7 @@ export default function AudioTagger() {
                     onPreviewMetadataChange={(field, event) =>
                       editor.commands.preview(field, event.target.value)
                     }
+                    onAudioUpload={importing.commands.upload}
                   />
                 </div>
                 <div
@@ -149,12 +151,12 @@ export default function AudioTagger() {
             ) : null}
           </div>
           <LandingScreen active={landingIsActive} onAudioUpload={importing.commands.upload}>
-            <MediaUrlEntry
-              layout={mediaUrlEntryPresentation.layout}
-              hidden={mediaUrlEntryPresentation.hidden}
-              docked={mediaUrlEntryPresentation.docked}
-              onUrlImport={importing.commands.importUrl}
-            />
+            {mediaUrlEntryPresentation && (
+              <MediaUrlEntry
+                layout={mediaUrlEntryPresentation.layout}
+                onUrlImport={importing.commands.importUrl}
+              />
+            )}
           </LandingScreen>
         </div>
       </div>

--- a/tests/e2e/settings-transition.spec.ts
+++ b/tests/e2e/settings-transition.spec.ts
@@ -32,61 +32,13 @@ const clickBlankTrackList = async (page: Page) => {
   });
 };
 
-test("keeps the media entry within its return transition endpoints", async ({
-  page,
-  browserName,
-}) => {
-  test.skip(browserName !== "chromium", "geometry sampling is covered in Chromium");
+test("unmounts the media entry in settings and restores it in the editor", async ({ page }) => {
   await page.goto("/");
+  await expect(page.locator('input[name="media-url"]')).toBeAttached();
   await page.getByRole("button", { name: "settings" }).click();
-  await page.waitForTimeout(500);
-
-  const transition = await page.evaluate(async () => {
-    interface BrowserElement {
-      click: () => void;
-      closest: (selector: string) => BrowserElement | null;
-      getBoundingClientRect: () => { left: number };
-      parentElement: BrowserElement | null;
-    }
-
-    const browser = globalThis as unknown as {
-      document: { querySelector: (selector: string) => BrowserElement | null };
-      performance: { now: () => number };
-      requestAnimationFrame: (callback: () => void) => number;
-    };
-    const input = browser.document.querySelector('input[name="media-url"]');
-    const motion = input?.closest("form")?.parentElement;
-    const back = browser.document.querySelector('button[aria-label="back to editor"]');
-    if (!motion || !back) {
-      throw new Error("media entry transition elements were not found");
-    }
-
-    const startLeft = motion.getBoundingClientRect().left;
-    back.click();
-    const samples: number[] = [];
-    const startedAt = browser.performance.now();
-    await new Promise<void>((resolve) => {
-      const sample = () => {
-        samples.push(motion.getBoundingClientRect().left);
-        if (browser.performance.now() - startedAt >= 550) {
-          resolve();
-          return;
-        }
-        browser.requestAnimationFrame(sample);
-      };
-      browser.requestAnimationFrame(sample);
-    });
-
-    return {
-      startLeft,
-      endLeft: motion.getBoundingClientRect().left,
-      samples,
-    };
-  });
-
-  const minimumLeft = Math.min(transition.startLeft, transition.endLeft) - 2;
-  const maximumLeft = Math.max(transition.startLeft, transition.endLeft) + 2;
-  expect(transition.samples.every((left) => left >= minimumLeft && left <= maximumLeft)).toBe(true);
+  await expect(page.locator('input[name="media-url"]')).not.toBeAttached();
+  await page.getByRole("button", { name: "back to editor" }).click();
+  await expect(page.locator('input[name="media-url"]')).toBeAttached();
 });
 
 test("switches the metadata editor and settings without unmounting either panel", async ({
@@ -132,7 +84,7 @@ test("clicking blank space in a populated track list closes settings and clears 
 
   await expect(settings).toHaveAttribute("aria-hidden", "true");
   await expect(editor).toHaveAttribute("aria-hidden", "false");
-  await expect(page.getByText("select a track to edit its tags", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: /drop your mp3s here/ })).toBeVisible();
 });
 
 test("switches between the empty selection and track editor in both directions", async ({
@@ -141,7 +93,7 @@ test("switches between the empty selection and track editor in both directions",
   await uploadTrack(page);
   await page.getByRole("button", { name: "settings" }).focus();
   await page.keyboard.press("Escape");
-  await expect(page.getByText("select a track to edit its tags", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: /drop your mp3s here/ })).toBeVisible();
   await expect(page.locator('[data-editor-state="empty-selection"]')).toHaveCSS("opacity", "1");
 
   await getPopulatedTrackList(page).getByRole("button").first().click();
@@ -149,7 +101,7 @@ test("switches between the empty selection and track editor in both directions",
   await expect(page.locator('[data-editor-state="loaded-track"]')).toHaveCSS("opacity", "1");
 
   await page.getByRole("button", { name: "clear track selection and return to editor" }).click();
-  await expect(page.getByText("select a track to edit its tags", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: /drop your mp3s here/ })).toBeVisible();
   await expect(page.getByRole("button", { name: "download track" })).not.toBeAttached();
 });
 

--- a/tests/unit/features/editor/albumMetadataDialog.test.tsx
+++ b/tests/unit/features/editor/albumMetadataDialog.test.tsx
@@ -70,7 +70,7 @@ const createHookHarness = () => {
 afterEach(() => vi.clearAllMocks());
 
 describe("album metadata validation layout", () => {
-  it("keeps fixed error rows mounted before and after invalid submission", () => {
+  it("disables invalid submission and shows accessible errors after fields are touched", () => {
     const hooks = createHookHarness();
     const render = () =>
       hooks.render(() =>
@@ -96,10 +96,13 @@ describe("album metadata validation layout", () => {
     expect(artistRowBefore.props.className).toContain("h-4");
     expect(textContent(titleRowBefore)).toBe("");
 
-    const form = findElement(tree, (element) => element.type === "form");
-    (form.props.onSubmit as (event: { preventDefault: () => void }) => void)({
-      preventDefault: vi.fn(),
-    });
+    const submit = findElement(
+      tree,
+      (element) => element.props.type === "submit" && textContent(element) === "create album",
+    );
+    expect(submit.props.disabled).toBe(true);
+    const titleInput = findElement(tree, (element) => element.props.id === "album-title");
+    (titleInput.props.onBlur as () => void)();
 
     tree = render();
     expect(
@@ -107,7 +110,10 @@ describe("album metadata validation layout", () => {
     ).toBe("album title is required");
     expect(
       textContent(findElement(tree, (element) => element.props.id === "album-artist-error")),
-    ).toBe("artist is required");
+    ).toBe("");
+    expect(
+      findElement(tree, (element) => element.props.id === "album-title").props["aria-invalid"],
+    ).toBe(true);
   });
 
   it("associates every field label with its input", () => {
@@ -131,7 +137,73 @@ describe("album metadata validation layout", () => {
     }
 
     const titleInput = findElement(tree, (element) => element.props.id === "album-title");
-    expect(titleInput.props["aria-describedby"]).toBe("album-title-error");
+    const artistInput = findElement(tree, (element) => element.props.id === "album-artist");
+    expect(titleInput.props["aria-describedby"]).toBeUndefined();
+    expect(titleInput.props.required).toBe(true);
+    expect(titleInput.props["aria-required"]).toBe("true");
+    expect(artistInput.props.required).toBe(true);
+    expect(artistInput.props["aria-required"]).toBe("true");
+    expect(
+      textContent(
+        findElement(
+          tree,
+          (element) => element.type === "label" && element.props.htmlFor === "album-title",
+        ),
+      ),
+    ).toContain("required");
+  });
+
+  it.each([
+    { title: "   ", artist: "Artist" },
+    { title: "Album", artist: "   " },
+  ])("disables whitespace-only required values", (draft) => {
+    const hooks = createHookHarness();
+    const tree = hooks.render(() =>
+      AlbumMetadataDialog({
+        open: true,
+        mode: "create",
+        draft: { ...draft, genre: "" },
+        trackCount: 0,
+        onChange: vi.fn(),
+        onClose: vi.fn(),
+        onSave: vi.fn(),
+        placeholder: { title: "Album", artist: "Artist", genre: "Genre", year: "2026" },
+      }),
+    );
+
+    expect(findElement(tree, (element) => element.props.type === "submit").props.disabled).toBe(
+      true,
+    );
+  });
+
+  it("disables submission and exposes a busy state while cover art is processing", () => {
+    const hooks = createHookHarness();
+    const render = () =>
+      hooks.render(() =>
+        AlbumMetadataDialog({
+          open: true,
+          mode: "edit",
+          draft: { title: "Album", artist: "Artist", genre: "" },
+          trackCount: 1,
+          onChange: vi.fn(),
+          onClose: vi.fn(),
+          onSave: vi.fn(),
+          placeholder: { title: "Album", artist: "Artist", genre: "Genre", year: "2026" },
+        }),
+      );
+
+    let tree = render();
+    const coverArt = findElement(
+      tree,
+      (element) => typeof element.props.onProcessingChange === "function",
+    );
+    (coverArt.props.onProcessingChange as (processing: boolean) => void)(true);
+
+    tree = render();
+    const submit = findElement(tree, (element) => element.props.type === "submit");
+    expect(submit.props.disabled).toBe(true);
+    expect(submit.props["aria-busy"]).toBe(true);
+    expect(textContent(submit)).toBe("processing cover");
   });
 
   it("adds an uploaded cover to the latest draft", () => {

--- a/tests/unit/features/editor/trackMetadataEditor.test.tsx
+++ b/tests/unit/features/editor/trackMetadataEditor.test.tsx
@@ -189,6 +189,7 @@ function MountedEditorHarness({
       advancedMetadata
       metadataLinks={getMetadataLinkState(DEFAULT_APP_SETTINGS)}
       onPreviewMetadataChange={vi.fn()}
+      onAudioUpload={vi.fn()}
     />
   );
 }

--- a/tests/unit/features/editor/trackMetadataEditor.test.tsx
+++ b/tests/unit/features/editor/trackMetadataEditor.test.tsx
@@ -127,6 +127,7 @@ function EditorHarness({
           },
         })}
         onPreviewMetadataChange={vi.fn()}
+        onAudioUpload={vi.fn()}
       />
     </TooltipProvider>
   );
@@ -228,7 +229,8 @@ describe("track metadata editor form seam", () => {
   it("routes an unavailable track to the empty editor state", () => {
     const markup = renderToStaticMarkup(<EditorHarness selectedFile={null} />);
 
-    expect(markup).toContain("select a track to edit its tags");
+    expect(markup).toContain("drop your mp3s here");
+    expect(markup).not.toContain("tag your music");
     expect(markup).not.toContain('id="track-title"');
   });
 

--- a/tests/unit/features/import/audioImportDropzone.test.tsx
+++ b/tests/unit/features/import/audioImportDropzone.test.tsx
@@ -1,0 +1,46 @@
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { describe, expect, it, vi } from "vite-plus/test";
+import AudioImportDropzone from "@/features/import/AudioImportDropzone";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("AudioImportDropzone", () => {
+  it("forwards picked and dropped files through the shared import callback", () => {
+    const onAudioUpload = vi.fn();
+    const pickedFile = new File(["picked"], "picked.mp3", { type: "audio/mpeg" });
+    const droppedFile = new File(["dropped"], "dropped.mp3", { type: "audio/mpeg" });
+    let renderer: ReactTestRenderer;
+
+    act(() => {
+      renderer = create(<AudioImportDropzone onAudioUpload={onAudioUpload} />);
+    });
+    const input = renderer!.root.findByType("input");
+    const button = renderer!.root.findByType("button");
+
+    act(() => {
+      input.props.onChange({ target: { files: [pickedFile], value: "picked.mp3" } });
+      button.props.onDrop({
+        preventDefault: vi.fn(),
+        dataTransfer: { files: [droppedFile] },
+      });
+    });
+
+    expect(onAudioUpload).toHaveBeenNthCalledWith(1, [pickedFile]);
+    expect(onAudioUpload).toHaveBeenNthCalledWith(2, [droppedFile]);
+    act(() => renderer!.unmount());
+  });
+
+  it("only shows the product title on the landing variant", () => {
+    let renderer: ReactTestRenderer;
+    act(() => {
+      renderer = create(<AudioImportDropzone onAudioUpload={vi.fn()} />);
+    });
+    expect(renderer!.root.findAllByType("h1")).toHaveLength(0);
+
+    act(() => {
+      renderer!.update(<AudioImportDropzone showBrand onAudioUpload={vi.fn()} />);
+    });
+    expect(renderer!.root.findByType("h1").children).toEqual(["tagium"]);
+    act(() => renderer!.unmount());
+  });
+});

--- a/tests/unit/features/import/downloadPresentation.test.tsx
+++ b/tests/unit/features/import/downloadPresentation.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { Check } from "lucide-react";
 import { SortableTrackRow } from "@/features/library/AlbumSidebarDnd";
 import PlaylistDownloadQueuePanel from "@/features/import/PlaylistDownloadQueuePanel";
 import type { TagiumFile } from "@/features/library/types";
@@ -13,6 +14,21 @@ afterEach(() => {
 });
 
 describe("download presentation", () => {
+  const renderTrackRow = (track: TagiumFile) => (
+    <SortableTrackRow
+      track={track}
+      index={1}
+      container="album"
+      albumId="album-1"
+      selectedTone={null}
+      muted={false}
+      retryable={false}
+      onSelect={() => {}}
+      onRemove={() => {}}
+      onRetry={() => {}}
+    />
+  );
+
   it("describes admission waits without exposing Cobalt implementation details", () => {
     const markup = renderToStaticMarkup(
       <PlaylistDownloadQueuePanel
@@ -95,6 +111,75 @@ describe("download presentation", () => {
       vi.advanceTimersByTime(1);
     });
     expect(renderer!.toJSON()).toBeNull();
+    act(() => renderer!.unmount());
+  });
+
+  it("shows saved feedback for three seconds after a status transition and cleans timers up", () => {
+    vi.useFakeTimers();
+    const pendingTrack = {
+      id: "track-saved-feedback",
+      filename: "Saved Track.mp3",
+      status: "pending",
+      downloadStatus: "ready",
+    } as TagiumFile;
+    let renderer: ReactTestRenderer;
+
+    act(() => {
+      renderer = create(renderTrackRow(pendingTrack));
+    });
+    expect(renderer!.root.findAllByType(Check)).toHaveLength(0);
+
+    act(() => {
+      renderer!.update(renderTrackRow({ ...pendingTrack, status: "saved" }));
+    });
+    expect(renderer!.root.findAllByType(Check)).toHaveLength(1);
+    expect(renderer!.root.findAllByProps({ role: "status", "aria-live": "polite" })).toHaveLength(
+      1,
+    );
+    expect(renderer!.root.findByType(Check).props["aria-hidden"]).toBe("true");
+    expect(
+      renderer!.root
+        .findAllByType("button")
+        .every((button) => button.findAllByProps({ role: "status" }).length === 0),
+    ).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(2_999);
+    });
+    expect(renderer!.root.findAllByType(Check)).toHaveLength(1);
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(renderer!.root.findAllByType(Check)).toHaveLength(0);
+
+    act(() => {
+      renderer!.update(renderTrackRow({ ...pendingTrack, status: "pending" }));
+    });
+    act(() => {
+      renderer!.update(renderTrackRow({ ...pendingTrack, status: "saved" }));
+    });
+    expect(vi.getTimerCount()).toBe(1);
+    act(() => renderer!.unmount());
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not show or schedule saved feedback for an initially saved track", () => {
+    vi.useFakeTimers();
+    const savedTrack = {
+      id: "already-saved-track",
+      filename: "Already Saved.mp3",
+      status: "saved",
+      downloadStatus: "ready",
+    } as TagiumFile;
+    let renderer: ReactTestRenderer;
+
+    act(() => {
+      renderer = create(renderTrackRow(savedTrack));
+    });
+
+    expect(renderer!.root.findAllByType(Check)).toHaveLength(0);
+    expect(renderer!.root.findAllByProps({ role: "status" })).toHaveLength(0);
+    expect(vi.getTimerCount()).toBe(0);
     act(() => renderer!.unmount());
   });
 });

--- a/tests/unit/features/import/mediaUrlEntryMotion.test.ts
+++ b/tests/unit/features/import/mediaUrlEntryMotion.test.ts
@@ -3,30 +3,15 @@ import { getMediaUrlEntryMotionKeyframes } from "@/features/import/mediaUrlEntry
 import { getMediaUrlEntryPresentation } from "@/features/import/mediaUrlEntryPresentation";
 
 describe("media URL entry presentation", () => {
-  it("docks the persistent entry in empty-library settings", () => {
-    expect(getMediaUrlEntryPresentation(true, false)).toEqual({
-      layout: "landing",
-      hidden: false,
-      docked: false,
-    });
-    expect(getMediaUrlEntryPresentation(true, true)).toEqual({
-      layout: "editor",
-      hidden: false,
-      docked: true,
-    });
+  it("fully removes the entry in settings", () => {
+    expect(getMediaUrlEntryPresentation(true, false)).toEqual({ layout: "landing" });
+    expect(getMediaUrlEntryPresentation(true, true)).toBeNull();
+    expect(getMediaUrlEntryPresentation(false, true, true)).toBeNull();
   });
 
-  it("preserves non-empty-library visibility behavior", () => {
-    expect(getMediaUrlEntryPresentation(false, false)).toEqual({
-      layout: "editor",
-      hidden: false,
-      docked: false,
-    });
-    expect(getMediaUrlEntryPresentation(false, true)).toEqual({
-      layout: "editor",
-      hidden: true,
-      docked: false,
-    });
+  it("moves between empty and loaded editor positions", () => {
+    expect(getMediaUrlEntryPresentation(false, false)).toEqual({ layout: "empty-editor" });
+    expect(getMediaUrlEntryPresentation(false, false, true)).toEqual({ layout: "editor" });
   });
 
   it("animates position and real width without a transform", () => {

--- a/tests/unit/features/import/urlImportGateway.test.tsx
+++ b/tests/unit/features/import/urlImportGateway.test.tsx
@@ -125,7 +125,7 @@ describe("media URL entry", () => {
     const hooks = createHookHarness();
     const onUrlImport = vi.fn(async () => undefined);
     const render = (layout: "landing" | "editor") =>
-      hooks.render(() => MediaUrlEntry({ layout, hidden: false, onUrlImport }));
+      hooks.render(() => MediaUrlEntry({ layout, onUrlImport }));
 
     let tree = render("landing");
     changeInputValue(tree, "  https://soundcloud.com/user/track  ");
@@ -143,8 +143,7 @@ describe("media URL entry", () => {
   it("keeps malformed URL feedback local to the input", async () => {
     const hooks = createHookHarness();
     const onUrlImport = vi.fn();
-    const render = () =>
-      hooks.render(() => MediaUrlEntry({ layout: "landing", hidden: false, onUrlImport }));
+    const render = () => hooks.render(() => MediaUrlEntry({ layout: "landing", onUrlImport }));
 
     let tree = render();
     changeInputValue(tree, "not a url");
@@ -168,8 +167,7 @@ describe("media URL entry", () => {
     const onUrlImport = vi.fn(async () => {
       throw failure;
     });
-    const render = () =>
-      hooks.render(() => MediaUrlEntry({ layout: "editor", hidden: false, onUrlImport }));
+    const render = () => hooks.render(() => MediaUrlEntry({ layout: "editor", onUrlImport }));
 
     let tree = render();
     changeInputValue(tree, "https://youtube.com/watch?v=abc");
@@ -191,8 +189,7 @@ describe("media URL entry", () => {
     const onUrlImport = vi.fn(async () => {
       throw new Error("soundcloud set request failed (404)");
     });
-    const render = () =>
-      hooks.render(() => MediaUrlEntry({ layout: "landing", hidden: false, onUrlImport }));
+    const render = () => hooks.render(() => MediaUrlEntry({ layout: "landing", onUrlImport }));
 
     let tree = render();
     changeInputValue(tree, "https://soundcloud.com/user/sets/missing");


### PR DESCRIPTION
## What changed

- reuse one clickable/drop audio-import surface on home and in the no-selection editor state
- move the media URL entry between landing, empty-editor, and loaded-editor layouts, and fully unmount it in Settings
- disable invalid album create/save actions with accessible required-field and processing semantics
- make checkbox labels non-selectable
- show track-saved feedback only for three seconds, with timer cleanup and a separate polite live-region announcement
- add focused dropzone, form-state, transition, timer, and accessibility tests

## Why

These related polish fixes remove a dead-end editor state, eliminate Settings layout residue, prevent invalid album submissions, and make transient download feedback behave consistently.

## Verification

- `bun run typecheck`
- `bun run lint` — 0 warnings/errors
- `bun run test` — 64 files, 401 tests passed
- `git diff --check`
- two fresh independent reviews; all findings resolved and re-reviewed

Playwright was not run because its configuration starts a development server, which this repository’s manual-review instructions prohibit for this workflow.
