### PR TITLE
research(audio): record FLAC support gate

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "tailwind-merge": "^3.3.1",
       },
       "devDependencies": {
+        "@akabeko/music-metadata-editor": "1.0.1",
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
@@ -38,9 +39,11 @@
         "@vitejs/plugin-react": "^6.0.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "music-metadata": "11.8.3",
         "nitro": "^3.0.260311-beta",
         "react-test-renderer": "19.1.0",
         "shadcn": "^3.0.0",
+        "taglib-wasm": "1.5.2",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.3.7",
         "typescript": "^5",
@@ -51,6 +54,8 @@
     },
   },
   "packages": {
+    "@akabeko/music-metadata-editor": ["@akabeko/music-metadata-editor@1.0.1", "", {}, "sha512-wRJVfU29hslJbJjXn4H76QYrkiq3yivNWBIrTGBk6JaIRIhomy+nCQema6ckJRJ44y6lDIPyo8yKNKdjn3JlTw=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "0.3.13", "@jridgewell/trace-mapping": "0.3.30" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
@@ -106,6 +111,8 @@
     "@babel/traverse": ["@babel/traverse@7.28.3", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/generator": "7.28.3", "@babel/helper-globals": "7.28.0", "@babel/parser": "7.28.3", "@babel/template": "7.27.2", "@babel/types": "7.28.2", "debug": "4.4.1" } }, "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ=="],
 
     "@babel/types": ["@babel/types@7.28.2", "", { "dependencies": { "@babel/helper-string-parser": "7.27.1", "@babel/helper-validator-identifier": "7.27.1" } }, "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ=="],
+
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
     "@bundled-es-modules/cookie": ["@bundled-es-modules/cookie@2.0.1", "", { "dependencies": { "cookie": "0.7.2" } }, "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw=="],
 
@@ -192,6 +199,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.30", "", { "dependencies": { "@jridgewell/resolve-uri": "3.1.2", "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.17.4", "", { "dependencies": { "ajv": "6.12.6", "content-type": "1.0.5", "cors": "2.8.5", "cross-spawn": "7.0.6", "eventsource": "3.0.7", "eventsource-parser": "3.0.6", "express": "5.1.0", "express-rate-limit": "7.5.1", "pkce-challenge": "5.0.0", "raw-body": "3.0.0", "zod": "3.25.76", "zod-to-json-schema": "3.24.6" } }, "sha512-zq24hfuAmmlNZvik0FLI58uE5sriN0WWsQzIlYnzSuKDAHFqJtBFrl/LfB1NLgJT5Y7dEBzaX4yAKqOPrcetaw=="],
+
+    "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
@@ -515,6 +524,10 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.12", "", { "dependencies": { "@alloc/quick-lru": "5.2.0", "@tailwindcss/node": "4.1.12", "@tailwindcss/oxide": "4.1.12", "postcss": "8.5.6", "tailwindcss": "4.1.12" } }, "sha512-5PpLYhCAwf9SJEeIsSmCDLgyVfdBhdBpzX1OJ87anT9IVR0Z9pjM0FNixCAUAHGnMBGB8K99SwAheXrT0Kh6QQ=="],
 
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "3.3.3", "minimatch": "10.0.3", "path-browserify": "1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
@@ -779,6 +792,8 @@
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "4.0.1" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
+
     "filename-reserved-regex": ["filename-reserved-regex@4.0.0", "", {}, "sha512-9ZT504KxEQDamsOogZImAWGEN24R1uFAxU3ZS4AZqn2ooidmN68Olh7n4/RcA4lLatZztjA0ZSuxeLHVoCc8JA=="],
 
     "filenamify": ["filenamify@7.0.1", "", { "dependencies": { "filename-reserved-regex": "^4.0.0" } }, "sha512-9b4rfnaX2MkJCgp27wypV6DAMvj4WMOSgJ+TdcpJIO84Dql+Cv6iJjdG4XDTLubOWkfNiBv3joO59sau/TXw+Q=="],
@@ -862,6 +877,8 @@
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": "2.1.2" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -1012,6 +1029,8 @@
     "msw": ["msw@2.10.5", "", { "dependencies": { "@bundled-es-modules/cookie": "2.0.1", "@bundled-es-modules/statuses": "1.0.1", "@bundled-es-modules/tough-cookie": "0.1.6", "@inquirer/confirm": "5.1.16", "@mswjs/interceptors": "0.39.6", "@open-draft/deferred-promise": "2.2.0", "@open-draft/until": "2.1.0", "@types/cookie": "0.6.0", "@types/statuses": "2.0.6", "graphql": "16.11.0", "headers-polyfill": "4.0.3", "is-node-process": "1.2.0", "outvariant": "1.4.3", "path-to-regexp": "6.3.0", "picocolors": "1.1.1", "strict-event-emitter": "0.5.1", "type-fest": "4.41.0", "yargs": "17.7.2" }, "optionalDependencies": { "typescript": "5.9.2" }, "bin": { "msw": "cli/index.js" } }, "sha512-0EsQCrCI1HbhpBWd89DvmxY6plmvrM96b0sCIztnvcNHQbXn5vqwm1KlXslo6u4wN9LFGLC1WFjjgljcQhe40A=="],
 
     "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
+
+    "music-metadata": ["music-metadata@11.8.3", "", { "dependencies": { "@borewit/text-codec": "^0.2.0", "@tokenizer/token": "^0.3.0", "content-type": "^1.0.5", "debug": "^4.4.1", "file-type": "^21.0.0", "media-typer": "^1.1.0", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.1" } }, "sha512-Tgiv4MlCgDb6XzelziB1mmL2xeoHls0KTpCm3Z3qr+LfF4mBEpkuc5vNrc927IT5+S5fv+vzStfI+HYC0igDpA=="],
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
@@ -1239,7 +1258,11 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "taglib-wasm": ["taglib-wasm@1.5.2", "", { "dependencies": { "@msgpack/msgpack": "^3.1.3" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-V4R8jLvMU0qJEEgtrvKJRzXxW9RqZc0MCu83U6YC7fn/XGFNRySuBevWWRn8BaO9yGzdqdfQmYh2+Ls8fwgbPA=="],
 
     "tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
 
@@ -1263,6 +1286,8 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
     "toml": ["toml@4.1.2", "", {}, "sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA=="],
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
@@ -1284,6 +1309,8 @@
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "1.0.5", "media-typer": "1.1.0", "mime-types": "3.0.1" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -1370,6 +1397,8 @@
     "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@tailwindcss/node/lightningcss": ["lightningcss@1.30.1", "", { "dependencies": { "detect-libc": "2.0.4" }, "optionalDependencies": { "lightningcss-darwin-arm64": "1.30.1", "lightningcss-darwin-x64": "1.30.1", "lightningcss-freebsd-x64": "1.30.1", "lightningcss-linux-arm-gnueabihf": "1.30.1", "lightningcss-linux-arm64-gnu": "1.30.1", "lightningcss-linux-arm64-musl": "1.30.1", "lightningcss-linux-x64-gnu": "1.30.1", "lightningcss-linux-x64-musl": "1.30.1", "lightningcss-win32-arm64-msvc": "1.30.1", "lightningcss-win32-x64-msvc": "1.30.1" } }, "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg=="],
+
+    "@tokenizer/inflate/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "@ts-morph/common/minimatch": ["minimatch@10.0.3", "", { "dependencies": { "@isaacs/brace-expansion": "5.0.0" } }, "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw=="],
 

--- a/docs/research/flac-writer-bakeoff-2026-07-17.md
+++ b/docs/research/flac-writer-bakeoff-2026-07-17.md
@@ -1,0 +1,182 @@
+# FLAC writer bake-off — 2026-07-17
+
+## Decision: stop now; candidate not approved
+
+Do not ship or advertise FLAC upload/edit/export in this PR. `taglib-wasm@1.5.2`
+is promising on the tested preservation cases, but there is no accepted physical iOS or
+Android memory measurement in this environment. The plan explicitly requires measured
+mobile memory. That missing evidence leaves the Phase 1 mobile gate unmet and is the
+reason to stop now; the Bun measurements below are not a substitute for browser/mobile
+measurements. The malformed-input screen also found cases needing policy or wrapper
+hardening before this candidate could be approved.
+
+The format-explicit MP3 architecture on the parent branch remains useful and should land
+independently. Cobalt and URL imports remain MP3-only.
+
+## Reproduce
+
+Prerequisites: Bun 1.3.10+, `ffmpeg` on `PATH`, and approximately 3 GiB of free memory.
+
+```sh
+bun install
+bun run evidence:flac
+```
+
+The executable assertion corpus is
+[`scripts/flac-writer-bakeoff.ts`](../../scripts/flac-writer-bakeoff.ts). It generates
+redistributable synthetic FLAC fixtures under `/tmp/tagium-flac-bakeoff-evidence` and
+writes the machine-readable result to `results.json` in that directory. Generated audio
+is a deterministic sine wave, so no copyrighted media is stored in the repository.
+
+## Candidate
+
+- `taglib-wasm@1.5.2`, published 2026-07-16; current maintained release at evaluation.
+- Browser entry: 101,287 bytes raw / 21,782 bytes gzip.
+- Browser wrapper chunk: 51,334 bytes raw / 13,411 bytes gzip.
+- Browser WASM: 683,733 bytes raw / 225,895 bytes gzip.
+- Sum of those installed artifacts: 836,354 bytes raw / 261,088 bytes when each artifact
+  is gzipped independently.
+- Independent reread: `music-metadata@11.8.3`.
+
+These are package-file sizes, not a production Tagium bundle measurement. A bundler may
+rewrite or split the wrapper, tree-shake JavaScript, emit the WASM separately, and apply
+different compression. If reconsidered, the dependency should be lazy-loaded in a worker
+and the actual production chunks measured; this bake-off did not implement that product
+path.
+
+The package's documentation says browsers and Web Workers use Emscripten and load the
+entire file into memory, while its seek-based partial path is for filesystem runtimes.
+That statement is upstream documentation, not a browser-memory measurement from this run.
+
+## Preservation and correctness results
+
+All positive checks below passed on generated native FLAC files. The script fails
+immediately if one regresses. This is a focused corpus, not a claim that all FLAC metadata
+blocks or Xiph tag dialects are preserved.
+
+| Check                      | Evidence                                                                                                                                                                              |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Independent reread         | `music-metadata@11.8.3` reread the writer output.                                                                                                                                     |
+| Common fields              | Edited title, the two exact artist values, album, preserved full date/year, genre, track number, and edited comment were asserted after independent reread.                           |
+| Advanced/Xiph fields       | Album artist, composer, disc number, and BPM round-tripped.                                                                                                                           |
+| Unicode                    | The asserted title contains Japanese, emoji, and accented Latin; the asserted comment contains Hebrew; the asserted composer contains Greek.                                          |
+| Repeated values            | Two `ARTIST` values survived as two values.                                                                                                                                           |
+| Unknown Vorbis comments    | `X_TAGIUM_SENTINEL=preserve-me` survived semantically.                                                                                                                                |
+| Non-modeled metadata block | One injected APPLICATION block (`TGM0` sentinel) survived byte-for-byte across tag and artwork edits. No broader unknown-block corpus was run.                                        |
+| Artwork                    | Front-cover add and replace were independently reread and asserted for exact bytes, `image/png` MIME, front-cover type, and exact description; removal was reread and asserted empty. |
+| Encoded audio              | SHA-256 of the bytes from the first audio frame onward remained `6e4b9a61e7d87648db2e98c660db85af4787636023b9e8c8bc1f284723843d13`.                                                   |
+
+The payload hash is stronger for this purpose than comparing FLAC STREAMINFO's decoded
+audio MD5: it proves the encoded frame bytes themselves were not rewritten.
+
+### Malformed-input screen
+
+The screen calls `open()` and `isValid()`; it does not claim later save behavior. `true`
+means the candidate rejected that mutation at this boundary.
+
+| Mutation                                     | Rejected at open/validation |
+| -------------------------------------------- | --------------------------- |
+| Truncated before complete STREAMINFO         | Yes                         |
+| Missing `fLaC` marker                        | Yes                         |
+| Metadata-block length beyond input           | Yes                         |
+| Reserved metadata-block type 127             | Yes                         |
+| Duplicate STREAMINFO block                   | **No**                      |
+| Vorbis comment with inconsistent field count | **No**                      |
+| Truncated PICTURE block                      | **No**                      |
+
+This mixed result is not a broad fail-closed guarantee. A future adapter would need an
+explicit, tested admission layer and product policy. No oversized-file or artwork-size
+admission wrapper was built, and no product size threshold is claimed by this artifact.
+
+## Time and isolated peak memory
+
+Measured on Apple Silicon macOS 26 with Bun 1.3.10 using taglib-wasm's Bun/WASI runtime
+while passing each complete fixture as a `Uint8Array`. Each row ran in a fresh process.
+Peak RSS is `process.resourceUsage().maxRSS`; the increase subtracts the initialized
+runtime's baseline. These are Bun/WASI buffer-path measurements only. They are not browser
+or mobile measurements and cannot establish browser amplification or a mobile limit.
+
+| Fixture             | Meaning                     |     Input |  Write | Baseline RSS |  Peak RSS | Peak increase | Amplification vs input |
+| ------------------- | --------------------------- | --------: | -----: | -----------: | --------: | ------------: | ---------------------: |
+| `small.flac`        | 5 minutes                   |  3.54 MiB |   6 ms |     88.7 MiB | 125.5 MiB |      36.9 MiB |                  10.4× |
+| `sixty-minute.flac` | 60 minutes                  |  42.9 MiB |  30 ms |     87.7 MiB | 519.3 MiB |     431.6 MiB |                  10.1× |
+| `large.flac`        | 6 hours / large-file stress | 275.0 MiB | 202 ms |     87.7 MiB |  2.77 GiB |      2.69 GiB |                  10.0× |
+
+These results identify a cost worth investigating, but they do not prove the same ratio in
+Emscripten browsers. A worker would isolate work from the UI thread, but its browser memory
+and transfer behavior still must be measured. Without accepted physical-device evidence,
+no mobile file-size or artwork-size policy is proposed.
+
+## Licensing and relinking obligations
+
+This is a mixed-license dependency:
+
+- TypeScript/JavaScript wrapper: MIT. Preserve the MIT copyright and permission notice.
+- `taglib-web.wasm` and `taglib-wasi.wasm`: LGPL-2.1-or-later, inherited from TagLib.
+- The installed package's `LICENSE` explicitly requires consumers to let users relink with
+  a modified TagLib and points to the upstream `lib/taglib/` source and `npm run build:wasm`.
+
+The following is an engineering compliance checklist inferred from the package notice,
+not a legal conclusion. If this candidate is later distributed, counsel should determine
+the actual obligations and approve the mechanism. Likely work includes:
+
+1. Ship the wrapper's MIT notice and the complete LGPL notice with the application.
+2. Publish or provide alongside the WASM the exact corresponding TagLib source, wrapper
+   source/build scripts, toolchain instructions, and any local modifications used to make
+   that binary—not merely a link to a moving `main` branch.
+3. Keep the WASM a separately loaded asset and document how a recipient can rebuild and
+   substitute a modified compatible binary. Tagium's source and build must not prevent
+   that replacement.
+4. Publish modifications to the LGPL-covered TagLib code under LGPL-2.1-or-later and not
+   prohibit reverse engineering needed to debug such modifications.
+5. Have counsel confirm the web-distribution/relinking mechanism before release.
+
+The npm tarball examined contains the wrapper license and compiled WASM, but not the
+referenced `lib/taglib/` directory. Whether and how Tagium must provide corresponding
+source and a relink path requires legal review; engineering should plan for an explicit,
+version-pinned source artifact and reproducible relink guide rather than assuming the
+tarball is sufficient.
+
+## Narrow alternative screen
+
+`@akabeko/music-metadata-editor@1.0.1` is maintained, MIT licensed, and its public API does
+accept `Uint8Array` for reads and writes. Its package declares Node 24+, exposes no separate
+browser entry, and the published graph imports `node:buffer`, `node:path`, and
+`node:fs/promises`.
+
+An actual smoke was run: a vanilla Vite browser bundle completed after externalizing those
+Node built-ins, but headless Chromium failed during module initialization with
+`TypeError: Cannot read properties of undefined (reading 'from')` at a `Buffer.from` call,
+before the FLAC write executed. This shows the published entry is not browser-ready in
+Tagium's current unpolyfilled Vite setup. It does **not** prove the library cannot work with
+carefully selected polyfills, a narrower source import, or upstream browser changes. Those
+paths and the alternative's preservation/memory corpus remain untested, so this is not an
+exhaustive alternative rejection.
+
+The smoke is reproducible with `bun run evidence:flac-alternative`; it generates its own
+one-second FLAC fixture and temporary Vite bundle under `/tmp`.
+
+A product-owned binary writer was not pursued because the plan excludes compensating for
+a failed gate with a broad custom writer.
+
+## What would reopen the gate
+
+Reconsider only when all of these are available:
+
+- a browser-integrated candidate (TagLib or an alternative) with a focused adapter and
+  expanded preservation/malformed corpus;
+- physical iOS Safari and Android Chrome runs for 5-minute, 60-minute, and policy-limit
+  inputs, recording browser survival, peak memory, write time, and download completion;
+- an accepted file-size/artwork policy derived from those device measurements;
+- for TagLib, a legally reviewed, reproducible corresponding-source and relinking path.
+
+Until then, support copy must continue to say MP3 only.
+
+## Primary references
+
+- [RFC 9639 — FLAC file-level metadata and frame structure](https://www.rfc-editor.org/rfc/rfc9639.html)
+- [TagLib-Wasm repository and licensing](https://github.com/CharlesWiltgen/TagLib-Wasm)
+- [TagLib-Wasm browser/runtime documentation](https://charleswiltgen.github.io/TagLib-Wasm/guide/platform-examples.html)
+- [Xiph Vorbis comment specification](https://xiph.org/vorbis/doc/v-comment.html)
+- [`music-metadata` repository](https://github.com/Borewit/music-metadata)
+- [`@akabeko/music-metadata-editor` repository](https://github.com/akabekobeko/npm-music-metadata-editor)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "deploy:preview": "bun run scripts/deploy-preview.ts",
     "deploy:production": "bun run scripts/deploy-production.ts",
     "load-test:cobalt": "bun run scripts/load-test-cobalt.ts",
+    "evidence:flac": "bun run scripts/flac-writer-bakeoff.ts",
+    "evidence:flac-alternative": "bun run scripts/flac-alternative-browser-smoke.ts",
     "doctor": "bunx react-doctor@latest",
     "shadcn": "shadcn"
   },
@@ -45,6 +47,7 @@
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
+    "@akabeko/music-metadata-editor": "1.0.1",
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
@@ -55,9 +58,11 @@
     "@vitejs/plugin-react": "^6.0.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "music-metadata": "11.8.3",
     "nitro": "^3.0.260311-beta",
     "react-test-renderer": "19.1.0",
     "shadcn": "^3.0.0",
+    "taglib-wasm": "1.5.2",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.7",
     "typescript": "^5",

--- a/scripts/flac-alternative-browser-smoke.ts
+++ b/scripts/flac-alternative-browser-smoke.ts
@@ -1,0 +1,118 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+import { build } from "vite";
+
+const OUTPUT_DIR = "/tmp/tagium-flac-alternative-smoke";
+const ENTRY_PATH = `${OUTPUT_DIR}/entry.ts`;
+const FIXTURE_PATH = `${OUTPUT_DIR}/fixture.flac`;
+const BUNDLE_PATH = `${OUTPUT_DIR}/dist/smoke.js`;
+
+const assert: (condition: unknown, message: string) => asserts condition = (condition, message) => {
+  if (!condition) throw new Error(message);
+};
+
+await mkdir(OUTPUT_DIR, { recursive: true });
+await writeFile(
+  ENTRY_PATH,
+  `import { writeMetadata } from "@akabeko/music-metadata-editor";\n` +
+    `export const smoke = (bytes: Uint8Array) => writeMetadata(bytes, { tag: { title: "Browser smoke" } });\n`,
+);
+
+const ffmpeg = spawnSync(
+  "ffmpeg",
+  [
+    "-hide_banner",
+    "-loglevel",
+    "error",
+    "-f",
+    "lavfi",
+    "-i",
+    "sine=frequency=440:sample_rate=44100:duration=1",
+    "-ac",
+    "2",
+    "-c:a",
+    "flac",
+    "-y",
+    FIXTURE_PATH,
+  ],
+  { encoding: "utf8" },
+);
+assert(ffmpeg.status === 0, ffmpeg.stderr || "failed to generate FLAC smoke fixture");
+
+await build({
+  configFile: false,
+  logLevel: "silent",
+  resolve: {
+    alias: {
+      "@akabeko/music-metadata-editor": fileURLToPath(
+        new URL("../node_modules/@akabeko/music-metadata-editor/dist/mme.js", import.meta.url),
+      ),
+    },
+  },
+  build: {
+    outDir: `${OUTPUT_DIR}/dist`,
+    emptyOutDir: true,
+    lib: { entry: ENTRY_PATH, formats: ["es"], fileName: "smoke" },
+    minify: false,
+  },
+});
+
+const bundle = await readFile(BUNDLE_PATH);
+const fixture = await readFile(FIXTURE_PATH);
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage();
+await page.route("http://smoke.test/**", async (route) => {
+  const url = route.request().url();
+  if (url.endsWith("smoke.js")) {
+    await route.fulfill({ status: 200, contentType: "text/javascript", body: bundle });
+  } else if (url.endsWith("fixture.flac")) {
+    await route.fulfill({ status: 200, contentType: "audio/flac", body: fixture });
+  } else {
+    await route.fulfill({ status: 200, contentType: "text/html", body: "<!doctype html>" });
+  }
+});
+
+try {
+  await page.goto("http://smoke.test/");
+  const result = await page.evaluate(async () => {
+    try {
+      const modulePath = "/smoke.js";
+      const module = (await import(modulePath)) as {
+        smoke: (bytes: Uint8Array) => Promise<Uint8Array>;
+      };
+      const bytes = new Uint8Array(await (await fetch("/fixture.flac")).arrayBuffer());
+      const output = await module.smoke(bytes);
+      return { ok: true as const, outputBytes: output.length };
+    } catch (error) {
+      return { ok: false as const, error: String(error) };
+    }
+  });
+
+  assert(
+    !result.ok,
+    "alternative unexpectedly became browser-ready; run its full preservation gate",
+  );
+  assert(
+    result.error.includes("reading 'from'") || result.error.includes("Buffer"),
+    `unexpected browser failure: ${result.error}`,
+  );
+  console.log(
+    JSON.stringify(
+      {
+        candidate: "@akabeko/music-metadata-editor@1.0.1",
+        viteBundleCompleted: true,
+        bundleBytes: bundle.length,
+        chromiumWriteCompleted: false,
+        observedError: result.error,
+        interpretation:
+          "The published entry is not browser-ready in vanilla Vite; polyfilled/custom builds remain untested.",
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  await browser.close();
+}

--- a/scripts/flac-writer-bakeoff.ts
+++ b/scripts/flac-writer-bakeoff.ts
@@ -1,0 +1,498 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
+import { parseBuffer } from "music-metadata";
+import { TagLib, type Picture, type PropertyMap } from "taglib-wasm";
+
+const OUTPUT_DIR = process.env.TAGIUM_FLAC_BAKEOFF_DIR ?? "/tmp/tagium-flac-bakeoff-evidence";
+
+type FlacBlock = {
+  type: number;
+  data: Uint8Array;
+};
+
+const assert: (condition: unknown, message: string) => asserts condition = (condition, message) => {
+  if (!condition) throw new Error(message);
+};
+
+const sha256 = (data: Uint8Array) => createHash("sha256").update(data).digest("hex");
+
+const readUint24 = (bytes: Uint8Array, offset: number) =>
+  (bytes[offset]! << 16) | (bytes[offset + 1]! << 8) | bytes[offset + 2]!;
+
+const parseFlac = (bytes: Uint8Array) => {
+  assert(bytes.length >= 8, "FLAC input is truncated");
+  assert(new TextDecoder().decode(bytes.subarray(0, 4)) === "fLaC", "FLAC marker is missing");
+
+  const blocks: FlacBlock[] = [];
+  let offset = 4;
+  let isLast = false;
+  while (!isLast) {
+    assert(offset + 4 <= bytes.length, "FLAC metadata header is truncated");
+    isLast = (bytes[offset]! & 0x80) !== 0;
+    const type = bytes[offset]! & 0x7f;
+    const size = readUint24(bytes, offset + 1);
+    assert(offset + 4 + size <= bytes.length, "FLAC metadata block is truncated");
+    blocks.push({ type, data: bytes.slice(offset + 4, offset + 4 + size) });
+    offset += 4 + size;
+  }
+  assert(blocks[0]?.type === 0 && blocks[0].data.length === 34, "FLAC STREAMINFO is invalid");
+  return { blocks, audioOffset: offset };
+};
+
+const encodeBlocks = (blocks: FlacBlock[], audio: Uint8Array) => {
+  const total = 4 + blocks.reduce((size, block) => size + 4 + block.data.length, 0) + audio.length;
+  const result = new Uint8Array(total);
+  result.set(new TextEncoder().encode("fLaC"));
+  let offset = 4;
+  blocks.forEach((block, index) => {
+    assert(block.data.length <= 0xffffff, "metadata block exceeds FLAC's 24-bit limit");
+    result[offset] = block.type | (index === blocks.length - 1 ? 0x80 : 0);
+    result[offset + 1] = (block.data.length >>> 16) & 0xff;
+    result[offset + 2] = (block.data.length >>> 8) & 0xff;
+    result[offset + 3] = block.data.length & 0xff;
+    result.set(block.data, offset + 4);
+    offset += 4 + block.data.length;
+  });
+  result.set(audio, offset);
+  return result;
+};
+
+const injectApplicationBlock = (bytes: Uint8Array) => {
+  const { blocks, audioOffset } = parseFlac(bytes);
+  const sentinel = new TextEncoder().encode("TGM0unknown-block-preservation-sentinel");
+  return {
+    bytes: encodeBlocks([...blocks, { type: 2, data: sentinel }], bytes.subarray(audioOffset)),
+    sentinelHash: sha256(sentinel),
+  };
+};
+
+const audioPayloadHash = (bytes: Uint8Array) => {
+  const { audioOffset } = parseFlac(bytes);
+  return sha256(bytes.subarray(audioOffset));
+};
+
+const applicationBlockHashes = (bytes: Uint8Array) =>
+  parseFlac(bytes)
+    .blocks.filter(({ type }) => type === 2)
+    .map(({ data }) => sha256(data));
+
+const runFfmpeg = (args: string[]) => {
+  const result = spawnSync("ffmpeg", ["-hide_banner", "-loglevel", "error", ...args], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) throw new Error(result.stderr || "ffmpeg fixture generation failed");
+};
+
+const generateFixtures = async () => {
+  await mkdir(OUTPUT_DIR, { recursive: true });
+  const fixtures = [
+    { name: "small.flac", seconds: 300, rate: 44_100, frequency: 440 },
+    { name: "sixty-minute.flac", seconds: 3_600, rate: 44_100, frequency: 330 },
+    { name: "large.flac", seconds: 21_600, rate: 48_000, frequency: 220 },
+  ] as const;
+
+  for (const fixture of fixtures) {
+    const path = `${OUTPUT_DIR}/${fixture.name}`;
+    runFfmpeg([
+      "-f",
+      "lavfi",
+      "-i",
+      `sine=frequency=${fixture.frequency}:sample_rate=${fixture.rate}:duration=${fixture.seconds}`,
+      "-ac",
+      "2",
+      "-c:a",
+      "flac",
+      "-compression_level",
+      "5",
+      "-metadata",
+      "title=Original שלום 🎵",
+      "-metadata",
+      "artist=Artist One",
+      "-metadata",
+      "album=Bakeoff Album",
+      "-metadata",
+      "genre=Ambient",
+      "-metadata",
+      "date=2024-03-02",
+      "-metadata",
+      "track=2/9",
+      "-metadata",
+      "album_artist=Album Artist",
+      "-metadata",
+      "composer=Composer Ω",
+      "-metadata",
+      "bpm=123",
+      "-metadata",
+      "comment=Original comment",
+      "-metadata",
+      "X_TAGIUM_SENTINEL=preserve-me",
+      "-y",
+      path,
+    ]);
+  }
+
+  const smallPath = `${OUTPUT_DIR}/small.flac`;
+  const injected = injectApplicationBlock(new Uint8Array(await readFile(smallPath)));
+  await writeFile(smallPath, injected.bytes);
+  return { fixtures, sentinelHash: injected.sentinelHash };
+};
+
+const onePixelPng = Uint8Array.from(
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    "base64",
+  ),
+);
+
+const alternatePng = Uint8Array.from(
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAFElEQVR42mP8z8AARAwMjDAGAC4HAQnWJQQAAAAASUVORK5CYII=",
+    "base64",
+  ),
+);
+
+const cover = (data: Uint8Array, description: string): Picture => ({
+  type: "FrontCover",
+  mimeType: "image/png",
+  description,
+  data,
+});
+
+const bytesEqual = (actual: Uint8Array, expected: Uint8Array) =>
+  actual.length === expected.length && actual.every((byte, index) => byte === expected[index]);
+
+const assertArtworkReadback = async (
+  label: string,
+  bytes: Uint8Array,
+  expectedData: Uint8Array,
+  expectedDescription: string,
+) => {
+  const reread = await parseBuffer(bytes, { mimeType: "audio/flac", size: bytes.length });
+  const pictures = reread.common.picture ?? [];
+  assert(pictures.length === 1, `${label}: expected exactly one picture`);
+  const picture = pictures[0]!;
+  assert(bytesEqual(picture.data, expectedData), `${label}: picture bytes changed`);
+  assert(picture.format === "image/png", `${label}: picture MIME mismatch`);
+  assert(picture.type === "Cover (front)", `${label}: picture type mismatch`);
+  assert(picture.description === expectedDescription, `${label}: picture description mismatch`);
+};
+
+const openAndSave = async (
+  taglib: Awaited<ReturnType<typeof TagLib.initialize>>,
+  input: Uint8Array,
+  edit: (file: Awaited<ReturnType<typeof taglib.open>>) => void,
+) => {
+  const file = await taglib.open(input);
+  try {
+    assert(file.isValid(), "taglib-wasm rejected a generated FLAC fixture");
+    edit(file);
+    assert(file.save(), "taglib-wasm failed to save FLAC metadata");
+    return file.getFileBuffer().slice();
+  } finally {
+    file.dispose();
+  }
+};
+
+const measureWrite = async (
+  taglib: Awaited<ReturnType<typeof TagLib.initialize>>,
+  path: string,
+) => {
+  const input = new Uint8Array(await readFile(path));
+  const before = process.memoryUsage().rss;
+  const started = performance.now();
+  const output = await openAndSave(taglib, input, (file) => {
+    file.setProperty("TITLE", "Measured write");
+  });
+  const elapsedMs = performance.now() - started;
+  const after = process.memoryUsage().rss;
+  assert(audioPayloadHash(input) === audioPayloadHash(output), `${path}: audio payload changed`);
+  return {
+    inputBytes: input.byteLength,
+    outputBytes: output.byteLength,
+    writeMs: Math.round(elapsedMs),
+    observedRssDeltaBytes: Math.max(0, after - before),
+  };
+};
+
+const measureInIsolatedProcess = (path: string) => {
+  const child = spawnSync(
+    process.execPath,
+    [fileURLToPath(import.meta.url), "--measure-one", path],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+    },
+  );
+  if (child.status !== 0) {
+    throw new Error(child.stderr || `isolated measurement failed for ${path}`);
+  }
+  return JSON.parse(child.stdout) as {
+    inputBytes: number;
+    outputBytes: number;
+    writeMs: number;
+    baselineRssBytes: number;
+    peakRssBytes: number;
+    peakRssIncreaseBytes: number;
+  };
+};
+
+const measureOne = async (path: string) => {
+  const taglib = await TagLib.initialize();
+  const baselineRssBytes = process.resourceUsage().maxRSS;
+  const measurement = await measureWrite(taglib, path);
+  const peakRssBytes = process.resourceUsage().maxRSS;
+  console.log(
+    JSON.stringify({
+      ...measurement,
+      baselineRssBytes,
+      peakRssBytes,
+      peakRssIncreaseBytes: Math.max(0, peakRssBytes - baselineRssBytes),
+    }),
+  );
+};
+
+const isRejected = async (
+  taglib: Awaited<ReturnType<typeof TagLib.initialize>>,
+  input: Uint8Array,
+) => {
+  let rejected = false;
+  try {
+    const file = await taglib.open(input);
+    try {
+      rejected = !file.isValid();
+    } finally {
+      file.dispose();
+    }
+  } catch {
+    rejected = true;
+  }
+  return rejected;
+};
+
+const main = async () => {
+  const { fixtures, sentinelHash } = await generateFixtures();
+  const taglib = await TagLib.initialize();
+  const source = new Uint8Array(await readFile(`${OUTPUT_DIR}/small.flac`));
+  const originalPayloadHash = audioPayloadHash(source);
+
+  const withTags = await openAndSave(taglib, source, (file) => {
+    const properties: PropertyMap = {
+      ...file.properties(),
+      TITLE: ["Edited café 東京 🎧"],
+      ARTIST: ["Artist One", "Artist Two"],
+      ALBUM: ["Edited Album"],
+      ALBUMARTIST: ["Album Artist"],
+      COMPOSER: ["Composer Ω"],
+      DISCNUMBER: ["2"],
+      BPM: ["127"],
+      COMMENT: ["Edited comment שלום"],
+    };
+    file.setProperties(properties);
+  });
+  assert(audioPayloadHash(withTags) === originalPayloadHash, "common/advanced edit changed audio");
+  assert(
+    applicationBlockHashes(withTags).includes(sentinelHash),
+    "unknown FLAC APPLICATION block was not preserved",
+  );
+
+  const withCover = await openAndSave(taglib, withTags, (file) =>
+    file.setPictures([cover(onePixelPng, "first")]),
+  );
+  const replacedCover = await openAndSave(taglib, withCover, (file) =>
+    file.setPictures([cover(alternatePng, "replacement")]),
+  );
+  const withoutCover = await openAndSave(taglib, replacedCover, (file) => file.removePictures());
+  for (const [label, bytes] of [
+    ["cover add", withCover],
+    ["cover replace", replacedCover],
+    ["cover remove", withoutCover],
+  ] as const) {
+    assert(audioPayloadHash(bytes) === originalPayloadHash, `${label} changed audio`);
+    assert(applicationBlockHashes(bytes).includes(sentinelHash), `${label} lost unknown block`);
+  }
+
+  const independent = await parseBuffer(withTags, {
+    mimeType: "audio/flac",
+    size: withTags.length,
+  });
+  assert(independent.common.title === "Edited café 東京 🎧", "independent parser title mismatch");
+  assert(independent.common.album === "Edited Album", "independent parser album mismatch");
+  assert(
+    independent.common.albumartist === "Album Artist",
+    "independent parser album artist mismatch",
+  );
+  assert(
+    independent.common.composer?.includes("Composer Ω"),
+    "independent parser composer mismatch",
+  );
+  assert(independent.common.disk.no === 2, "independent parser disc number mismatch");
+  assert(independent.common.bpm === 127, "independent parser BPM mismatch");
+  assert(independent.common.artists?.length === 2, "repeated artist values did not round-trip");
+  assert(independent.common.artists.includes("Artist One"), "first artist value mismatch");
+  assert(independent.common.artists.includes("Artist Two"), "second artist value mismatch");
+  assert(independent.common.year === 2024, "independent parser year mismatch");
+  assert(independent.common.date === "2024-03-02", "independent parser full date mismatch");
+  assert(independent.common.genre?.includes("Ambient"), "independent parser genre mismatch");
+  assert(independent.common.track.no === 2, "independent parser track number mismatch");
+  assert(
+    independent.common.comment?.some(({ text }) => text === "Edited comment שלום"),
+    "independent parser edited Hebrew comment mismatch",
+  );
+  const nativeValues = independent.native.vorbis?.flatMap(({ id, value }) =>
+    id.toUpperCase() === "X_TAGIUM_SENTINEL" ? [String(value)] : [],
+  );
+  assert(nativeValues?.includes("preserve-me"), "unknown Vorbis comment was not preserved");
+
+  await assertArtworkReadback("cover add", withCover, onePixelPng, "first");
+  await assertArtworkReadback("cover replacement", replacedCover, alternatePng, "replacement");
+  const noCoverRead = await parseBuffer(withoutCover, {
+    mimeType: "audio/flac",
+    size: withoutCover.length,
+  });
+  assert(!noCoverRead.common.picture?.length, "cover removal mismatch");
+
+  const malformedCorpus: Record<string, boolean> = {};
+  malformedCorpus.truncated = await isRejected(taglib, source.subarray(0, 31));
+  const malformed = source.slice();
+  malformed[0] = 0;
+  malformedCorpus.missingMarker = await isRejected(taglib, malformed);
+
+  const invalidBlockLength = source.slice();
+  invalidBlockLength[5] = 0xff;
+  invalidBlockLength[6] = 0xff;
+  invalidBlockLength[7] = 0xff;
+  malformedCorpus.invalidBlockLength = await isRejected(taglib, invalidBlockLength);
+
+  const invalidBlockType = source.slice();
+  invalidBlockType[4] = (invalidBlockType[4]! & 0x80) | 0x7f;
+  malformedCorpus.reservedBlockType = await isRejected(taglib, invalidBlockType);
+
+  const parsedSource = parseFlac(source);
+  const duplicateStreamInfo = encodeBlocks(
+    [parsedSource.blocks[0]!, ...parsedSource.blocks],
+    source.subarray(parsedSource.audioOffset),
+  );
+  malformedCorpus.duplicateStreamInfo = await isRejected(taglib, duplicateStreamInfo);
+
+  const malformedVorbisBlocks = parsedSource.blocks.map((block) => {
+    if (block.type !== 4) return block;
+    const data = block.data.slice();
+    const vendorLength = data[0]! | (data[1]! << 8) | (data[2]! << 16) | (data[3]! << 24);
+    const countOffset = 4 + vendorLength;
+    data.fill(0xff, countOffset, countOffset + 4);
+    return { type: block.type, data };
+  });
+  malformedCorpus.invalidVorbisCommentCount = await isRejected(
+    taglib,
+    encodeBlocks(malformedVorbisBlocks, source.subarray(parsedSource.audioOffset)),
+  );
+
+  const malformedPicture = new Uint8Array(12);
+  malformedPicture.set([0, 0, 0, 3, 0xff, 0xff, 0xff, 0xff]);
+  malformedCorpus.truncatedPicture = await isRejected(
+    taglib,
+    encodeBlocks(
+      [...parsedSource.blocks, { type: 6, data: malformedPicture }],
+      source.subarray(parsedSource.audioOffset),
+    ),
+  );
+
+  const measurements: Record<string, ReturnType<typeof measureInIsolatedProcess>> = {};
+  for (const fixture of fixtures) {
+    measurements[fixture.name] = measureInIsolatedProcess(`${OUTPUT_DIR}/${fixture.name}`);
+  }
+
+  const browserEntry = new Uint8Array(
+    await readFile("node_modules/taglib-wasm/dist/index.browser.js"),
+  );
+  const browserWasm = new Uint8Array(
+    await readFile("node_modules/taglib-wasm/dist/taglib-web.wasm"),
+  );
+  const browserWrapper = new Uint8Array(
+    await readFile("node_modules/taglib-wasm/dist/taglib-wrapper.js"),
+  );
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    runtime: `Bun ${process.versions.bun ?? "unknown"} on ${process.platform}/${process.arch}`,
+    candidate: "taglib-wasm@1.5.2",
+    independentParser: "music-metadata@11.8.3",
+    gates: {
+      commonAndAdvancedFields: "pass",
+      unicodeAndRepeatedValues: "pass",
+      coverAddReplaceRemove: "pass",
+      coverArtworkExactBytesAndAttributes: "pass",
+      unknownVorbisComment: "pass",
+      unknownApplicationBlock: "pass",
+      encodedAudioPayloadHash: originalPayloadHash,
+      malformedCorpusRejected: malformedCorpus,
+    },
+    browserPayload: {
+      entryRawBytes: browserEntry.length,
+      entryGzipBytes: gzipSync(browserEntry, { level: 9 }).length,
+      wasmRawBytes: browserWasm.length,
+      wasmGzipBytes: gzipSync(browserWasm, { level: 9 }).length,
+      wrapperRawBytes: browserWrapper.length,
+      wrapperGzipBytes: gzipSync(browserWrapper, { level: 9 }).length,
+    },
+    measurements,
+  };
+  await writeFile(`${OUTPUT_DIR}/results.json`, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(JSON.stringify(report, null, 2));
+};
+
+const verifyArtworkOnly = async (path: string) => {
+  const taglib = await TagLib.initialize();
+  const source = new Uint8Array(await readFile(path));
+  const originalPayloadHash = audioPayloadHash(source);
+  const baseline = await openAndSave(taglib, source, (file) => file.removePictures());
+  const withCover = await openAndSave(taglib, baseline, (file) =>
+    file.setPictures([cover(onePixelPng, "first")]),
+  );
+  const replacedCover = await openAndSave(taglib, withCover, (file) =>
+    file.setPictures([cover(alternatePng, "replacement")]),
+  );
+  const withoutCover = await openAndSave(taglib, replacedCover, (file) => file.removePictures());
+
+  await assertArtworkReadback("cover add", withCover, onePixelPng, "first");
+  await assertArtworkReadback("cover replacement", replacedCover, alternatePng, "replacement");
+  const removedRead = await parseBuffer(withoutCover, {
+    mimeType: "audio/flac",
+    size: withoutCover.length,
+  });
+  assert(!removedRead.common.picture?.length, "cover removal mismatch");
+  for (const [label, bytes] of [
+    ["cover add", withCover],
+    ["cover replace", replacedCover],
+    ["cover remove", withoutCover],
+  ] as const) {
+    assert(audioPayloadHash(bytes) === originalPayloadHash, `${label} changed audio`);
+  }
+  console.log(
+    JSON.stringify({
+      fixture: path,
+      coverAddExactBytes: "pass",
+      coverReplaceExactBytes: "pass",
+      coverMimePictureTypeDescription: "pass",
+      coverRemove: "pass",
+      encodedAudioPayloadHash: originalPayloadHash,
+    }),
+  );
+};
+
+if (process.argv[2] === "--measure-one") {
+  const path = process.argv[3];
+  assert(path, "measurement path is required");
+  await measureOne(path);
+} else if (process.argv[2] === "--artwork-only") {
+  const path = process.argv[3] ?? `${OUTPUT_DIR}/small.flac`;
+  await verifyArtworkOnly(path);
+} else {
+  await main();
+}


### PR DESCRIPTION
## Outcome: STOP — no product FLAC support yet

This is a research-only PR. It deliberately makes no runtime, UI, or support-copy claim that Tagium supports FLAC.

The writer bake-off found `taglib-wasm` promising for metadata and encoded-audio preservation, but the required physical iOS/Android mobile-memory evidence is absent. That is a hard gate, so product implementation stopped.

## Evidence included
- reproducible FLAC writer bake-off with exact common/advanced metadata checks
- exact artwork bytes plus MIME/type/description add/replace/remove checks
- unknown Vorbis comment and APPLICATION block preservation checks
- malformed-input behavior matrix
- payload and Bun/WASI RSS measurements with browser/mobile caveats
- alternative writer vanilla-Vite/Chromium smoke
- licensing and source/relinking questions requiring legal review
- explicit reopen criteria for physical mobile testing

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run test` (399 tests)
- `bun run build`
- `bun run evidence:flac-alternative`
- focused `bun run evidence:flac --artwork-only ...`
- full bake-off previously executed and recorded; not rerun after the focused artwork assertion fix because it peaks around 3 GiB
- two independent evidence reviews passed after corrections

## Dependency
Targets #119 (`codex/format-aware-audio-core`) because the research branch was intentionally created from the format-aware audio core.