### PR TITLE
feat(metadata): reopen cleanup suggestions

### DIFF
--- a/src/features/library/AlbumSidebar.tsx
+++ b/src/features/library/AlbumSidebar.tsx
@@ -30,6 +30,7 @@ interface AlbumSidebarProps {
   selectedAlbumId: string | null;
   selectedFileId: string | null;
   selectedFileIds: Set<string>;
+  albumIdsWithCleanupSuggestions: ReadonlySet<string>;
   onSelectAlbum: (albumId: string, event?: ReactMouseEvent) => void;
   onSelectFile: (albumId: string, fileId: string, event?: ReactMouseEvent) => void;
   onSelectLooseTrack: (fileId: string, event?: ReactMouseEvent) => void;
@@ -38,6 +39,7 @@ interface AlbumSidebarProps {
   onRetryDownload: (fileId: string) => void;
   onAddAlbum: () => void;
   onEditAlbum: (albumId: string) => void;
+  onReviewAlbumCleanup: (albumId: string) => void;
   onDownloadAlbum: (albumId: string) => void;
   onUploadToAlbum: (albumId: string, files: File[]) => void;
   onMoveTrackToAlbum: (
@@ -69,6 +71,7 @@ export default function AlbumSidebar({
   selectedAlbumId,
   selectedFileId,
   selectedFileIds,
+  albumIdsWithCleanupSuggestions,
   onSelectAlbum,
   onSelectFile,
   onSelectLooseTrack,
@@ -77,6 +80,7 @@ export default function AlbumSidebar({
   onRetryDownload,
   onAddAlbum,
   onEditAlbum,
+  onReviewAlbumCleanup,
   onDownloadAlbum,
   onUploadToAlbum,
   onMoveTrackToAlbum,
@@ -175,8 +179,10 @@ export default function AlbumSidebar({
                   album={album}
                   selected={selectedAlbumId === album.id}
                   canDownload={canDownloadAlbum}
+                  hasCleanupSuggestions={albumIdsWithCleanupSuggestions.has(album.id)}
                   onSelect={(event) => onSelectAlbum(album.id, event)}
                   onEdit={() => onEditAlbum(album.id)}
+                  onReviewCleanup={() => onReviewAlbumCleanup(album.id)}
                   onDownload={() => onDownloadAlbum(album.id)}
                   {...fileDropProps}
                 >

--- a/src/features/library/AlbumSidebarDnd.tsx
+++ b/src/features/library/AlbumSidebarDnd.tsx
@@ -6,6 +6,7 @@ import { useDroppable } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import {
   AlertCircle,
+  CircleAlert,
   Ban,
   Check,
   Download,
@@ -207,9 +208,11 @@ type AlbumCardProps = {
   album: AlbumGroup;
   selected: boolean;
   canDownload: boolean;
+  hasCleanupSuggestions: boolean;
   children: ReactNode;
   onSelect: (event: ReactMouseEvent) => void;
   onEdit: () => void;
+  onReviewCleanup: () => void;
   onDownload: () => void;
   onFileDragOver: (event: React.DragEvent<HTMLDivElement>) => void;
   onFileDrop: (event: React.DragEvent<HTMLDivElement>) => void;
@@ -219,9 +222,11 @@ export function SortableAlbumCard({
   album,
   selected,
   canDownload,
+  hasCleanupSuggestions,
   children,
   onSelect,
   onEdit,
+  onReviewCleanup,
   onDownload,
   onFileDragOver,
   onFileDrop,
@@ -269,6 +274,23 @@ export function SortableAlbumCard({
             </div>
           </div>
         </button>
+        {hasCleanupSuggestions && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 text-amber-600 hover:bg-amber-500/10 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300"
+                onClick={onReviewCleanup}
+                aria-label={`apply suggested edits to ${album.title}`}
+              >
+                <CircleAlert className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>apply edits?</TooltipContent>
+          </Tooltip>
+        )}
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="inline-flex">

--- a/src/features/library/MetadataCleanupDialog.tsx
+++ b/src/features/library/MetadataCleanupDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -14,22 +14,23 @@ import type { MetadataCleanupSuggestion } from "@/features/library/metadataClean
 
 export interface MetadataCleanupDialogProps {
   open: boolean;
+  selectionSessionKey: number;
   suggestions: MetadataCleanupSuggestion[];
   onOpenChange: (open: boolean) => void;
   onApply: (suggestions: MetadataCleanupSuggestion[]) => void;
 }
 
-export default function MetadataCleanupDialog({
+type MetadataCleanupDialogSessionProps = Omit<MetadataCleanupDialogProps, "selectionSessionKey">;
+
+function MetadataCleanupDialogSession({
   open,
   suggestions,
   onOpenChange,
   onApply,
-}: MetadataCleanupDialogProps) {
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-
-  useEffect(() => {
-    if (open) setSelectedIds(new Set(suggestions.map((suggestion) => suggestion.trackId)));
-  }, [open, suggestions]);
+}: MetadataCleanupDialogSessionProps) {
+  const [selectedIds, setSelectedIds] = useState(
+    () => new Set(suggestions.map((suggestion) => suggestion.trackId)),
+  );
 
   const selectedSuggestions = suggestions.filter((suggestion) =>
     selectedIds.has(suggestion.trackId),
@@ -91,4 +92,11 @@ export default function MetadataCleanupDialog({
       </DialogContent>
     </Dialog>
   );
+}
+
+export default function MetadataCleanupDialog({
+  selectionSessionKey,
+  ...dialogProps
+}: MetadataCleanupDialogProps) {
+  return <MetadataCleanupDialogSession key={selectionSessionKey} {...dialogProps} />;
 }

--- a/src/features/library/TagSidebarPanel.tsx
+++ b/src/features/library/TagSidebarPanel.tsx
@@ -22,6 +22,7 @@ export interface TagSidebarPanelProps {
   selectedAlbumId: string | null;
   selectedFileId: string | null;
   selectedFileIds: Set<string>;
+  albumIdsWithCleanupSuggestions: ReadonlySet<string>;
   settingsOpen: boolean;
   onAudioUpload: (files: File[]) => void;
   onSelectAlbum: (albumId: string, event?: ReactMouseEvent) => void;
@@ -32,6 +33,7 @@ export interface TagSidebarPanelProps {
   onRetryDownload: (fileId: string) => void;
   onAddAlbum: () => void;
   onEditAlbum: (albumId: string) => void;
+  onReviewAlbumCleanup: (albumId: string) => void;
   onDownloadAlbum: (albumId: string) => void;
   onUploadToAlbum: (albumId: string, files: File[]) => void;
   onMoveTrackToAlbum: (
@@ -65,6 +67,7 @@ export default function TagSidebarPanel({
   selectedAlbumId,
   selectedFileId,
   selectedFileIds,
+  albumIdsWithCleanupSuggestions,
   settingsOpen,
   onAudioUpload,
   onSelectAlbum,
@@ -75,6 +78,7 @@ export default function TagSidebarPanel({
   onRetryDownload,
   onAddAlbum,
   onEditAlbum,
+  onReviewAlbumCleanup,
   onDownloadAlbum,
   onUploadToAlbum,
   onMoveTrackToAlbum,
@@ -162,6 +166,7 @@ export default function TagSidebarPanel({
         selectedAlbumId={selectedAlbumId}
         selectedFileId={selectedFileId}
         selectedFileIds={selectedFileIds}
+        albumIdsWithCleanupSuggestions={albumIdsWithCleanupSuggestions}
         onSelectAlbum={onSelectAlbum}
         onSelectFile={onSelectFile}
         onSelectLooseTrack={onSelectLooseTrack}
@@ -170,6 +175,7 @@ export default function TagSidebarPanel({
         onRetryDownload={onRetryDownload}
         onAddAlbum={onAddAlbum}
         onEditAlbum={onEditAlbum}
+        onReviewAlbumCleanup={onReviewAlbumCleanup}
         onDownloadAlbum={onDownloadAlbum}
         onUploadToAlbum={onUploadToAlbum}
         onMoveTrackToAlbum={onMoveTrackToAlbum}

--- a/src/features/library/metadataCleanup.ts
+++ b/src/features/library/metadataCleanup.ts
@@ -168,6 +168,17 @@ export function findMetadataCleanupSuggestions(
   });
 }
 
+export function findAlbumMetadataCleanupSuggestions(
+  files: TagiumFile[],
+  albums: AlbumGroup[],
+  albumId: string,
+): MetadataCleanupSuggestion[] {
+  const album = albums.find((candidate) => candidate.id === albumId);
+  if (!album) return [];
+
+  return findMetadataCleanupSuggestions(files, albums, new Set(album.trackIds));
+}
+
 export function applyMetadataCleanupSuggestions(
   files: TagiumFile[],
   suggestions: MetadataCleanupSuggestion[],

--- a/src/features/workspace/useAudioWorkspace.ts
+++ b/src/features/workspace/useAudioWorkspace.ts
@@ -29,6 +29,8 @@ type WorkspaceSidebarProps = Pick<
   | "onRemoveFile"
   | "onAddAlbum"
   | "onEditAlbum"
+  | "albumIdsWithCleanupSuggestions"
+  | "onReviewAlbumCleanup"
   | "onMoveTrackToAlbum"
   | "onMoveTrackToLoose"
   | "onPromptCreateAlbumFromLooseTracks"
@@ -63,7 +65,7 @@ export const useAudioWorkspace = ({
   removeDownloads: (trackIds: string[]) => void;
   busy: boolean;
 }): AudioWorkspace => {
-  const cleanupDialogProps = useWorkspaceCleanup({ library, editor, settings, busy });
+  const cleanup = useWorkspaceCleanup({ library, editor, settings, busy });
   const selection = useWorkspaceSelection({
     library,
     editor,
@@ -81,13 +83,15 @@ export const useAudioWorkspace = ({
   });
 
   return {
-    cleanupDialogProps,
+    cleanupDialogProps: cleanup.dialogProps,
     removalDialogProps: selection.removalDialogProps,
     albumDialogProps: album.dialogProps,
     settingsPageProps,
     sidebarProps: {
       ...selection.sidebarProps,
       ...album.sidebarProps,
+      albumIdsWithCleanupSuggestions: cleanup.albumIdsWithSuggestions,
+      onReviewAlbumCleanup: cleanup.onReviewAlbum,
       settingsOpen: activeView === "settings",
       onOpenSettings: settingsPageProps.onBack,
     },

--- a/src/features/workspace/useWorkspaceCleanup.ts
+++ b/src/features/workspace/useWorkspaceCleanup.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { toast } from "sonner";
 import {
   applyMetadataCleanupSuggestions,
+  findAlbumMetadataCleanupSuggestions,
   findMetadataCleanupSuggestions,
   undoMetadataCleanupSuggestions,
   type MetadataCleanupSuggestion,
@@ -13,6 +14,16 @@ import type { AppSettings } from "@/features/library/types";
 
 type CleanupEditor = { form: Pick<TrackEditorSession["form"], "reset"> };
 
+type CleanupDialogScope =
+  | { type: "album"; albumId: string }
+  | { type: "tracks"; trackIds: ReadonlySet<string> };
+
+export interface WorkspaceCleanup {
+  dialogProps: MetadataCleanupDialogProps;
+  albumIdsWithSuggestions: ReadonlySet<string>;
+  onReviewAlbum: (albumId: string) => void;
+}
+
 export const useWorkspaceCleanup = ({
   library,
   editor,
@@ -23,8 +34,9 @@ export const useWorkspaceCleanup = ({
   editor: CleanupEditor;
   settings: AppSettings;
   busy: boolean;
-}): MetadataCleanupDialogProps => {
-  const [suggestions, setSuggestions] = useState<MetadataCleanupSuggestion[]>([]);
+}): WorkspaceCleanup => {
+  const [dialogScope, setDialogScope] = useState<CleanupDialogScope | null>(null);
+  const [selectionSessionKey, setSelectionSessionKey] = useState(0);
   const [open, setOpen] = useState(false);
   const offeredKeysRef = useRef(new Set<string>());
   const editorRef = useRef(editor);
@@ -35,11 +47,47 @@ export const useWorkspaceCleanup = ({
   }, [editor, settings]);
 
   const availableSuggestions = useMemo(
-    () => (busy ? [] : findMetadataCleanupSuggestions(library.state.files, library.state.albums)),
-    [busy, library.state.albums, library.state.files],
+    () => findMetadataCleanupSuggestions(library.state.files, library.state.albums),
+    [library.state.albums, library.state.files],
   );
 
+  const albumIdsWithSuggestions = useMemo(() => {
+    const albumIds = new Set<string>();
+    const albumIdByTrackId = new Map(
+      library.state.albums.flatMap((album) =>
+        album.trackIds.map((trackId) => [trackId, album.id] as const),
+      ),
+    );
+    availableSuggestions.forEach((suggestion) => {
+      const albumId = albumIdByTrackId.get(suggestion.trackId);
+      if (albumId) albumIds.add(albumId);
+    });
+    return albumIds;
+  }, [availableSuggestions, library.state.albums]);
+
+  const suggestions = useMemo(() => {
+    if (!dialogScope) return [];
+    if (dialogScope.type === "tracks") {
+      return availableSuggestions.filter((suggestion) =>
+        dialogScope.trackIds.has(suggestion.trackId),
+      );
+    }
+
+    return findAlbumMetadataCleanupSuggestions(
+      library.state.files,
+      library.state.albums,
+      dialogScope.albumId,
+    );
+  }, [availableSuggestions, dialogScope, library.state.albums, library.state.files]);
+
+  const openDialog = useCallback((scope: CleanupDialogScope) => {
+    setDialogScope(scope);
+    setSelectionSessionKey((current) => current + 1);
+    setOpen(true);
+  }, []);
+
   useEffect(() => {
+    if (busy) return;
     const newSuggestions = availableSuggestions.filter((suggestion) => {
       const key = `${suggestion.trackId}:${suggestion.beforeTitle}:${suggestion.afterTitle}`;
       if (offeredKeysRef.current.has(key)) return false;
@@ -53,12 +101,14 @@ export const useWorkspaceCleanup = ({
       action: {
         label: "review",
         onClick: () => {
-          setSuggestions(newSuggestions);
-          setOpen(true);
+          openDialog({
+            type: "tracks",
+            trackIds: new Set(newSuggestions.map(({ trackId }) => trackId)),
+          });
         },
       },
     });
-  }, [availableSuggestions]);
+  }, [availableSuggestions, busy, openDialog]);
 
   const apply = useCallback(
     (selectedSuggestions: MetadataCleanupSuggestion[]) => {
@@ -97,5 +147,22 @@ export const useWorkspaceCleanup = ({
     [library],
   );
 
-  return { open, suggestions, onOpenChange: setOpen, onApply: apply };
+  const onReviewAlbum = useCallback(
+    (albumId: string) => {
+      openDialog({ type: "album", albumId });
+    },
+    [openDialog],
+  );
+
+  return {
+    dialogProps: {
+      open,
+      selectionSessionKey,
+      suggestions,
+      onOpenChange: setOpen,
+      onApply: apply,
+    },
+    albumIdsWithSuggestions,
+    onReviewAlbum,
+  };
 };

--- a/tests/unit/features/library/AlbumSidebar.test.tsx
+++ b/tests/unit/features/library/AlbumSidebar.test.tsx
@@ -29,7 +29,15 @@ vi.mock("@/features/library/AlbumSidebarDnd", () => ({
     </div>
   ),
   SidebarDragPreview: () => null,
-  SortableAlbumCard: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SortableAlbumCard: ({
+    children,
+    hasCleanupSuggestions,
+  }: {
+    children?: ReactNode;
+    hasCleanupSuggestions: boolean;
+  }) => (
+    <div data-cleanup-suggestions={hasCleanupSuggestions ? "available" : "none"}>{children}</div>
+  ),
   SortableTrackRow: () => null,
 }));
 
@@ -54,6 +62,7 @@ describe("AlbumSidebar", () => {
         selectedAlbumId={null}
         selectedFileId={null}
         selectedFileIds={new Set()}
+        albumIdsWithCleanupSuggestions={new Set()}
         onSelectAlbum={noOp}
         onSelectFile={noOp}
         onSelectLooseTrack={noOp}
@@ -62,6 +71,7 @@ describe("AlbumSidebar", () => {
         onRetryDownload={noOp}
         onAddAlbum={noOp}
         onEditAlbum={noOp}
+        onReviewAlbumCleanup={noOp}
         onDownloadAlbum={noOp}
         onUploadToAlbum={noOp}
         onMoveTrackToAlbum={noOp}
@@ -76,5 +86,41 @@ describe("AlbumSidebar", () => {
       `data-drop-container="${LOOSE_CONTAINER_ID}" class="min-h-0 shrink-0"`,
     );
     expect(markup).not.toContain("min-h-12");
+  });
+
+  it("marks only albums with derived cleanup suggestions", () => {
+    const markup = renderToStaticMarkup(
+      <AlbumSidebar
+        albums={[
+          { id: "album-a", title: "Album A", artist: "Artist", genre: "", trackIds: [] },
+          { id: "album-b", title: "Album B", artist: "Artist", genre: "", trackIds: [] },
+        ]}
+        looseTrackIds={[]}
+        files={[]}
+        selectedAlbumId={null}
+        selectedFileId={null}
+        selectedFileIds={new Set()}
+        albumIdsWithCleanupSuggestions={new Set(["album-b"])}
+        onSelectAlbum={noOp}
+        onSelectFile={noOp}
+        onSelectLooseTrack={noOp}
+        onClearSelection={noOp}
+        onRemoveFile={noOp}
+        onRetryDownload={noOp}
+        onAddAlbum={noOp}
+        onEditAlbum={noOp}
+        onReviewAlbumCleanup={noOp}
+        onDownloadAlbum={noOp}
+        onUploadToAlbum={noOp}
+        onMoveTrackToAlbum={noOp}
+        onMoveTrackToLoose={noOp}
+        onPromptCreateAlbumFromLooseTracks={noOp}
+        onReorderAlbums={noOp}
+        onAudioUpload={noOp}
+      />,
+    );
+
+    expect(markup.match(/data-cleanup-suggestions="available"/g)).toHaveLength(1);
+    expect(markup.match(/data-cleanup-suggestions="none"/g)).toHaveLength(1);
   });
 });

--- a/tests/unit/features/library/AlbumSidebarDnd.test.tsx
+++ b/tests/unit/features/library/AlbumSidebarDnd.test.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from "react";
+import { act, create } from "react-test-renderer";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setActivatorNodeRef: vi.fn(),
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}));
+
+import { SortableAlbumCard } from "@/features/library/AlbumSidebarDnd";
+
+describe("album cleanup action", () => {
+  it("offers an accessible apply-edits action only when suggestions exist", () => {
+    const onReviewCleanup = vi.fn();
+    let renderer: ReturnType<typeof create>;
+    act(() => {
+      renderer = create(
+        <SortableAlbumCard
+          album={{
+            id: "album",
+            title: "Untrue",
+            artist: "Burial",
+            genre: "Electronic",
+            trackIds: ["track"],
+          }}
+          selected={false}
+          canDownload={false}
+          hasCleanupSuggestions
+          onSelect={vi.fn()}
+          onEdit={vi.fn()}
+          onDownload={vi.fn()}
+          onReviewCleanup={onReviewCleanup}
+          onFileDragOver={vi.fn()}
+          onFileDrop={vi.fn()}
+        >
+          <div />
+        </SortableAlbumCard>,
+      );
+    });
+
+    const action = renderer!.root.findByProps({
+      "aria-label": "apply suggested edits to Untrue",
+    });
+    expect(
+      renderer!.root.findAllByType("span").some((node) => node.children.includes("apply edits?")),
+    ).toBe(true);
+    void act(() => action.props.onClick());
+    expect(onReviewCleanup).toHaveBeenCalledOnce();
+    act(() => renderer!.unmount());
+  });
+});

--- a/tests/unit/features/library/MetadataCleanupDialog.test.tsx
+++ b/tests/unit/features/library/MetadataCleanupDialog.test.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react";
+import { act, create, type ReactTestInstance } from "react-test-renderer";
+import { describe, expect, it, vi } from "vite-plus/test";
+import type { MetadataCleanupSuggestion } from "@/features/library/metadataCleanup";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children?: ReactNode }) => <footer>{children}</footer>,
+  DialogHeader: ({ children }: { children?: ReactNode }) => <header>{children}</header>,
+  DialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/checkbox", () => ({
+  Checkbox: ({ checked, onCheckedChange }: { checked: boolean; onCheckedChange: () => void }) => (
+    <button data-checkbox aria-pressed={checked} onClick={onCheckedChange} />
+  ),
+}));
+
+import MetadataCleanupDialog from "@/features/library/MetadataCleanupDialog";
+
+const suggestion = (trackId: string): MetadataCleanupSuggestion => ({
+  trackId,
+  beforeTitle: `Artist - ${trackId}`,
+  afterTitle: trackId,
+  beforeFilename: `Artist - ${trackId}.mp3`,
+  afterFilename: `${trackId}.mp3`,
+  reasons: ["artist"],
+});
+
+const textContent = (node: ReactTestInstance) =>
+  node.children.filter((child): child is string => typeof child === "string").join("");
+
+describe("MetadataCleanupDialog", () => {
+  it("preserves unchecked suggestions when an unrelated library update recomputes them", () => {
+    const onApply = vi.fn();
+    const props = {
+      open: true,
+      selectionSessionKey: 1,
+      suggestions: [suggestion("one"), suggestion("two")],
+      onOpenChange: vi.fn(),
+      onApply,
+    };
+    let renderer: ReturnType<typeof create>;
+    act(() => {
+      renderer = create(<MetadataCleanupDialog {...props} />);
+    });
+
+    const checkboxes = renderer!.root.findAllByProps({ "data-checkbox": true });
+    void act(() => checkboxes[0].props.onClick());
+    expect(checkboxes[0].props["aria-pressed"]).toBe(false);
+
+    act(() => {
+      renderer!.update(
+        <MetadataCleanupDialog {...props} suggestions={[suggestion("one"), suggestion("two")]} />,
+      );
+    });
+
+    const apply = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button).startsWith("apply "));
+    void act(() => apply!.props.onClick());
+    expect(onApply).toHaveBeenCalledWith([expect.objectContaining({ trackId: "two" })]);
+
+    act(() => {
+      renderer!.update(
+        <MetadataCleanupDialog
+          {...props}
+          selectionSessionKey={2}
+          suggestions={[suggestion("one"), suggestion("two")]}
+        />,
+      );
+    });
+    const reopenedApply = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button).startsWith("apply "));
+    expect(reopenedApply && textContent(reopenedApply)).toBe("apply 2 changes");
+    act(() => renderer!.unmount());
+  });
+});

--- a/tests/unit/features/library/metadataCleanup.test.ts
+++ b/tests/unit/features/library/metadataCleanup.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   applyMetadataCleanupSuggestions,
+  findAlbumMetadataCleanupSuggestions,
   findMetadataCleanupSuggestions,
   suggestTitleCleanup,
   undoMetadataCleanupSuggestions,
@@ -104,6 +105,19 @@ describe("metadata cleanup suggestions", () => {
     expect(
       findMetadataCleanupSuggestions([file("Good Girls (XCX WORLD)")], [album("XCX WORLD")]),
     ).toEqual([expect.objectContaining({ afterTitle: "Good Girls", reasons: ["album"] })]);
+  });
+
+  it("derives suggestions for only the requested album", () => {
+    const first = file("Burial - Archangel (Official Audio)");
+    const second = { ...file("Burial - Ghost Hardware (Official Audio)"), id: "track-2" };
+    const albums = [
+      album("Untrue", first.id),
+      { ...album("Ghost Hardware", second.id), id: "album-2" },
+    ];
+
+    expect(findAlbumMetadataCleanupSuggestions([first, second], albums, "album-2")).toEqual([
+      expect.objectContaining({ trackId: "track-2", afterTitle: "Ghost Hardware" }),
+    ]);
   });
 
   it("uses album artist metadata as a confident prefix match", () => {

--- a/tests/unit/features/workspace/useWorkspaceCleanup.test.tsx
+++ b/tests/unit/features/workspace/useWorkspaceCleanup.test.tsx
@@ -1,0 +1,181 @@
+import { act } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { AlbumGroup, AppSettings, AudioMetadata, TagiumFile } from "@/features/library/types";
+
+const toastMocks = vi.hoisted(() => {
+  const toast = vi.fn();
+  return { toast: Object.assign(toast, { success: vi.fn() }) };
+});
+
+vi.mock("sonner", () => ({ toast: toastMocks.toast }));
+
+import { renderHook } from "../../support/hookTestHarness";
+import { useLibraryStore } from "@/features/library/useLibraryStore";
+import { useWorkspaceCleanup } from "@/features/workspace/useWorkspaceCleanup";
+
+const settings: AppSettings = {
+  syncTrackNumbers: false,
+  syncFilenames: true,
+  audioBitrate: "320",
+  applySoundCloudAlbumCoverToTracks: false,
+};
+
+const metadata = (title: string): AudioMetadata => ({
+  filename: title,
+  title,
+  artist: "Burial",
+  album: "Untrue",
+  year: 2007,
+  genre: "Electronic",
+  duration: 240,
+  bitrate: 320,
+  sampleRate: 44_100,
+  picture: [],
+  trackNumber: 1,
+});
+
+const file = (id: string, title: string): TagiumFile => ({
+  id,
+  status: "saved",
+  downloadStatus: "ready",
+  filename: `${title}.mp3`,
+  metadata: metadata(title),
+});
+
+const album = (id: string, title: string, trackId: string): AlbumGroup => ({
+  id,
+  title,
+  artist: "Burial",
+  genre: "Electronic",
+  trackIds: [trackId],
+});
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.restoreAllMocks());
+
+describe("workspace title cleanup", () => {
+  it("keeps warnings and an open album review intact while the workspace becomes busy", () => {
+    const hook = renderHook(
+      ({ busy }: { busy: boolean }) => {
+        const library = useLibraryStore();
+        const cleanup = useWorkspaceCleanup({
+          library,
+          editor: { form: { reset: vi.fn() } },
+          settings,
+          busy,
+        });
+        return { library, cleanup };
+      },
+      { busy: false },
+    );
+
+    act(() => {
+      hook.result.library.dispatch({
+        type: "content-replaced",
+        files: [file("track", "Burial - Archangel (Official Audio)")],
+        albums: [album("album", "Untrue", "track")],
+      });
+    });
+    act(() => hook.result.cleanup.onReviewAlbum("album"));
+    expect(hook.result.cleanup.dialogProps.suggestions).toHaveLength(1);
+
+    hook.rerender({ busy: true });
+
+    expect(hook.result.cleanup.albumIdsWithSuggestions).toContain("album");
+    expect(hook.result.cleanup.dialogProps).toMatchObject({ open: true });
+    expect(hook.result.cleanup.dialogProps.suggestions.map(({ trackId }) => trackId)).toEqual([
+      "track",
+    ]);
+    hook.unmount();
+  });
+
+  it("keeps album suggestions isolated and available after dismissing the dialog", () => {
+    const hook = renderHook(() => {
+      const library = useLibraryStore();
+      const cleanup = useWorkspaceCleanup({
+        library,
+        editor: { form: { reset: vi.fn() } },
+        settings,
+        busy: false,
+      });
+      return { library, cleanup };
+    }, undefined);
+
+    act(() => {
+      hook.result.library.dispatch({
+        type: "content-replaced",
+        files: [
+          file("one", "Burial - Archangel (Official Audio)"),
+          file("two", "Burial - Near Dark (Official Audio)"),
+        ],
+        albums: [album("first", "Untrue", "one"), album("second", "Untrue", "two")],
+      });
+    });
+
+    expect(hook.result.cleanup.albumIdsWithSuggestions).toEqual(new Set(["first", "second"]));
+
+    act(() => hook.result.cleanup.onReviewAlbum("first"));
+    expect(hook.result.cleanup.dialogProps).toMatchObject({ open: true });
+    expect(hook.result.cleanup.dialogProps.suggestions.map(({ trackId }) => trackId)).toEqual([
+      "one",
+    ]);
+
+    act(() => hook.result.cleanup.dialogProps.onOpenChange(false));
+    expect(hook.result.cleanup.albumIdsWithSuggestions).toContain("first");
+    act(() => hook.result.cleanup.onReviewAlbum("first"));
+    expect(hook.result.cleanup.dialogProps.suggestions).toHaveLength(1);
+    hook.unmount();
+  });
+
+  it("removes an applied warning, restores it on undo, and reappears after a later title edit", () => {
+    const reset = vi.fn();
+    const hook = renderHook(() => {
+      const library = useLibraryStore();
+      const cleanup = useWorkspaceCleanup({
+        library,
+        editor: { form: { reset } },
+        settings,
+        busy: false,
+      });
+      return { library, cleanup };
+    }, undefined);
+    const group = album("album", "Untrue", "track");
+
+    act(() => {
+      hook.result.library.dispatch({
+        type: "content-replaced",
+        files: [file("track", "Burial - Archangel (Official Audio)")],
+        albums: [group],
+        selection: { selectedAlbumId: "album", selectedFileId: "track" },
+      });
+    });
+    act(() => hook.result.cleanup.onReviewAlbum("album"));
+    act(() => hook.result.cleanup.dialogProps.onApply(hook.result.cleanup.dialogProps.suggestions));
+
+    expect(hook.result.library.getSnapshot().files[0].metadata?.title).toBe("Archangel");
+    expect(hook.result.cleanup.albumIdsWithSuggestions).not.toContain("album");
+
+    const undo = toastMocks.toast.success.mock.calls.at(-1)?.[1].action.onClick;
+    void act(() => undo());
+    expect(hook.result.cleanup.albumIdsWithSuggestions).toContain("album");
+
+    act(() => hook.result.cleanup.onReviewAlbum("album"));
+    act(() => hook.result.cleanup.dialogProps.onApply(hook.result.cleanup.dialogProps.suggestions));
+    expect(hook.result.cleanup.albumIdsWithSuggestions).not.toContain("album");
+
+    act(() => {
+      const current = hook.result.library.getSnapshot().files[0];
+      hook.result.library.dispatch({
+        type: "content-replaced",
+        files: [
+          {
+            ...current,
+            metadata: { ...current.metadata!, title: "Burial - Archangel (Official Video)" },
+          },
+        ],
+      });
+    });
+    expect(hook.result.cleanup.albumIdsWithSuggestions).toContain("album");
+    hook.unmount();
+  });
+});

--- a/tests/unit/features/workspace/useWorkspaceCleanup.test.tsx
+++ b/tests/unit/features/workspace/useWorkspaceCleanup.test.tsx
@@ -1,6 +1,7 @@
 import { act } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { AlbumGroup, AppSettings, AudioMetadata, TagiumFile } from "@/features/library/types";
+import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 
 const toastMocks = vi.hoisted(() => {
   const toast = vi.fn();
@@ -14,6 +15,7 @@ import { useLibraryStore } from "@/features/library/useLibraryStore";
 import { useWorkspaceCleanup } from "@/features/workspace/useWorkspaceCleanup";
 
 const settings: AppSettings = {
+  ...DEFAULT_APP_SETTINGS,
   syncTrackNumbers: false,
   syncFilenames: true,
   audioBitrate: "320",
@@ -24,6 +26,7 @@ const metadata = (title: string): AudioMetadata => ({
   filename: title,
   title,
   artist: "Burial",
+  albumArtist: "Burial",
   album: "Untrue",
   year: 2007,
   genre: "Electronic",
@@ -32,10 +35,15 @@ const metadata = (title: string): AudioMetadata => ({
   sampleRate: 44_100,
   picture: [],
   trackNumber: 1,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
 });
 
 const file = (id: string, title: string): TagiumFile => ({
   id,
+  format: "mp3",
   status: "saved",
   downloadStatus: "ready",
   filename: `${title}.mp3`,


### PR DESCRIPTION
## What changed

- derive current title-cleanup suggestions per album
- show an accessible album warning action with an “apply edits?” tooltip only while suggestions exist
- reopen the existing cleanup dialog scoped to the selected album
- preserve user checkbox choices across equivalent live recomputations and background busy transitions
- keep dismissal stateless; applying, undoing, and later title edits naturally recompute warning state
- add focused sidebar, dialog, cleanup, and workspace-hook regression coverage

## Why

The initial cleanup toast was easy to dismiss permanently. Albums with unapplied suggestions now retain a discoverable, current re-entry point without persisting duplicate suggestion state.

## Verification

- post-rebase `bun run typecheck`
- post-rebase `bun run lint` — 0 warnings/errors
- post-rebase `bun run test` — 66 files, 401 tests passed
- `git diff --check`
- two fresh independent reviews; findings fixed and re-reviewed

This branch was rebased onto `origin/main` after implementation, so the PR is independently mergeable and does not include PR #120.
