### PR TITLE
feat(export): confirm bulk downloads

### DIFF
--- a/src/features/editor/useTrackEditorSession.ts
+++ b/src/features/editor/useTrackEditorSession.ts
@@ -172,6 +172,7 @@ export interface TrackEditorSession {
     "register" | "control" | "reset" | "getValues" | "setError" | "clearErrors" | "setFocus"
   >;
   commands: {
+    projectFiles: (trackIds?: string[]) => TagiumFile[];
     flush: (trackIds?: string[]) => TagiumFile[];
     preview: (field: PreviewField, value: string) => void;
     uploadCover: (
@@ -324,16 +325,24 @@ export const useTrackEditorSession = ({
     [createCurrentFormProjection, getValues],
   );
 
+  const projectFiles = useCallback(
+    (trackIds?: string[]) => {
+      const currentFiles = library.getSnapshot().files;
+      return applyCurrentFormMetadataToFiles(currentFiles, trackIds);
+    },
+    [applyCurrentFormMetadataToFiles, library],
+  );
+
   const flush = useCallback(
     (trackIds?: string[]) => {
       const currentFiles = library.getSnapshot().files;
-      const nextFiles = applyCurrentFormMetadataToFiles(currentFiles, trackIds);
+      const nextFiles = projectFiles(trackIds);
       if (nextFiles !== currentFiles) {
         library.dispatch({ type: "content-replaced", files: nextFiles });
       }
       return nextFiles;
     },
-    [applyCurrentFormMetadataToFiles, library],
+    [library, projectFiles],
   );
 
   const preview = useCallback(
@@ -577,6 +586,7 @@ export const useTrackEditorSession = ({
       setFocus,
     },
     commands: {
+      projectFiles,
       flush,
       preview,
       uploadCover: (picture, sourceFileId) => {

--- a/src/features/export/ExportConfirmationDialog.tsx
+++ b/src/features/export/ExportConfirmationDialog.tsx
@@ -88,6 +88,7 @@ export default function ExportConfirmationDialog({
     <Dialog open={Boolean(summary)} onOpenChange={(open) => !open && !busy && onCancel()}>
       <DialogContent
         showCloseButton={false}
+        aria-describedby={undefined}
         className="max-h-[calc(100dvh-1rem)] grid-rows-[auto_minmax(0,1fr)_auto] p-4 sm:max-h-[calc(100dvh-2rem)] sm:max-w-lg sm:p-6"
         onOpenAutoFocus={(event) => {
           event.preventDefault();

--- a/src/features/export/ExportConfirmationDialog.tsx
+++ b/src/features/export/ExportConfirmationDialog.tsx
@@ -111,7 +111,7 @@ export default function ExportConfirmationDialog({
               className="rounded-md bg-accent px-3 py-2 text-sm text-accent-foreground"
             >
               {status === "changed"
-                ? "Your export changed. Review the updated files and confirm again."
+                ? "Your export changed. Confirm the updated download again."
                 : "Your export changed and some files are no longer ready. Close this dialog and try again."}
             </p>
           )}

--- a/src/features/export/ExportConfirmationDialog.tsx
+++ b/src/features/export/ExportConfirmationDialog.tsx
@@ -23,11 +23,7 @@ export interface ExportConfirmationDialogProps {
   onRestoreFocus: () => void;
 }
 
-export function ExportConfirmationDisclosure({
-  group,
-}: {
-  group: ExportConfirmationGroup;
-}) {
+export function ExportConfirmationDisclosure({ group }: { group: ExportConfirmationGroup }) {
   const [open, setOpen] = useState(false);
   const contentId = useId();
 
@@ -82,7 +78,9 @@ export default function ExportConfirmationDialog({
   onRestoreFocus,
 }: ExportConfirmationDialogProps) {
   const noun = summary?.trackCount === 1 ? "track" : "tracks";
-  const downloadLabel = summary ? `Download ${formatMegabyteSize(summary.totalSizeBytes)}` : "Download";
+  const downloadLabel = summary
+    ? `Download ${formatMegabyteSize(summary.totalSizeBytes)}`
+    : "Download";
 
   return (
     <Dialog open={Boolean(summary)} onOpenChange={(open) => !open && !busy && onCancel()}>

--- a/src/features/export/ExportConfirmationDialog.tsx
+++ b/src/features/export/ExportConfirmationDialog.tsx
@@ -1,14 +1,16 @@
+import { ChevronDown } from "lucide-react";
+import { useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
-  formatByteSize,
+  formatMegabyteSize,
+  type ExportConfirmationGroup,
   type ExportConfirmationSummary,
 } from "@/features/export/exportConfirmation";
 
@@ -21,6 +23,56 @@ export interface ExportConfirmationDialogProps {
   onRestoreFocus: () => void;
 }
 
+export function ExportConfirmationDisclosure({
+  group,
+}: {
+  group: ExportConfirmationGroup;
+}) {
+  const [open, setOpen] = useState(false);
+  const contentId = useId();
+
+  return (
+    <div className="group/disclosure px-3 py-2.5" data-state={open ? "open" : "closed"}>
+      <button
+        type="button"
+        className="flex w-full cursor-pointer items-start gap-3 rounded-sm text-left text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-expanded={open}
+        aria-controls={contentId}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span className="min-w-0 flex-1">
+          <span className="block truncate font-medium">{group.title}</span>
+          <span className="text-xs text-muted-foreground">
+            {group.tracks.length} {group.tracks.length === 1 ? "track" : "tracks"}
+          </span>
+        </span>
+        <ChevronDown
+          className="mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform duration-200 ease-out group-data-[state=open]/disclosure:rotate-180 motion-reduce:transition-none"
+          aria-hidden="true"
+        />
+      </button>
+      <div
+        id={contentId}
+        role="region"
+        aria-label={`${group.title} tracks`}
+        aria-hidden={!open}
+        inert={!open}
+        className="grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out group-data-[state=open]/disclosure:grid-rows-[1fr] group-data-[state=open]/disclosure:opacity-100 motion-reduce:transition-none"
+      >
+        <div className="min-h-0 overflow-hidden">
+          <ul className="mt-2 space-y-1 border-t pt-2">
+            {group.tracks.map((track) => (
+              <li key={track.id} className="min-w-0 truncate text-xs">
+                {track.title}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function ExportConfirmationDialog({
   summary,
   status,
@@ -30,6 +82,7 @@ export default function ExportConfirmationDialog({
   onRestoreFocus,
 }: ExportConfirmationDialogProps) {
   const noun = summary?.trackCount === 1 ? "track" : "tracks";
+  const downloadLabel = summary ? `Download ${formatMegabyteSize(summary.totalSizeBytes)}` : "Download";
 
   return (
     <Dialog open={Boolean(summary)} onOpenChange={(open) => !open && !busy && onCancel()}>
@@ -50,11 +103,8 @@ export default function ExportConfirmationDialog({
       >
         <DialogHeader>
           <DialogTitle>
-            download {summary?.trackCount ?? 0} {noun}?
+            Download {summary?.trackCount ?? 0} {noun}
           </DialogTitle>
-          <DialogDescription>
-            Review the files before Tagium applies metadata and creates the download.
-          </DialogDescription>
           {status !== "ready" && (
             <p
               role="alert"
@@ -69,42 +119,9 @@ export default function ExportConfirmationDialog({
 
         {summary && (
           <div className="min-h-0 overflow-y-auto -mx-2 px-2" data-testid="export-summary">
-            <div className="mb-3 flex items-baseline justify-between gap-4 rounded-md bg-muted px-3 py-2.5 text-sm">
-              <span className="font-medium">estimated download size</span>
-              <span className="text-right tabular-nums text-muted-foreground">
-                {formatByteSize(summary.totalSizeBytes)}
-              </span>
-            </div>
-            <p className="mb-3 text-xs text-muted-foreground">
-              Current file bytes before metadata updates and ZIP compression.
-            </p>
             <div className="divide-y rounded-md border">
               {summary.groups.map((group) => (
-                <details key={group.id} className="group px-3 py-2.5">
-                  <summary className="cursor-pointer select-none list-none rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
-                    <span className="flex items-start justify-between gap-4 text-sm">
-                      <span className="min-w-0">
-                        <span className="block truncate font-medium">{group.title}</span>
-                        <span className="text-xs text-muted-foreground">
-                          {group.tracks.length} {group.tracks.length === 1 ? "track" : "tracks"}
-                        </span>
-                      </span>
-                      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
-                        {formatByteSize(group.sizeBytes)}
-                      </span>
-                    </span>
-                  </summary>
-                  <ul className="mt-2 space-y-1 border-t pt-2" aria-label={`${group.title} tracks`}>
-                    {group.tracks.map((track) => (
-                      <li key={track.id} className="flex justify-between gap-4 text-xs">
-                        <span className="min-w-0 truncate">{track.title}</span>
-                        <span className="shrink-0 tabular-nums text-muted-foreground">
-                          {formatByteSize(track.sizeBytes)}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </details>
+                <ExportConfirmationDisclosure key={group.id} group={group} />
               ))}
             </div>
           </div>
@@ -125,8 +142,9 @@ export default function ExportConfirmationDialog({
             onClick={onConfirm}
             disabled={busy || status === "unavailable"}
             aria-busy={busy}
+            className="w-[10.5rem] justify-center tabular-nums"
           >
-            {busy ? "preparing download..." : "download"}
+            {busy ? "preparing download..." : downloadLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/features/export/ExportConfirmationDialog.tsx
+++ b/src/features/export/ExportConfirmationDialog.tsx
@@ -1,0 +1,136 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  formatByteSize,
+  type ExportConfirmationSummary,
+} from "@/features/export/exportConfirmation";
+
+export interface ExportConfirmationDialogProps {
+  summary: ExportConfirmationSummary | null;
+  status: "ready" | "changed" | "unavailable";
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  onRestoreFocus: () => void;
+}
+
+export default function ExportConfirmationDialog({
+  summary,
+  status,
+  busy,
+  onCancel,
+  onConfirm,
+  onRestoreFocus,
+}: ExportConfirmationDialogProps) {
+  const noun = summary?.trackCount === 1 ? "track" : "tracks";
+
+  return (
+    <Dialog open={Boolean(summary)} onOpenChange={(open) => !open && !busy && onCancel()}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-h-[calc(100dvh-1rem)] grid-rows-[auto_minmax(0,1fr)_auto] p-4 sm:max-h-[calc(100dvh-2rem)] sm:max-w-lg sm:p-6"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          const content = event.currentTarget as HTMLElement;
+          content.querySelector<HTMLElement>("[data-export-cancel]")?.focus();
+        }}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          onRestoreFocus();
+        }}
+        onEscapeKeyDown={(event) => busy && event.preventDefault()}
+        onPointerDownOutside={(event) => busy && event.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>
+            download {summary?.trackCount ?? 0} {noun}?
+          </DialogTitle>
+          <DialogDescription>
+            Review the files before Tagium applies metadata and creates the download.
+          </DialogDescription>
+          {status !== "ready" && (
+            <p
+              role="status"
+              aria-live="assertive"
+              className="rounded-md bg-accent px-3 py-2 text-sm text-accent-foreground"
+            >
+              {status === "changed"
+                ? "Your export changed. Review the updated files and confirm again."
+                : "Your export changed and some files are no longer ready. Close this dialog and try again."}
+            </p>
+          )}
+        </DialogHeader>
+
+        {summary && (
+          <div className="min-h-0 overflow-y-auto -mx-2 px-2" data-testid="export-summary">
+            <div className="mb-3 flex items-baseline justify-between gap-4 rounded-md bg-muted px-3 py-2.5 text-sm">
+              <span className="font-medium">estimated download size</span>
+              <span className="text-right tabular-nums text-muted-foreground">
+                {formatByteSize(summary.totalSizeBytes)}
+              </span>
+            </div>
+            <p className="mb-3 text-xs text-muted-foreground">
+              Current file bytes before metadata updates and ZIP compression.
+            </p>
+            <div className="divide-y rounded-md border">
+              {summary.groups.map((group) => (
+                <details key={group.id} className="group px-3 py-2.5">
+                  <summary className="cursor-pointer select-none list-none rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+                    <span className="flex items-start justify-between gap-4 text-sm">
+                      <span className="min-w-0">
+                        <span className="block truncate font-medium">{group.title}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {group.tracks.length} {group.tracks.length === 1 ? "track" : "tracks"}
+                        </span>
+                      </span>
+                      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                        {formatByteSize(group.sizeBytes)}
+                      </span>
+                    </span>
+                  </summary>
+                  <ul className="mt-2 space-y-1 border-t pt-2" aria-label={`${group.title} tracks`}>
+                    {group.tracks.map((track) => (
+                      <li key={track.id} className="flex justify-between gap-4 text-xs">
+                        <span className="min-w-0 truncate">{track.title}</span>
+                        <span className="shrink-0 tabular-nums text-muted-foreground">
+                          {formatByteSize(track.sizeBytes)}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            disabled={busy}
+            data-export-cancel
+          >
+            cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={onConfirm}
+            disabled={busy || status === "unavailable"}
+            aria-busy={busy}
+          >
+            {busy ? "preparing download..." : "download"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/export/ExportConfirmationDialog.tsx
+++ b/src/features/export/ExportConfirmationDialog.tsx
@@ -57,7 +57,7 @@ export default function ExportConfirmationDialog({
           </DialogDescription>
           {status !== "ready" && (
             <p
-              role="status"
+              role="alert"
               className="rounded-md bg-accent px-3 py-2 text-sm text-accent-foreground"
             >
               {status === "changed"

--- a/src/features/export/ExportConfirmationDialog.tsx
+++ b/src/features/export/ExportConfirmationDialog.tsx
@@ -58,7 +58,6 @@ export default function ExportConfirmationDialog({
           {status !== "ready" && (
             <p
               role="status"
-              aria-live="assertive"
               className="rounded-md bg-accent px-3 py-2 text-sm text-accent-foreground"
             >
               {status === "changed"

--- a/src/features/export/exportConfirmation.ts
+++ b/src/features/export/exportConfirmation.ts
@@ -2,8 +2,15 @@ import type { LibraryState } from "@/features/library/libraryState";
 import type { AppSettings, TagiumFile } from "@/features/library/types";
 import { isTrackReadyForDownload } from "@/features/export/downloadLibrary";
 
-const byteFormatter = new Intl.NumberFormat("en-US");
-const compactByteFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
+const megabyteFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
+const smallMegabyteFormatter = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+const largeMegabyteFormatter = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
 
 export type ConfirmedExportTarget = { kind: "library" } | { kind: "album"; albumId: string };
 
@@ -203,15 +210,13 @@ export const createExportPlanFingerprint = (
   );
 };
 
-export const formatByteSize = (sizeBytes: number) => {
-  const exact = `${byteFormatter.format(sizeBytes)} ${sizeBytes === 1 ? "byte" : "bytes"}`;
-  if (sizeBytes < 1_000) return exact;
-  const units = ["kB", "MB", "GB", "TB"];
-  let value = sizeBytes / 1_000;
-  let unit = units[0];
-  for (let index = 1; value >= 1_000 && index < units.length; index++) {
-    value /= 1_000;
-    unit = units[index];
-  }
-  return `${compactByteFormatter.format(value)} ${unit} (${exact})`;
+export const formatMegabyteSize = (sizeBytes: number) => {
+  const megabytes = sizeBytes / 1_000_000;
+  const formatted =
+    megabytes < 0.1
+      ? smallMegabyteFormatter.format(megabytes)
+      : megabytes >= 10_000
+        ? largeMegabyteFormatter.format(megabytes)
+        : megabyteFormatter.format(megabytes);
+  return `${formatted} MB`;
 };

--- a/src/features/export/exportConfirmation.ts
+++ b/src/features/export/exportConfirmation.ts
@@ -2,14 +2,22 @@ import type { LibraryState } from "@/features/library/libraryState";
 import type { AppSettings, TagiumFile } from "@/features/library/types";
 import { isTrackReadyForDownload } from "@/features/export/downloadLibrary";
 
-const megabyteFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
+const fractionalMegabyteFormatter = new Intl.NumberFormat("en-US", {
+  useGrouping: false,
+  maximumFractionDigits: 1,
+});
+const wholeMegabyteFormatter = new Intl.NumberFormat("en-US", {
+  useGrouping: false,
+  maximumFractionDigits: 0,
+});
 const smallMegabyteFormatter = new Intl.NumberFormat("en-US", {
+  useGrouping: false,
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
 });
 const largeMegabyteFormatter = new Intl.NumberFormat("en-US", {
   notation: "compact",
-  maximumFractionDigits: 1,
+  maximumSignificantDigits: 2,
 });
 
 export type ConfirmedExportTarget = { kind: "library" } | { kind: "album"; albumId: string };
@@ -215,8 +223,10 @@ export const formatMegabyteSize = (sizeBytes: number) => {
   const formatted =
     megabytes < 0.1
       ? smallMegabyteFormatter.format(megabytes)
-      : megabytes >= 10_000
+      : megabytes >= 999.5
         ? largeMegabyteFormatter.format(megabytes)
-        : megabyteFormatter.format(megabytes);
+        : megabytes < 100
+          ? fractionalMegabyteFormatter.format(megabytes)
+          : wholeMegabyteFormatter.format(megabytes);
   return `${formatted} MB`;
 };

--- a/src/features/export/exportConfirmation.ts
+++ b/src/features/export/exportConfirmation.ts
@@ -2,6 +2,9 @@ import type { LibraryState } from "@/features/library/libraryState";
 import type { AppSettings, TagiumFile } from "@/features/library/types";
 import { isTrackReadyForDownload } from "@/features/export/downloadLibrary";
 
+const byteFormatter = new Intl.NumberFormat("en-US");
+const compactByteFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
+
 export type ConfirmedExportTarget = { kind: "library" } | { kind: "album"; albumId: string };
 
 export interface ExportConfirmationTrack {
@@ -72,10 +75,20 @@ export const deriveExportConfirmationSummary = (
   }
 
   if (target.kind === "library") {
-    const looseIds = [
-      ...state.looseTrackIds,
-      ...state.files.filter((file) => !includedTrackIds.has(file.id)).map((file) => file.id),
-    ].filter((id, index, ids) => ids.indexOf(id) === index && !includedTrackIds.has(id));
+    const looseIds: string[] = [];
+    const seenLooseIds = new Set<string>();
+    for (const id of state.looseTrackIds) {
+      if (!includedTrackIds.has(id) && !seenLooseIds.has(id)) {
+        seenLooseIds.add(id);
+        looseIds.push(id);
+      }
+    }
+    for (const { id } of state.files) {
+      if (!includedTrackIds.has(id) && !seenLooseIds.has(id)) {
+        seenLooseIds.add(id);
+        looseIds.push(id);
+      }
+    }
     const looseTracks = looseIds.map((id) => filesById.get(id));
     if (!looseTracks.every(readyTrack)) return null;
     if (looseTracks.length > 0) groups.push(summarizeGroup("loose", "Loose tracks", looseTracks));
@@ -134,11 +147,13 @@ const normalizeFingerprintValue = (value: unknown): unknown => {
   if (value instanceof Uint8Array) return getBinaryFingerprint(value);
   if (Array.isArray(value)) return value.map(normalizeFingerprintValue);
   if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, entry]) => [key, normalizeFingerprintValue(entry)]),
-    );
+    const normalizedEntries: [string, unknown][] = [];
+    for (const [key, entry] of Object.entries(value).sort(([left], [right]) =>
+      left.localeCompare(right),
+    )) {
+      normalizedEntries.push([key, normalizeFingerprintValue(entry)]);
+    }
+    return Object.fromEntries(normalizedEntries);
   }
   return value;
 };
@@ -173,19 +188,23 @@ export const createExportPlanFingerprint = (
     target.kind === "album"
       ? new Set(albums.flatMap((album) => album.trackIds))
       : new Set(state.files.map(({ id }) => id));
+  const files: ReturnType<typeof fileFingerprint>[] = [];
+  for (const file of state.files) {
+    if (trackIds.has(file.id)) files.push(fileFingerprint(file));
+  }
   return JSON.stringify(
     normalizeFingerprintValue({
       target,
       settings,
       albums,
       looseTrackIds: target.kind === "library" ? state.looseTrackIds : [],
-      files: state.files.filter(({ id }) => trackIds.has(id)).map(fileFingerprint),
+      files,
     }),
   );
 };
 
 export const formatByteSize = (sizeBytes: number) => {
-  const exact = `${new Intl.NumberFormat("en-US").format(sizeBytes)} ${sizeBytes === 1 ? "byte" : "bytes"}`;
+  const exact = `${byteFormatter.format(sizeBytes)} ${sizeBytes === 1 ? "byte" : "bytes"}`;
   if (sizeBytes < 1_000) return exact;
   const units = ["kB", "MB", "GB", "TB"];
   let value = sizeBytes / 1_000;
@@ -194,5 +213,5 @@ export const formatByteSize = (sizeBytes: number) => {
     value /= 1_000;
     unit = units[index];
   }
-  return `${new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(value)} ${unit} (${exact})`;
+  return `${compactByteFormatter.format(value)} ${unit} (${exact})`;
 };

--- a/src/features/export/exportConfirmation.ts
+++ b/src/features/export/exportConfirmation.ts
@@ -1,0 +1,198 @@
+import type { LibraryState } from "@/features/library/libraryState";
+import type { AppSettings, TagiumFile } from "@/features/library/types";
+import { isTrackReadyForDownload } from "@/features/export/downloadLibrary";
+
+export type ConfirmedExportTarget = { kind: "library" } | { kind: "album"; albumId: string };
+
+export interface ExportConfirmationTrack {
+  id: string;
+  title: string;
+  sizeBytes: number;
+}
+
+export interface ExportConfirmationGroup {
+  id: string;
+  title: string;
+  tracks: ExportConfirmationTrack[];
+  sizeBytes: number;
+}
+
+export interface ExportConfirmationSummary {
+  target: ConfirmedExportTarget;
+  groups: ExportConfirmationGroup[];
+  trackCount: number;
+  totalSizeBytes: number;
+  fingerprint: string;
+}
+
+const readyTrack = (track: TagiumFile | undefined): track is TagiumFile & { file: File } =>
+  Boolean(track?.file && isTrackReadyForDownload(track));
+
+const summarizeTrack = (track: TagiumFile & { file: File }): ExportConfirmationTrack => ({
+  id: track.id,
+  title: track.metadata?.title.trim() || track.filename,
+  sizeBytes: track.file.size,
+});
+
+const summarizeGroup = (
+  id: string,
+  title: string,
+  tracks: Array<TagiumFile & { file: File }>,
+): ExportConfirmationGroup => {
+  const summarizedTracks = tracks.map(summarizeTrack);
+  return {
+    id,
+    title,
+    tracks: summarizedTracks,
+    sizeBytes: summarizedTracks.reduce((total, track) => total + track.sizeBytes, 0),
+  };
+};
+
+export const deriveExportConfirmationSummary = (
+  state: LibraryState,
+  target: ConfirmedExportTarget,
+  settings: AppSettings,
+): ExportConfirmationSummary | null => {
+  const filesById = new Map(state.files.map((file) => [file.id, file]));
+  const groups: ExportConfirmationGroup[] = [];
+  const includedTrackIds = new Set<string>();
+
+  const albums =
+    target.kind === "album"
+      ? state.albums.filter((album) => album.id === target.albumId)
+      : state.albums;
+  if (target.kind === "album" && albums.length !== 1) return null;
+
+  for (const album of albums) {
+    if (target.kind === "library" && album.trackIds.length === 0) continue;
+    const tracks = album.trackIds.map((id) => filesById.get(id));
+    if (tracks.length === 0 || !tracks.every(readyTrack)) return null;
+    album.trackIds.forEach((id) => includedTrackIds.add(id));
+    groups.push(summarizeGroup(`album:${album.id}`, album.title, tracks));
+  }
+
+  if (target.kind === "library") {
+    const looseIds = [
+      ...state.looseTrackIds,
+      ...state.files.filter((file) => !includedTrackIds.has(file.id)).map((file) => file.id),
+    ].filter((id, index, ids) => ids.indexOf(id) === index && !includedTrackIds.has(id));
+    const looseTracks = looseIds.map((id) => filesById.get(id));
+    if (!looseTracks.every(readyTrack)) return null;
+    if (looseTracks.length > 0) groups.push(summarizeGroup("loose", "Loose tracks", looseTracks));
+  }
+
+  const trackCount = groups.reduce((total, group) => total + group.tracks.length, 0);
+  if (trackCount === 0) return null;
+  return {
+    target,
+    groups,
+    trackCount,
+    totalSizeBytes: groups.reduce((total, group) => total + group.sizeBytes, 0),
+    fingerprint: createExportPlanFingerprint(state, target, settings),
+  };
+};
+
+export const exportConfirmationSummariesMatch = (
+  left: ExportConfirmationSummary,
+  right: ExportConfirmationSummary,
+) => JSON.stringify(left) === JSON.stringify(right);
+
+const binaryFingerprints = new WeakMap<Uint8Array, { identity: number; signature: string }>();
+let nextBinaryIdentity = 1;
+
+const hashBinarySample = (bytes: Uint8Array) => {
+  let hash = 2_166_136_261;
+  const hashByte = (value: number) => {
+    hash ^= value;
+    hash = Math.imul(hash, 16_777_619);
+  };
+  const edgeLength = Math.min(64, bytes.length);
+  for (let index = 0; index < edgeLength; index++) hashByte(bytes[index] ?? 0);
+  for (let index = Math.max(edgeLength, bytes.length - edgeLength); index < bytes.length; index++) {
+    hashByte(bytes[index] ?? 0);
+  }
+  const interiorSamples = Math.min(64, Math.max(0, bytes.length - edgeLength * 2));
+  for (let sample = 1; sample <= interiorSamples; sample++) {
+    const index = Math.floor((sample * bytes.length) / (interiorSamples + 1));
+    hashByte(bytes[index] ?? 0);
+  }
+  return hash.toString(16).padStart(8, "0");
+};
+
+const getBinaryFingerprint = (bytes: Uint8Array) => {
+  const cached = binaryFingerprints.get(bytes);
+  if (cached) return cached;
+  const fingerprint = {
+    identity: nextBinaryIdentity++,
+    signature: `${bytes.byteLength}:${hashBinarySample(bytes)}`,
+  };
+  binaryFingerprints.set(bytes, fingerprint);
+  return fingerprint;
+};
+
+const normalizeFingerprintValue = (value: unknown): unknown => {
+  if (value instanceof Uint8Array) return getBinaryFingerprint(value);
+  if (Array.isArray(value)) return value.map(normalizeFingerprintValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, normalizeFingerprintValue(entry)]),
+    );
+  }
+  return value;
+};
+
+const fileFingerprint = (file: TagiumFile) => ({
+  id: file.id,
+  filename: file.filename,
+  status: file.status,
+  downloadStatus: file.downloadStatus,
+  downloadRequest: file.downloadRequest,
+  pendingMetadataPatch: file.pendingMetadataPatch,
+  metadata: file.metadata,
+  file: file.file
+    ? {
+        name: file.file.name,
+        size: file.file.size,
+        type: file.file.type,
+        lastModified: file.file.lastModified,
+      }
+    : null,
+});
+
+export const createExportPlanFingerprint = (
+  state: LibraryState,
+  target: ConfirmedExportTarget,
+  settings: AppSettings,
+) => {
+  const albumIds =
+    target.kind === "album" ? new Set([target.albumId]) : new Set(state.albums.map(({ id }) => id));
+  const albums = state.albums.filter(({ id }) => albumIds.has(id));
+  const trackIds =
+    target.kind === "album"
+      ? new Set(albums.flatMap((album) => album.trackIds))
+      : new Set(state.files.map(({ id }) => id));
+  return JSON.stringify(
+    normalizeFingerprintValue({
+      target,
+      settings,
+      albums,
+      looseTrackIds: target.kind === "library" ? state.looseTrackIds : [],
+      files: state.files.filter(({ id }) => trackIds.has(id)).map(fileFingerprint),
+    }),
+  );
+};
+
+export const formatByteSize = (sizeBytes: number) => {
+  const exact = `${new Intl.NumberFormat("en-US").format(sizeBytes)} ${sizeBytes === 1 ? "byte" : "bytes"}`;
+  if (sizeBytes < 1_000) return exact;
+  const units = ["kB", "MB", "GB", "TB"];
+  let value = sizeBytes / 1_000;
+  let unit = units[0];
+  for (let index = 1; value >= 1_000 && index < units.length; index++) {
+    value /= 1_000;
+    unit = units[index];
+  }
+  return `${new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(value)} ${unit} (${exact})`;
+};

--- a/src/features/export/useExportSession.ts
+++ b/src/features/export/useExportSession.ts
@@ -22,15 +22,25 @@ import { reportSystemFailure } from "@/features/workspace/systemFailure";
 import type { TrackEditorSession } from "@/features/editor/useTrackEditorSession";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
 import type { AppSettings, AudioMetadata, TagiumFile } from "@/features/library/types";
+import {
+  deriveExportConfirmationSummary,
+  exportConfirmationSummariesMatch,
+  type ExportConfirmationSummary,
+} from "@/features/export/exportConfirmation";
 
 export interface ExportSession {
   exporting: boolean;
-  downloadAll: () => Promise<void>;
-  downloadAlbum: (albumId: string) => Promise<void>;
+  confirmation: ExportConfirmationSummary | null;
+  confirmationStatus: "ready" | "changed" | "unavailable";
+  downloadAll: () => void;
+  downloadAlbum: (albumId: string) => void;
   downloadTrack: SubmitHandler<AudioMetadata>;
+  cancelConfirmation: () => void;
+  confirmDownload: () => Promise<void>;
+  restoreConfirmationFocus: () => void;
 }
 
-type ExportEditor = Pick<TrackEditorSession["commands"], "flush" | "updateTags">;
+type ExportEditor = Pick<TrackEditorSession["commands"], "projectFiles" | "flush" | "updateTags">;
 
 export const useExportSession = ({
   library,
@@ -42,6 +52,12 @@ export const useExportSession = ({
   settings: AppSettings;
 }): ExportSession => {
   const [exporting, setExporting] = useState(false);
+  const [confirmation, setConfirmation] = useState<ExportConfirmationSummary | null>(null);
+  const [confirmationStatus, setConfirmationStatus] = useState<"ready" | "changed" | "unavailable">(
+    "ready",
+  );
+  const confirmingRef = useRef(false);
+  const confirmationTriggerRef = useRef<{ focus: () => void; isConnected?: boolean } | null>(null);
   const settingsRef = useRef(settings);
   useLayoutEffect(() => {
     settingsRef.current = settings;
@@ -83,88 +99,77 @@ export const useExportSession = ({
     [updateTags],
   );
 
-  const downloadAll = useCallback(async () => {
-    const before = library.getSnapshot();
-    if (before.files.length === 0 || !allTracksReadyForDownload(before.files)) return;
-    const trackCount = before.files.length;
-    const albumCount = before.albums.length;
-    analytics.capture({ type: "export_started", exportKind: "library", trackCount, albumCount });
-    setExporting(true);
-    try {
-      const syncedFiles = prepareFiles();
-      if (!allTracksReadyForDownload(syncedFiles)) return;
-      await writeFiles(syncedFiles);
-      const snapshot = library.getSnapshot();
-      const entries = getLibraryDownloadEntries(snapshot);
-      if (entries.length === 0) throw new Error("library export had no entries.");
-
-      const blob = await createZipBlob(entries);
-      downloadBlob(blob, createLibraryDownloadFilename());
-      analytics.capture({
-        type: "export_prepared",
-        exportKind: "library",
-        trackCount,
-        albumCount,
-        sizeBytes: blob.size,
-      });
-    } catch (error) {
-      analytics.capture({ type: "export_failed", exportKind: "library", error });
-      reportSystemFailure(error, "export");
-    } finally {
-      setExporting(false);
-    }
-  }, [library, prepareFiles, writeFiles]);
-
-  const downloadAlbum = useCallback(
-    async (albumId: string) => {
+  const executeConfirmedExport = useCallback(
+    async (target: ExportConfirmationSummary["target"]) => {
       const before = library.getSnapshot();
-      const album = before.albums.find((entry) => entry.id === albumId);
-      if (!album) return;
-      const currentAlbumFiles = album.trackIds
-        .map((trackId) => before.files.find((file) => file.id === trackId))
-        .filter((file): file is TagiumFile => Boolean(file));
+      const album =
+        target.kind === "album"
+          ? before.albums.find((entry) => entry.id === target.albumId)
+          : undefined;
+      if (target.kind === "album" && !album) return;
+      const targetFiles = album
+        ? album.trackIds
+            .map((trackId) => before.files.find((file) => file.id === trackId))
+            .filter((file): file is TagiumFile => Boolean(file))
+        : before.files;
       if (
-        currentAlbumFiles.length !== album.trackIds.length ||
-        !allTracksReadyForDownload(currentAlbumFiles)
+        targetFiles.length === 0 ||
+        (album && targetFiles.length !== album.trackIds.length) ||
+        !allTracksReadyForDownload(targetFiles)
       ) {
         return;
       }
-      const trackCount = album.trackIds.length;
-      analytics.capture({ type: "export_started", exportKind: "album", trackCount, albumCount: 1 });
+      const trackCount = targetFiles.length;
+      const albumCount = target.kind === "album" ? 1 : before.albums.length;
+      analytics.capture({
+        type: "export_started",
+        exportKind: target.kind,
+        trackCount,
+        albumCount,
+      });
       setExporting(true);
       try {
-        const syncedFiles = prepareFiles([albumId]);
-        const albumFiles = album.trackIds
-          .map((id) => syncedFiles.find((file) => file.id === id))
-          .filter((file): file is TagiumFile & { file: File; metadata: AudioMetadata } =>
-            Boolean(file && isTrackReadyForDownload(file)),
-          );
-        if (albumFiles.length !== album.trackIds.length) {
-          throw new Error("album export tracks were not ready.");
+        const syncedFiles = prepareFiles(album ? [album.id] : undefined);
+        const filesToWrite = album
+          ? album.trackIds
+              .map((id) => syncedFiles.find((file) => file.id === id))
+              .filter((file): file is TagiumFile & { file: File; metadata: AudioMetadata } =>
+                Boolean(file && isTrackReadyForDownload(file)),
+              )
+          : syncedFiles;
+        if (filesToWrite.length !== trackCount || !allTracksReadyForDownload(filesToWrite)) {
+          throw new Error(`${target.kind} export tracks were not ready.`);
         }
-        await writeFiles(albumFiles);
+        await writeFiles(filesToWrite);
 
-        const entries = getLibraryDownloadEntries({
-          albums: [album],
-          looseTrackIds: [],
-          files: library.getSnapshot().files,
-          albumRoot: "",
-          includeUnassignedFiles: false,
-        });
-        if (entries.length === 0) throw new Error("album export had no entries.");
+        const entries = album
+          ? getLibraryDownloadEntries({
+              albums: [album],
+              looseTrackIds: [],
+              files: library.getSnapshot().files,
+              albumRoot: "",
+              includeUnassignedFiles: false,
+            })
+          : getLibraryDownloadEntries(library.getSnapshot());
+        if (entries.length === 0) throw new Error(`${target.kind} export had no entries.`);
 
         const blob = await createZipBlob(entries);
-        const albumFilename = filenamify(album.title, { replacement: "-" });
-        downloadBlob(blob, albumFilename ? `${albumFilename}.zip` : "album.zip");
+        const albumFilename = album && filenamify(album.title, { replacement: "-" });
+        const filename = album
+          ? albumFilename
+            ? `${albumFilename}.zip`
+            : "album.zip"
+          : createLibraryDownloadFilename();
+        downloadBlob(blob, filename);
         analytics.capture({
           type: "export_prepared",
-          exportKind: "album",
+          exportKind: target.kind,
           trackCount,
-          albumCount: 1,
+          albumCount,
           sizeBytes: blob.size,
         });
       } catch (error) {
-        analytics.capture({ type: "export_failed", exportKind: "album", error });
+        analytics.capture({ type: "export_failed", exportKind: target.kind, error });
         reportSystemFailure(error, "export");
       } finally {
         setExporting(false);
@@ -172,6 +177,91 @@ export const useExportSession = ({
     },
     [library, prepareFiles, writeFiles],
   );
+
+  const deriveConfirmation = useCallback(
+    (target: ExportConfirmationSummary["target"]) => {
+      const snapshot = library.getSnapshot();
+      const trackIds =
+        target.kind === "album"
+          ? snapshot.albums.find(({ id }) => id === target.albumId)?.trackIds
+          : undefined;
+      return deriveExportConfirmationSummary(
+        { ...snapshot, files: editor.projectFiles(trackIds) },
+        target,
+        settingsRef.current,
+      );
+    },
+    [editor, library],
+  );
+
+  const rememberConfirmationTrigger = useCallback(() => {
+    if (typeof document === "undefined") return;
+    const activeElement = document.activeElement;
+    if (activeElement && "focus" in activeElement && typeof activeElement.focus === "function") {
+      confirmationTriggerRef.current = activeElement as {
+        focus: () => void;
+        isConnected?: boolean;
+      };
+    }
+  }, []);
+
+  const restoreConfirmationFocus = useCallback(() => {
+    const trigger = confirmationTriggerRef.current;
+    confirmationTriggerRef.current = null;
+    if (trigger && trigger.isConnected !== false) trigger.focus();
+  }, []);
+
+  const downloadAll = useCallback(() => {
+    if (exporting || confirmingRef.current) return;
+    const summary = deriveConfirmation({ kind: "library" });
+    if (summary) {
+      rememberConfirmationTrigger();
+      setConfirmationStatus("ready");
+      setConfirmation(summary);
+    }
+  }, [deriveConfirmation, exporting, rememberConfirmationTrigger]);
+
+  const downloadAlbum = useCallback(
+    (albumId: string) => {
+      if (exporting || confirmingRef.current) return;
+      const summary = deriveConfirmation({
+        kind: "album",
+        albumId,
+      });
+      if (summary) {
+        rememberConfirmationTrigger();
+        setConfirmationStatus("ready");
+        setConfirmation(summary);
+      }
+    },
+    [deriveConfirmation, exporting, rememberConfirmationTrigger],
+  );
+
+  const cancelConfirmation = useCallback(() => {
+    if (!confirmingRef.current) setConfirmation(null);
+  }, []);
+
+  const confirmDownload = useCallback(async () => {
+    if (!confirmation || confirmingRef.current) return;
+    const latest = deriveConfirmation(confirmation.target);
+    if (!latest) {
+      setConfirmationStatus("unavailable");
+      return;
+    }
+    if (!exportConfirmationSummariesMatch(confirmation, latest)) {
+      setConfirmation(latest);
+      setConfirmationStatus("changed");
+      return;
+    }
+
+    confirmingRef.current = true;
+    try {
+      await executeConfirmedExport(confirmation.target);
+    } finally {
+      confirmingRef.current = false;
+      setConfirmation(null);
+    }
+  }, [confirmation, deriveConfirmation, executeConfirmedExport]);
 
   const downloadTrack = useCallback<SubmitHandler<AudioMetadata>>(
     async (data) => {
@@ -210,5 +300,15 @@ export const useExportSession = ({
     [library, updateTags],
   );
 
-  return { exporting, downloadAll, downloadAlbum, downloadTrack };
+  return {
+    exporting,
+    confirmation,
+    confirmationStatus,
+    downloadAll,
+    downloadAlbum,
+    downloadTrack,
+    cancelConfirmation,
+    confirmDownload,
+    restoreConfirmationFocus,
+  };
 };

--- a/src/features/workspace/audioTagger.tsx
+++ b/src/features/workspace/audioTagger.tsx
@@ -19,6 +19,7 @@ import { loadAppSettings } from "@/features/settings/settings";
 import { useAudioImportSession } from "@/features/workspace/useAudioImportSession";
 import { useAudioWorkspace, type ActiveView } from "@/features/workspace/useAudioWorkspace";
 import { useExportSession } from "@/features/export/useExportSession";
+import ExportConfirmationDialog from "@/features/export/ExportConfirmationDialog";
 import { useLibraryStore } from "@/features/library/useLibraryStore";
 import { useTrackEditorSession } from "@/features/editor/useTrackEditorSession";
 import type { AppSettings } from "@/features/library/types";
@@ -69,6 +70,14 @@ export default function AudioTagger() {
       <MetadataCleanupDialog {...workspace.cleanupDialogProps} />
       <DestructiveActionDialog {...workspace.removalDialogProps} />
       <AlbumMetadataDialog {...workspace.albumDialogProps} />
+      <ExportConfirmationDialog
+        summary={exporting.confirmation}
+        status={exporting.confirmationStatus}
+        busy={exporting.exporting}
+        onCancel={exporting.cancelConfirmation}
+        onConfirm={() => void exporting.confirmDownload()}
+        onRestoreFocus={exporting.restoreConfirmationFocus}
+      />
       <div className="min-h-svh flex flex-col bg-background md:h-svh md:flex-row md:overflow-hidden">
         <TagSidebarPanel
           loading={busy}

--- a/tests/e2e/export-confirmation.spec.ts
+++ b/tests/e2e/export-confirmation.spec.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 const mp3Upload = (name: string) => {
   const bytes = new Uint8Array(834);
@@ -8,16 +8,20 @@ const mp3Upload = (name: string) => {
   return { name, mimeType: "audio/mpeg", buffer: Buffer.from(bytes) };
 };
 
+const downloadAllButton = (page: Page) =>
+  page.getByRole("button", { name: "download all", exact: true });
+
 test("download confirmation owns focus, dismisses safely, and restores its trigger", async ({
   page,
 }) => {
   await page.goto("/");
   await page.locator('input[type="file"]').setInputFiles(mp3Upload("focus-track.mp3"));
-  const trigger = page.getByRole("button", { name: "download all" });
+  const trigger = downloadAllButton(page);
+  await expect(trigger).toBeAttached();
   await expect(trigger).toBeEnabled();
 
   await trigger.click();
-  const dialog = page.getByRole("dialog", { name: "download 1 track?" });
+  const dialog = page.getByRole("dialog", { name: "Download 1 track" });
   await expect(dialog).toBeVisible();
   await expect(dialog.getByRole("button", { name: "cancel" })).toBeFocused();
 
@@ -37,9 +41,12 @@ test("download contents scroll inside a constrained mobile dialog", async ({ pag
   await page
     .locator('input[type="file"]')
     .setInputFiles(Array.from({ length: 18 }, (_, index) => mp3Upload(`track-${index + 1}.mp3`)));
-  await page.getByRole("button", { name: "download all" }).click();
-  const dialog = page.getByRole("dialog", { name: "download 18 tracks?" });
-  await dialog.getByText("Loose tracks", { exact: true }).click();
+  const trigger = downloadAllButton(page);
+  await expect(trigger).toBeAttached();
+  await expect(trigger).toBeEnabled();
+  await trigger.click();
+  const dialog = page.getByRole("dialog", { name: "Download 18 tracks" });
+  await dialog.getByRole("button", { name: "Loose tracks 18 tracks" }).click();
 
   const summary = dialog.getByTestId("export-summary");
   await expect(summary).toBeVisible();

--- a/tests/e2e/export-confirmation.spec.ts
+++ b/tests/e2e/export-confirmation.spec.ts
@@ -1,0 +1,56 @@
+import { Buffer } from "node:buffer";
+import { expect, test } from "@playwright/test";
+
+const mp3Upload = (name: string) => {
+  const bytes = new Uint8Array(834);
+  bytes.set([0xff, 0xfb, 0x90, 0x00], 0);
+  bytes.set([0xff, 0xfb, 0x90, 0x00], 417);
+  return { name, mimeType: "audio/mpeg", buffer: Buffer.from(bytes) };
+};
+
+test("download confirmation owns focus, dismisses safely, and restores its trigger", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.locator('input[type="file"]').setInputFiles(mp3Upload("focus-track.mp3"));
+  const trigger = page.getByRole("button", { name: "download all" });
+  await expect(trigger).toBeEnabled();
+
+  await trigger.click();
+  const dialog = page.getByRole("dialog", { name: "download 1 track?" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "cancel" })).toBeFocused();
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+  await expect(trigger).toBeFocused();
+
+  await trigger.click();
+  await page.mouse.click(4, 4);
+  await expect(dialog).toBeHidden();
+  await expect(trigger).toBeFocused();
+});
+
+test("download contents scroll inside a constrained mobile dialog", async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 400 });
+  await page.goto("/");
+  await page
+    .locator('input[type="file"]')
+    .setInputFiles(Array.from({ length: 18 }, (_, index) => mp3Upload(`track-${index + 1}.mp3`)));
+  await page.getByRole("button", { name: "download all" }).click();
+  const dialog = page.getByRole("dialog", { name: "download 18 tracks?" });
+  await dialog.getByText("Loose tracks", { exact: true }).click();
+
+  const summary = dialog.getByTestId("export-summary");
+  await expect(summary).toBeVisible();
+  expect(
+    await summary.evaluate((element) => ({
+      scrollHeight: element.scrollHeight,
+      clientHeight: element.clientHeight,
+    })),
+  ).toMatchObject({ scrollHeight: expect.any(Number), clientHeight: expect.any(Number) });
+  expect(await summary.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(
+    true,
+  );
+  await expect(dialog.getByRole("button", { name: "cancel" })).toBeVisible();
+});

--- a/tests/e2e/export-confirmation.spec.ts
+++ b/tests/e2e/export-confirmation.spec.ts
@@ -30,13 +30,13 @@ test("download confirmation owns focus, dismisses safely, and restores its trigg
   await expect(trigger).toBeFocused();
 
   await trigger.click();
-  await page.mouse.click(4, 4);
+  await page.locator('[data-slot="dialog-overlay"]').click({ position: { x: 4, y: 4 } });
   await expect(dialog).toBeHidden();
   await expect(trigger).toBeFocused();
 });
 
 test("download contents scroll inside a constrained mobile dialog", async ({ page }) => {
-  await page.setViewportSize({ width: 375, height: 400 });
+  await page.setViewportSize({ width: 375, height: 240 });
   await page.goto("/");
   await page
     .locator('input[type="file"]')
@@ -50,14 +50,11 @@ test("download contents scroll inside a constrained mobile dialog", async ({ pag
 
   const summary = dialog.getByTestId("export-summary");
   await expect(summary).toBeVisible();
-  expect(
-    await summary.evaluate((element) => ({
-      scrollHeight: element.scrollHeight,
-      clientHeight: element.clientHeight,
-    })),
-  ).toMatchObject({ scrollHeight: expect.any(Number), clientHeight: expect.any(Number) });
-  expect(await summary.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(
-    true,
-  );
+  const summaryMetrics = await summary.evaluate((element) => ({
+    scrollHeight: element.scrollHeight,
+    clientHeight: element.clientHeight,
+  }));
+  expect(summaryMetrics.clientHeight).toBeGreaterThan(0);
+  expect(summaryMetrics.scrollHeight).toBeGreaterThan(summaryMetrics.clientHeight);
   await expect(dialog.getByRole("button", { name: "cancel" })).toBeVisible();
 });

--- a/tests/unit/features/export/ExportConfirmationDialog.test.tsx
+++ b/tests/unit/features/export/ExportConfirmationDialog.test.tsx
@@ -102,8 +102,9 @@ describe("ExportConfirmationDialog", () => {
       onConfirm: vi.fn(),
       onRestoreFocus: vi.fn(),
     });
-    const status = findAll(tree, (element) => element.props.role === "status")[0];
-    expect(textContent(status)).toContain("no longer ready");
+    const alert = findAll(tree, (element) => element.props.role === "alert")[0];
+    expect(textContent(alert)).toContain("no longer ready");
+    expect(alert?.props["aria-live"]).toBeUndefined();
     const download = findAll(tree, (element) => element.type === Button).find((button) =>
       textContent(button).includes("download"),
     );

--- a/tests/unit/features/export/ExportConfirmationDialog.test.tsx
+++ b/tests/unit/features/export/ExportConfirmationDialog.test.tsx
@@ -133,6 +133,20 @@ describe("ExportConfirmationDialog", () => {
   });
 
   it("announces stale state and prevents an unavailable export", () => {
+    const changedTree = ExportConfirmationDialog({
+      summary,
+      status: "changed",
+      busy: false,
+      onCancel: vi.fn(),
+      onConfirm: vi.fn(),
+      onRestoreFocus: vi.fn(),
+    });
+    const changedAlert = findAll(changedTree, (element) => element.props.role === "alert")[0];
+    expect(textContent(changedAlert)).toBe(
+      "Your export changed. Confirm the updated download again.",
+    );
+    expect(textContent(changedAlert)).not.toMatch(/review/i);
+
     const tree = ExportConfirmationDialog({
       summary,
       status: "unavailable",

--- a/tests/unit/features/export/ExportConfirmationDialog.test.tsx
+++ b/tests/unit/features/export/ExportConfirmationDialog.test.tsx
@@ -1,0 +1,182 @@
+import type { ReactElement, ReactNode } from "react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import ExportConfirmationDialog from "@/features/export/ExportConfirmationDialog";
+import { Button } from "@/components/ui/button";
+
+type TestElement = ReactElement<Record<string, unknown> & { children?: ReactNode }>;
+const isElement = (node: ReactNode): node is TestElement =>
+  typeof node === "object" && node !== null && "props" in node;
+const childrenOf = (node: TestElement): ReactNode[] => {
+  const children = node.props.children;
+  if (children === undefined || children === null || typeof children === "boolean") return [];
+  return Array.isArray(children) ? children : [children];
+};
+const findAll = (node: ReactNode, predicate: (element: TestElement) => boolean): TestElement[] => {
+  if (!isElement(node)) return [];
+  return [
+    ...(predicate(node) ? [node] : []),
+    ...childrenOf(node).flatMap((child) => findAll(child, predicate)),
+  ];
+};
+const textContent = (node: ReactNode): string => {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (!isElement(node)) return "";
+  return childrenOf(node).map(textContent).join("");
+};
+
+const summary = {
+  target: { kind: "library" as const },
+  groups: [
+    {
+      id: "album:one",
+      title: "Album One",
+      tracks: [{ id: "track", title: "A Track", sizeBytes: 1_500 }],
+      sizeBytes: 1_500,
+    },
+  ],
+  trackCount: 1,
+  totalSizeBytes: 1_500,
+  fingerprint: "fingerprint",
+};
+
+describe("ExportConfirmationDialog", () => {
+  it("renders grouped exact sizes and expandable track details", () => {
+    const tree = ExportConfirmationDialog({
+      summary,
+      status: "ready",
+      busy: false,
+      onCancel: vi.fn(),
+      onConfirm: vi.fn(),
+      onRestoreFocus: vi.fn(),
+    });
+
+    expect(textContent(tree)).toContain("download 1 track?");
+    expect(textContent(tree)).toContain("Album One");
+    expect(textContent(tree)).toContain("1.5 kB (1,500 bytes)");
+    expect(textContent(tree)).toContain("estimated download size");
+    expect(textContent(tree)).toContain("Current file bytes");
+    expect(findAll(tree, (element) => element.type === "details")).toHaveLength(1);
+    expect(textContent(tree)).toContain("A Track");
+  });
+
+  it("wires cancel and confirm and locks both controls while busy", () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    const readyTree = ExportConfirmationDialog({
+      summary,
+      status: "ready",
+      busy: false,
+      onCancel,
+      onConfirm,
+      onRestoreFocus: vi.fn(),
+    });
+    const readyButtons = findAll(readyTree, (element) => element.type === Button);
+    const cancel = readyButtons.find((button) => textContent(button) === "cancel");
+    const confirm = readyButtons.find((button) => textContent(button) === "download");
+    expect(cancel).toBeDefined();
+    expect(confirm).toBeDefined();
+    (cancel?.props.onClick as (() => void) | undefined)?.();
+    (confirm?.props.onClick as (() => void) | undefined)?.();
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onConfirm).toHaveBeenCalledOnce();
+
+    const busyTree = ExportConfirmationDialog({
+      summary,
+      status: "ready",
+      busy: true,
+      onCancel,
+      onConfirm,
+      onRestoreFocus: vi.fn(),
+    });
+    const busyButtons = findAll(busyTree, (element) => element.type === Button);
+    expect(busyButtons.every((button) => button.props.disabled === true)).toBe(true);
+    expect(textContent(busyTree)).toContain("preparing download...");
+  });
+
+  it("announces stale state and prevents an unavailable export", () => {
+    const tree = ExportConfirmationDialog({
+      summary,
+      status: "unavailable",
+      busy: false,
+      onCancel: vi.fn(),
+      onConfirm: vi.fn(),
+      onRestoreFocus: vi.fn(),
+    });
+    const status = findAll(tree, (element) => element.props.role === "status")[0];
+    expect(textContent(status)).toContain("no longer ready");
+    const download = findAll(tree, (element) => element.type === Button).find((button) =>
+      textContent(button).includes("download"),
+    );
+    expect(download?.props.disabled).toBe(true);
+  });
+
+  it("focuses cancel, restores the initiating control, and constrains mobile scrolling", () => {
+    const onRestoreFocus = vi.fn();
+    const tree = ExportConfirmationDialog({
+      summary,
+      status: "ready",
+      busy: false,
+      onCancel: vi.fn(),
+      onConfirm: vi.fn(),
+      onRestoreFocus,
+    });
+    const content = findAll(
+      tree,
+      (element) => typeof element.props.onOpenAutoFocus === "function",
+    )[0];
+    if (!content) throw new Error("dialog content not found");
+    const focus = vi.fn();
+    const preventOpen = vi.fn();
+    (content.props.onOpenAutoFocus as (event: unknown) => void)({
+      preventDefault: preventOpen,
+      currentTarget: { querySelector: () => ({ focus }) },
+    });
+    expect(preventOpen).toHaveBeenCalledOnce();
+    expect(focus).toHaveBeenCalledOnce();
+
+    const preventClose = vi.fn();
+    (content.props.onCloseAutoFocus as (event: unknown) => void)({ preventDefault: preventClose });
+    expect(preventClose).toHaveBeenCalledOnce();
+    expect(onRestoreFocus).toHaveBeenCalledOnce();
+    expect(content.props.className).toContain("max-h-[calc(100dvh-1rem)]");
+    const scrollArea = findAll(
+      tree,
+      (element) => element.props["data-testid"] === "export-summary",
+    )[0];
+    expect(scrollArea?.props.className).toContain("overflow-y-auto");
+  });
+
+  it("allows Escape while idle but blocks Escape and outside dismissal while busy", () => {
+    const render = (busy: boolean) =>
+      ExportConfirmationDialog({
+        summary,
+        status: "ready",
+        busy,
+        onCancel: vi.fn(),
+        onConfirm: vi.fn(),
+        onRestoreFocus: vi.fn(),
+      });
+    const content = (tree: ReactNode) =>
+      findAll(tree, (element) => typeof element.props.onEscapeKeyDown === "function")[0];
+    const idlePrevent = vi.fn();
+    const idleContent = content(render(false));
+    if (!idleContent) throw new Error("idle dialog content not found");
+    (idleContent.props.onEscapeKeyDown as (event: unknown) => void)({
+      preventDefault: idlePrevent,
+    });
+    expect(idlePrevent).not.toHaveBeenCalled();
+
+    const escapePrevent = vi.fn();
+    const outsidePrevent = vi.fn();
+    const busyContent = content(render(true));
+    if (!busyContent) throw new Error("busy dialog content not found");
+    (busyContent.props.onEscapeKeyDown as (event: unknown) => void)({
+      preventDefault: escapePrevent,
+    });
+    (busyContent.props.onPointerDownOutside as (event: unknown) => void)({
+      preventDefault: outsidePrevent,
+    });
+    expect(escapePrevent).toHaveBeenCalledOnce();
+    expect(outsidePrevent).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/features/export/ExportConfirmationDialog.test.tsx
+++ b/tests/unit/features/export/ExportConfirmationDialog.test.tsx
@@ -1,6 +1,9 @@
 import type { ReactElement, ReactNode } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { describe, expect, it, vi } from "vite-plus/test";
-import ExportConfirmationDialog from "@/features/export/ExportConfirmationDialog";
+import ExportConfirmationDialog, {
+  ExportConfirmationDisclosure,
+} from "@/features/export/ExportConfirmationDialog";
 import { Button } from "@/components/ui/button";
 
 type TestElement = ReactElement<Record<string, unknown> & { children?: ReactNode }>;
@@ -40,7 +43,7 @@ const summary = {
 };
 
 describe("ExportConfirmationDialog", () => {
-  it("renders grouped exact sizes and expandable track details", () => {
+  it("uses concise download copy without exposing byte counts", () => {
     const tree = ExportConfirmationDialog({
       summary,
       status: "ready",
@@ -50,13 +53,49 @@ describe("ExportConfirmationDialog", () => {
       onRestoreFocus: vi.fn(),
     });
 
-    expect(textContent(tree)).toContain("download 1 track?");
-    expect(textContent(tree)).toContain("Album One");
-    expect(textContent(tree)).toContain("1.5 kB (1,500 bytes)");
-    expect(textContent(tree)).toContain("estimated download size");
-    expect(textContent(tree)).toContain("Current file bytes");
-    expect(findAll(tree, (element) => element.type === "details")).toHaveLength(1);
-    expect(textContent(tree)).toContain("A Track");
+    expect(textContent(tree)).toContain("Download 1 track");
+    expect(textContent(tree)).not.toContain("?");
+    expect(textContent(tree)).not.toContain("Review the files");
+    expect(textContent(tree)).not.toContain("estimated download size");
+    expect(textContent(tree)).not.toContain("Current file bytes");
+    expect(textContent(tree)).not.toMatch(/\bbytes?\b/i);
+    const disclosures = findAll(tree, (element) => element.type === ExportConfirmationDisclosure);
+    expect(disclosures).toHaveLength(1);
+    expect(disclosures[0]?.props.group).toMatchObject({ title: "Album One" });
+    const download = findAll(tree, (element) => element.type === Button).find((button) =>
+      textContent(button).startsWith("Download"),
+    );
+    expect(textContent(download)).toBe("Download 0.00 MB");
+    expect(download?.props.className).toContain("w-[10.5rem]");
+    expect(download?.props.className).toContain("tabular-nums");
+    expect(download?.props.className).not.toContain("justify-between");
+  });
+
+  it("keeps album track disclosures keyboard-accessible and animated in both directions", async () => {
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<ExportConfirmationDisclosure group={summary.groups[0]!} />);
+    });
+
+    const trigger = () => renderer.root.findByType("button");
+    const region = () => renderer.root.findByProps({ role: "region" });
+    expect(trigger().props["aria-expanded"]).toBe(false);
+    expect(trigger().props["aria-controls"]).toBe(region().props.id);
+    expect(region().props["aria-hidden"]).toBe(true);
+    expect(region().props.inert).toBe(true);
+    expect(region().props.className).toContain("grid-rows-[0fr]");
+    expect(region().props.className).toContain("transition-[grid-template-rows,opacity]");
+    expect(region().props.className).toContain("duration-200");
+    expect(region().props.className).toContain("motion-reduce:transition-none");
+
+    await act(() => trigger().props.onClick());
+    expect(trigger().props["aria-expanded"]).toBe(true);
+    expect(region().props["aria-hidden"]).toBe(false);
+    expect(region().props.inert).toBe(false);
+
+    await act(() => trigger().props.onClick());
+    expect(trigger().props["aria-expanded"]).toBe(false);
+    expect(region().props["aria-hidden"]).toBe(true);
   });
 
   it("wires cancel and confirm and locks both controls while busy", () => {
@@ -72,7 +111,7 @@ describe("ExportConfirmationDialog", () => {
     });
     const readyButtons = findAll(readyTree, (element) => element.type === Button);
     const cancel = readyButtons.find((button) => textContent(button) === "cancel");
-    const confirm = readyButtons.find((button) => textContent(button) === "download");
+    const confirm = readyButtons.find((button) => textContent(button) === "Download 0.00 MB");
     expect(cancel).toBeDefined();
     expect(confirm).toBeDefined();
     (cancel?.props.onClick as (() => void) | undefined)?.();
@@ -106,7 +145,7 @@ describe("ExportConfirmationDialog", () => {
     expect(textContent(alert)).toContain("no longer ready");
     expect(alert?.props["aria-live"]).toBeUndefined();
     const download = findAll(tree, (element) => element.type === Button).find((button) =>
-      textContent(button).includes("download"),
+      textContent(button).toLowerCase().includes("download"),
     );
     expect(download?.props.disabled).toBe(true);
   });

--- a/tests/unit/features/export/ExportConfirmationDialog.test.tsx
+++ b/tests/unit/features/export/ExportConfirmationDialog.test.tsx
@@ -179,6 +179,8 @@ describe("ExportConfirmationDialog", () => {
       (element) => typeof element.props.onOpenAutoFocus === "function",
     )[0];
     if (!content) throw new Error("dialog content not found");
+    expect("aria-describedby" in content.props).toBe(true);
+    expect(content.props["aria-describedby"]).toBeUndefined();
     const focus = vi.fn();
     const preventOpen = vi.fn();
     (content.props.onOpenAutoFocus as (event: unknown) => void)({

--- a/tests/unit/features/export/exportConfirmation.test.ts
+++ b/tests/unit/features/export/exportConfirmation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   deriveExportConfirmationSummary,
-  formatByteSize,
+  formatMegabyteSize,
 } from "@/features/export/exportConfirmation";
 import { createLibraryState } from "@/features/library/libraryState";
 import type { AlbumGroup, AppSettings, AudioMetadata, TagiumFile } from "@/features/library/types";
@@ -137,10 +137,11 @@ describe("export confirmation summary", () => {
     ).toBeNull();
   });
 
-  it("formats a readable size while preserving the exact byte count", () => {
-    expect(formatByteSize(1)).toBe("1 byte");
-    expect(formatByteSize(999)).toBe("999 bytes");
-    expect(formatByteSize(1_234_567)).toBe("1.2 MB (1,234,567 bytes)");
+  it("formats a compact MB-only download size", () => {
+    expect(formatMegabyteSize(1)).toBe("0.00 MB");
+    expect(formatMegabyteSize(999)).toBe("0.00 MB");
+    expect(formatMegabyteSize(1_234_567)).toBe("1.2 MB");
+    expect(formatMegabyteSize(10_000_000_000)).toBe("10K MB");
   });
 
   it("keeps shared large-cover fingerprints bounded and detects same-size replacement artwork", () => {

--- a/tests/unit/features/export/exportConfirmation.test.ts
+++ b/tests/unit/features/export/exportConfirmation.test.ts
@@ -4,9 +4,11 @@ import {
   formatByteSize,
 } from "@/features/export/exportConfirmation";
 import { createLibraryState } from "@/features/library/libraryState";
-import type { AlbumGroup, AudioMetadata, TagiumFile } from "@/features/library/types";
+import type { AlbumGroup, AppSettings, AudioMetadata, TagiumFile } from "@/features/library/types";
+import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 
-const settings = {
+const settings: AppSettings = {
+  ...DEFAULT_APP_SETTINGS,
   syncTrackNumbers: false,
   syncFilenames: false,
   audioBitrate: "320" as const,
@@ -17,6 +19,7 @@ const metadata = (title: string): AudioMetadata => ({
   filename: title,
   title,
   artist: "",
+  albumArtist: "",
   album: "",
   year: null,
   genre: "",
@@ -25,10 +28,15 @@ const metadata = (title: string): AudioMetadata => ({
   sampleRate: 0,
   picture: [],
   trackNumber: null,
+  discNumber: null,
+  composer: "",
+  bpm: null,
+  comment: "",
 });
 
 const track = (id: string, title: string, bytes: number): TagiumFile => ({
   id,
+  format: "mp3",
   filename: `${title}.mp3`,
   file: new File([new Uint8Array(bytes)], `${title}.mp3`),
   originalFile: new File([new Uint8Array(bytes)], `${title}.mp3`),

--- a/tests/unit/features/export/exportConfirmation.test.ts
+++ b/tests/unit/features/export/exportConfirmation.test.ts
@@ -141,6 +141,12 @@ describe("export confirmation summary", () => {
     expect(formatMegabyteSize(1)).toBe("0.00 MB");
     expect(formatMegabyteSize(999)).toBe("0.00 MB");
     expect(formatMegabyteSize(1_234_567)).toBe("1.2 MB");
+    expect(formatMegabyteSize(99_940_000)).toBe("99.9 MB");
+    expect(formatMegabyteSize(99_950_000)).toBe("100 MB");
+    expect(formatMegabyteSize(999_490_000)).toBe("999 MB");
+    expect(formatMegabyteSize(999_500_000)).toBe("1K MB");
+    expect(formatMegabyteSize(999_950_000)).toBe("1K MB");
+    expect(formatMegabyteSize(1_000_000_000)).toBe("1K MB");
     expect(formatMegabyteSize(10_000_000_000)).toBe("10K MB");
   });
 

--- a/tests/unit/features/export/exportConfirmation.test.ts
+++ b/tests/unit/features/export/exportConfirmation.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  deriveExportConfirmationSummary,
+  formatByteSize,
+} from "@/features/export/exportConfirmation";
+import { createLibraryState } from "@/features/library/libraryState";
+import type { AlbumGroup, AudioMetadata, TagiumFile } from "@/features/library/types";
+
+const settings = {
+  syncTrackNumbers: false,
+  syncFilenames: false,
+  audioBitrate: "320" as const,
+  applySoundCloudAlbumCoverToTracks: false,
+};
+
+const metadata = (title: string): AudioMetadata => ({
+  filename: title,
+  title,
+  artist: "",
+  album: "",
+  year: null,
+  genre: "",
+  duration: 0,
+  bitrate: 0,
+  sampleRate: 0,
+  picture: [],
+  trackNumber: null,
+});
+
+const track = (id: string, title: string, bytes: number): TagiumFile => ({
+  id,
+  filename: `${title}.mp3`,
+  file: new File([new Uint8Array(bytes)], `${title}.mp3`),
+  originalFile: new File([new Uint8Array(bytes)], `${title}.mp3`),
+  status: "saved",
+  downloadStatus: "ready",
+  metadata: metadata(title),
+});
+
+const album = (id: string, title: string, trackIds: string[]): AlbumGroup => ({
+  id,
+  title,
+  artist: "",
+  genre: "",
+  trackIds,
+});
+
+describe("export confirmation summary", () => {
+  it("groups albums and loose tracks while deriving exact totals", () => {
+    const state = {
+      ...createLibraryState(),
+      files: [track("one", "One", 1_200), track("two", "Two", 300), track("loose", "Loose", 7)],
+      albums: [album("album", "Album", ["one", "two"])],
+      looseTrackIds: ["loose"],
+    };
+
+    const summary = deriveExportConfirmationSummary(state, { kind: "library" }, settings);
+    expect(summary?.fingerprint).toBeTypeOf("string");
+    expect(summary).toMatchObject({
+      target: { kind: "library" },
+      groups: [
+        {
+          id: "album:album",
+          title: "Album",
+          tracks: [
+            { id: "one", title: "One", sizeBytes: 1_200 },
+            { id: "two", title: "Two", sizeBytes: 300 },
+          ],
+          sizeBytes: 1_500,
+        },
+        {
+          id: "loose",
+          title: "Loose tracks",
+          tracks: [{ id: "loose", title: "Loose", sizeBytes: 7 }],
+          sizeBytes: 7,
+        },
+      ],
+      trackCount: 3,
+      totalSizeBytes: 1_507,
+    });
+  });
+
+  it("includes unassigned files as loose tracks without duplicating explicit loose tracks", () => {
+    const state = {
+      ...createLibraryState(),
+      files: [track("loose", "Loose", 5), track("orphan", "Orphan", 8)],
+      looseTrackIds: ["loose"],
+    };
+
+    const summary = deriveExportConfirmationSummary(state, { kind: "library" }, settings);
+    expect(summary?.groups[0]?.tracks.map(({ id }) => id)).toEqual(["loose", "orphan"]);
+    expect(summary?.totalSizeBytes).toBe(13);
+  });
+
+  it("rejects missing, empty, or unready targets", () => {
+    const ready = track("ready", "Ready", 5);
+    const unready = { ...track("unready", "Unready", 5), file: undefined };
+    const state = {
+      ...createLibraryState(),
+      files: [ready, unready],
+      albums: [album("album", "Album", ["ready", "missing"])],
+      looseTrackIds: ["unready"],
+    };
+
+    expect(
+      deriveExportConfirmationSummary(state, { kind: "album", albumId: "missing" }, settings),
+    ).toBeNull();
+    expect(
+      deriveExportConfirmationSummary(state, { kind: "album", albumId: "album" }, settings),
+    ).toBeNull();
+    expect(deriveExportConfirmationSummary(state, { kind: "library" }, settings)).toBeNull();
+    expect(
+      deriveExportConfirmationSummary(createLibraryState(), { kind: "library" }, settings),
+    ).toBeNull();
+  });
+
+  it("skips empty albums in a library export but rejects an empty album target", () => {
+    const state = {
+      ...createLibraryState(),
+      files: [track("loose", "Loose", 4)],
+      albums: [album("empty", "Empty", [])],
+      looseTrackIds: ["loose"],
+    };
+
+    const librarySummary = deriveExportConfirmationSummary(state, { kind: "library" }, settings);
+    expect(librarySummary?.groups.map(({ title }) => title)).toEqual(["Loose tracks"]);
+    expect(
+      deriveExportConfirmationSummary(state, { kind: "album", albumId: "empty" }, settings),
+    ).toBeNull();
+  });
+
+  it("formats a readable size while preserving the exact byte count", () => {
+    expect(formatByteSize(1)).toBe("1 byte");
+    expect(formatByteSize(999)).toBe("999 bytes");
+    expect(formatByteSize(1_234_567)).toBe("1.2 MB (1,234,567 bytes)");
+  });
+
+  it("keeps shared large-cover fingerprints bounded and detects same-size replacement artwork", () => {
+    const coverBytes = new Uint8Array(8 * 1024 * 1024);
+    coverBytes[0] = 12;
+    coverBytes[coverBytes.length - 1] = 34;
+    const picture = {
+      format: "image/jpeg",
+      type: 3,
+      description: "front cover",
+      data: coverBytes,
+    };
+    const files = Array.from({ length: 40 }, (_, index) => {
+      const current = track(`track-${index}`, `Track ${index}`, 100);
+      return { ...current, metadata: { ...current.metadata!, picture: [picture] } };
+    });
+    const state = {
+      ...createLibraryState(),
+      files,
+      albums: [
+        {
+          ...album(
+            "album",
+            "Large shared cover",
+            files.map(({ id }) => id),
+          ),
+          cover: [picture],
+        },
+      ],
+    };
+
+    const first = deriveExportConfirmationSummary(state, { kind: "library" }, settings);
+    const repeated = deriveExportConfirmationSummary(state, { kind: "library" }, settings);
+    expect(first?.fingerprint).toBe(repeated?.fingerprint);
+    expect(first?.fingerprint.length).toBeLessThan(60_000);
+    expect(first?.fingerprint).not.toContain('"0":12');
+
+    const replacementBytes = coverBytes.slice();
+    replacementBytes[Math.floor(replacementBytes.length / 3)] = 99;
+    const replacement = { ...picture, data: replacementBytes };
+    const replacedState = {
+      ...state,
+      files: files.map((file) => ({
+        ...file,
+        metadata: { ...file.metadata, picture: [replacement] },
+      })),
+      albums: [{ ...state.albums[0]!, cover: [replacement] }],
+    };
+    const replaced = deriveExportConfirmationSummary(replacedState, { kind: "library" }, settings);
+
+    expect(replaced?.fingerprint).not.toBe(first?.fingerprint);
+    expect(replaced?.fingerprint.length).toBeLessThan(60_000);
+  });
+});

--- a/tests/unit/features/export/useExportSession.test.ts
+++ b/tests/unit/features/export/useExportSession.test.ts
@@ -65,6 +65,7 @@ describe("export session", () => {
   const createHarness = (initialSettings = settings) => {
     const file: TagiumFile = {
       id: "track-1",
+      format: "mp3",
       filename: "track.mp3",
       file: new File(["audio"], "track.mp3"),
       originalFile: new File(["audio"], "track.mp3"),

--- a/tests/unit/features/export/useExportSession.test.ts
+++ b/tests/unit/features/export/useExportSession.test.ts
@@ -6,6 +6,7 @@ import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 
 const exportMocks = vi.hoisted(() => ({
   createZipBlob: vi.fn(),
+  downloadBlob: vi.fn(),
   reportFailure: vi.fn(),
   capture: vi.fn(),
 }));
@@ -18,7 +19,7 @@ vi.mock("@/features/export/downloadLibrary", () => ({
   allTracksReadyForDownload: () => true,
   createLibraryDownloadFilename: () => "tagium.zip",
   createZipBlob: exportMocks.createZipBlob,
-  downloadBlob: vi.fn(),
+  downloadBlob: exportMocks.downloadBlob,
   getLibraryDownloadEntries: () => [{ path: "track.mp3", file: new File([], "track.mp3") }],
   isTrackReadyForDownload: () => true,
 }));
@@ -55,9 +56,232 @@ const settings: AppSettings = {
   metadataLinks: { ...DEFAULT_APP_SETTINGS.metadataLinks, albumArtist: false },
 };
 
-afterEach(() => vi.clearAllMocks());
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe("export session", () => {
+  const createHarness = (initialSettings = settings) => {
+    const file: TagiumFile = {
+      id: "track-1",
+      filename: "track.mp3",
+      file: new File(["audio"], "track.mp3"),
+      originalFile: new File(["audio"], "track.mp3"),
+      status: "saved",
+      downloadStatus: "ready",
+      metadata,
+    };
+    let snapshot = libraryReducer(createLibraryState(), {
+      type: "content-replaced",
+      files: [file],
+      looseTrackIds: [file.id],
+      selection: { selectedFileId: file.id, selectedAlbumId: null },
+    });
+    const library: LibraryStore = {
+      get state() {
+        return snapshot;
+      },
+      getSnapshot: () => snapshot,
+      dispatch: (action) => {
+        snapshot = libraryReducer(snapshot, action);
+      },
+    };
+    const updateTags = vi.fn(async () => undefined);
+    const flush = vi.fn(() => library.getSnapshot().files);
+    const projectFiles = vi.fn(() => library.getSnapshot().files);
+    const hook = renderHook(
+      (currentSettings: AppSettings) =>
+        useExportSession({
+          library,
+          editor: { projectFiles, flush, updateTags },
+          settings: currentSettings,
+        }),
+      initialSettings,
+    );
+    return { file, hook, library, updateTags, flush, projectFiles };
+  };
+
+  it("does nothing before confirmation and cancel has no side effects", () => {
+    const { hook, updateTags, flush } = createHarness();
+
+    act(() => hook.result.downloadAll());
+    expect(hook.result.confirmation?.trackCount).toBe(1);
+    expect(exportMocks.capture).not.toHaveBeenCalled();
+    expect(flush).not.toHaveBeenCalled();
+    expect(updateTags).not.toHaveBeenCalled();
+    expect(exportMocks.createZipBlob).not.toHaveBeenCalled();
+    expect(exportMocks.downloadBlob).not.toHaveBeenCalled();
+
+    act(() => hook.result.cancelConfirmation());
+    expect(hook.result.confirmation).toBeNull();
+    expect(exportMocks.capture).not.toHaveBeenCalled();
+    hook.unmount();
+  });
+
+  it("restores focus to the control that opened confirmation", () => {
+    const trigger = { focus: vi.fn(), isConnected: true };
+    vi.stubGlobal("document", { activeElement: trigger });
+    const { hook } = createHarness();
+
+    act(() => hook.result.downloadAll());
+    act(() => hook.result.cancelConfirmation());
+    act(() => hook.result.restoreConfirmationFocus());
+
+    expect(trigger.focus).toHaveBeenCalledOnce();
+    hook.unmount();
+  });
+
+  it("starts analytics and the export pipeline only after one confirmation", async () => {
+    exportMocks.createZipBlob.mockResolvedValue(new Blob(["zip"]));
+    const { hook, updateTags, flush } = createHarness();
+
+    act(() => hook.result.downloadAll());
+    await act(async () => {
+      await Promise.all([hook.result.confirmDownload(), hook.result.confirmDownload()]);
+    });
+
+    expect(exportMocks.capture).toHaveBeenNthCalledWith(1, {
+      type: "export_started",
+      exportKind: "library",
+      trackCount: 1,
+      albumCount: 0,
+    });
+    expect(flush).toHaveBeenCalledTimes(1);
+    expect(updateTags).toHaveBeenCalledTimes(1);
+    expect(exportMocks.createZipBlob).toHaveBeenCalledTimes(1);
+    expect(exportMocks.downloadBlob).toHaveBeenCalledTimes(1);
+    expect(hook.result.confirmation).toBeNull();
+    hook.unmount();
+  });
+
+  it("confirms an album export with album-scoped analytics", async () => {
+    exportMocks.createZipBlob.mockResolvedValue(new Blob(["zip"]));
+    const { hook, library, flush } = createHarness();
+    act(() =>
+      library.dispatch({
+        type: "content-replaced",
+        albums: [
+          {
+            id: "album-1",
+            title: "Album",
+            artist: "Artist",
+            genre: "",
+            trackIds: ["track-1"],
+          },
+        ],
+        looseTrackIds: [],
+      }),
+    );
+
+    act(() => hook.result.downloadAlbum("album-1"));
+    expect(hook.result.confirmation?.groups[0]?.title).toBe("Album");
+    expect(exportMocks.capture).not.toHaveBeenCalled();
+    await act(async () => hook.result.confirmDownload());
+
+    expect(exportMocks.capture).toHaveBeenNthCalledWith(1, {
+      type: "export_started",
+      exportKind: "album",
+      trackCount: 1,
+      albumCount: 1,
+    });
+    expect(flush).toHaveBeenCalledWith(["track-1"]);
+    expect(exportMocks.downloadBlob).toHaveBeenCalledTimes(1);
+    hook.unmount();
+  });
+
+  it("keeps a single-track download immediate", async () => {
+    const { hook, updateTags } = createHarness();
+
+    await act(async () => {
+      await hook.result.downloadTrack(metadata);
+    });
+
+    expect(hook.result.confirmation).toBeNull();
+    expect(updateTags).toHaveBeenCalledTimes(1);
+    expect(exportMocks.downloadBlob).toHaveBeenCalledTimes(1);
+    expect(exportMocks.capture).toHaveBeenNthCalledWith(1, {
+      type: "export_started",
+      exportKind: "track",
+      trackCount: 1,
+    });
+    hook.unmount();
+  });
+
+  it("keeps a stale confirmation open when its track becomes unready", async () => {
+    const { hook, library } = createHarness();
+    act(() => hook.result.downloadAll());
+    const current = library.getSnapshot().files[0];
+    act(() =>
+      library.dispatch({
+        type: "content-replaced",
+        files: current ? [{ ...current, file: undefined }] : [],
+      }),
+    );
+
+    await act(async () => hook.result.confirmDownload());
+
+    expect(hook.result.confirmation).not.toBeNull();
+    expect(hook.result.confirmationStatus).toBe("unavailable");
+    expect(exportMocks.capture).not.toHaveBeenCalled();
+    expect(exportMocks.createZipBlob).not.toHaveBeenCalled();
+    hook.unmount();
+  });
+
+  it("requires review again when non-rendered metadata changes", async () => {
+    exportMocks.createZipBlob.mockResolvedValue(new Blob(["zip"]));
+    const { hook, library } = createHarness();
+    act(() => hook.result.downloadAll());
+    const current = library.getSnapshot().files[0];
+    if (!current?.metadata) throw new Error("test track missing metadata");
+    const changedMetadata = { ...current.metadata, genre: "changed" };
+    act(() =>
+      library.dispatch({
+        type: "content-replaced",
+        files: [{ ...current, metadata: changedMetadata }],
+      }),
+    );
+
+    await act(async () => hook.result.confirmDownload());
+    expect(hook.result.confirmationStatus).toBe("changed");
+    expect(exportMocks.capture).not.toHaveBeenCalled();
+
+    await act(async () => hook.result.confirmDownload());
+    expect(exportMocks.capture).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "export_started", exportKind: "library" }),
+    );
+    hook.unmount();
+  });
+
+  it("requires review again when export settings change", async () => {
+    const { hook } = createHarness();
+    act(() => hook.result.downloadAll());
+    hook.rerender({ ...settings, syncFilenames: true });
+
+    await act(async () => hook.result.confirmDownload());
+
+    expect(hook.result.confirmationStatus).toBe("changed");
+    expect(exportMocks.capture).not.toHaveBeenCalled();
+    hook.unmount();
+  });
+
+  it("fingerprints unsaved editor values without flushing them before confirmation", async () => {
+    const { hook, library, projectFiles, flush } = createHarness();
+    act(() => hook.result.downloadAll());
+    const current = library.getSnapshot().files[0];
+    if (!current?.metadata) throw new Error("test track missing metadata");
+    projectFiles.mockReturnValue([
+      { ...current, metadata: { ...current.metadata, artist: "Unsaved artist" } },
+    ]);
+
+    await act(async () => hook.result.confirmDownload());
+
+    expect(hook.result.confirmationStatus).toBe("changed");
+    expect(flush).not.toHaveBeenCalled();
+    expect(exportMocks.capture).not.toHaveBeenCalled();
+    hook.unmount();
+  });
+
   it("keeps the interface busy until a failed export is routed through cleanup", async () => {
     const file: TagiumFile = {
       id: "track-1",
@@ -103,7 +327,11 @@ describe("export session", () => {
       () =>
         useExportSession({
           library,
-          editor: { flush: () => library.getSnapshot().files, updateTags },
+          editor: {
+            projectFiles: () => library.getSnapshot().files,
+            flush: () => library.getSnapshot().files,
+            updateTags,
+          },
           settings,
         }),
       undefined,
@@ -111,7 +339,10 @@ describe("export session", () => {
 
     let exporting: Promise<void> | undefined;
     act(() => {
-      exporting = hook.result.downloadAll();
+      hook.result.downloadAll();
+    });
+    act(() => {
+      exporting = hook.result.confirmDownload();
     });
     await vi.waitFor(() => expect(rejectZip).toBeTypeOf("function"));
     expect(hook.result.exporting).toBe(true);


### PR DESCRIPTION
## What changed

- confirm album and library downloads before analytics, metadata writes, ZIP creation, or browser download
- show album-grouped counts and current-file byte estimates with expandable per-track details and explicit loose-track grouping
- keep single-track downloads immediate
- consolidate album/library execution into one target-driven pipeline
- revalidate complete export-affecting state before confirm, announce stale/unavailable changes, and require explicit reconfirmation
- guard double confirmation, busy dismissal, empty albums, and stale ready→unready transitions
- focus Cancel initially and restore focus to the initiating download control
- use bounded artwork fingerprints rather than serializing binary cover data
- add unit and Playwright interaction coverage

## Why

Bulk downloads can include many files and significant data. This makes scope and estimated size inspectable without adding friction to single-track export.

## Verification

- post-rebase `bun run typecheck`
- post-rebase `bun run lint` — 0 warnings/errors
- post-rebase `bun run test` — 65 files, 414 tests passed
- `git diff --check`
- two fresh independent reviews; all correctness, focus, stale-state, and performance findings fixed and re-reviewed

The Playwright interaction spec covers mounted focus, Escape/outside dismissal, restoration, and constrained mobile scrolling. It was typechecked but not executed because no server was already listening and repository instructions prohibit starting a dev server for this workflow.

This branch was rebased onto `origin/main` and is independently mergeable.
