### PR TITLE
feat(metadata): add advanced field policy

### DIFF
--- a/src/features/audio/audioMetadataIO.ts
+++ b/src/features/audio/audioMetadataIO.ts
@@ -25,9 +25,15 @@ interface MP3TagPicture {
   data: number[];
 }
 
+interface MP3TagComment {
+  language: string;
+  descriptor: string;
+  text: string;
+}
+
 interface MP3TagReader {
-  read: () => void;
-  save?: () => void;
+  read: (options?: { unsupported?: boolean }) => void;
+  save?: (options?: { id3v2?: { unsupported?: boolean } }) => void;
   error?: string;
   buffer?: ArrayBuffer;
   tags: {
@@ -37,8 +43,30 @@ interface MP3TagReader {
     year?: string;
     genre?: string;
     track?: string;
+    comment?: string;
+    v1?: { comment?: string; [field: string]: unknown };
     v2?: {
       APIC?: MP3TagPicture[];
+      TPE2?: string;
+      TP2?: string;
+      TCOM?: string;
+      TCM?: string;
+      TBPM?: string;
+      TBP?: string;
+      TPOS?: string;
+      TPA?: string;
+      COMM?: MP3TagComment[];
+      COM?: MP3TagComment[];
+      [frame: string]: unknown;
+    };
+    v2Details?: {
+      version: number[];
+      size?: number;
+      flags?: {
+        unsynchronisation: boolean;
+        extendedHeader: boolean;
+        experimentalIndicator: boolean;
+      };
     };
   };
 }
@@ -55,6 +83,53 @@ const parseTagNumber = (value: string | undefined) => {
   const [head] = value.split("/");
   const parsed = Number.parseInt(head ?? "", 10);
   return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+const toTagNumber = (value: number | null) =>
+  value !== null && !Number.isNaN(value) ? value.toString() : "";
+
+const setVersionedTextFrame = (
+  tags: NonNullable<MP3TagReader["tags"]["v2"]>,
+  version: number | undefined,
+  frame: "TPE2" | "TCOM" | "TBPM" | "TPOS",
+  legacyFrame: "TP2" | "TCM" | "TBP" | "TPA",
+  value: string,
+) => {
+  if (version === 2) {
+    tags[legacyFrame] = value;
+    delete tags[frame];
+    return;
+  }
+  tags[frame] = value;
+  delete tags[legacyFrame];
+};
+
+const ensureId3v2 = (tags: MP3TagReader["tags"]) => {
+  tags.v2 ??= {};
+  tags.v2Details ??= {
+    version: [4, 0],
+    size: 0,
+    flags: {
+      unsynchronisation: false,
+      extendedHeader: false,
+      experimentalIndicator: false,
+    },
+  };
+  return { frames: tags.v2, version: tags.v2Details.version[0] };
+};
+
+const setComment = (tags: MP3TagReader["tags"], value: string) => {
+  const { frames, version } = ensureId3v2(tags);
+  const frame = version === 2 ? "COM" : "COMM";
+  const legacyFrame = version === 2 ? "COMM" : "COM";
+  const comments = (frames[frame] as MP3TagComment[] | undefined) ?? [];
+  const primaryIndex = comments.findIndex(
+    (comment) => comment.language === "eng" && comment.descriptor === "",
+  );
+  const primary = { language: "eng", descriptor: "", text: value };
+  frames[frame] = [primary, ...comments.filter((_, index) => index !== primaryIndex)];
+  delete frames[legacyFrame];
+  if (tags.v1) tags.v1.comment = value;
 };
 
 const getDuration = (file: File) =>
@@ -123,7 +198,7 @@ const readMp3Tags = (MP3Tag: MP3TagConstructor, arrayBuffer: ArrayBuffer, verbos
   Effect.try({
     try: () => {
       const mp3tag = new MP3Tag(arrayBuffer, verbose);
-      mp3tag.read();
+      mp3tag.read({ unsupported: true });
       if (mp3tag.error) throw new Error(mp3tag.error);
       return mp3tag;
     },
@@ -137,7 +212,7 @@ const readMp3Tags = (MP3Tag: MP3TagConstructor, arrayBuffer: ArrayBuffer, verbos
 const saveMp3Tags = (mp3tag: MP3TagReader) =>
   Effect.try({
     try: () => {
-      mp3tag.save?.();
+      mp3tag.save?.({ id3v2: { unsupported: true } });
       if (mp3tag.error || !mp3tag.buffer) {
         throw new Error(mp3tag.error || "unable to save metadata");
       }
@@ -178,6 +253,7 @@ const parseUploadedTrack = (file: File) =>
         filename: withoutAudioExtension(normalizeMp3Filename(file.name), "mp3"),
         title: mp3tag.tags.title || "",
         artist: mp3tag.tags.artist || "",
+        albumArtist: mp3tag.tags.v2?.TPE2 || mp3tag.tags.v2?.TP2 || mp3tag.tags.artist || "",
         album: mp3tag.tags.album || "",
         year: parseTagNumber(mp3tag.tags.year) ?? null,
         genre: mp3tag.tags.genre || "",
@@ -186,6 +262,10 @@ const parseUploadedTrack = (file: File) =>
         sampleRate: 0,
         picture: pictureData,
         trackNumber: parseTrackTagNumber(mp3tag.tags.track) ?? null,
+        discNumber: parseTagNumber(mp3tag.tags.v2?.TPOS || mp3tag.tags.v2?.TPA) ?? null,
+        composer: mp3tag.tags.v2?.TCOM || mp3tag.tags.v2?.TCM || "",
+        bpm: parseTagNumber(mp3tag.tags.v2?.TBPM || mp3tag.tags.v2?.TBP) ?? null,
+        comment: mp3tag.tags.comment || "",
       });
 
       return {
@@ -273,6 +353,7 @@ const writeMetadata = (fileToUpdate: TagiumFile, newTags: AudioMetadata) =>
       ),
     );
 
+    const { frames: v2Frames, version: v2Version } = ensureId3v2(mp3tag.tags);
     mp3tag.tags.title = metadataToWrite.title || "";
     mp3tag.tags.artist = metadataToWrite.artist || "";
     mp3tag.tags.album = metadataToWrite.album || "";
@@ -289,9 +370,23 @@ const writeMetadata = (fileToUpdate: TagiumFile, newTags: AudioMetadata) =>
       !Number.isNaN(metadataToWrite.trackNumber)
         ? metadataToWrite.trackNumber.toString()
         : "";
+    setComment(mp3tag.tags, metadataToWrite.comment);
 
-    if (metadataToWrite.picture && metadataToWrite.picture.length > 0 && mp3tag.tags.v2) {
-      mp3tag.tags.v2.APIC = metadataToWrite.picture.map((picture) => ({
+    {
+      setVersionedTextFrame(v2Frames, v2Version, "TPE2", "TP2", metadataToWrite.albumArtist);
+      setVersionedTextFrame(v2Frames, v2Version, "TCOM", "TCM", metadataToWrite.composer);
+      setVersionedTextFrame(v2Frames, v2Version, "TBPM", "TBP", toTagNumber(metadataToWrite.bpm));
+      setVersionedTextFrame(
+        v2Frames,
+        v2Version,
+        "TPOS",
+        "TPA",
+        toTagNumber(metadataToWrite.discNumber),
+      );
+    }
+
+    if (metadataToWrite.picture && metadataToWrite.picture.length > 0) {
+      v2Frames.APIC = metadataToWrite.picture.map((picture) => ({
         format: picture.format || "image/jpeg",
         type: typeof picture.type === "number" ? picture.type : 3,
         description: picture.description || "",

--- a/src/features/audio/metadata.ts
+++ b/src/features/audio/metadata.ts
@@ -27,6 +27,7 @@ const metadataSnapshotSchema = Schema.Struct({
   filename: Schema.mutableKey(Schema.String),
   title: Schema.mutableKey(Schema.String),
   artist: Schema.mutableKey(Schema.String),
+  albumArtist: Schema.mutableKey(Schema.String),
   album: Schema.mutableKey(Schema.String),
   year: Schema.mutableKey(Schema.NullOr(Schema.Number)),
   genre: Schema.mutableKey(metadataGenreSchema),
@@ -35,17 +36,26 @@ const metadataSnapshotSchema = Schema.Struct({
   sampleRate: Schema.mutableKey(Schema.Number),
   picture: Schema.mutableKey(metadataPictureArraySchema),
   trackNumber: Schema.mutableKey(Schema.NullOr(Schema.Number)),
+  discNumber: Schema.mutableKey(Schema.NullOr(Schema.Number)),
+  composer: Schema.mutableKey(Schema.String),
+  bpm: Schema.mutableKey(Schema.NullOr(Schema.Number)),
+  comment: Schema.mutableKey(Schema.String),
 });
 
 const metadataPatchSchema = Schema.Struct({
   filename: optionalMutableKey(Schema.String),
   title: optionalMutableKey(Schema.String),
   artist: optionalMutableKey(Schema.String),
+  albumArtist: optionalMutableKey(Schema.String),
   album: optionalMutableKey(Schema.String),
   year: optionalMutableKey(Schema.NullOr(Schema.Number)),
   genre: optionalMutableKey(metadataGenreSchema),
   picture: optionalMutableKey(metadataPictureArraySchema),
   trackNumber: optionalMutableKey(Schema.NullOr(Schema.Number)),
+  discNumber: optionalMutableKey(Schema.NullOr(Schema.Number)),
+  composer: optionalMutableKey(Schema.String),
+  bpm: optionalMutableKey(Schema.NullOr(Schema.Number)),
+  comment: optionalMutableKey(Schema.String),
 });
 
 export const audioMetadataSchema = metadataSnapshotSchema;

--- a/src/features/editor/audioTaggerUtils.ts
+++ b/src/features/editor/audioTaggerUtils.ts
@@ -10,11 +10,16 @@ const metadataPatchFields = [
   "filename",
   "title",
   "artist",
+  "albumArtist",
   "album",
   "year",
   "genre",
   "picture",
   "trackNumber",
+  "discNumber",
+  "composer",
+  "bpm",
+  "comment",
 ] as const satisfies readonly MetadataPatchField[];
 
 export const getFileImportKey = (file: File) => `${file.name}:${file.size}:${file.lastModified}`;
@@ -54,11 +59,16 @@ export const getNullableNumericPatchValue = (
 export const getSubmittedAudioMetadata = (
   data: AudioMetadata,
   syncFilenames: boolean,
+  advancedMetadata = true,
+  linkAlbumArtist = false,
 ): AudioMetadata => ({
   ...data,
   filename: sanitizeFilenameBase(syncFilenames ? data.title : data.filename),
+  albumArtist: !advancedMetadata || linkAlbumArtist ? data.artist : data.albumArtist,
   year: getNullableNumericMetadataValue(data.year),
   trackNumber: getNullableNumericMetadataValue(data.trackNumber),
+  discNumber: getNullableNumericMetadataValue(data.discNumber),
+  bpm: getNullableNumericMetadataValue(data.bpm),
 });
 
 export const createSparseMetadataPatch = (
@@ -85,6 +95,9 @@ export const createSparseMetadataPatch = (
       case "artist":
         patch.artist = metadata.artist;
         break;
+      case "albumArtist":
+        patch.albumArtist = metadata.albumArtist;
+        break;
       case "album":
         patch.album = metadata.album;
         break;
@@ -99,6 +112,18 @@ export const createSparseMetadataPatch = (
         break;
       case "trackNumber":
         patch.trackNumber = getNullableNumericPatchValue(metadata.trackNumber);
+        break;
+      case "discNumber":
+        patch.discNumber = getNullableNumericPatchValue(metadata.discNumber);
+        break;
+      case "composer":
+        patch.composer = metadata.composer;
+        break;
+      case "bpm":
+        patch.bpm = getNullableNumericPatchValue(metadata.bpm);
+        break;
+      case "comment":
+        patch.comment = metadata.comment;
         break;
     }
   }

--- a/src/features/editor/useTrackEditorSession.ts
+++ b/src/features/editor/useTrackEditorSession.ts
@@ -43,11 +43,16 @@ const createSubmittedMetadataPatch = (metadata: AudioMetadata): MetadataPatch =>
   filename: metadata.filename,
   title: metadata.title,
   artist: metadata.artist,
+  albumArtist: metadata.albumArtist,
   album: metadata.album,
   year: getNullableNumericPatchValue(metadata.year),
   genre: metadata.genre,
   picture: metadata.picture,
   trackNumber: getNullableNumericPatchValue(metadata.trackNumber),
+  discNumber: getNullableNumericPatchValue(metadata.discNumber),
+  composer: metadata.composer,
+  bpm: getNullableNumericPatchValue(metadata.bpm),
+  comment: metadata.comment,
 });
 
 const applyMetadataPatch = (metadata: AudioMetadata, patch: MetadataPatch): AudioMetadata => ({
@@ -55,6 +60,7 @@ const applyMetadataPatch = (metadata: AudioMetadata, patch: MetadataPatch): Audi
   ...(hasOwn(patch, "filename") ? { filename: patch.filename } : {}),
   ...(hasOwn(patch, "title") ? { title: patch.title } : {}),
   ...(hasOwn(patch, "artist") ? { artist: patch.artist } : {}),
+  ...(hasOwn(patch, "albumArtist") ? { albumArtist: patch.albumArtist } : {}),
   ...(hasOwn(patch, "album") ? { album: patch.album } : {}),
   ...(hasOwn(patch, "year") ? { year: getNullableNumericMetadataValue(patch.year) } : {}),
   ...(hasOwn(patch, "genre") ? { genre: patch.genre } : {}),
@@ -62,6 +68,12 @@ const applyMetadataPatch = (metadata: AudioMetadata, patch: MetadataPatch): Audi
   ...(hasOwn(patch, "trackNumber")
     ? { trackNumber: getNullableNumericMetadataValue(patch.trackNumber) }
     : {}),
+  ...(hasOwn(patch, "discNumber")
+    ? { discNumber: getNullableNumericMetadataValue(patch.discNumber) }
+    : {}),
+  ...(hasOwn(patch, "composer") ? { composer: patch.composer } : {}),
+  ...(hasOwn(patch, "bpm") ? { bpm: getNullableNumericMetadataValue(patch.bpm) } : {}),
+  ...(hasOwn(patch, "comment") ? { comment: patch.comment } : {}),
 });
 
 const getFilenameFromPatch = (file: TagiumFile, patch: MetadataPatch) =>
@@ -161,7 +173,36 @@ export const useTrackEditorSession = ({
   }, [formIsDirty, library.state.selectedFileId, reset, selectedFile]);
 
   const getSubmittedMetadata = useCallback(
-    (data: AudioMetadata) => getSubmittedAudioMetadata(data, settingsRef.current.syncFilenames),
+    (data: AudioMetadata) =>
+      getSubmittedAudioMetadata(
+        data,
+        settingsRef.current.syncFilenames,
+        settingsRef.current.advancedMetadata,
+        settingsRef.current.metadataLinks.albumArtist,
+      ),
+    [],
+  );
+
+  const createCurrentMetadataPatch = useCallback(
+    (
+      metadata: AudioMetadata,
+      dirtyFields: Partial<Record<keyof AudioMetadata, unknown>>,
+      extraFields: Iterable<keyof MetadataPatch> = [],
+    ) => {
+      const fields = new Set(extraFields);
+      if (
+        (!settingsRef.current.advancedMetadata || settingsRef.current.metadataLinks.albumArtist) &&
+        (dirtyFields.artist || fields.has("artist"))
+      ) {
+        fields.add("albumArtist");
+      }
+      return createDirtyMetadataPatch(
+        metadata,
+        dirtyFields,
+        settingsRef.current.syncFilenames,
+        fields,
+      );
+    },
     [],
   );
 
@@ -172,11 +213,7 @@ export const useTrackEditorSession = ({
       if (trackIds && !trackIds.includes(selectedId)) return files;
 
       const submittedData = getSubmittedMetadata(getValues());
-      const metadataPatch = createDirtyMetadataPatch(
-        submittedData,
-        dirtyFieldsRef.current,
-        settingsRef.current.syncFilenames,
-      );
+      const metadataPatch = createCurrentMetadataPatch(submittedData, dirtyFieldsRef.current);
       if (!metadataPatch) return files;
       return files.map((file) =>
         file.id === selectedId
@@ -194,7 +231,7 @@ export const useTrackEditorSession = ({
           : file,
       );
     },
-    [getSubmittedMetadata, getValues],
+    [createCurrentMetadataPatch, getSubmittedMetadata, getValues],
   );
 
   const flush = useCallback(
@@ -216,12 +253,9 @@ export const useTrackEditorSession = ({
 
       formDirtyRef.current = true;
       const submittedData = getSubmittedMetadata({ ...getValues(), [field]: value });
-      const metadataPatch = createDirtyMetadataPatch(
-        submittedData,
-        dirtyFieldsRef.current,
-        settingsRef.current.syncFilenames,
-        [field],
-      );
+      const metadataPatch = createCurrentMetadataPatch(submittedData, dirtyFieldsRef.current, [
+        field,
+      ]);
       if (!metadataPatch) return;
       const nextFiles = library.getSnapshot().files.map((file) =>
         file.id === selectedId
@@ -240,7 +274,7 @@ export const useTrackEditorSession = ({
       );
       library.dispatch({ type: "content-replaced", files: nextFiles });
     },
-    [getSubmittedMetadata, getValues, library],
+    [createCurrentMetadataPatch, getSubmittedMetadata, getValues, library],
   );
 
   const updateTags = useCallback(
@@ -248,14 +282,13 @@ export const useTrackEditorSession = ({
       const snapshot = library.getSnapshot();
       const latestFileToUpdate =
         snapshot.files.find((file) => file.id === fileToUpdate.id) ?? fileToUpdate;
+      const submittedMetadata = getSubmittedMetadata(newTags);
       const metadata = {
-        ...newTags,
-        year: getNullableNumericMetadataValue(newTags.year),
-        trackNumber: getNullableNumericMetadataValue(newTags.trackNumber),
+        ...submittedMetadata,
         duration: latestFileToUpdate.metadata?.duration || 0,
         bitrate: latestFileToUpdate.metadata?.bitrate || 0,
         sampleRate: latestFileToUpdate.metadata?.sampleRate || 0,
-        picture: newTags.picture || [],
+        picture: submittedMetadata.picture || [],
       };
 
       if (!latestFileToUpdate.file) {
@@ -264,8 +297,8 @@ export const useTrackEditorSession = ({
             ? withPendingMetadataPatch(
                 {
                   ...file,
-                  filename: newTags.filename
-                    ? withAudioExtension(newTags.filename, file.format)
+                  filename: metadata.filename
+                    ? withAudioExtension(metadata.filename, file.format)
                     : file.filename,
                   metadata,
                   status: "pending" as const,
@@ -280,7 +313,7 @@ export const useTrackEditorSession = ({
       }
 
       try {
-        const updatedFile = await runAudioBackendEffect(writeTags(latestFileToUpdate, newTags));
+        const updatedFile = await runAudioBackendEffect(writeTags(latestFileToUpdate, metadata));
         const nextFiles = library.getSnapshot().files.map((file) =>
           file.id === fileToUpdate.id
             ? clearPendingMetadataPatch({
@@ -311,12 +344,12 @@ export const useTrackEditorSession = ({
                     bitrate: file.metadata?.bitrate || 0,
                     sampleRate: file.metadata?.sampleRate || 0,
                   },
-                  filename: newTags.filename
-                    ? withAudioExtension(newTags.filename, file.format)
+                  filename: metadata.filename
+                    ? withAudioExtension(metadata.filename, file.format)
                     : file.filename,
                   downloadError: message,
                 },
-                createSubmittedMetadataPatch(newTags),
+                createSubmittedMetadataPatch(metadata),
               )
             : file,
         );
@@ -324,7 +357,7 @@ export const useTrackEditorSession = ({
         throw error;
       }
     },
-    [library, reset],
+    [getSubmittedMetadata, library, reset],
   );
 
   const hydrateDownloadedTrack = useCallback(
@@ -348,11 +381,7 @@ export const useTrackEditorSession = ({
                 ? getSubmittedMetadata(getValues())
                 : undefined;
             const currentPendingPatch = formMetadata
-              ? createDirtyMetadataPatch(
-                  formMetadata,
-                  dirtyFieldsRef.current,
-                  settingsRef.current.syncFilenames,
-                )
+              ? createCurrentMetadataPatch(formMetadata, dirtyFieldsRef.current)
               : getPendingMetadataPatch(currentFile);
             const currentFileWithPendingPatch =
               currentPendingPatch && currentPendingPatch !== currentFile.pendingMetadataPatch
@@ -372,8 +401,13 @@ export const useTrackEditorSession = ({
 
           let { hydratedFile } = hydrationState;
           const { currentFileWithPendingPatch, metadataToWrite, parsedFile } = hydrationState;
-          if (metadataToWrite) {
-            const writeResult = yield* writeTags(hydratedFile, metadataToWrite).pipe(Effect.exit);
+          const normalizedMetadataToWrite = metadataToWrite
+            ? getSubmittedMetadata(metadataToWrite)
+            : undefined;
+          if (normalizedMetadataToWrite) {
+            const writeResult = yield* writeTags(hydratedFile, normalizedMetadataToWrite).pipe(
+              Effect.exit,
+            );
             yield* Effect.sync(() => signal.throwIfAborted());
             const nextHydratedFile = yield* Effect.sync(() => {
               const latestFile = library.getSnapshot().files.find((file) => file.id === fileId);
@@ -384,11 +418,7 @@ export const useTrackEditorSession = ({
                     ? getSubmittedMetadata(getValues())
                     : undefined;
                 const latestFormPatch = latestFormMetadata
-                  ? createDirtyMetadataPatch(
-                      latestFormMetadata,
-                      dirtyFieldsRef.current,
-                      settingsRef.current.syncFilenames,
-                    )
+                  ? createCurrentMetadataPatch(latestFormMetadata, dirtyFieldsRef.current)
                   : undefined;
                 const latestMetadataForResolve =
                   latestFormPatch && latestFile.metadata
@@ -402,7 +432,7 @@ export const useTrackEditorSession = ({
                   parsedFile,
                   hydratedFile,
                   writeResult.value,
-                  metadataToWrite,
+                  normalizedMetadataToWrite,
                   latestMetadataForResolve,
                 );
               }
@@ -426,11 +456,11 @@ export const useTrackEditorSession = ({
           yield* Effect.sync(() => signal.throwIfAborted());
           yield* Effect.sync(() => {
             const hydratedPendingPatch =
-              metadataToWrite && hydratedFile.status !== "saved"
+              normalizedMetadataToWrite && hydratedFile.status !== "saved"
                 ? (getPendingMetadataPatch(hydratedFile) ??
                   (hydratedFile.metadata
                     ? createSubmittedMetadataPatch(hydratedFile.metadata)
-                    : metadataToWrite))
+                    : normalizedMetadataToWrite))
                 : undefined;
             const nextFile = withPendingMetadataPatch(hydratedFile, hydratedPendingPatch);
             const nextFiles = library
@@ -440,7 +470,7 @@ export const useTrackEditorSession = ({
           });
         }),
       ),
-    [getSubmittedMetadata, getValues, library],
+    [createCurrentMetadataPatch, getSubmittedMetadata, getValues, library],
   );
 
   return {

--- a/src/features/export/useExportSession.ts
+++ b/src/features/export/useExportSession.ts
@@ -59,13 +59,14 @@ export const useExportSession = ({
       let syncedFiles = editor.flush(trackIds);
 
       for (const album of albumsToSync) {
-        syncedFiles = applyAlbumSharedTagsToFiles(syncedFiles, album);
+        syncedFiles = applyAlbumSharedTagsToFiles(syncedFiles, album, settingsRef.current);
       }
       if (settingsRef.current.syncTrackNumbers) {
         syncedFiles = applyTrackOrderNumbersToFiles(
           syncedFiles,
           snapshot.albums,
           albumsToSync.map((album) => album.id),
+          settingsRef.current,
         );
       }
       if (settingsRef.current.syncFilenames) {
@@ -178,7 +179,12 @@ export const useExportSession = ({
         .getSnapshot()
         .files.find((file) => file.id === library.getSnapshot().selectedFileId);
       if (!selectedFile) return;
-      const submittedData = getSubmittedAudioMetadata(data, settingsRef.current.syncFilenames);
+      const submittedData = getSubmittedAudioMetadata(
+        data,
+        settingsRef.current.syncFilenames,
+        settingsRef.current.advancedMetadata,
+        settingsRef.current.metadataLinks.albumArtist,
+      );
       if (!isValidFilenameBase(submittedData.filename)) return;
       const fileId = selectedFile.id;
       analytics.capture({ type: "export_started", exportKind: "track", trackCount: 1 });

--- a/src/features/import/audioUploadSession.ts
+++ b/src/features/import/audioUploadSession.ts
@@ -145,13 +145,18 @@ export const createAudioUploadSession = ({
           const targetAlbum = nextAlbums.find((album) => album.id === targetAlbumId);
           let finalFiles = current.files;
           if (targetAlbum) {
-            finalFiles = applyAlbumSharedTagsToFiles(finalFiles, targetAlbum);
             const settings = getSettings();
+            finalFiles = applyAlbumSharedTagsToFiles(finalFiles, targetAlbum, settings);
             if (settings.syncFilenames) {
               finalFiles = applySyncedFilenamesToFiles(finalFiles, targetAlbum.trackIds);
             }
             if (settings.syncTrackNumbers) {
-              finalFiles = applyTrackOrderNumbersToFiles(finalFiles, nextAlbums, [targetAlbumId]);
+              finalFiles = applyTrackOrderNumbersToFiles(
+                finalFiles,
+                nextAlbums,
+                [targetAlbumId],
+                settings,
+              );
             }
           }
           library.dispatch({
@@ -185,15 +190,18 @@ export const createAudioUploadSession = ({
           };
           const latest = library.getSnapshot();
           const nextAlbums = [...latest.albums, downloadedAlbum];
-          let finalFiles = applyAlbumSharedTagsToFiles(latest.files, downloadedAlbum);
           const settings = getSettings();
+          let finalFiles = applyAlbumSharedTagsToFiles(latest.files, downloadedAlbum, settings);
           if (settings.syncFilenames) {
             finalFiles = applySyncedFilenamesToFiles(finalFiles, downloadedAlbum.trackIds);
           }
           if (settings.syncTrackNumbers) {
-            finalFiles = applyTrackOrderNumbersToFiles(finalFiles, nextAlbums, [
-              downloadedAlbum.id,
-            ]);
+            finalFiles = applyTrackOrderNumbersToFiles(
+              finalFiles,
+              nextAlbums,
+              [downloadedAlbum.id],
+              settings,
+            );
           }
           library.dispatch({
             type: "content-replaced",
@@ -218,6 +226,12 @@ export const createAudioUploadSession = ({
               : latest.looseTrackIds;
           let finalFiles = latest.files;
           const uploadedTrackIds = orderedUploads.map((entry) => entry.file.id);
+          const uploadedTrackIdSet = new Set(uploadedTrackIds);
+          for (const album of merged.albums) {
+            if (album.trackIds.some((trackId) => uploadedTrackIdSet.has(trackId))) {
+              finalFiles = applyAlbumSharedTagsToFiles(finalFiles, album, settings);
+            }
+          }
           if (settings.syncFilenames) {
             finalFiles = applySyncedFilenamesToFiles(finalFiles, uploadedTrackIds);
           }
@@ -226,6 +240,7 @@ export const createAudioUploadSession = ({
               finalFiles,
               merged.albums,
               merged.albumsToSync,
+              settings,
             );
           }
           const firstTrack = orderedUploads[0];

--- a/src/features/import/downloadTrack.ts
+++ b/src/features/import/downloadTrack.ts
@@ -143,6 +143,7 @@ export const createDownloadMetadata = ({
   filename: withoutAudioExtension(filenameFromTitle(title), "mp3"),
   title,
   artist,
+  albumArtist: artist,
   album,
   genre,
   duration: duration ?? 0,
@@ -151,6 +152,10 @@ export const createDownloadMetadata = ({
   picture: [],
   year: year ?? null,
   trackNumber: trackNumber ?? null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
 });
 
 export const createPendingDownloadTrack = (
@@ -243,6 +248,7 @@ const createPlaylistPendingMetadataPatch = (
 ): MetadataPatch => ({
   title: track.title,
   artist: playlist.artist,
+  albumArtist: playlist.artist,
   album: playlist.title,
   genre: playlist.genre,
   ...(playlist.year !== undefined ? { year: playlist.year } : {}),

--- a/src/features/import/soundcloudSetImport.ts
+++ b/src/features/import/soundcloudSetImport.ts
@@ -9,7 +9,7 @@ import type { SoundCloudSet } from "@/features/import/soundcloudSet";
 import type { AppSettings, AudioMetadata, TagiumFile } from "@/features/library/types";
 
 interface SoundCloudSetImportDeps extends SoundCloudSetDownloadWorkflowDeps {
-  settings: Pick<AppSettings, "audioBitrate" | "applySoundCloudAlbumCoverToTracks">;
+  settings: AppSettings;
   createId: () => string;
   fetchImportedCover: (coverUrl: string) => Promise<AudioMetadata["picture"]>;
   updateTags: (file: TagiumFile, metadata: AudioMetadata) => Promise<void>;

--- a/src/features/library/fileMetadataOps.ts
+++ b/src/features/library/fileMetadataOps.ts
@@ -3,6 +3,7 @@ import type { Playlist } from "@/features/import/playlist";
 import type { SoundCloudSet } from "@/features/import/soundcloudSet";
 import type {
   AlbumGroup,
+  AppSettings,
   AudioMetadata,
   MetadataPatch,
   TagiumFile,
@@ -27,14 +28,19 @@ const patchFields = [
   "filename",
   "title",
   "artist",
+  "albumArtist",
   "album",
   "year",
   "genre",
   "picture",
   "trackNumber",
+  "discNumber",
+  "composer",
+  "bpm",
+  "comment",
 ] as const satisfies readonly DownloadedTrackWritableMetadataField[];
 
-const nullableNumericPatchFields = ["year", "trackNumber"] as const;
+const nullableNumericPatchFields = ["year", "trackNumber", "discNumber", "bpm"] as const;
 
 const markPendingMetadataPatch = (
   file: TagiumFile,
@@ -56,11 +62,16 @@ const createMetadataPatch = (metadata: AudioMetadata): DownloadedTrackMetadataPa
   filename: metadata.filename,
   title: metadata.title,
   artist: metadata.artist,
+  albumArtist: metadata.albumArtist,
   album: metadata.album,
   year: metadata.year,
   genre: metadata.genre,
   picture: metadata.picture,
   trackNumber: metadata.trackNumber,
+  discNumber: metadata.discNumber,
+  composer: metadata.composer,
+  bpm: metadata.bpm,
+  comment: metadata.comment,
 });
 
 const mergeLatestMetadataWithHydratedTechnicalFields = (
@@ -105,11 +116,16 @@ const areWritableMetadataFieldsEqual = (
   firstMetadata.filename === secondMetadata.filename &&
   firstMetadata.title === secondMetadata.title &&
   firstMetadata.artist === secondMetadata.artist &&
+  firstMetadata.albumArtist === secondMetadata.albumArtist &&
   firstMetadata.album === secondMetadata.album &&
   firstMetadata.year === secondMetadata.year &&
   areGenresEqual(firstMetadata.genre, secondMetadata.genre) &&
   arePicturesEqual(firstMetadata.picture, secondMetadata.picture) &&
-  firstMetadata.trackNumber === secondMetadata.trackNumber;
+  firstMetadata.trackNumber === secondMetadata.trackNumber &&
+  firstMetadata.discNumber === secondMetadata.discNumber &&
+  firstMetadata.composer === secondMetadata.composer &&
+  firstMetadata.bpm === secondMetadata.bpm &&
+  firstMetadata.comment === secondMetadata.comment;
 
 const applyProviderDisplayMetadata = (
   parsedMetadata: AudioMetadata,
@@ -200,36 +216,19 @@ export function applyTrackOrderNumbersToFiles(
   files: TagiumFile[],
   albums: AlbumGroup[],
   albumIdsToSync: string[],
+  settings: MetadataPolicySettings = defaultMetadataPolicySettings,
 ) {
-  const albumsById = new Map(albums.map((album) => [album.id, album]));
-  const numbersByTrackId = new Map<string, number>();
-
-  for (const albumId of albumIdsToSync) {
-    const album = albumsById.get(albumId);
-    if (!album) continue;
-    album.trackIds.forEach((trackId, index) => {
-      numbersByTrackId.set(trackId, index + 1);
-    });
-  }
-
-  if (numbersByTrackId.size === 0) return files;
-
-  return files.map((file) => {
-    const trackNumber = numbersByTrackId.get(file.id);
-    if (trackNumber === undefined || !file.metadata) return file;
-
-    return markPendingMetadataPatch(
-      {
-        ...file,
-        status: file.status === "saved" ? "pending" : file.status,
-        metadata: {
-          ...file.metadata,
-          trackNumber,
-        },
-      },
-      { trackNumber },
-    );
-  });
+  const albumIds = new Set(albumIdsToSync);
+  return albums.reduce(
+    (nextFiles, album) =>
+      albumIds.has(album.id)
+        ? applyAlbumMetadataPolicyToFiles(nextFiles, album, settings, {
+            shared: false,
+            trackNumbers: true,
+          })
+        : nextFiles,
+    files,
+  );
 }
 
 export function applySyncedFilenamesToFiles(files: TagiumFile[], trackIds?: string[]) {
@@ -261,15 +260,63 @@ export function applySyncedFilenamesToFiles(files: TagiumFile[], trackIds?: stri
   });
 }
 
-export function applyAlbumSharedTagsToFiles(files: TagiumFile[], album: AlbumGroup) {
+type MetadataPolicySettings = Pick<
+  AppSettings,
+  "advancedMetadata" | "metadataLinks" | "syncTrackNumbers"
+>;
+
+const defaultMetadataPolicySettings: MetadataPolicySettings = {
+  advancedMetadata: false,
+  syncTrackNumbers: true,
+  metadataLinks: {
+    artist: true,
+    year: true,
+    genre: true,
+    artwork: true,
+    albumArtist: true,
+  },
+};
+
+interface AlbumMetadataPolicyOptions {
+  shared?: boolean;
+  artwork?: boolean;
+  trackNumbers?: boolean;
+}
+
+/** Applies every album-to-track link decision through one non-destructive policy. */
+export function applyAlbumMetadataPolicyToFiles(
+  files: TagiumFile[],
+  album: AlbumGroup,
+  settings: MetadataPolicySettings = defaultMetadataPolicySettings,
+  options: AlbumMetadataPolicyOptions = {},
+) {
   if (album.trackIds.length === 0) return files;
 
   const trackSet = new Set(album.trackIds);
+  const shared = options.shared ?? true;
 
   return files.map((file) => {
     if (!trackSet.has(file.id) || !file.metadata) return file;
+    const patch: MetadataPatch = {};
+    if (shared) {
+      patch.album = album.title;
+      if (settings.metadataLinks.artist) patch.artist = album.artist;
+      if (settings.metadataLinks.genre) patch.genre = album.genre;
+      if (settings.metadataLinks.year && album.year !== undefined) patch.year = album.year;
+    }
+    if (options.artwork && settings.metadataLinks.artwork && album.cover?.length) {
+      patch.picture = album.cover;
+    }
+    if (options.trackNumbers && settings.syncTrackNumbers) {
+      patch.trackNumber = album.trackIds.indexOf(file.id) + 1;
+    }
 
-    const yearPatch = album.year !== undefined ? { year: album.year } : {};
+    const nextArtist = patch.artist ?? file.metadata.artist;
+    if (shared && (!settings.advancedMetadata || settings.metadataLinks.albumArtist)) {
+      patch.albumArtist = nextArtist;
+    }
+
+    if (Object.keys(patch).length === 0) return file;
 
     return markPendingMetadataPatch(
       {
@@ -277,46 +324,35 @@ export function applyAlbumSharedTagsToFiles(files: TagiumFile[], album: AlbumGro
         status: file.status === "saved" ? "pending" : file.status,
         metadata: {
           ...file.metadata,
-          artist: album.artist,
-          album: album.title,
-          genre: album.genre,
-          year: album.year !== undefined ? album.year : file.metadata.year,
+          ...patch,
         },
       },
-      {
-        artist: album.artist,
-        album: album.title,
-        genre: album.genre,
-        ...yearPatch,
-      },
+      patch,
     );
   });
+}
+
+export function applyAlbumSharedTagsToFiles(
+  files: TagiumFile[],
+  album: AlbumGroup,
+  settings?: MetadataPolicySettings,
+) {
+  return applyAlbumMetadataPolicyToFiles(files, album, settings);
 }
 
 export function applyAlbumCoverToFiles(
   files: TagiumFile[],
   trackIds: string[],
   cover: AudioMetadata["picture"],
+  settings?: MetadataPolicySettings,
 ) {
   if (trackIds.length === 0 || cover.length === 0) return files;
-
-  const trackSet = new Set(trackIds);
-
-  return files.map((file) => {
-    if (!trackSet.has(file.id) || !file.metadata) return file;
-
-    return markPendingMetadataPatch(
-      {
-        ...file,
-        status: file.status === "saved" ? "pending" : file.status,
-        metadata: {
-          ...file.metadata,
-          picture: cover,
-        },
-      },
-      { picture: cover },
-    );
-  });
+  return applyAlbumMetadataPolicyToFiles(
+    files,
+    { id: "cover-sync", title: "", artist: "", genre: "", trackIds, cover },
+    settings,
+    { shared: false, artwork: true },
+  );
 }
 
 export function applyAlbumCoverToFilesWithSelectedMetadata(
@@ -324,8 +360,9 @@ export function applyAlbumCoverToFilesWithSelectedMetadata(
   trackIds: string[],
   cover: AudioMetadata["picture"],
   selectedFileId: string | null,
+  settings?: MetadataPolicySettings,
 ): { files: TagiumFile[]; selectedMetadata?: AudioMetadata } {
-  const coveredFiles = applyAlbumCoverToFiles(files, trackIds, cover);
+  const coveredFiles = applyAlbumCoverToFiles(files, trackIds, cover, settings);
   if (!selectedFileId) {
     return { files: coveredFiles };
   }
@@ -379,7 +416,7 @@ export function applyPlaylistImportedCover(
   albumId: string,
   trackIds: string[],
   playlist: Pick<Playlist, "isAlbum">,
-  settings: { applySoundCloudAlbumCoverToTracks: boolean },
+  settings: AppSettings,
   cover: AudioMetadata["picture"],
   selectedFileId: string | null,
 ) {
@@ -387,13 +424,17 @@ export function applyPlaylistImportedCover(
     currentAlbum.id === albumId ? { ...currentAlbum, cover } : currentAlbum,
   );
 
-  if (!playlist.isAlbum || !settings.applySoundCloudAlbumCoverToTracks) {
+  if (
+    !playlist.isAlbum ||
+    !settings.applySoundCloudAlbumCoverToTracks ||
+    settings.metadataLinks?.artwork === false
+  ) {
     return { albums: coveredAlbums, files };
   }
 
   return {
     albums: coveredAlbums,
-    ...applyAlbumCoverToFilesWithSelectedMetadata(files, trackIds, cover, selectedFileId),
+    ...applyAlbumCoverToFilesWithSelectedMetadata(files, trackIds, cover, selectedFileId, settings),
   };
 }
 
@@ -403,7 +444,7 @@ export const applySoundCloudSetImportedCover = (
   albumId: string,
   trackIds: string[],
   set: Pick<SoundCloudSet, "isAlbum">,
-  settings: { applySoundCloudAlbumCoverToTracks: boolean },
+  settings: AppSettings,
   cover: AudioMetadata["picture"],
   selectedFileId: string | null,
 ) =>

--- a/src/features/library/types.ts
+++ b/src/features/library/types.ts
@@ -41,6 +41,14 @@ export interface AppSettings {
   syncFilenames: boolean;
   audioBitrate: AudioDownloadBitrate;
   applySoundCloudAlbumCoverToTracks: boolean;
+  advancedMetadata: boolean;
+  metadataLinks: {
+    artist: boolean;
+    year: boolean;
+    genre: boolean;
+    artwork: boolean;
+    albumArtist: boolean;
+  };
 }
 
 export interface ImportedAlbumMetadata {

--- a/src/features/settings/settings.ts
+++ b/src/features/settings/settings.ts
@@ -15,6 +15,14 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   syncFilenames: true,
   audioBitrate: "320",
   applySoundCloudAlbumCoverToTracks: true,
+  advancedMetadata: false,
+  metadataLinks: {
+    artist: true,
+    year: true,
+    genre: true,
+    artwork: true,
+    albumArtist: true,
+  },
 };
 
 export const APP_SETTINGS_STORAGE_KEY = "tagium:app-settings";
@@ -34,6 +42,17 @@ const storedAppSettingsSchema = Schema.Struct({
   ),
   applySoundCloudAlbumCoverToTracks: booleanWithDefault(
     DEFAULT_APP_SETTINGS.applySoundCloudAlbumCoverToTracks,
+  ),
+  advancedMetadata: booleanWithDefault(DEFAULT_APP_SETTINGS.advancedMetadata),
+  metadataLinks: Schema.Struct({
+    artist: booleanWithDefault(DEFAULT_APP_SETTINGS.metadataLinks.artist),
+    year: booleanWithDefault(DEFAULT_APP_SETTINGS.metadataLinks.year),
+    genre: booleanWithDefault(DEFAULT_APP_SETTINGS.metadataLinks.genre),
+    artwork: booleanWithDefault(DEFAULT_APP_SETTINGS.metadataLinks.artwork),
+    albumArtist: booleanWithDefault(DEFAULT_APP_SETTINGS.metadataLinks.albumArtist),
+  }).pipe(
+    Schema.catchDecoding(() => Effect.succeed(Option.some(DEFAULT_APP_SETTINGS.metadataLinks))),
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_APP_SETTINGS.metadataLinks)),
   ),
 });
 

--- a/src/features/settings/useWorkspaceSettings.ts
+++ b/src/features/settings/useWorkspaceSettings.ts
@@ -1,9 +1,5 @@
 import { useCallback, useLayoutEffect, useRef } from "react";
 import { analytics } from "@/analytics";
-import {
-  applySyncedFilenamesToFiles,
-  applyTrackOrderNumbersToFiles,
-} from "@/features/library/fileMetadataOps";
 import { saveAppSettings } from "@/features/settings/settings";
 import type { SettingsPageProps } from "@/features/settings/SettingsPage";
 import { reportSystemFailure } from "@/features/workspace/systemFailure";
@@ -15,7 +11,6 @@ import type { SetActiveView } from "@/features/workspace/audioWorkspaceTypes";
 type SettingsEditor = Pick<TrackEditorSession, "isCoverProcessing">;
 
 export const useWorkspaceSettings = ({
-  library,
   editor,
   settings,
   setSettings,
@@ -42,7 +37,9 @@ export const useWorkspaceSettings = ({
         previous.syncFilenames !== nextSettings.syncFilenames ||
         previous.audioBitrate !== nextSettings.audioBitrate ||
         previous.applySoundCloudAlbumCoverToTracks !==
-          nextSettings.applySoundCloudAlbumCoverToTracks;
+          nextSettings.applySoundCloudAlbumCoverToTracks ||
+        previous.advancedMetadata !== nextSettings.advancedMetadata ||
+        JSON.stringify(previous.metadataLinks) !== JSON.stringify(nextSettings.metadataLinks);
       const saved = saveAppSettings(nextSettings);
       setSettings(nextSettings);
       settingsRef.current = nextSettings;
@@ -58,23 +55,8 @@ export const useWorkspaceSettings = ({
           applySoundCloudCover: nextSettings.applySoundCloudAlbumCoverToTracks,
         });
       }
-      const snapshot = library.getSnapshot();
-      let syncedFiles = snapshot.files;
-      if (!previous.syncTrackNumbers && nextSettings.syncTrackNumbers) {
-        syncedFiles = applyTrackOrderNumbersToFiles(
-          syncedFiles,
-          snapshot.albums,
-          snapshot.albums.map((album) => album.id),
-        );
-      }
-      if (!previous.syncFilenames && nextSettings.syncFilenames) {
-        syncedFiles = applySyncedFilenamesToFiles(syncedFiles);
-      }
-      if (syncedFiles !== snapshot.files) {
-        library.dispatch({ type: "content-replaced", files: syncedFiles });
-      }
     },
-    [library, setSettings],
+    [setSettings],
   );
 
   const onBack = useCallback(() => {

--- a/src/features/workspace/useWorkspaceAlbumDialog.ts
+++ b/src/features/workspace/useWorkspaceAlbumDialog.ts
@@ -97,16 +97,21 @@ export const useWorkspaceAlbumDialog = ({
         const shouldSyncCover =
           Boolean(updatedAlbum.cover?.length) &&
           areAlbumTrackCoversSynced(bufferedFiles, updatedAlbum.trackIds, currentAlbum?.cover);
-        let taggedFiles = applyAlbumSharedTagsToFiles(bufferedFiles, updatedAlbum);
+        let taggedFiles = applyAlbumSharedTagsToFiles(
+          bufferedFiles,
+          updatedAlbum,
+          settingsRef.current,
+        );
         if (settingsRef.current.syncFilenames) {
           taggedFiles = applySyncedFilenamesToFiles(taggedFiles, updatedAlbum.trackIds);
         }
-        if (shouldSyncCover && updatedAlbum.cover) {
+        if (shouldSyncCover && settingsRef.current.metadataLinks.artwork && updatedAlbum.cover) {
           const covered = applyAlbumCoverToFilesWithSelectedMetadata(
             taggedFiles,
             updatedAlbum.trackIds,
             updatedAlbum.cover,
             library.getSnapshot().selectedFileId,
+            settingsRef.current,
           );
           taggedFiles = covered.files;
           if (covered.selectedMetadata) {
@@ -134,12 +139,21 @@ export const useWorkspaceAlbumDialog = ({
     );
     let finalFiles = snapshot.files;
     if (created.syncAlbums.length > 0) {
-      finalFiles = applyTrackOrderNumbersToFiles(finalFiles, created.albums, created.syncAlbums);
+      finalFiles = applyTrackOrderNumbersToFiles(
+        finalFiles,
+        created.albums,
+        created.syncAlbums,
+        settingsRef.current,
+      );
     }
     if (created.newAlbumId) {
       const createdAlbum = created.albums.find((album) => album.id === created.newAlbumId);
       if (createdAlbum) {
-        const taggedFiles = applyAlbumSharedTagsToFiles(finalFiles, createdAlbum);
+        const taggedFiles = applyAlbumSharedTagsToFiles(
+          finalFiles,
+          createdAlbum,
+          settingsRef.current,
+        );
         finalFiles = settingsRef.current.syncFilenames
           ? applySyncedFilenamesToFiles(taggedFiles, createdAlbum.trackIds)
           : taggedFiles;
@@ -168,7 +182,13 @@ export const useWorkspaceAlbumDialog = ({
   }, [dialog, library]);
 
   const syncCover = useCallback(() => {
-    if (dialog.mode !== "edit" || !dialog.editingAlbumId || !dialog.draft.cover?.length) return;
+    if (
+      dialog.mode !== "edit" ||
+      !dialog.editingAlbumId ||
+      !dialog.draft.cover?.length ||
+      !settingsRef.current.metadataLinks.artwork
+    )
+      return;
     const album = library.getSnapshot().albums.find((entry) => entry.id === dialog.editingAlbumId);
     if (!album) return;
     const bufferedFiles = editorRef.current.commands.flush(album.trackIds);
@@ -177,6 +197,7 @@ export const useWorkspaceAlbumDialog = ({
       album.trackIds,
       dialog.draft.cover,
       library.getSnapshot().selectedFileId,
+      settingsRef.current,
     );
     library.dispatch({ type: "content-replaced", files: covered.files });
     if (covered.selectedMetadata) {

--- a/src/features/workspace/useWorkspaceSelection.ts
+++ b/src/features/workspace/useWorkspaceSelection.ts
@@ -12,7 +12,10 @@ import {
   subscribeToEditorKeyboardShortcuts,
   type EditorKeyboardShortcutActions,
 } from "@/features/editor/editorKeyboardShortcuts";
-import { applyTrackOrderNumbersToFiles } from "@/features/library/fileMetadataOps";
+import {
+  applyAlbumSharedTagsToFiles,
+  applyTrackOrderNumbersToFiles,
+} from "@/features/library/fileMetadataOps";
 import type { TagSidebarPanelProps } from "@/features/library/TagSidebarPanel";
 import type { TrackEditorSession } from "@/features/editor/useTrackEditorSession";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
@@ -82,7 +85,12 @@ export const useWorkspaceSelection = ({
       );
       let nextFiles = snapshot.files.filter((file) => !idSet.has(file.id));
       if (settingsRef.current.syncTrackNumbers && affectedAlbumIds.length > 0) {
-        nextFiles = applyTrackOrderNumbersToFiles(nextFiles, nextAlbums, affectedAlbumIds);
+        nextFiles = applyTrackOrderNumbersToFiles(
+          nextFiles,
+          nextAlbums,
+          affectedAlbumIds,
+          settingsRef.current,
+        );
       }
       library.dispatch({
         type: "tracks-removed",
@@ -177,7 +185,18 @@ export const useWorkspaceSelection = ({
       );
       let finalFiles = snapshot.files;
       if (moved.albumsToSync.length > 0) {
-        finalFiles = applyTrackOrderNumbersToFiles(finalFiles, moved.albums, moved.albumsToSync);
+        finalFiles = applyTrackOrderNumbersToFiles(
+          finalFiles,
+          moved.albums,
+          moved.albumsToSync,
+          settingsRef.current,
+        );
+      }
+      if (destination.type === "album") {
+        const targetAlbum = moved.albums.find((album) => album.id === destination.albumId);
+        if (targetAlbum) {
+          finalFiles = applyAlbumSharedTagsToFiles(finalFiles, targetAlbum, settingsRef.current);
+        }
       }
       library.dispatch({
         type: "content-replaced",

--- a/tests/unit/features/audio/audioMetadataIO.real.test.ts
+++ b/tests/unit/features/audio/audioMetadataIO.real.test.ts
@@ -1,0 +1,111 @@
+import { Effect } from "effect";
+import MP3Tag from "mp3tag.js";
+import { describe, expect, it } from "vite-plus/test";
+import { AudioMetadataIO, AudioMetadataIOLive } from "@/features/audio/audioMetadataIO";
+import { makeAudioRuntime } from "@/features/audio/audioRuntime";
+import type { AudioMetadata, TagiumFile } from "@/features/library/types";
+import { validMp3Bytes } from "../../support/mp3TestFixtures";
+
+const runtime = makeAudioRuntime(AudioMetadataIOLive);
+
+const metadata = (overrides: Partial<AudioMetadata> = {}): AudioMetadata => ({
+  filename: "track",
+  title: "Track",
+  artist: "Artist",
+  albumArtist: "Album Artist",
+  album: "Album",
+  year: 2026,
+  genre: "Electronic",
+  duration: 0,
+  bitrate: 0,
+  sampleRate: 0,
+  picture: [],
+  trackNumber: 1,
+  discNumber: 2,
+  composer: "Composer",
+  bpm: 128,
+  comment: "Primary comment",
+  ...overrides,
+});
+
+const write = (source: Uint8Array, nextMetadata = metadata()) => {
+  const sourceFile = new File([Uint8Array.from(source)], "track.mp3", { type: "audio/mpeg" });
+  const file: TagiumFile = {
+    id: "track",
+    format: "mp3",
+    file: sourceFile,
+    originalFile: sourceFile,
+    filename: sourceFile.name,
+    status: "pending",
+    downloadStatus: "ready",
+    metadata: nextMetadata,
+  };
+
+  return runtime.runPromise(
+    Effect.gen(function* () {
+      const io = yield* AudioMetadataIO;
+      return yield* io.writeMetadataToFile(file, nextMetadata);
+    }),
+  );
+};
+
+const bytesOf = (buffer: unknown) =>
+  buffer instanceof ArrayBuffer
+    ? new Uint8Array(buffer)
+    : Uint8Array.from(buffer as ArrayLike<number>);
+
+describe("AudioMetadataIO with real mp3tag.js", () => {
+  it("creates ID3v2 metadata when writing an untagged MP3", async () => {
+    const updated = await write(validMp3Bytes());
+    const tags = new MP3Tag(await updated.arrayBuffer());
+    tags.read({ unsupported: true });
+
+    expect(tags.error).toBe("");
+    expect(tags.tags.v2Details?.version[0]).toBe(4);
+    expect(tags.tags.v2).toMatchObject({
+      TPE2: "Album Artist",
+      TCOM: "Composer",
+      TBPM: "128",
+      TPOS: "2",
+      COMM: [{ language: "eng", descriptor: "", text: "Primary comment" }],
+    });
+  });
+
+  it("preserves unsupported frames, alternate comments, and audio payload", async () => {
+    const sourceAudio = validMp3Bytes();
+    const seeded = new MP3Tag(sourceAudio.buffer.slice(0));
+    seeded.read({ unsupported: true });
+    seeded.tags.v2 = {
+      TIT2: "Original",
+      COMM: [
+        { language: "eng", descriptor: "", text: "Original primary" },
+        { language: "spa", descriptor: "archivo", text: "Conservar" },
+      ],
+    };
+    seeded.tags.v2Details = {
+      version: [4, 0],
+      size: 0,
+      flags: {
+        unsynchronisation: false,
+        extendedHeader: false,
+        experimentalIndicator: false,
+      },
+    };
+    (seeded.tags.v2 as Record<string, unknown>).ZZZZ = [[1, 2, 3, 4]];
+    seeded.save({ id3v2: { unsupported: true, padding: 0 } });
+    expect(seeded.error).toBe("");
+
+    const updated = await write(bytesOf(seeded.buffer), metadata({ comment: "Updated primary" }));
+    const outputBuffer = await updated.arrayBuffer();
+    const reread = new MP3Tag(outputBuffer);
+    reread.read({ unsupported: true });
+
+    expect(reread.error).toBe("");
+    expect((reread.tags.v2 as Record<string, unknown>).ZZZZ).toEqual([[1, 2, 3, 4]]);
+    expect(reread.tags.v2?.COMM).toEqual([
+      { language: "eng", descriptor: "", text: "Updated primary" },
+      { language: "spa", descriptor: "archivo", text: "Conservar" },
+    ]);
+    expect(bytesOf(MP3Tag.getAudioBuffer(outputBuffer))).toEqual(sourceAudio);
+  });
+});

--- a/tests/unit/features/audio/audioMetadataIO.test.ts
+++ b/tests/unit/features/audio/audioMetadataIO.test.ts
@@ -14,6 +14,7 @@ const mp3tagMock = vi.hoisted(() => ({
       year?: string;
       genre?: string;
       track?: string;
+      comment?: string;
       v2?: {
         APIC?: Array<{
           format: string;
@@ -21,7 +22,13 @@ const mp3tagMock = vi.hoisted(() => ({
           description: string;
           data: number[];
         }>;
+        TPE2?: string;
+        TCOM?: string;
+        TBPM?: string;
+        TPOS?: string;
+        [key: string]: unknown;
       };
+      v2Details?: { version: number[] };
     };
     error?: string;
     buffer?: ArrayBuffer;
@@ -35,7 +42,18 @@ const mp3tagMock = vi.hoisted(() => ({
     year: "2024",
     genre: "Electronic",
     track: "3/12",
+    comment: "Field notes",
+    v2Details: { version: [4] },
     v2: {
+      TPE2: "Album Artist",
+      TCOM: "Composer",
+      TBPM: "128",
+      TPOS: "2/3",
+      TXXX: [{ description: "KEEP", text: "unmodeled" }],
+      COMM: [
+        { language: "eng", descriptor: "", text: "Field notes" },
+        { language: "spa", descriptor: "archivo", text: "Conservar" },
+      ],
       APIC: [
         {
           format: "image/png",
@@ -67,6 +85,7 @@ const metadata = (overrides: Partial<AudioMetadata> = {}): AudioMetadata => ({
   filename: "track",
   title: "Track",
   artist: "Artist",
+  albumArtist: "Artist",
   album: "Album",
   year: 2024,
   genre: "",
@@ -75,6 +94,10 @@ const metadata = (overrides: Partial<AudioMetadata> = {}): AudioMetadata => ({
   sampleRate: 0,
   picture: [],
   trackNumber: null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
   ...overrides,
 });
 
@@ -155,6 +178,11 @@ describe("AudioMetadataIO", () => {
       genre: "Electronic",
       duration: 123,
       trackNumber: 3,
+      albumArtist: "Album Artist",
+      composer: "Composer",
+      bpm: 128,
+      discNumber: 2,
+      comment: "Field notes",
     });
     expect(upload.file.metadata?.picture[0]?.data).toBeInstanceOf(Uint8Array);
     expect(Array.from(upload.file.metadata?.picture[0]?.data ?? [])).toEqual([1, 2, 3]);
@@ -257,6 +285,11 @@ describe("AudioMetadataIO", () => {
         filename: "written",
         year: Number.NaN,
         trackNumber: null,
+        discNumber: null,
+        bpm: null,
+        albumArtist: "New Album Artist",
+        composer: "New Composer",
+        comment: "New comment",
         picture: [
           {
             format: "image/jpeg",
@@ -276,6 +309,15 @@ describe("AudioMetadataIO", () => {
       year: "",
       track: "",
       v2: {
+        TPE2: "New Album Artist",
+        TCOM: "New Composer",
+        TBPM: "",
+        TPOS: "",
+        TXXX: [{ description: "KEEP", text: "unmodeled" }],
+        COMM: [
+          { language: "eng", descriptor: "", text: "New comment" },
+          { language: "spa", descriptor: "archivo", text: "Conservar" },
+        ],
         APIC: [
           {
             format: "image/jpeg",
@@ -292,6 +334,26 @@ describe("AudioMetadataIO", () => {
     await expect(writeMetadataToFile(tagiumFile({ file: undefined }), metadata())).rejects.toThrow(
       "audio file is still downloading.",
     );
+  });
+
+  it("uses the supported short frame names for ID3v2.2 files", async () => {
+    const originalVersion = mp3tagMock.nextTags.v2Details.version;
+    mp3tagMock.nextTags.v2Details.version = [2];
+
+    await writeMetadataToFile(
+      tagiumFile(),
+      metadata({ albumArtist: "Album Artist", composer: "Composer", bpm: 120, discNumber: 3 }),
+    );
+    mp3tagMock.nextTags.v2Details.version = originalVersion;
+
+    expect(mp3tagMock.instances[0]?.tags.v2).toMatchObject({
+      TP2: "Album Artist",
+      TCM: "Composer",
+      TBP: "120",
+      TPA: "3",
+    });
+    expect(mp3tagMock.instances[0]?.tags.v2).not.toHaveProperty("TPE2");
+    expect(mp3tagMock.instances[0]?.tags.v2).not.toHaveProperty("TCOM");
   });
 
   it("preserves the current filename when a write does not request a rename", async () => {

--- a/tests/unit/features/audio/mp3Utils.test.ts
+++ b/tests/unit/features/audio/mp3Utils.test.ts
@@ -11,6 +11,7 @@ const metadata = (trackNumber?: number): AudioMetadata => ({
   filename: "track",
   title: "Track",
   artist: "Artist",
+  albumArtist: "Artist",
   album: "Album",
   year: 2024,
   genre: "",
@@ -19,6 +20,10 @@ const metadata = (trackNumber?: number): AudioMetadata => ({
   sampleRate: 0,
   picture: [],
   trackNumber: trackNumber ?? null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
 });
 
 const upload = (id: string, trackNumber?: number): UploadedTrack => ({

--- a/tests/unit/features/editor/albumDialogState.test.ts
+++ b/tests/unit/features/editor/albumDialogState.test.ts
@@ -22,6 +22,7 @@ const metadata = (overrides: Partial<AudioMetadata> = {}): AudioMetadata => ({
   filename: "track",
   title: "Track",
   artist: "Seed Artist",
+  albumArtist: "Seed Artist",
   album: "",
   genre: ["Ambient", "Electronic"],
   year: 2025,
@@ -30,6 +31,10 @@ const metadata = (overrides: Partial<AudioMetadata> = {}): AudioMetadata => ({
   sampleRate: 44_100,
   picture,
   trackNumber: null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
   ...overrides,
 });
 

--- a/tests/unit/features/editor/audioTagger.test.ts
+++ b/tests/unit/features/editor/audioTagger.test.ts
@@ -15,6 +15,7 @@ const metadata = (overrides: Partial<AudioMetadata> = {}): AudioMetadata => ({
   filename: "old-title",
   title: "Old Title",
   artist: "Artist",
+  albumArtist: "Artist",
   album: "Album",
   year: 2024,
   genre: "Genre",
@@ -23,6 +24,10 @@ const metadata = (overrides: Partial<AudioMetadata> = {}): AudioMetadata => ({
   sampleRate: 44_100,
   picture: [],
   trackNumber: 7,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
   ...overrides,
 });
 
@@ -181,6 +186,26 @@ describe("audioTagger metadata patches", () => {
     );
 
     expect(patch).toEqual({ title: "New Title" });
+  });
+
+  it("patches advanced fields and normalizes cleared advanced numbers", () => {
+    const patch = createDirtyMetadataPatch(
+      metadata({ composer: "New Composer", discNumber: Number.NaN, bpm: 124 }),
+      { composer: true, discNumber: true, bpm: true },
+      false,
+    );
+
+    expect(patch).toEqual({ discNumber: null, composer: "New Composer", bpm: 124 });
+  });
+
+  it("mirrors album artist only when the advanced policy requires it", () => {
+    const data = metadata({ artist: "Track Artist", albumArtist: "Custom Album Artist" });
+
+    expect(getSubmittedAudioMetadata(data, false, false, false).albumArtist).toBe("Track Artist");
+    expect(getSubmittedAudioMetadata(data, false, true, true).albumArtist).toBe("Track Artist");
+    expect(getSubmittedAudioMetadata(data, false, true, false).albumArtist).toBe(
+      "Custom Album Artist",
+    );
   });
 
   it("summarizes removed track sources without exposing their URLs", () => {

--- a/tests/unit/features/editor/trackMetadataEditor.test.tsx
+++ b/tests/unit/features/editor/trackMetadataEditor.test.tsx
@@ -9,6 +9,7 @@ const metadata: AudioMetadata = {
   filename: "",
   title: "",
   artist: "",
+  albumArtist: "",
   album: "",
   year: null,
   genre: "",
@@ -17,6 +18,10 @@ const metadata: AudioMetadata = {
   sampleRate: 44_100,
   picture: [],
   trackNumber: null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
 };
 
 const loadedTrack: TagiumFile = {

--- a/tests/unit/features/editor/useTrackEditorSession.test.ts
+++ b/tests/unit/features/editor/useTrackEditorSession.test.ts
@@ -6,8 +6,10 @@ import { renderHook } from "../../support/hookTestHarness";
 import { useLibraryStore } from "@/features/library/useLibraryStore";
 import { useTrackEditorSession } from "@/features/editor/useTrackEditorSession";
 import type { AppSettings, AudioMetadata, TagiumFile } from "@/features/library/types";
+import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 
 const settings: AppSettings = {
+  ...DEFAULT_APP_SETTINGS,
   syncTrackNumbers: false,
   syncFilenames: false,
   audioBitrate: "320",
@@ -17,6 +19,7 @@ const metadata = (title: string): AudioMetadata => ({
   filename: title.toLowerCase().replaceAll(" ", "-"),
   title,
   artist: "Artist",
+  albumArtist: "Artist",
   album: "",
   year: null,
   genre: "",
@@ -25,6 +28,10 @@ const metadata = (title: string): AudioMetadata => ({
   sampleRate: 44_100,
   picture: [],
   trackNumber: null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
 });
 const readyFile = (id: string, title: string): TagiumFile => {
   const file = new File([id], `${id}.mp3`);
@@ -146,6 +153,109 @@ describe("track editor session", () => {
       hasBufferedChanges: false,
       metadata: { title: "Edited", duration: 120 },
     });
+    hook.unmount();
+  });
+
+  it("buffers linked album artist whenever artist is edited", () => {
+    const hook = renderHook(() => {
+      const library = useLibraryStore();
+      return { library, editor: useTrackEditorSession({ library, settings }) };
+    }, undefined);
+    const file = readyFile("track", "Track");
+    act(() => {
+      hook.result.library.dispatch({
+        type: "content-replaced",
+        files: [file],
+        looseTrackIds: [file.id],
+        selection: { selectedAlbumId: null, selectedFileId: file.id },
+      });
+    });
+
+    const artist = hook.result.editor.form.register("artist");
+    act(() => {
+      void artist.onChange({ target: { name: "artist", value: "New Artist" }, type: "change" });
+    });
+    act(() => {
+      hook.result.editor.commands.flush();
+    });
+
+    expect(hook.result.library.getSnapshot().files[0]).toMatchObject({
+      metadata: { artist: "New Artist", albumArtist: "New Artist" },
+      pendingMetadataPatch: { artist: "New Artist", albumArtist: "New Artist" },
+    });
+    hook.unmount();
+  });
+
+  it("mirrors album artist when the advanced gate is turned off before hydration writes", async () => {
+    const advancedSettings: AppSettings = {
+      ...settings,
+      advancedMetadata: true,
+      metadataLinks: { ...settings.metadataLinks, albumArtist: false },
+    };
+    const hook = renderHook(
+      ({ currentSettings }: { currentSettings: AppSettings }) => {
+        const library = useLibraryStore();
+        return {
+          library,
+          editor: useTrackEditorSession({ library, settings: currentSettings }),
+        };
+      },
+      { currentSettings: advancedSettings },
+    );
+    const pending: TagiumFile = {
+      id: "remote",
+      format: "mp3",
+      filename: "remote.mp3",
+      status: "pending",
+      downloadStatus: "downloading",
+      hasBufferedChanges: true,
+      pendingMetadataPatch: { albumArtist: "Custom Album Artist" },
+      metadata: { ...metadata("Track"), albumArtist: "Custom Album Artist" },
+    };
+    act(() => {
+      hook.result.library.dispatch({
+        type: "content-replaced",
+        files: [pending],
+        looseTrackIds: [pending.id],
+        selection: { selectedAlbumId: null, selectedFileId: pending.id },
+      });
+    });
+    hook.rerender({
+      currentSettings: {
+        ...advancedSettings,
+        advancedMetadata: false,
+      },
+    });
+
+    const downloaded = new File(["download"], "downloaded.mp3");
+    const parsedFile: TagiumFile = {
+      ...readyFile("parsed", "Parsed"),
+      file: downloaded,
+      originalFile: downloaded,
+      filename: downloaded.name,
+    };
+    const written = new File(["written"], "remote.mp3");
+    const writeTags = vi.fn(() => Effect.succeed(written));
+    const backend = AudioBackend.of({
+      downloadFromCobalt: () => Effect.fail(new Error("unused")),
+      parseUploads: () =>
+        Effect.succeed([{ file: parsedFile, albumSeed: { title: "", artist: "", genre: "" } }]),
+      writeTags,
+    });
+
+    await act(async () => {
+      await Effect.runPromise(
+        hook.result.editor.commands
+          .hydrateDownloadedTrack(pending.id, downloaded)
+          .pipe(Effect.provideService(AudioBackend, backend)),
+      );
+    });
+
+    expect(writeTags).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ artist: "Artist", albumArtist: "Artist" }),
+    );
+    expect(hook.result.library.getSnapshot().files[0].metadata?.albumArtist).toBe("Artist");
     hook.unmount();
   });
 });

--- a/tests/unit/features/export/downloadLibrary.test.ts
+++ b/tests/unit/features/export/downloadLibrary.test.ts
@@ -12,6 +12,7 @@ const metadata = (filename: string): AudioMetadata => ({
   filename: filename.replace(/\.mp3$/i, ""),
   title: filename,
   artist: "",
+  albumArtist: "",
   album: "",
   year: null,
   genre: "",
@@ -20,6 +21,10 @@ const metadata = (filename: string): AudioMetadata => ({
   sampleRate: 0,
   picture: [],
   trackNumber: null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
 });
 
 const file = (id: string, filename: string, contents = id): TagiumFile => ({

--- a/tests/unit/features/export/exportMetadataWrites.test.ts
+++ b/tests/unit/features/export/exportMetadataWrites.test.ts
@@ -6,6 +6,7 @@ const metadata = (title: string): AudioMetadata => ({
   filename: title,
   title,
   artist: "Artist",
+  albumArtist: "Artist",
   album: "Album",
   year: 2024,
   genre: "",
@@ -14,6 +15,10 @@ const metadata = (title: string): AudioMetadata => ({
   sampleRate: 0,
   picture: [],
   trackNumber: null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
 });
 
 const readyFile = (id: string): TagiumFile => ({

--- a/tests/unit/features/export/useExportSession.test.ts
+++ b/tests/unit/features/export/useExportSession.test.ts
@@ -2,6 +2,7 @@ import { act } from "react-test-renderer";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
 import type { AppSettings, AudioMetadata, TagiumFile } from "@/features/library/types";
+import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 
 const exportMocks = vi.hoisted(() => ({
   createZipBlob: vi.fn(),
@@ -30,6 +31,7 @@ const metadata: AudioMetadata = {
   filename: "track",
   title: "Track",
   artist: "Artist",
+  albumArtist: "Custom Album Artist",
   album: "Album",
   year: null,
   genre: "",
@@ -38,12 +40,19 @@ const metadata: AudioMetadata = {
   sampleRate: 44_100,
   picture: [],
   trackNumber: null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
 };
 const settings: AppSettings = {
+  ...DEFAULT_APP_SETTINGS,
   syncTrackNumbers: false,
   syncFilenames: false,
   audioBitrate: "320",
   applySoundCloudAlbumCoverToTracks: false,
+  advancedMetadata: true,
+  metadataLinks: { ...DEFAULT_APP_SETTINGS.metadataLinks, albumArtist: false },
 };
 
 afterEach(() => vi.clearAllMocks());
@@ -63,7 +72,15 @@ describe("export session", () => {
     let snapshot = libraryReducer(createLibraryState(), {
       type: "content-replaced",
       files: [file],
-      looseTrackIds: [file.id],
+      albums: [
+        {
+          id: "album-1",
+          title: "Album",
+          artist: "Album Artist",
+          genre: "",
+          trackIds: [file.id],
+        },
+      ],
     });
     const library: LibraryStore = {
       get state() {
@@ -101,7 +118,10 @@ describe("export session", () => {
     rejectZip?.(new Error("zip failed"));
     await act(async () => exporting);
 
-    expect(updateTags).toHaveBeenCalledWith(file, metadata);
+    expect(updateTags).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ albumArtist: "Custom Album Artist" }),
+    );
     expect(exportMocks.reportFailure).toHaveBeenCalledWith(expect.any(Error), "export");
     expect(hook.result.exporting).toBe(false);
     hook.unmount();

--- a/tests/unit/features/import/audioUrlImportSession.test.ts
+++ b/tests/unit/features/import/audioUrlImportSession.test.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect";
 import { act } from "react-test-renderer";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { AppSettings } from "@/features/library/types";
+import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 
 const mocks = vi.hoisted(() => ({ resolveTrackMetadata: vi.fn() }));
 
@@ -22,6 +23,7 @@ import { useLibraryStore } from "@/features/library/useLibraryStore";
 import { useTrackEditorSession } from "@/features/editor/useTrackEditorSession";
 
 const settings = (audioBitrate: AppSettings["audioBitrate"]): AppSettings => ({
+  ...DEFAULT_APP_SETTINGS,
   syncTrackNumbers: false,
   syncFilenames: false,
   audioBitrate,

--- a/tests/unit/features/import/soundcloudSet.test.ts
+++ b/tests/unit/features/import/soundcloudSet.test.ts
@@ -8,6 +8,7 @@ import { resolveSoundCloudSet } from "@/features/import/soundcloudSet";
 import { startSoundCloudSetImport } from "@/features/import/soundcloudSetImport";
 import type { SoundCloudSet } from "@/features/import/soundcloudSet";
 import type { AlbumGroup, AppSettings, AudioMetadata, TagiumFile } from "@/features/library/types";
+import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -41,6 +42,7 @@ const cover: AudioMetadata["picture"] = [
 ];
 
 const defaultSettings: AppSettings = {
+  ...DEFAULT_APP_SETTINGS,
   audioBitrate: "320",
   syncFilenames: false,
   syncTrackNumbers: false,
@@ -255,6 +257,7 @@ describe("download track plans", () => {
       {
         title: "First Track",
         artist: "Set Artist",
+        albumArtist: "Set Artist",
         album: "Imported Set",
         genre: "Electronic",
         year: 2024,
@@ -263,6 +266,7 @@ describe("download track plans", () => {
       {
         title: "Second Track",
         artist: "Set Artist",
+        albumArtist: "Set Artist",
         album: "Imported Set",
         genre: "Electronic",
         year: 2024,
@@ -330,6 +334,7 @@ describe("soundcloud set import", () => {
       {
         title: "First Track",
         artist: "Set Artist",
+        albumArtist: "Set Artist",
         album: "Imported Set",
         genre: "Electronic",
         year: 2024,
@@ -338,6 +343,7 @@ describe("soundcloud set import", () => {
       {
         title: "Second Track",
         artist: "Set Artist",
+        albumArtist: "Set Artist",
         album: "Imported Set",
         genre: "Electronic",
         year: 2024,

--- a/tests/unit/features/library/albumOps.test.ts
+++ b/tests/unit/features/library/albumOps.test.ts
@@ -11,6 +11,7 @@ const metadata = (trackNumber?: number): AudioMetadata => ({
   filename: "track",
   title: "Track",
   artist: "Artist",
+  albumArtist: "Artist",
   album: "Album",
   year: 2024,
   genre: "",
@@ -19,6 +20,10 @@ const metadata = (trackNumber?: number): AudioMetadata => ({
   sampleRate: 0,
   picture: [],
   trackNumber: trackNumber ?? null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
 });
 
 const upload = (

--- a/tests/unit/features/library/fileMetadataOps.test.ts
+++ b/tests/unit/features/library/fileMetadataOps.test.ts
@@ -11,11 +11,13 @@ import {
   resolveDownloadedTrackHydrationWriteError,
 } from "@/features/library/fileMetadataOps";
 import { AudioMetadata, TagiumFile } from "@/features/library/types";
+import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 
 const metadata = (overrides: Partial<AudioMetadata> = {}): AudioMetadata => ({
   filename: "track",
   title: "Track",
   artist: "Artist",
+  albumArtist: "Artist",
   album: "Album",
   year: 2024,
   genre: "",
@@ -24,6 +26,10 @@ const metadata = (overrides: Partial<AudioMetadata> = {}): AudioMetadata => ({
   sampleRate: 0,
   picture: [],
   trackNumber: null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
   ...overrides,
 });
 
@@ -52,19 +58,7 @@ describe("fileMetadataOps", () => {
         status: "saved" as const,
         downloadStatus: "ready" as const,
         hasBufferedChanges: false,
-        metadata: {
-          filename: "track-1",
-          title: "Track 1",
-          artist: "Artist",
-          album: "Album",
-          year: 2024,
-          genre: "",
-          duration: 0,
-          bitrate: 0,
-          sampleRate: 0,
-          picture: [],
-          trackNumber: null,
-        },
+        metadata: metadata({ filename: "track-1", title: "Track 1" }),
       },
       {
         id: "track-2",
@@ -75,19 +69,7 @@ describe("fileMetadataOps", () => {
         status: "pending" as const,
         downloadStatus: "ready" as const,
         hasBufferedChanges: false,
-        metadata: {
-          filename: "track-2",
-          title: "Track 2",
-          artist: "Artist",
-          album: "Album",
-          year: 2024,
-          genre: "",
-          duration: 0,
-          bitrate: 0,
-          sampleRate: 0,
-          picture: [],
-          trackNumber: null,
-        },
+        metadata: metadata({ filename: "track-2", title: "Track 2" }),
       },
     ];
 
@@ -111,6 +93,48 @@ describe("fileMetadataOps", () => {
     expect(result[1].pendingMetadataPatch?.trackNumber).toBe(1);
   });
 
+  it("does not rewrite unlinked album artist during track reordering or cover sync", () => {
+    const file = readyFile({
+      metadata: metadata({ albumArtist: "Custom Album Artist", trackNumber: 9 }),
+    });
+    const album = {
+      id: "album-1",
+      title: "Album",
+      artist: "Album Artist",
+      genre: "",
+      trackIds: [file.id],
+    };
+    const unlinkedSettings = {
+      ...DEFAULT_APP_SETTINGS,
+      advancedMetadata: true,
+      metadataLinks: { ...DEFAULT_APP_SETTINGS.metadataLinks, albumArtist: false },
+    };
+
+    const [reordered] = applyTrackOrderNumbersToFiles(
+      [file],
+      [album],
+      [album.id],
+      unlinkedSettings,
+    );
+    const [covered] = applyAlbumCoverToFiles(
+      [reordered],
+      [file.id],
+      [
+        {
+          format: "image/jpeg",
+          type: 3,
+          description: "cover",
+          data: new Uint8Array([1]),
+        },
+      ],
+      unlinkedSettings,
+    );
+
+    expect(covered.metadata?.albumArtist).toBe("Custom Album Artist");
+    expect(covered.pendingMetadataPatch).toMatchObject({ trackNumber: 1 });
+    expect(covered.pendingMetadataPatch).not.toHaveProperty("albumArtist");
+  });
+
   it("applies shared album metadata without applying album cover", () => {
     const originalCover = [
       {
@@ -131,19 +155,14 @@ describe("fileMetadataOps", () => {
         status: "saved" as const,
         downloadStatus: "ready" as const,
         hasBufferedChanges: false,
-        metadata: {
+        metadata: metadata({
           filename: "track-1",
           title: "Track 1",
           artist: "Old Artist",
           album: "Old Album",
-          year: 2024,
-          genre: "",
-          duration: 0,
-          bitrate: 0,
-          sampleRate: 0,
           picture: originalCover,
           trackNumber: 9,
-        },
+        }),
       },
     ];
 
@@ -180,6 +199,77 @@ describe("fileMetadataOps", () => {
     expect(
       Object.prototype.hasOwnProperty.call(updatedFile.pendingMetadataPatch ?? {}, "year"),
     ).toBe(false);
+  });
+
+  it("keeps album title linked while respecting every unlinkable shared field", () => {
+    const file = readyFile({
+      metadata: metadata({
+        artist: "Track Artist",
+        albumArtist: "Custom Album Artist",
+        album: "Old Album",
+        year: 1999,
+        genre: "Track Genre",
+        composer: "Hidden Composer",
+        discNumber: 2,
+        bpm: 123,
+        comment: "Hidden comment",
+      }),
+    });
+    const album = {
+      id: "album-1",
+      title: "New Album",
+      artist: "Album Artist",
+      genre: "Album Genre",
+      year: 2026,
+      trackIds: [file.id],
+    };
+
+    const [updated] = applyAlbumSharedTagsToFiles([file], album, {
+      ...DEFAULT_APP_SETTINGS,
+      advancedMetadata: true,
+      metadataLinks: {
+        artist: false,
+        year: false,
+        genre: false,
+        artwork: false,
+        albumArtist: false,
+      },
+    });
+
+    expect(updated.metadata).toMatchObject({
+      album: "New Album",
+      artist: "Track Artist",
+      albumArtist: "Custom Album Artist",
+      year: 1999,
+      genre: "Track Genre",
+      composer: "Hidden Composer",
+      discNumber: 2,
+      bpm: 123,
+      comment: "Hidden comment",
+    });
+    expect(updated.pendingMetadataPatch).toEqual({ album: "New Album" });
+  });
+
+  it("mirrors album artist from the resulting track artist when advanced metadata is off", () => {
+    const file = readyFile({
+      metadata: metadata({ artist: "Track Artist", albumArtist: "Custom Album Artist" }),
+    });
+    const album = {
+      id: "album-1",
+      title: "Album",
+      artist: "Album Artist",
+      genre: "",
+      trackIds: [file.id],
+    };
+
+    const [linkedArtist] = applyAlbumSharedTagsToFiles([file], album, DEFAULT_APP_SETTINGS);
+    const [unlinkedArtist] = applyAlbumSharedTagsToFiles([file], album, {
+      ...DEFAULT_APP_SETTINGS,
+      metadataLinks: { ...DEFAULT_APP_SETTINGS.metadataLinks, artist: false },
+    });
+
+    expect(linkedArtist.metadata?.albumArtist).toBe("Album Artist");
+    expect(unlinkedArtist.metadata?.albumArtist).toBe("Track Artist");
   });
 
   it("explicitly applies album cover to album tracks", () => {

--- a/tests/unit/features/library/metadataCleanup.test.ts
+++ b/tests/unit/features/library/metadataCleanup.test.ts
@@ -11,6 +11,7 @@ const metadata = (title: string, artist = "Burial"): AudioMetadata => ({
   filename: title,
   title,
   artist,
+  albumArtist: artist,
   album: "Untrue",
   year: 2007,
   genre: "Electronic",
@@ -19,6 +20,10 @@ const metadata = (title: string, artist = "Burial"): AudioMetadata => ({
   sampleRate: 44_100,
   picture: [],
   trackNumber: 1,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
 });
 
 const file = (title: string): TagiumFile => ({

--- a/tests/unit/features/settings/settings.test.ts
+++ b/tests/unit/features/settings/settings.test.ts
@@ -45,6 +45,18 @@ describe("settings", () => {
     });
   });
 
+  it("migrates partial metadata-link settings independently", () => {
+    const storage = storageWith(
+      JSON.stringify({ advancedMetadata: true, metadataLinks: { artist: false } }),
+    );
+
+    expect(loadAppSettings(storage)).toEqual({
+      ...DEFAULT_APP_SETTINGS,
+      advancedMetadata: true,
+      metadataLinks: { ...DEFAULT_APP_SETTINGS.metadataLinks, artist: false },
+    });
+  });
+
   it("ignores invalid stored setting values", () => {
     const storage = storageWith(
       JSON.stringify({
@@ -64,6 +76,7 @@ describe("settings", () => {
   it("saves app settings", () => {
     const storage = storageWith(null);
     const settings: AppSettings = {
+      ...DEFAULT_APP_SETTINGS,
       syncTrackNumbers: false,
       syncFilenames: false,
       audioBitrate: "256",
@@ -83,6 +96,7 @@ describe("settings", () => {
       },
     };
     const settings: AppSettings = {
+      ...DEFAULT_APP_SETTINGS,
       syncTrackNumbers: false,
       syncFilenames: false,
       audioBitrate: "256",

--- a/tests/unit/features/workspace/useAudioImportSession.test.ts
+++ b/tests/unit/features/workspace/useAudioImportSession.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
 import type { AppSettings, AudioMetadata } from "@/features/library/types";
+import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 
 const backendMocks = vi.hoisted(() => ({ parseUploads: vi.fn() }));
 
@@ -16,6 +17,7 @@ const metadata: AudioMetadata = {
   filename: "track",
   title: "Track",
   artist: "Artist",
+  albumArtist: "Artist",
   album: "",
   year: null,
   genre: "",
@@ -24,8 +26,13 @@ const metadata: AudioMetadata = {
   sampleRate: 44_100,
   picture: [],
   trackNumber: null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
 };
 const defaultSettings: AppSettings = {
+  ...DEFAULT_APP_SETTINGS,
   syncTrackNumbers: false,
   syncFilenames: false,
   audioBitrate: "320",
@@ -109,4 +116,67 @@ describe("audio upload session", () => {
 
     expect(library.getSnapshot().files[0].filename).toBe("Track.mp3");
   });
+
+  it.each([
+    { linked: true, expectedAlbumArtist: "Grouped Artist" },
+    { linked: false, expectedAlbumArtist: "Embedded Album Artist" },
+  ])(
+    "applies forced album policy with album artist linked=$linked",
+    async ({ linked, expectedAlbumArtist }) => {
+      const sources = [
+        new File(["one"], "one.mp3", { lastModified: 1 }),
+        new File(["two"], "two.mp3", { lastModified: 2 }),
+      ];
+      backendMocks.parseUploads.mockImplementation(async () =>
+        sources.map((source, index) => ({
+          file: {
+            id: `track-${index + 1}`,
+            format: "mp3" as const,
+            filename: source.name,
+            file: source,
+            originalFile: source,
+            status: "saved" as const,
+            downloadStatus: "ready" as const,
+            metadata: {
+              ...metadata,
+              filename: `track-${index + 1}`,
+              artist: "Embedded Artist",
+              albumArtist: "Embedded Album Artist",
+              album: "Embedded Album",
+            },
+          },
+          albumSeed: {
+            title: "Grouped Album",
+            artist: "Grouped Artist",
+            genre: "Ambient",
+          },
+        })),
+      );
+      const library = createLibrary();
+      const importSettings: AppSettings = {
+        ...defaultSettings,
+        advancedMetadata: !linked,
+        metadataLinks: { ...defaultSettings.metadataLinks, albumArtist: linked },
+      };
+      const session = createAudioUploadSession({
+        library,
+        getSettings: () => importSettings,
+        bufferEditor: vi.fn(),
+        activateEditor: vi.fn(),
+        setUploading: vi.fn(),
+      });
+
+      await session.upload(sources);
+
+      expect(library.getSnapshot().files).toHaveLength(2);
+      for (const file of library.getSnapshot().files) {
+        expect(file.metadata).toMatchObject({
+          album: "Grouped Album",
+          artist: "Grouped Artist",
+          albumArtist: expectedAlbumArtist,
+          genre: "Ambient",
+        });
+      }
+    },
+  );
 });

--- a/tests/unit/features/workspace/useAudioWorkspace.test.tsx
+++ b/tests/unit/features/workspace/useAudioWorkspace.test.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { act } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { AppSettings, AudioMetadata, TagiumFile } from "@/features/library/types";
+import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 
 const toastMocks = vi.hoisted(() => {
   const toast = vi.fn();
@@ -16,6 +17,7 @@ import { useLibraryStore } from "@/features/library/useLibraryStore";
 import { useTrackEditorSession } from "@/features/editor/useTrackEditorSession";
 
 const initialSettings: AppSettings = {
+  ...DEFAULT_APP_SETTINGS,
   syncTrackNumbers: false,
   syncFilenames: false,
   audioBitrate: "320",
@@ -25,6 +27,7 @@ const metadata = (title: string): AudioMetadata => ({
   filename: title.toLowerCase().replaceAll(" ", "-"),
   title,
   artist: "Artist",
+  albumArtist: "Artist",
   album: "",
   year: null,
   genre: "",
@@ -33,6 +36,10 @@ const metadata = (title: string): AudioMetadata => ({
   sampleRate: 44_100,
   picture: [],
   trackNumber: null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
 });
 const readyFile = (id: string, title: string): TagiumFile => {
   const file = new File([id], `${id}.mp3`);
@@ -128,6 +135,20 @@ describe("audio workspace", () => {
       selectedAlbumId: albumId,
       selectedFileId: first.id,
       albums: [{ id: albumId, trackIds: [first.id] }],
+    });
+    expect(hook.result.library.getSnapshot().files[0]).toMatchObject({
+      metadata: {
+        album: "New Album",
+        artist: "Artist",
+        albumArtist: "Artist",
+        genre: "Rock",
+      },
+      pendingMetadataPatch: {
+        album: "New Album",
+        artist: "Artist",
+        albumArtist: "Artist",
+        genre: "Rock",
+      },
     });
 
     act(() => hook.result.workspace.sidebarProps.onRemoveFile(second.id));


### PR DESCRIPTION
## What changed

- add album artist, disc number, composer, BPM, and comment across metadata snapshots, sparse patches, hydration, editor sessions, export, and MP3 I/O
- add an off-by-default Advanced Metadata gate and one backward-compatible global metadata-link policy
- centralize album-to-track policy application for album operations, imports, moves, cover/number sync, hydration, and export
- preserve current library values when settings change; apply policy only at defined future synchronization/write seams
- preserve unknown ID3v2 frames, alternate comments, and byte-identical audio payloads during real mp3tag.js round trips
- upgrade untagged/ID3v1 inputs to ID3v2.4 when advanced fields require it
- add real-codec and policy regression coverage

## Why

Advanced editor controls need a behavior-preserving metadata and synchronization foundation. This PR keeps visible behavior unchanged while making link semantics and advanced field persistence explicit.

## Verification

- post-commit `bun run typecheck`
- post-commit `bun run lint` — 0 warnings/errors
- post-commit `bun run test` — 65 files, 412 tests passed
- `git diff --check`
- two fresh independent reviews; all data-loss and hydration findings fixed and re-reviewed

## Known format constraint

Album artist, composer, BPM, and disc number have no ID3v1 representation. When they are written to an ID3v1-only or untagged MP3, Tagium adds ID3v2.4 while preserving the audio payload.

This PR intentionally targets `codex/format-aware-audio-core` (PR #119); its format identity and naming seam are a genuine dependency.
