### PR TITLE
feat(audio): add waveform preview playback

### DIFF
--- a/src/features/editor/TrackMetadataEditor.tsx
+++ b/src/features/editor/TrackMetadataEditor.tsx
@@ -46,6 +46,7 @@ import { METADATA_EDITOR_FORM_LAYOUT } from "@/features/editor/trackMetadataEdit
 type LoadedTrack = TagiumFile & { metadata: AudioMetadata };
 
 interface TrackMetadataEditorProps {
+  previewActive: boolean;
   selectedFile: TagiumFile | null;
   selectedFileId: string | null;
   register: UseFormRegister<AudioMetadata>;
@@ -892,7 +893,7 @@ export default function TrackMetadataEditor(props: TrackMetadataEditorProps) {
               focusedTitleFileIdRef={focusedTitleFileIdRef}
               editorMode={editorMode}
               onEditorModeChange={setEditorMode}
-              previewActive={trackIsSelected}
+              previewActive={trackIsSelected && props.previewActive}
             />
           ) : (
             <PendingTrackMetadataEditor

--- a/src/features/editor/TrackMetadataEditor.tsx
+++ b/src/features/editor/TrackMetadataEditor.tsx
@@ -740,7 +740,7 @@ function LoadedTrackMetadataEditor({
         onSubmit={(event) => {
           event.preventDefault();
         }}
-        className="flex min-h-0 flex-col h-full"
+        className="flex h-full min-h-0 min-w-0 flex-col"
       >
         <div className="relative">
           <TrackFilenameHeader
@@ -760,60 +760,62 @@ function LoadedTrackMetadataEditor({
             </div>
           )}
         </div>
-        <div className="flex-1 min-h-0 overflow-y-auto p-3 pb-3 max-lg:[@media(max-height:700px)]:p-2 lg:p-6 lg:pb-28">
-          <div className="flex min-h-full flex-col gap-3 max-lg:[@media(max-height:700px)]:gap-2 lg:min-h-0 lg:flex-row lg:gap-4">
-            <Controller
-              name="picture"
-              control={control}
-              render={({ field }) => (
-                <CoverArt
-                  resetKey={selectedFileId}
-                  picture={field.value}
-                  onCoverUpload={onTrackCoverUpload}
-                  onProcessingChange={onTrackCoverProcessingChange}
-                  disabled={Boolean(selectedFileAlbum) && metadataLinks.artwork}
-                  disabledReason={getMetadataLinkDescriptor("artwork").disabledReason}
-                />
-              )}
-            />
-            <div className="flex flex-1 flex-col gap-2 max-lg:[@media(max-height:700px)]:gap-1.5 lg:gap-3">
-              <div data-editor-form-area className={METADATA_EDITOR_FORM_LAYOUT.className}>
-                {advancedMetadata && editorMode === "advanced" ? (
-                  <AdvancedTrackDetailsFields
-                    registrations={advancedFields.registrations}
-                    errors={advancedFields.errors}
-                    albumArtistLinked={metadataLinks.albumArtist}
-                    linkedArtistValue={linkedAlbumArtistDisplay}
-                    onFieldsMount={focusPendingAdvancedField}
-                  />
-                ) : (
-                  <TrackDetailsFields
-                    selectedFileId={selectedFileId}
-                    focusedTitleFileIdRef={focusedTitleFileIdRef}
-                    register={register}
-                    placeholder={placeholder}
-                    inAlbum={Boolean(selectedFileAlbum)}
-                    syncFilenames={syncFilenames}
-                    metadataLinks={metadataLinks}
-                    filenameInvalid={filenameInvalid}
-                    onPreviewMetadataChange={onPreviewMetadataChange}
+        <div className="min-w-0 flex-1 overflow-x-hidden overflow-y-auto p-3 pb-3 max-lg:[@media(max-height:700px)]:p-2 lg:p-6 lg:pb-28">
+          <div className="flex min-h-full min-w-0 flex-col gap-3 max-lg:[@media(max-height:700px)]:gap-2 lg:min-h-0 lg:gap-4">
+            <div className="flex min-w-0 flex-col gap-3 max-lg:[@media(max-height:700px)]:gap-2 lg:flex-row lg:gap-4">
+              <Controller
+                name="picture"
+                control={control}
+                render={({ field }) => (
+                  <CoverArt
+                    resetKey={selectedFileId}
+                    picture={field.value}
+                    onCoverUpload={onTrackCoverUpload}
+                    onProcessingChange={onTrackCoverProcessingChange}
+                    disabled={Boolean(selectedFileAlbum) && metadataLinks.artwork}
+                    disabledReason={getMetadataLinkDescriptor("artwork").disabledReason}
                   />
                 )}
+              />
+              <div className="flex min-w-0 flex-1 flex-col gap-2 max-lg:[@media(max-height:700px)]:gap-1.5 lg:gap-3">
+                <div data-editor-form-area className={METADATA_EDITOR_FORM_LAYOUT.className}>
+                  {advancedMetadata && editorMode === "advanced" ? (
+                    <AdvancedTrackDetailsFields
+                      registrations={advancedFields.registrations}
+                      errors={advancedFields.errors}
+                      albumArtistLinked={metadataLinks.albumArtist}
+                      linkedArtistValue={linkedAlbumArtistDisplay}
+                      onFieldsMount={focusPendingAdvancedField}
+                    />
+                  ) : (
+                    <TrackDetailsFields
+                      selectedFileId={selectedFileId}
+                      focusedTitleFileIdRef={focusedTitleFileIdRef}
+                      register={register}
+                      placeholder={placeholder}
+                      inAlbum={Boolean(selectedFileAlbum)}
+                      syncFilenames={syncFilenames}
+                      metadataLinks={metadataLinks}
+                      filenameInvalid={filenameInvalid}
+                      onPreviewMetadataChange={onPreviewMetadataChange}
+                    />
+                  )}
+                </div>
+                <TrackFileSummary selectedFile={selectedFile} />
+                <DownloadTrackButton
+                  onClick={submitDownload}
+                  disabled={!canDownloadTrack}
+                  disabledReason={downloadDisabledReason}
+                />
               </div>
-              <TrackFileSummary selectedFile={selectedFile} />
-              <TrackWaveformPreview
-                active={previewActive}
-                file={selectedFile.file}
-                fileId={selectedFile.id}
-                fallbackDuration={selectedFile.metadata.duration}
-                title={watchedTitle}
-              />
-              <DownloadTrackButton
-                onClick={submitDownload}
-                disabled={!canDownloadTrack}
-                disabledReason={downloadDisabledReason}
-              />
             </div>
+            <TrackWaveformPreview
+              active={previewActive}
+              file={selectedFile.file}
+              fileId={selectedFile.id}
+              fallbackDuration={selectedFile.metadata.duration}
+              title={watchedTitle}
+            />
           </div>
         </div>
       </form>

--- a/src/features/editor/TrackMetadataEditor.tsx
+++ b/src/features/editor/TrackMetadataEditor.tsx
@@ -21,6 +21,7 @@ import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import CoverArt from "@/features/editor/coverArt";
 import AudioImportDropzone from "@/features/import/AudioImportDropzone";
+import TrackWaveformPreview from "@/features/editor/TrackWaveformPreview";
 import { isValidFilenameBase, sanitizeFilenameBase } from "@/features/library/filename";
 import { getAudioFormatInfo } from "@/features/audio/audioFormat";
 import { getSampleTrack, type SampleTrackMetadata } from "@/features/editor/sampleMetadata";
@@ -76,6 +77,7 @@ interface LoadedTrackMetadataEditorProps extends Omit<TrackMetadataEditorProps, 
   focusedTitleFileIdRef: RefObject<string | null>;
   editorMode: MetadataEditorMode;
   onEditorModeChange: (mode: MetadataEditorMode) => void;
+  previewActive: boolean;
 }
 
 interface PendingTrackMetadataEditorProps extends Pick<
@@ -647,6 +649,7 @@ function LoadedTrackMetadataEditor({
   selectedFile,
   selectedFileId,
   focusedTitleFileIdRef,
+  previewActive,
   register,
   control,
   getValues,
@@ -797,6 +800,13 @@ function LoadedTrackMetadataEditor({
                 )}
               </div>
               <TrackFileSummary selectedFile={selectedFile} />
+              <TrackWaveformPreview
+                active={previewActive}
+                file={selectedFile.file}
+                fileId={selectedFile.id}
+                fallbackDuration={selectedFile.metadata.duration}
+                title={watchedTitle}
+              />
               <DownloadTrackButton
                 onClick={submitDownload}
                 disabled={!canDownloadTrack}
@@ -882,6 +892,7 @@ export default function TrackMetadataEditor(props: TrackMetadataEditorProps) {
               focusedTitleFileIdRef={focusedTitleFileIdRef}
               editorMode={editorMode}
               onEditorModeChange={setEditorMode}
+              previewActive={trackIsSelected}
             />
           ) : (
             <PendingTrackMetadataEditor

--- a/src/features/editor/TrackWaveformPreview.tsx
+++ b/src/features/editor/TrackWaveformPreview.tsx
@@ -231,6 +231,7 @@ export default function TrackWaveformPreview({
       aria-label={`preview ${title || file?.name || "selected track"}`}
       data-waveform-status={waveformStatus}
     >
+      {/* react-doctor-disable-next-line media-has-caption -- previews play user-provided music files, and Tagium has no truthful timed-text cue data to attach. */}
       <audio
         ref={audioRef}
         preload="metadata"
@@ -269,9 +270,7 @@ export default function TrackWaveformPreview({
           dispatch({ type: "playbackUnavailable", value: true });
           if (decodeDuration === 0) dispatch({ type: "waveformStatus", value: "unavailable" });
         }}
-      >
-        <track kind="captions" label="No spoken content" />
-      </audio>
+      />
       <div className="flex items-center gap-2">
         <Button
           type="button"

--- a/src/features/editor/TrackWaveformPreview.tsx
+++ b/src/features/editor/TrackWaveformPreview.tsx
@@ -2,7 +2,7 @@
 
 import { Pause, Play } from "lucide-react";
 import { useCallback, useEffect, useLayoutEffect, useReducer, useRef } from "react";
-import type { KeyboardEvent, PointerEvent } from "react";
+import type { CSSProperties, KeyboardEvent, PointerEvent } from "react";
 import { Button } from "@/components/ui/button";
 import {
   formatPreviewTime,
@@ -44,26 +44,44 @@ type PreviewAction =
 const previewReducer = (state: PreviewState, action: PreviewAction): PreviewState => {
   switch (action.type) {
     case "reset":
-      return { waveform: null, waveformStatus: action.file ? "loading" : "idle", playbackUnavailable: false, playing: false, currentTime: 0, mediaDuration: null };
-    case "playing": return { ...state, playing: action.value };
-    case "currentTime": return { ...state, currentTime: action.value };
-    case "mediaDuration": return { ...state, mediaDuration: action.value };
-    case "playbackUnavailable": return { ...state, playbackUnavailable: action.value };
-    case "waveform": return { ...state, waveform: action.value };
-    case "waveformStatus": return { ...state, waveformStatus: action.value };
+      return {
+        waveform: null,
+        waveformStatus: action.file ? "loading" : "idle",
+        playbackUnavailable: false,
+        playing: false,
+        currentTime: 0,
+        mediaDuration: null,
+      };
+    case "playing":
+      return { ...state, playing: action.value };
+    case "currentTime":
+      return { ...state, currentTime: action.value };
+    case "mediaDuration":
+      return { ...state, mediaDuration: action.value };
+    case "playbackUnavailable":
+      return { ...state, playbackUnavailable: action.value };
+    case "waveform":
+      return { ...state, waveform: action.value };
+    case "waveformStatus":
+      return { ...state, waveformStatus: action.value };
   }
 };
 
-const initialPreviewState: PreviewState = { waveform: null, waveformStatus: "idle", playbackUnavailable: false, playing: false, currentTime: 0, mediaDuration: null };
-
-const getWaveformWidth = (duration: number) =>
-  Math.min(4_800, Math.max(640, Math.round(duration * 6)));
+const initialPreviewState: PreviewState = {
+  waveform: null,
+  waveformStatus: "idle",
+  playbackUnavailable: false,
+  playing: false,
+  currentTime: 0,
+  mediaDuration: null,
+};
 
 const getStatusMessage = ({
   file,
   playbackUnavailable,
   waveformStatus,
-}: Pick<TrackWaveformPreviewProps, "file"> & Pick<PreviewState, "playbackUnavailable" | "waveformStatus">) =>
+}: Pick<TrackWaveformPreviewProps, "file"> &
+  Pick<PreviewState, "playbackUnavailable" | "waveformStatus">) =>
   !file
     ? "preview is available after this track finishes downloading"
     : playbackUnavailable
@@ -86,7 +104,8 @@ export default function TrackWaveformPreview({
   const mediaGenerationRef = useRef<number | null>(null);
   const dragRef = useRef({ active: false, startX: 0, moved: false });
   const [state, dispatch] = useReducer(previewReducer, initialPreviewState);
-  const { waveform, waveformStatus, playbackUnavailable, playing, currentTime, mediaDuration } = state;
+  const { waveform, waveformStatus, playbackUnavailable, playing, currentTime, mediaDuration } =
+    state;
   const currentMediaDuration = mediaDuration?.fileId === fileId ? mediaDuration.duration : 0;
   const duration =
     normalizePreviewDuration(currentMediaDuration) ||
@@ -94,7 +113,6 @@ export default function TrackWaveformPreview({
     normalizePreviewDuration(fallbackDuration);
   const normalizedCurrentTime = Math.min(duration, normalizePreviewDuration(currentTime));
   const progress = duration > 0 ? Math.min(1, normalizedCurrentTime / duration) : 0;
-  const waveformWidth = getWaveformWidth(duration);
   const canPlay = active && Boolean(file) && !playbackUnavailable;
   const canSeek = canPlay && duration > 0;
   const decodeDuration =
@@ -145,7 +163,8 @@ export default function TrackWaveformPreview({
     const generation = sourceGenerationRef.current;
     if (decodeDuration === 0) {
       const timeoutId = globalThis.setTimeout(() => {
-        if (sourceGenerationRef.current === generation) dispatch({ type: "waveformStatus", value: "unavailable" });
+        if (sourceGenerationRef.current === generation)
+          dispatch({ type: "waveformStatus", value: "unavailable" });
       }, METADATA_WAIT_TIMEOUT_MS);
       return () => globalThis.clearTimeout(timeoutId);
     }
@@ -227,7 +246,7 @@ export default function TrackWaveformPreview({
 
   return (
     <section
-      className="flex min-h-32 flex-1 flex-col justify-end gap-2 pt-1"
+      className="flex min-h-32 min-w-0 w-full flex-col justify-end gap-2 pt-1"
       aria-label={`preview ${title || file?.name || "selected track"}`}
       data-waveform-status={waveformStatus}
     >
@@ -237,27 +256,38 @@ export default function TrackWaveformPreview({
         preload="metadata"
         onLoadedMetadata={(event) =>
           mediaGenerationRef.current === sourceGenerationRef.current &&
-          dispatch({ type: "mediaDuration", value: {
-            fileId,
-            duration: normalizePreviewDuration(event.currentTarget.duration),
-          } })
+          dispatch({
+            type: "mediaDuration",
+            value: {
+              fileId,
+              duration: normalizePreviewDuration(event.currentTarget.duration),
+            },
+          })
         }
         onDurationChange={(event) =>
           mediaGenerationRef.current === sourceGenerationRef.current &&
-          dispatch({ type: "mediaDuration", value: {
-            fileId,
-            duration: normalizePreviewDuration(event.currentTarget.duration),
-          } })
+          dispatch({
+            type: "mediaDuration",
+            value: {
+              fileId,
+              duration: normalizePreviewDuration(event.currentTarget.duration),
+            },
+          })
         }
         onTimeUpdate={(event) => {
           if (mediaGenerationRef.current !== sourceGenerationRef.current) return;
-          dispatch({ type: "currentTime", value: normalizePreviewDuration(event.currentTarget.currentTime) });
+          dispatch({
+            type: "currentTime",
+            value: normalizePreviewDuration(event.currentTarget.currentTime),
+          });
         }}
         onPlay={() => {
-          if (mediaGenerationRef.current === sourceGenerationRef.current) dispatch({ type: "playing", value: true });
+          if (mediaGenerationRef.current === sourceGenerationRef.current)
+            dispatch({ type: "playing", value: true });
         }}
         onPause={() => {
-          if (mediaGenerationRef.current === sourceGenerationRef.current) dispatch({ type: "playing", value: false });
+          if (mediaGenerationRef.current === sourceGenerationRef.current)
+            dispatch({ type: "playing", value: false });
         }}
         onEnded={(event) => {
           if (mediaGenerationRef.current !== sourceGenerationRef.current) return;
@@ -288,10 +318,7 @@ export default function TrackWaveformPreview({
             <span>{formatPreviewTime(normalizedCurrentTime)}</span>
             <span>{formatPreviewTime(duration)}</span>
           </div>
-          <div
-            className="overflow-x-auto overscroll-x-contain rounded-md border bg-muted/15 focus-within:ring-2 focus-within:ring-ring/50"
-            data-waveform-scroller
-          >
+          <div className="min-w-0 w-full overflow-hidden" data-waveform-scroller>
             <div
               role="slider"
               tabIndex={canSeek ? 0 : -1}
@@ -324,25 +351,18 @@ export default function TrackWaveformPreview({
               onPointerCancel={() => {
                 dragRef.current.active = false;
               }}
-              className={`relative h-20 touch-pan-x select-none overflow-hidden outline-none motion-reduce:scroll-auto ${
+              className={`relative h-20 min-w-0 w-full touch-pan-x select-none overflow-hidden outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${
                 canSeek ? "cursor-pointer" : "cursor-not-allowed"
               }`}
-              style={{ width: waveformWidth }}
             >
               {waveform ? (
                 <>
                   <WaveformBars samples={waveform.samples} className="fill-muted-foreground/35" />
-                  <div
-                    className="pointer-events-none absolute inset-y-0 left-0 overflow-hidden"
-                    style={{ width: `${progress * 100}%` }}
-                    aria-hidden
-                  >
-                    <WaveformBars
-                      samples={waveform.samples}
-                      className="fill-primary"
-                      width={waveformWidth}
-                    />
-                  </div>
+                  <WaveformBars
+                    samples={waveform.samples}
+                    className="fill-primary"
+                    style={{ clipPath: `inset(0 ${100 - progress * 100}% 0 0)` }}
+                  />
                   <span
                     className="pointer-events-none absolute inset-y-1 w-px bg-primary motion-reduce:transition-none"
                     style={{ left: `${progress * 100}%` }}
@@ -373,20 +393,21 @@ export default function TrackWaveformPreview({
 function WaveformBars({
   samples,
   className,
-  width = "100%",
+  style,
 }: {
   samples: number[];
   className: string;
-  width?: number | string;
+  style?: CSSProperties;
 }) {
   return (
     <svg
       className={`pointer-events-none absolute inset-0 h-full ${className}`}
-      width={width}
+      width="100%"
       height="100%"
       viewBox={`0 0 ${samples.length * 3} 80`}
       preserveAspectRatio="none"
       aria-hidden
+      style={style}
     >
       {samples.map((sample, index) => {
         const height = Math.max(2, sample * 68);

--- a/src/features/editor/TrackWaveformPreview.tsx
+++ b/src/features/editor/TrackWaveformPreview.tsx
@@ -351,7 +351,7 @@ export default function TrackWaveformPreview({
               onPointerCancel={() => {
                 dragRef.current.active = false;
               }}
-              className={`relative h-20 min-w-0 w-full touch-pan-x select-none overflow-hidden outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${
+              className={`relative h-20 min-w-0 w-full touch-pan-x select-none overflow-hidden outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50 ${
                 canSeek ? "cursor-pointer" : "cursor-not-allowed"
               }`}
             >

--- a/src/features/editor/TrackWaveformPreview.tsx
+++ b/src/features/editor/TrackWaveformPreview.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import { Pause, Play } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { KeyboardEvent, PointerEvent } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  formatPreviewTime,
+  getSeekTime,
+  loadWaveformPreview,
+  normalizePreviewDuration,
+  type WaveformPreviewData,
+} from "@/features/editor/waveformPreview";
+
+interface TrackWaveformPreviewProps {
+  active: boolean;
+  file?: File;
+  fileId: string;
+  fallbackDuration: number;
+  title: string;
+}
+
+type WaveformStatus = "idle" | "loading" | "ready" | "unavailable";
+const METADATA_WAIT_TIMEOUT_MS = 5_000;
+
+const getWaveformWidth = (duration: number) =>
+  Math.min(4_800, Math.max(640, Math.round(duration * 6)));
+
+export default function TrackWaveformPreview({
+  active,
+  file,
+  fileId,
+  fallbackDuration,
+  title,
+}: TrackWaveformPreviewProps) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const dragRef = useRef({ active: false, startX: 0, moved: false });
+  const [waveform, setWaveform] = useState<WaveformPreviewData | null>(null);
+  const [waveformStatus, setWaveformStatus] = useState<WaveformStatus>("idle");
+  const [playbackUnavailable, setPlaybackUnavailable] = useState(false);
+  const [playing, setPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [mediaDuration, setMediaDuration] = useState<{ fileId: string; duration: number } | null>(
+    null,
+  );
+  const currentMediaDuration = mediaDuration?.fileId === fileId ? mediaDuration.duration : 0;
+  const duration =
+    normalizePreviewDuration(currentMediaDuration) ||
+    normalizePreviewDuration(waveform?.duration) ||
+    normalizePreviewDuration(fallbackDuration);
+  const normalizedCurrentTime = Math.min(duration, normalizePreviewDuration(currentTime));
+  const progress = duration > 0 ? Math.min(1, normalizedCurrentTime / duration) : 0;
+  const waveformWidth = getWaveformWidth(duration);
+  const canPlay = active && Boolean(file) && !playbackUnavailable;
+  const canSeek = canPlay && duration > 0;
+  const decodeDuration =
+    normalizePreviewDuration(fallbackDuration) || normalizePreviewDuration(currentMediaDuration);
+
+  useEffect(() => {
+    if (active) return;
+    const audio = audioRef.current;
+    audio?.pause();
+    setPlaying(false);
+  }, [active]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    setPlaying(false);
+    setCurrentTime(0);
+    setMediaDuration(null);
+    setPlaybackUnavailable(false);
+    setWaveform(null);
+    setWaveformStatus(file ? "loading" : "idle");
+
+    if (!file || !audio) {
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(file);
+    audio.currentTime = 0;
+    audio.src = objectUrl;
+    audio.load();
+    return () => {
+      audio.pause();
+      audio.removeAttribute("src");
+      audio.load();
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [file, fileId]);
+
+  useEffect(() => {
+    if (!file) return;
+    if (decodeDuration === 0) {
+      const timeoutId = globalThis.setTimeout(
+        () => setWaveformStatus("unavailable"),
+        METADATA_WAIT_TIMEOUT_MS,
+      );
+      return () => globalThis.clearTimeout(timeoutId);
+    }
+
+    const controller = new AbortController();
+    setWaveformStatus("loading");
+    void loadWaveformPreview(file, controller.signal, decodeDuration).then(
+      (preview) => {
+        if (controller.signal.aborted) return;
+        setWaveform(preview);
+        setWaveformStatus("ready");
+      },
+      (error: unknown) => {
+        if (
+          controller.signal.aborted ||
+          (error instanceof DOMException && error.name === "AbortError")
+        ) {
+          return;
+        }
+        setWaveformStatus("unavailable");
+      },
+    );
+
+    return () => {
+      controller.abort();
+    };
+  }, [decodeDuration, file, fileId]);
+
+  const seekTo = useCallback(
+    (time: number) => {
+      const audio = audioRef.current;
+      if (!audio || !canSeek) return;
+      const nextTime = Math.min(duration, Math.max(0, time));
+      audio.currentTime = nextTime;
+      setCurrentTime(nextTime);
+    },
+    [canSeek, duration],
+  );
+
+  const seekFromPointer = (event: PointerEvent<HTMLDivElement>) => {
+    if (!canSeek) return;
+    const bounds = event.currentTarget.getBoundingClientRect();
+    seekTo(getSeekTime(event.clientX, bounds.left, bounds.width, duration));
+  };
+
+  const togglePlayback = async () => {
+    const audio = audioRef.current;
+    if (!audio || !canPlay) return;
+    if (!audio.paused) {
+      audio.pause();
+      return;
+    }
+    try {
+      await audio.play();
+    } catch {
+      setPlaybackUnavailable(true);
+      setPlaying(false);
+    }
+  };
+
+  const handleWaveformKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!canPlay) return;
+    if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+      if (!canSeek) return;
+      event.preventDefault();
+      seekTo(currentTime + (event.key === "ArrowLeft" ? -5 : 5));
+    } else if (event.key === "Home" || event.key === "End") {
+      if (!canSeek) return;
+      event.preventDefault();
+      seekTo(event.key === "Home" ? 0 : duration);
+    } else if (event.key === " " || event.key === "Enter") {
+      event.preventDefault();
+      void togglePlayback();
+    }
+  };
+
+  const statusMessage = !file
+    ? "preview is available after this track finishes downloading"
+    : playbackUnavailable
+      ? "this audio format cannot be previewed here"
+      : waveformStatus === "loading"
+        ? "building waveform"
+        : waveformStatus === "unavailable"
+          ? "waveform unavailable — playback may still work"
+          : null;
+
+  return (
+    <section
+      className="flex min-h-32 flex-1 flex-col justify-end gap-2 pt-1"
+      aria-label={`preview ${title || file?.name || "selected track"}`}
+      data-waveform-status={waveformStatus}
+    >
+      <audio
+        ref={audioRef}
+        preload="metadata"
+        onLoadedMetadata={(event) =>
+          setMediaDuration({
+            fileId,
+            duration: normalizePreviewDuration(event.currentTarget.duration),
+          })
+        }
+        onDurationChange={(event) =>
+          setMediaDuration({
+            fileId,
+            duration: normalizePreviewDuration(event.currentTarget.duration),
+          })
+        }
+        onTimeUpdate={(event) =>
+          setCurrentTime(normalizePreviewDuration(event.currentTarget.currentTime))
+        }
+        onPlay={() => setPlaying(true)}
+        onPause={() => setPlaying(false)}
+        onEnded={(event) => {
+          event.currentTarget.currentTime = 0;
+          setPlaying(false);
+          setCurrentTime(0);
+        }}
+        onError={() => {
+          setPlaybackUnavailable(true);
+          if (decodeDuration === 0) setWaveformStatus("unavailable");
+        }}
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="size-10"
+          onClick={() => void togglePlayback()}
+          disabled={!canPlay}
+          aria-label={playing ? "pause preview" : "play preview"}
+        >
+          {playing ? <Pause className="size-4" /> : <Play className="size-4" />}
+        </Button>
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 flex items-center justify-between gap-3 font-mono text-[11px] tabular-nums text-muted-foreground">
+            <span>{formatPreviewTime(normalizedCurrentTime)}</span>
+            <span>{formatPreviewTime(duration)}</span>
+          </div>
+          <div
+            className="overflow-x-auto overscroll-x-contain rounded-md border bg-muted/15 focus-within:ring-2 focus-within:ring-ring/50"
+            data-waveform-scroller
+          >
+            <div
+              role="slider"
+              tabIndex={canSeek ? 0 : -1}
+              aria-label="track position"
+              aria-valuemin={0}
+              aria-valuemax={Math.max(0, Math.round(duration))}
+              aria-valuenow={Math.round(normalizedCurrentTime)}
+              aria-valuetext={`${formatPreviewTime(normalizedCurrentTime)} of ${formatPreviewTime(duration)}`}
+              aria-disabled={!canSeek}
+              onKeyDown={handleWaveformKeyDown}
+              onPointerDown={(event) => {
+                if (!canSeek) return;
+                dragRef.current = { active: true, startX: event.clientX, moved: false };
+                if (event.pointerType === "mouse") {
+                  event.currentTarget.setPointerCapture(event.pointerId);
+                  seekFromPointer(event);
+                }
+              }}
+              onPointerMove={(event) => {
+                if (!dragRef.current.active) return;
+                if (Math.abs(event.clientX - dragRef.current.startX) > 8) {
+                  dragRef.current.moved = true;
+                }
+                if (event.pointerType === "mouse") seekFromPointer(event);
+              }}
+              onPointerUp={(event) => {
+                if (event.pointerType !== "mouse" && !dragRef.current.moved) seekFromPointer(event);
+                dragRef.current.active = false;
+              }}
+              onPointerCancel={() => {
+                dragRef.current.active = false;
+              }}
+              className={`relative h-20 touch-pan-x select-none overflow-hidden outline-none motion-reduce:scroll-auto ${
+                canSeek ? "cursor-pointer" : "cursor-not-allowed"
+              }`}
+              style={{ width: waveformWidth }}
+            >
+              {waveform ? (
+                <>
+                  <WaveformBars samples={waveform.samples} className="fill-muted-foreground/35" />
+                  <div
+                    className="pointer-events-none absolute inset-y-0 left-0 overflow-hidden"
+                    style={{ width: `${progress * 100}%` }}
+                    aria-hidden
+                  >
+                    <WaveformBars
+                      samples={waveform.samples}
+                      className="fill-primary"
+                      width={waveformWidth}
+                    />
+                  </div>
+                  <span
+                    className="pointer-events-none absolute inset-y-1 w-px bg-primary motion-reduce:transition-none"
+                    style={{ left: `${progress * 100}%` }}
+                    aria-hidden
+                  />
+                </>
+              ) : (
+                <div
+                  className="absolute inset-0 flex items-center justify-center px-4 text-center text-xs text-muted-foreground"
+                  role="status"
+                >
+                  {statusMessage ?? "waveform preview"}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+      {statusMessage && waveform && (
+        <p className="text-xs text-muted-foreground" role="status">
+          {statusMessage}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function WaveformBars({
+  samples,
+  className,
+  width = "100%",
+}: {
+  samples: number[];
+  className: string;
+  width?: number | string;
+}) {
+  return (
+    <svg
+      className={`pointer-events-none absolute inset-0 h-full ${className}`}
+      width={width}
+      height="100%"
+      viewBox={`0 0 ${samples.length * 3} 80`}
+      preserveAspectRatio="none"
+      aria-hidden
+    >
+      {samples.map((sample, index) => {
+        const height = Math.max(2, sample * 68);
+        return (
+          <rect key={index} x={index * 3} y={(80 - height) / 2} width={2} height={height} rx={1} />
+        );
+      })}
+    </svg>
+  );
+}

--- a/src/features/editor/TrackWaveformPreview.tsx
+++ b/src/features/editor/TrackWaveformPreview.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Pause, Play } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { KeyboardEvent, PointerEvent } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -34,6 +34,8 @@ export default function TrackWaveformPreview({
   title,
 }: TrackWaveformPreviewProps) {
   const audioRef = useRef<HTMLAudioElement>(null);
+  const sourceGenerationRef = useRef(0);
+  const mediaGenerationRef = useRef<number | null>(null);
   const dragRef = useRef({ active: false, startX: 0, moved: false });
   const [waveform, setWaveform] = useState<WaveformPreviewData | null>(null);
   const [waveformStatus, setWaveformStatus] = useState<WaveformStatus>("idle");
@@ -56,31 +58,43 @@ export default function TrackWaveformPreview({
   const decodeDuration =
     normalizePreviewDuration(fallbackDuration) || normalizePreviewDuration(currentMediaDuration);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (active) return;
     const audio = audioRef.current;
     audio?.pause();
+    if (audio) audio.currentTime = 0;
     setPlaying(false);
+    setCurrentTime(0);
   }, [active]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    sourceGenerationRef.current += 1;
     const audio = audioRef.current;
+    audio?.pause();
+    if (audio) audio.currentTime = 0;
     setPlaying(false);
     setCurrentTime(0);
     setMediaDuration(null);
     setPlaybackUnavailable(false);
     setWaveform(null);
     setWaveformStatus(file ? "loading" : "idle");
+  }, [file, fileId]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
 
     if (!file || !audio) {
       return;
     }
 
     const objectUrl = URL.createObjectURL(file);
+    const generation = sourceGenerationRef.current;
+    mediaGenerationRef.current = generation;
     audio.currentTime = 0;
     audio.src = objectUrl;
     audio.load();
     return () => {
+      if (mediaGenerationRef.current === generation) mediaGenerationRef.current = null;
       audio.pause();
       audio.removeAttribute("src");
       audio.load();
@@ -90,11 +104,11 @@ export default function TrackWaveformPreview({
 
   useEffect(() => {
     if (!file) return;
+    const generation = sourceGenerationRef.current;
     if (decodeDuration === 0) {
-      const timeoutId = globalThis.setTimeout(
-        () => setWaveformStatus("unavailable"),
-        METADATA_WAIT_TIMEOUT_MS,
-      );
+      const timeoutId = globalThis.setTimeout(() => {
+        if (sourceGenerationRef.current === generation) setWaveformStatus("unavailable");
+      }, METADATA_WAIT_TIMEOUT_MS);
       return () => globalThis.clearTimeout(timeoutId);
     }
 
@@ -102,12 +116,13 @@ export default function TrackWaveformPreview({
     setWaveformStatus("loading");
     void loadWaveformPreview(file, controller.signal, decodeDuration).then(
       (preview) => {
-        if (controller.signal.aborted) return;
+        if (controller.signal.aborted || sourceGenerationRef.current !== generation) return;
         setWaveform(preview);
         setWaveformStatus("ready");
       },
       (error: unknown) => {
         if (
+          sourceGenerationRef.current !== generation ||
           controller.signal.aborted ||
           (error instanceof DOMException && error.name === "AbortError")
         ) {
@@ -190,28 +205,37 @@ export default function TrackWaveformPreview({
         ref={audioRef}
         preload="metadata"
         onLoadedMetadata={(event) =>
+          mediaGenerationRef.current === sourceGenerationRef.current &&
           setMediaDuration({
             fileId,
             duration: normalizePreviewDuration(event.currentTarget.duration),
           })
         }
         onDurationChange={(event) =>
+          mediaGenerationRef.current === sourceGenerationRef.current &&
           setMediaDuration({
             fileId,
             duration: normalizePreviewDuration(event.currentTarget.duration),
           })
         }
-        onTimeUpdate={(event) =>
-          setCurrentTime(normalizePreviewDuration(event.currentTarget.currentTime))
-        }
-        onPlay={() => setPlaying(true)}
-        onPause={() => setPlaying(false)}
+        onTimeUpdate={(event) => {
+          if (mediaGenerationRef.current !== sourceGenerationRef.current) return;
+          setCurrentTime(normalizePreviewDuration(event.currentTarget.currentTime));
+        }}
+        onPlay={() => {
+          if (mediaGenerationRef.current === sourceGenerationRef.current) setPlaying(true);
+        }}
+        onPause={() => {
+          if (mediaGenerationRef.current === sourceGenerationRef.current) setPlaying(false);
+        }}
         onEnded={(event) => {
+          if (mediaGenerationRef.current !== sourceGenerationRef.current) return;
           event.currentTarget.currentTime = 0;
           setPlaying(false);
           setCurrentTime(0);
         }}
         onError={() => {
+          if (mediaGenerationRef.current !== sourceGenerationRef.current) return;
           setPlaybackUnavailable(true);
           if (decodeDuration === 0) setWaveformStatus("unavailable");
         }}

--- a/src/features/editor/TrackWaveformPreview.tsx
+++ b/src/features/editor/TrackWaveformPreview.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Pause, Play } from "lucide-react";
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useReducer, useRef } from "react";
 import type { KeyboardEvent, PointerEvent } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,8 +23,56 @@ interface TrackWaveformPreviewProps {
 type WaveformStatus = "idle" | "loading" | "ready" | "unavailable";
 const METADATA_WAIT_TIMEOUT_MS = 5_000;
 
+interface PreviewState {
+  waveform: WaveformPreviewData | null;
+  waveformStatus: WaveformStatus;
+  playbackUnavailable: boolean;
+  playing: boolean;
+  currentTime: number;
+  mediaDuration: { fileId: string; duration: number } | null;
+}
+
+type PreviewAction =
+  | { type: "reset"; file?: File }
+  | { type: "playing"; value: boolean }
+  | { type: "currentTime"; value: number }
+  | { type: "mediaDuration"; value: PreviewState["mediaDuration"] }
+  | { type: "playbackUnavailable"; value: boolean }
+  | { type: "waveform"; value: WaveformPreviewData | null }
+  | { type: "waveformStatus"; value: WaveformStatus };
+
+const previewReducer = (state: PreviewState, action: PreviewAction): PreviewState => {
+  switch (action.type) {
+    case "reset":
+      return { waveform: null, waveformStatus: action.file ? "loading" : "idle", playbackUnavailable: false, playing: false, currentTime: 0, mediaDuration: null };
+    case "playing": return { ...state, playing: action.value };
+    case "currentTime": return { ...state, currentTime: action.value };
+    case "mediaDuration": return { ...state, mediaDuration: action.value };
+    case "playbackUnavailable": return { ...state, playbackUnavailable: action.value };
+    case "waveform": return { ...state, waveform: action.value };
+    case "waveformStatus": return { ...state, waveformStatus: action.value };
+  }
+};
+
+const initialPreviewState: PreviewState = { waveform: null, waveformStatus: "idle", playbackUnavailable: false, playing: false, currentTime: 0, mediaDuration: null };
+
 const getWaveformWidth = (duration: number) =>
   Math.min(4_800, Math.max(640, Math.round(duration * 6)));
+
+const getStatusMessage = ({
+  file,
+  playbackUnavailable,
+  waveformStatus,
+}: Pick<TrackWaveformPreviewProps, "file"> & Pick<PreviewState, "playbackUnavailable" | "waveformStatus">) =>
+  !file
+    ? "preview is available after this track finishes downloading"
+    : playbackUnavailable
+      ? "this audio format cannot be previewed here"
+      : waveformStatus === "loading"
+        ? "building waveform"
+        : waveformStatus === "unavailable"
+          ? "waveform unavailable — playback may still work"
+          : null;
 
 export default function TrackWaveformPreview({
   active,
@@ -37,14 +85,8 @@ export default function TrackWaveformPreview({
   const sourceGenerationRef = useRef(0);
   const mediaGenerationRef = useRef<number | null>(null);
   const dragRef = useRef({ active: false, startX: 0, moved: false });
-  const [waveform, setWaveform] = useState<WaveformPreviewData | null>(null);
-  const [waveformStatus, setWaveformStatus] = useState<WaveformStatus>("idle");
-  const [playbackUnavailable, setPlaybackUnavailable] = useState(false);
-  const [playing, setPlaying] = useState(false);
-  const [currentTime, setCurrentTime] = useState(0);
-  const [mediaDuration, setMediaDuration] = useState<{ fileId: string; duration: number } | null>(
-    null,
-  );
+  const [state, dispatch] = useReducer(previewReducer, initialPreviewState);
+  const { waveform, waveformStatus, playbackUnavailable, playing, currentTime, mediaDuration } = state;
   const currentMediaDuration = mediaDuration?.fileId === fileId ? mediaDuration.duration : 0;
   const duration =
     normalizePreviewDuration(currentMediaDuration) ||
@@ -63,8 +105,8 @@ export default function TrackWaveformPreview({
     const audio = audioRef.current;
     audio?.pause();
     if (audio) audio.currentTime = 0;
-    setPlaying(false);
-    setCurrentTime(0);
+    dispatch({ type: "playing", value: false });
+    dispatch({ type: "currentTime", value: 0 });
   }, [active]);
 
   useLayoutEffect(() => {
@@ -72,12 +114,7 @@ export default function TrackWaveformPreview({
     const audio = audioRef.current;
     audio?.pause();
     if (audio) audio.currentTime = 0;
-    setPlaying(false);
-    setCurrentTime(0);
-    setMediaDuration(null);
-    setPlaybackUnavailable(false);
-    setWaveform(null);
-    setWaveformStatus(file ? "loading" : "idle");
+    dispatch({ type: "reset", file });
   }, [file, fileId]);
 
   useEffect(() => {
@@ -87,6 +124,7 @@ export default function TrackWaveformPreview({
       return;
     }
 
+    // react-doctor-disable-next-line no-create-object-url-without-revoke -- the cleanup below revokes this exact URL before the source is replaced or unmounted.
     const objectUrl = URL.createObjectURL(file);
     const generation = sourceGenerationRef.current;
     mediaGenerationRef.current = generation;
@@ -107,18 +145,18 @@ export default function TrackWaveformPreview({
     const generation = sourceGenerationRef.current;
     if (decodeDuration === 0) {
       const timeoutId = globalThis.setTimeout(() => {
-        if (sourceGenerationRef.current === generation) setWaveformStatus("unavailable");
+        if (sourceGenerationRef.current === generation) dispatch({ type: "waveformStatus", value: "unavailable" });
       }, METADATA_WAIT_TIMEOUT_MS);
       return () => globalThis.clearTimeout(timeoutId);
     }
 
     const controller = new AbortController();
-    setWaveformStatus("loading");
+    dispatch({ type: "waveformStatus", value: "loading" });
     void loadWaveformPreview(file, controller.signal, decodeDuration).then(
       (preview) => {
         if (controller.signal.aborted || sourceGenerationRef.current !== generation) return;
-        setWaveform(preview);
-        setWaveformStatus("ready");
+        dispatch({ type: "waveform", value: preview });
+        dispatch({ type: "waveformStatus", value: "ready" });
       },
       (error: unknown) => {
         if (
@@ -128,7 +166,7 @@ export default function TrackWaveformPreview({
         ) {
           return;
         }
-        setWaveformStatus("unavailable");
+        dispatch({ type: "waveformStatus", value: "unavailable" });
       },
     );
 
@@ -143,7 +181,7 @@ export default function TrackWaveformPreview({
       if (!audio || !canSeek) return;
       const nextTime = Math.min(duration, Math.max(0, time));
       audio.currentTime = nextTime;
-      setCurrentTime(nextTime);
+      dispatch({ type: "currentTime", value: nextTime });
     },
     [canSeek, duration],
   );
@@ -164,8 +202,8 @@ export default function TrackWaveformPreview({
     try {
       await audio.play();
     } catch {
-      setPlaybackUnavailable(true);
-      setPlaying(false);
+      dispatch({ type: "playbackUnavailable", value: true });
+      dispatch({ type: "playing", value: false });
     }
   };
 
@@ -185,15 +223,7 @@ export default function TrackWaveformPreview({
     }
   };
 
-  const statusMessage = !file
-    ? "preview is available after this track finishes downloading"
-    : playbackUnavailable
-      ? "this audio format cannot be previewed here"
-      : waveformStatus === "loading"
-        ? "building waveform"
-        : waveformStatus === "unavailable"
-          ? "waveform unavailable — playback may still work"
-          : null;
+  const statusMessage = getStatusMessage({ file, playbackUnavailable, waveformStatus });
 
   return (
     <section
@@ -206,40 +236,42 @@ export default function TrackWaveformPreview({
         preload="metadata"
         onLoadedMetadata={(event) =>
           mediaGenerationRef.current === sourceGenerationRef.current &&
-          setMediaDuration({
+          dispatch({ type: "mediaDuration", value: {
             fileId,
             duration: normalizePreviewDuration(event.currentTarget.duration),
-          })
+          } })
         }
         onDurationChange={(event) =>
           mediaGenerationRef.current === sourceGenerationRef.current &&
-          setMediaDuration({
+          dispatch({ type: "mediaDuration", value: {
             fileId,
             duration: normalizePreviewDuration(event.currentTarget.duration),
-          })
+          } })
         }
         onTimeUpdate={(event) => {
           if (mediaGenerationRef.current !== sourceGenerationRef.current) return;
-          setCurrentTime(normalizePreviewDuration(event.currentTarget.currentTime));
+          dispatch({ type: "currentTime", value: normalizePreviewDuration(event.currentTarget.currentTime) });
         }}
         onPlay={() => {
-          if (mediaGenerationRef.current === sourceGenerationRef.current) setPlaying(true);
+          if (mediaGenerationRef.current === sourceGenerationRef.current) dispatch({ type: "playing", value: true });
         }}
         onPause={() => {
-          if (mediaGenerationRef.current === sourceGenerationRef.current) setPlaying(false);
+          if (mediaGenerationRef.current === sourceGenerationRef.current) dispatch({ type: "playing", value: false });
         }}
         onEnded={(event) => {
           if (mediaGenerationRef.current !== sourceGenerationRef.current) return;
           event.currentTarget.currentTime = 0;
-          setPlaying(false);
-          setCurrentTime(0);
+          dispatch({ type: "playing", value: false });
+          dispatch({ type: "currentTime", value: 0 });
         }}
         onError={() => {
           if (mediaGenerationRef.current !== sourceGenerationRef.current) return;
-          setPlaybackUnavailable(true);
-          if (decodeDuration === 0) setWaveformStatus("unavailable");
+          dispatch({ type: "playbackUnavailable", value: true });
+          if (decodeDuration === 0) dispatch({ type: "waveformStatus", value: "unavailable" });
         }}
-      />
+      >
+        <track kind="captions" label="No spoken content" />
+      </audio>
       <div className="flex items-center gap-2">
         <Button
           type="button"

--- a/src/features/editor/waveformPreview.ts
+++ b/src/features/editor/waveformPreview.ts
@@ -1,0 +1,142 @@
+export const MAX_WAVEFORM_SAMPLES = 320;
+export const MAX_WAVEFORM_DECODE_BYTES = 96 * 1024 * 1024;
+export const MAX_DECODED_PCM_BYTES = 256 * 1024 * 1024;
+
+const CONSERVATIVE_SAMPLE_RATE = 48_000;
+const CONSERVATIVE_CHANNEL_COUNT = 2;
+const PCM_BYTES_PER_SAMPLE = Float32Array.BYTES_PER_ELEMENT;
+
+export interface WaveformPreviewData {
+  duration: number;
+  samples: number[];
+}
+
+type DecodedAudio = Pick<
+  AudioBuffer,
+  "duration" | "getChannelData" | "length" | "numberOfChannels"
+>;
+
+const waveformCache = new WeakMap<File, WaveformPreviewData>();
+let decodeQueue: Promise<void> = Promise.resolve();
+
+const canceled = () => new DOMException("waveform load canceled", "AbortError");
+
+const throwIfCanceled = (signal: AbortSignal) => {
+  if (signal.aborted) throw canceled();
+};
+
+export const normalizePreviewDuration = (duration: number | null | undefined) =>
+  Number.isFinite(duration) && Number(duration) > 0 ? Number(duration) : 0;
+
+export const estimateDecodedPcmBytes = (
+  duration: number,
+  sampleRate = CONSERVATIVE_SAMPLE_RATE,
+  channelCount = CONSERVATIVE_CHANNEL_COUNT,
+) => normalizePreviewDuration(duration) * sampleRate * channelCount * PCM_BYTES_PER_SAMPLE;
+
+const enqueueDecode = <Result>(signal: AbortSignal, task: () => Promise<Result>) => {
+  const result = decodeQueue.then(async () => {
+    throwIfCanceled(signal);
+    return task();
+  });
+  decodeQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+};
+
+export const formatPreviewTime = (seconds: number) => {
+  const safeSeconds = Number.isFinite(seconds) ? Math.max(0, Math.floor(seconds)) : 0;
+  const minutes = Math.floor(safeSeconds / 60);
+  const remainingSeconds = safeSeconds % 60;
+  return `${minutes}:${String(remainingSeconds).padStart(2, "0")}`;
+};
+
+export const getSeekTime = (clientX: number, left: number, width: number, duration: number) => {
+  const safeDuration = normalizePreviewDuration(duration);
+  if (width <= 0 || safeDuration === 0) return 0;
+  const ratio = Math.min(1, Math.max(0, (clientX - left) / width));
+  return ratio * safeDuration;
+};
+
+export const downsampleWaveform = (audio: DecodedAudio, sampleCount = MAX_WAVEFORM_SAMPLES) => {
+  const boundedSampleCount = Math.max(1, Math.min(MAX_WAVEFORM_SAMPLES, sampleCount));
+  if (audio.length === 0 || audio.numberOfChannels === 0) {
+    return Array.from({ length: boundedSampleCount }, () => 0);
+  }
+
+  const samples = Array.from({ length: boundedSampleCount }, () => 0);
+  const framesPerSample = audio.length / boundedSampleCount;
+
+  for (let sampleIndex = 0; sampleIndex < boundedSampleCount; sampleIndex += 1) {
+    const start = Math.floor(sampleIndex * framesPerSample);
+    const end = Math.max(start + 1, Math.floor((sampleIndex + 1) * framesPerSample));
+    let peak = 0;
+
+    for (let channelIndex = 0; channelIndex < audio.numberOfChannels; channelIndex += 1) {
+      const channel = audio.getChannelData(channelIndex);
+      for (let frameIndex = start; frameIndex < Math.min(end, channel.length); frameIndex += 1) {
+        peak = Math.max(peak, Math.abs(channel[frameIndex] ?? 0));
+      }
+    }
+    samples[sampleIndex] = peak;
+  }
+
+  const loudestSample = Math.max(...samples, 0);
+  if (loudestSample === 0) return samples;
+  return samples.map((sample) => sample / loudestSample);
+};
+
+const decodeWaveform = async (
+  file: File,
+  signal: AbortSignal,
+  durationHint: number,
+): Promise<WaveformPreviewData> => {
+  if (file.size > MAX_WAVEFORM_DECODE_BYTES) throw new Error("audio is too large to decode safely");
+  const safeDurationHint = normalizePreviewDuration(durationHint);
+  if (safeDurationHint === 0) throw new Error("audio duration is required for safe decoding");
+  if (estimateDecodedPcmBytes(safeDurationHint) > MAX_DECODED_PCM_BYTES) {
+    throw new Error("audio duration exceeds the waveform memory budget");
+  }
+  if (typeof AudioContext === "undefined") throw new Error("audio decoding is unavailable");
+
+  const bytes = await file.arrayBuffer();
+  throwIfCanceled(signal);
+  const context = new AudioContext();
+  try {
+    // Web Audio cannot cancel decodeAudioData. The serialized queue keeps this bounded
+    // context exclusive; cancellation only discards its result after the decode settles.
+    const decodedAudio = await context.decodeAudioData(bytes);
+    throwIfCanceled(signal);
+    const decodedBytes = decodedAudio.length * decodedAudio.numberOfChannels * PCM_BYTES_PER_SAMPLE;
+    if (decodedBytes > MAX_DECODED_PCM_BYTES) {
+      throw new Error("decoded audio exceeds the waveform memory budget");
+    }
+    return {
+      duration: normalizePreviewDuration(decodedAudio.duration),
+      samples: downsampleWaveform(decodedAudio),
+    };
+  } finally {
+    await context.close().catch(() => undefined);
+  }
+};
+
+export const loadWaveformPreview = async (file: File, signal: AbortSignal, durationHint = 0) => {
+  throwIfCanceled(signal);
+  const cached = waveformCache.get(file);
+  if (cached) return cached;
+  if (normalizePreviewDuration(durationHint) === 0) {
+    throw new Error("audio duration is required for safe decoding");
+  }
+
+  return enqueueDecode(signal, async () => {
+    throwIfCanceled(signal);
+    const queuedCache = waveformCache.get(file);
+    if (queuedCache) return queuedCache;
+    const preview = await decodeWaveform(file, signal, durationHint);
+    throwIfCanceled(signal);
+    waveformCache.set(file, preview);
+    return preview;
+  });
+};

--- a/src/features/workspace/audioTagger.tsx
+++ b/src/features/workspace/audioTagger.tsx
@@ -27,6 +27,7 @@ import { useTrackEditorSession } from "@/features/editor/useTrackEditorSession";
 import type { AppSettings } from "@/features/library/types";
 import { useMobileWorkspaceNavigation } from "@/features/workspace/useMobileWorkspaceNavigation";
 import { useDrawerSwipe } from "@/features/workspace/drawerSwipe";
+import { isTrackPreviewActive } from "@/features/workspace/trackPreviewVisibility";
 
 export default function AudioTagger() {
   const library = useLibraryStore();
@@ -107,6 +108,11 @@ export default function AudioTagger() {
     : mobileNavigation.drawerOpen
       ? "drawer"
       : "hidden";
+  const previewActive = isTrackPreviewActive({
+    activeView,
+    isMobile: mobileNavigation.isMobile,
+    drawerOpen: mobileNavigation.drawerOpen,
+  });
   const sidebarProps = {
     ...workspace.sidebarProps,
     onSelectFile: (...args: Parameters<typeof workspace.sidebarProps.onSelectFile>) => {
@@ -226,6 +232,7 @@ export default function AudioTagger() {
                     }`}
                   >
                     <TrackMetadataEditor
+                      previewActive={previewActive}
                       selectedFile={editor.selectedFile}
                       selectedFileId={selectedFileId}
                       register={editor.form.register}

--- a/src/features/workspace/trackPreviewVisibility.ts
+++ b/src/features/workspace/trackPreviewVisibility.ts
@@ -1,0 +1,9 @@
+export const isTrackPreviewActive = ({
+  activeView,
+  isMobile,
+  drawerOpen,
+}: {
+  activeView: "editor" | "settings";
+  isMobile: boolean;
+  drawerOpen: boolean;
+}) => activeView === "editor" && (!isMobile || !drawerOpen);

--- a/tests/e2e/waveform-preview.spec.ts
+++ b/tests/e2e/waveform-preview.spec.ts
@@ -1,0 +1,162 @@
+import { Buffer } from "node:buffer";
+import { expect, test } from "@playwright/test";
+
+const previewUpload = (name = "waveform-track.mp3") => {
+  const bytes = new Uint8Array(834);
+  bytes.set([0xff, 0xfb, 0x90, 0x00], 0);
+  bytes.set([0xff, 0xfb, 0x90, 0x00], 417);
+  return {
+    name,
+    mimeType: "audio/mpeg",
+    buffer: Buffer.from(bytes),
+  };
+};
+
+const installPlayablePreview = async (page: import("@playwright/test").Page) => {
+  await page.addInitScript(() => {
+    type TestMedia = { dispatchEvent: (event: unknown) => boolean };
+    const browser = globalThis as unknown as {
+      Event: new (type: string) => unknown;
+      HTMLMediaElement: { prototype: TestMedia & Record<string, unknown> };
+    };
+    const playback = new WeakMap<object, { currentTime: number; paused: boolean }>();
+    const stateFor = (media: object) => {
+      const existing = playback.get(media);
+      if (existing) return existing;
+      const created = { currentTime: 0, paused: true };
+      playback.set(media, created);
+      return created;
+    };
+    Object.defineProperties(browser.HTMLMediaElement.prototype, {
+      currentTime: {
+        configurable: true,
+        get() {
+          return stateFor(this).currentTime;
+        },
+        set(value: number) {
+          stateFor(this).currentTime = value;
+        },
+      },
+      duration: { configurable: true, get: () => 120 },
+      paused: {
+        configurable: true,
+        get() {
+          return stateFor(this).paused;
+        },
+      },
+    });
+    browser.HTMLMediaElement.prototype.load = function (this: TestMedia) {
+      stateFor(this).currentTime = 0;
+      queueMicrotask(() => this.dispatchEvent(new browser.Event("loadedmetadata")));
+    };
+    browser.HTMLMediaElement.prototype.play = function (this: TestMedia) {
+      stateFor(this).paused = false;
+      this.dispatchEvent(new browser.Event("play"));
+      return Promise.resolve();
+    };
+    browser.HTMLMediaElement.prototype.pause = function (this: TestMedia) {
+      stateFor(this).paused = true;
+      this.dispatchEvent(new browser.Event("pause"));
+    };
+    class PlayableAudioContext {
+      decodeAudioData() {
+        return Promise.resolve({
+          duration: 120,
+          length: 4,
+          numberOfChannels: 1,
+          getChannelData: () => new Float32Array([0, 0.5, 1, 0.5]),
+        });
+      }
+
+      close() {
+        return Promise.resolve();
+      }
+    }
+    Object.defineProperty(globalThis, "AudioContext", {
+      configurable: true,
+      value: PlayableAudioContext,
+    });
+  });
+};
+
+const rejectWaveformDecoding = async (page: import("@playwright/test").Page) => {
+  await page.addInitScript(() => {
+    class UnsupportedAudioContext {
+      decodeAudioData() {
+        return Promise.reject(new Error("unsupported test audio"));
+      }
+
+      close() {
+        return Promise.resolve();
+      }
+    }
+    Object.defineProperty(globalThis, "AudioContext", {
+      configurable: true,
+      value: UnsupportedAudioContext,
+    });
+  });
+};
+
+test("keeps metadata editing available when waveform decoding is unsupported", async ({ page }) => {
+  await rejectWaveformDecoding(page);
+  await page.goto("/");
+  await page.locator('input[type="file"]').setInputFiles(previewUpload());
+
+  const preview = page.getByRole("region", { name: /preview waveform-track/i });
+  await expect(preview).toBeVisible();
+  await expect(preview).toHaveAttribute("data-waveform-status", "unavailable");
+  await expect(preview.getByText(/waveform unavailable/i)).toBeVisible();
+
+  const title = page.getByLabel("title:");
+  await title.fill("still editable");
+  await expect(title).toHaveValue("still editable");
+  await expect(page.getByRole("button", { name: "download track" })).toBeEnabled();
+});
+
+test("plays, seeks, and horizontally pans without blocking editor interaction", async ({
+  page,
+}) => {
+  await installPlayablePreview(page);
+  await page.setViewportSize({ width: 900, height: 700 });
+  await page.goto("/");
+  await page.locator('input[type="file"]').setInputFiles(previewUpload());
+
+  const preview = page.getByRole("region", { name: /preview waveform-track/i });
+  await expect(preview).toHaveAttribute("data-waveform-status", "ready");
+  await preview.getByRole("button", { name: "play preview" }).click();
+  await expect(preview.getByRole("button", { name: "pause preview" })).toBeVisible();
+  await preview.getByRole("button", { name: "pause preview" }).click();
+  await expect(preview.getByRole("button", { name: "play preview" })).toBeVisible();
+
+  const slider = preview.getByRole("slider", { name: "track position" });
+  await slider.focus();
+  await page.keyboard.press("ArrowRight");
+  await expect(slider).toHaveAttribute("aria-valuenow", "5");
+
+  const bounds = await slider.boundingBox();
+  if (!bounds) throw new Error("waveform slider has no bounds");
+  await page.mouse.click(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);
+  await expect(slider).toHaveAttribute("aria-valuenow", "60");
+  await slider.dispatchEvent("pointerdown", {
+    clientX: bounds.x + bounds.width / 4,
+    pointerId: 3,
+    pointerType: "touch",
+  });
+  await slider.dispatchEvent("pointerup", {
+    clientX: bounds.x + bounds.width / 4,
+    pointerId: 3,
+    pointerType: "touch",
+  });
+  await expect(slider).toHaveAttribute("aria-valuenow", "30");
+
+  const scroller = page.locator("[data-waveform-scroller]");
+  await expect(scroller).toBeVisible();
+  const scrollLeft = await scroller.evaluate((element) => {
+    element.scrollLeft = 120;
+    return element.scrollLeft;
+  });
+  expect(scrollLeft).toBeGreaterThan(0);
+
+  await page.getByLabel("title:").fill("transport remains editable");
+  await expect(page.getByLabel("title:")).toHaveValue("transport remains editable");
+});

--- a/tests/e2e/waveform-preview.spec.ts
+++ b/tests/e2e/waveform-preview.spec.ts
@@ -113,11 +113,11 @@ test("keeps metadata editing available when waveform decoding is unsupported", a
   await expect(page.getByRole("button", { name: "download track" })).toBeEnabled();
 });
 
-test("plays, seeks, and horizontally pans without blocking editor interaction", async ({
+test("plays and seeks within the responsive waveform without widening the mobile editor", async ({
   page,
 }) => {
   await installPlayablePreview(page);
-  await page.setViewportSize({ width: 900, height: 700 });
+  await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");
   await page.locator('input[type="file"]').setInputFiles(previewUpload());
 
@@ -151,11 +151,21 @@ test("plays, seeks, and horizontally pans without blocking editor interaction", 
 
   const scroller = page.locator("[data-waveform-scroller]");
   await expect(scroller).toBeVisible();
-  const scrollLeft = await scroller.evaluate((element) => {
-    element.scrollLeft = 120;
-    return element.scrollLeft;
+  const dimensions = await scroller.evaluate((element) => {
+    const slider = element.querySelector('[role="slider"]');
+    if (!slider) throw new Error("waveform slider missing");
+    return {
+      scrollerOverflows: element.scrollWidth > element.clientWidth,
+      sliderWidth: slider.getBoundingClientRect().width,
+      scrollerWidth: element.getBoundingClientRect().width,
+    };
   });
-  expect(scrollLeft).toBeGreaterThan(0);
+  const editorOverflows = await page
+    .locator("html")
+    .evaluate((element) => element.scrollWidth > element.clientWidth);
+  expect(editorOverflows).toBe(false);
+  expect(dimensions.scrollerOverflows).toBe(false);
+  expect(dimensions.sliderWidth).toBeCloseTo(dimensions.scrollerWidth, 0);
 
   await page.getByLabel("title:").fill("transport remains editable");
   await expect(page.getByLabel("title:")).toHaveValue("transport remains editable");

--- a/tests/unit/features/editor/TrackWaveformPreview.test.tsx
+++ b/tests/unit/features/editor/TrackWaveformPreview.test.tsx
@@ -32,6 +32,7 @@ describe("track waveform transport", () => {
     expect(scroller.props.className).not.toContain("border");
     expect(scroller.props.className).not.toContain("bg-");
     expect(slider.props.className).toContain("w-full");
+    expect(slider.props.className).toContain("focus-visible:ring-inset");
     expect(slider.props.style).toBeUndefined();
     act(() => renderer!.unmount());
   });

--- a/tests/unit/features/editor/TrackWaveformPreview.test.tsx
+++ b/tests/unit/features/editor/TrackWaveformPreview.test.tsx
@@ -11,6 +11,18 @@ afterEach(() => {
 });
 
 describe("track waveform transport", () => {
+  it("does not fabricate caption tracks for user-provided music", () => {
+    let renderer: ReactTestRenderer;
+    act(() => {
+      renderer = create(
+        <TrackWaveformPreview file={undefined} fileId="" title="" fallbackDuration={0} active />,
+      );
+    });
+
+    expect(renderer!.root.findAllByType("track")).toHaveLength(0);
+    act(() => renderer!.unmount());
+  });
+
   it("plays, seeks by pointer and keyboard, and cleans up without autoplaying a replacement", async () => {
     const createdUrls: string[] = [];
     const revokedUrls: string[] = [];

--- a/tests/unit/features/editor/TrackWaveformPreview.test.tsx
+++ b/tests/unit/features/editor/TrackWaveformPreview.test.tsx
@@ -20,6 +20,19 @@ describe("track waveform transport", () => {
     });
 
     expect(renderer!.root.findAllByType("track")).toHaveLength(0);
+    const waveform = renderer!.root.findByType("section");
+    const scroller = renderer!.root.findByProps({ "data-waveform-scroller": true });
+    const slider = renderer!.root.findByProps({ role: "slider" });
+
+    expect(waveform.props.className).toContain("min-w-0");
+    expect(waveform.props.className).toContain("w-full");
+    expect(scroller.props.className).toContain("min-w-0");
+    expect(scroller.props.className).toContain("w-full");
+    expect(scroller.props.className).toContain("overflow-hidden");
+    expect(scroller.props.className).not.toContain("border");
+    expect(scroller.props.className).not.toContain("bg-");
+    expect(slider.props.className).toContain("w-full");
+    expect(slider.props.style).toBeUndefined();
     act(() => renderer!.unmount());
   });
 

--- a/tests/unit/features/editor/TrackWaveformPreview.test.tsx
+++ b/tests/unit/features/editor/TrackWaveformPreview.test.tsx
@@ -1,0 +1,362 @@
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import TrackWaveformPreview from "@/features/editor/TrackWaveformPreview";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("track waveform transport", () => {
+  it("plays, seeks by pointer and keyboard, and cleans up without autoplaying a replacement", async () => {
+    const createdUrls: string[] = [];
+    const revokedUrls: string[] = [];
+    vi.spyOn(URL, "createObjectURL").mockImplementation(() => {
+      const url = `blob:preview-${createdUrls.length + 1}`;
+      createdUrls.push(url);
+      return url;
+    });
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation((url) => revokedUrls.push(url));
+    class TestAudioContext {
+      async decodeAudioData() {
+        return {
+          duration: 120,
+          length: 4,
+          numberOfChannels: 1,
+          getChannelData: () => new Float32Array([0, 0.5, 1, 0.5]),
+        };
+      }
+
+      async close() {}
+    }
+    vi.stubGlobal("AudioContext", TestAudioContext);
+
+    const audio = {
+      currentTime: 0,
+      duration: 120,
+      paused: true,
+      src: "",
+      load: vi.fn(),
+      pause: vi.fn(() => {
+        audio.paused = true;
+      }),
+      play: vi.fn(async () => {
+        audio.paused = false;
+      }),
+      removeAttribute: vi.fn(() => {
+        audio.src = "";
+      }),
+    };
+    const firstFile = new File(["first"], "first.mp3", { type: "audio/mpeg" });
+    const secondFile = new File(["second"], "second.mp3", { type: "audio/mpeg" });
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <TrackWaveformPreview
+          active
+          file={firstFile}
+          fileId="first"
+          fallbackDuration={120}
+          title="first"
+        />,
+        { createNodeMock: (element) => (element.type === "audio" ? audio : null) },
+      );
+    });
+
+    const getAudioElement = () => renderer!.root.findByType("audio");
+    const getSlider = () => renderer!.root.findByProps({ role: "slider" });
+    const getPlayButton = () => renderer!.root.findByProps({ "aria-label": "play preview" });
+
+    await act(async () => {
+      await getPlayButton().props.onClick();
+      getAudioElement().props.onPlay();
+    });
+    expect(audio.play).toHaveBeenCalledOnce();
+    expect(renderer!.root.findByProps({ "aria-label": "pause preview" })).toBeDefined();
+
+    act(() => {
+      getSlider().props.onPointerDown({
+        clientX: 150,
+        pointerId: 1,
+        pointerType: "mouse",
+        currentTarget: {
+          getBoundingClientRect: () => ({ left: 100, width: 200 }),
+          setPointerCapture: vi.fn(),
+        },
+      });
+    });
+    expect(audio.currentTime).toBe(30);
+
+    act(() => {
+      getSlider().props.onKeyDown({ key: "ArrowRight", preventDefault: vi.fn() });
+    });
+    expect(audio.currentTime).toBe(35);
+
+    act(() => {
+      getSlider().props.onPointerDown({
+        clientX: 100,
+        pointerId: 2,
+        pointerType: "touch",
+        currentTarget: { getBoundingClientRect: () => ({ left: 100, width: 200 }) },
+      });
+      getSlider().props.onPointerUp({
+        clientX: 200,
+        pointerType: "touch",
+        currentTarget: { getBoundingClientRect: () => ({ left: 100, width: 200 }) },
+      });
+    });
+    expect(audio.currentTime).toBe(60);
+
+    await act(async () => {
+      renderer!.root.findByProps({ "aria-label": "pause preview" }).props.onClick();
+      getAudioElement().props.onPause();
+    });
+    expect(audio.pause).toHaveBeenCalled();
+
+    await act(async () => {
+      renderer!.update(
+        <TrackWaveformPreview
+          active
+          file={secondFile}
+          fileId="second"
+          fallbackDuration={90}
+          title="second"
+        />,
+      );
+    });
+    expect(audio.play).toHaveBeenCalledOnce();
+    expect(audio.currentTime).toBe(0);
+    expect(revokedUrls).toContain("blob:preview-1");
+    expect(renderer!.root.findByProps({ "aria-label": "play preview" })).toBeDefined();
+
+    act(() => renderer!.unmount());
+    expect(revokedUrls).toEqual(["blob:preview-1", "blob:preview-2"]);
+  });
+
+  it("blocks every seek path while the preview is inactive", async () => {
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:inactive");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    const audio = {
+      currentTime: 12,
+      paused: true,
+      src: "",
+      load: vi.fn(),
+      pause: vi.fn(),
+      play: vi.fn(),
+      removeAttribute: vi.fn(),
+    };
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <TrackWaveformPreview
+          active={false}
+          file={new File(["audio"], "inactive.mp3")}
+          fileId="inactive"
+          fallbackDuration={120}
+          title="inactive"
+        />,
+        { createNodeMock: (element) => (element.type === "audio" ? audio : null) },
+      );
+    });
+    const slider = renderer!.root.findByProps({ role: "slider" });
+    expect(slider.props["aria-disabled"]).toBe(true);
+    expect(slider.props.className).toContain("cursor-not-allowed");
+    audio.currentTime = 12;
+
+    act(() => {
+      slider.props.onPointerDown({ clientX: 150, pointerType: "mouse" });
+      slider.props.onKeyDown({ key: "ArrowRight", preventDefault: vi.fn() });
+    });
+    expect(audio.currentTime).toBe(12);
+    expect(audio.play).not.toHaveBeenCalled();
+    act(() => renderer!.unmount());
+  });
+
+  it("pauses and resets its play state as soon as an active preview becomes inactive", async () => {
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:deactivated");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    class TestAudioContext {
+      async decodeAudioData() {
+        return {
+          duration: 120,
+          length: 1,
+          numberOfChannels: 1,
+          getChannelData: () => new Float32Array([1]),
+        };
+      }
+
+      async close() {}
+    }
+    vi.stubGlobal("AudioContext", TestAudioContext);
+    const audio = {
+      currentTime: 0,
+      paused: true,
+      src: "",
+      load: vi.fn(),
+      pause: vi.fn(() => {
+        audio.paused = true;
+      }),
+      play: vi.fn(async () => {
+        audio.paused = false;
+      }),
+      removeAttribute: vi.fn(),
+    };
+    const file = new File(["audio"], "deactivated.mp3");
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <TrackWaveformPreview
+          active
+          file={file}
+          fileId="deactivated"
+          fallbackDuration={120}
+          title="deactivated"
+        />,
+        { createNodeMock: (element) => (element.type === "audio" ? audio : null) },
+      );
+    });
+    await act(async () => {
+      await renderer!.root.findByProps({ "aria-label": "play preview" }).props.onClick();
+      renderer!.root.findByType("audio").props.onPlay();
+    });
+    expect(renderer!.root.findByProps({ "aria-label": "pause preview" })).toBeDefined();
+
+    await act(async () => {
+      renderer!.update(
+        <TrackWaveformPreview
+          active={false}
+          file={file}
+          fileId="deactivated"
+          fallbackDuration={120}
+          title="deactivated"
+        />,
+      );
+    });
+    expect(audio.pause).toHaveBeenCalled();
+    expect(renderer!.root.findByProps({ "aria-label": "play preview" })).toBeDefined();
+    expect(renderer!.root.findByProps({ role: "slider" }).props["aria-disabled"]).toBe(true);
+    act(() => renderer!.unmount());
+  });
+
+  it("marks missing media duration unavailable without constructing a decoder", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:unknown-duration");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    const construct = vi.fn();
+    class TestAudioContext {
+      constructor() {
+        construct();
+      }
+    }
+    vi.stubGlobal("AudioContext", TestAudioContext);
+    const audio = {
+      currentTime: 0,
+      paused: true,
+      src: "",
+      load: vi.fn(),
+      pause: vi.fn(),
+      play: vi.fn(),
+      removeAttribute: vi.fn(),
+    };
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <TrackWaveformPreview
+          active
+          file={new File(["audio"], "unknown-duration.mp3")}
+          fileId="unknown-duration"
+          fallbackDuration={0}
+          title="unknown duration"
+        />,
+        { createNodeMock: (element) => (element.type === "audio" ? audio : null) },
+      );
+    });
+    expect(renderer!.root.findByType("section").props["data-waveform-status"]).toBe("loading");
+    expect(construct).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(renderer!.root.findByType("section").props["data-waveform-status"]).toBe("unavailable");
+    expect(construct).not.toHaveBeenCalled();
+    act(() => renderer!.unmount());
+  });
+
+  it("never carries a known duration into a new unknown-duration file", async () => {
+    vi.spyOn(URL, "createObjectURL").mockImplementation((file) => `blob:${(file as File).name}`);
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    const construct = vi.fn();
+    class TestAudioContext {
+      constructor() {
+        construct();
+      }
+
+      async decodeAudioData() {
+        return {
+          duration: 60,
+          length: 1,
+          numberOfChannels: 1,
+          getChannelData: () => new Float32Array([1]),
+        };
+      }
+
+      async close() {}
+    }
+    vi.stubGlobal("AudioContext", TestAudioContext);
+    const audio = {
+      currentTime: 0,
+      paused: true,
+      src: "",
+      load: vi.fn(),
+      pause: vi.fn(),
+      play: vi.fn(),
+      removeAttribute: vi.fn(),
+    };
+    const knownFile = new File(["known"], "known.mp3");
+    const unknownFile = new File(["unknown"], "unknown.mp3");
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <TrackWaveformPreview
+          active
+          file={knownFile}
+          fileId="known"
+          fallbackDuration={60}
+          title="known"
+        />,
+        { createNodeMock: (element) => (element.type === "audio" ? audio : null) },
+      );
+    });
+    expect(construct).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      renderer!.root.findByType("audio").props.onLoadedMetadata({
+        currentTarget: { duration: 60 },
+      });
+    });
+    expect(construct).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer!.update(
+        <TrackWaveformPreview
+          active
+          file={unknownFile}
+          fileId="unknown"
+          fallbackDuration={0}
+          title="unknown"
+        />,
+      );
+    });
+    expect(construct).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer!.root.findByType("audio").props.onLoadedMetadata({
+        currentTarget: { duration: 60 },
+      });
+    });
+    expect(construct).toHaveBeenCalledTimes(2);
+    act(() => renderer!.unmount());
+  });
+});

--- a/tests/unit/features/editor/TrackWaveformPreview.test.tsx
+++ b/tests/unit/features/editor/TrackWaveformPreview.test.tsx
@@ -223,6 +223,7 @@ describe("track waveform transport", () => {
       renderer!.root.findByType("audio").props.onPlay();
     });
     expect(renderer!.root.findByProps({ "aria-label": "pause preview" })).toBeDefined();
+    audio.currentTime = 42;
 
     await act(async () => {
       renderer!.update(
@@ -236,8 +237,185 @@ describe("track waveform transport", () => {
       );
     });
     expect(audio.pause).toHaveBeenCalled();
+    expect(audio.currentTime).toBe(0);
     expect(renderer!.root.findByProps({ "aria-label": "play preview" })).toBeDefined();
     expect(renderer!.root.findByProps({ role: "slider" }).props["aria-disabled"]).toBe(true);
+    act(() => renderer!.unmount());
+  });
+
+  it("resets an active A to B switch in layout phase before passive source cleanup", async () => {
+    const phases: string[] = [];
+    vi.spyOn(URL, "createObjectURL").mockImplementation((file) => `blob:${(file as File).name}`);
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => phases.push("revoke"));
+    let decodeCount = 0;
+    let resolveSecondDecode!: () => void;
+    class TestAudioContext {
+      decodeAudioData() {
+        decodeCount += 1;
+        const decoded = {
+          duration: 60,
+          length: 1,
+          numberOfChannels: 1,
+          getChannelData: () => new Float32Array([1]),
+        };
+        if (decodeCount === 1) return Promise.resolve(decoded);
+        return new Promise<typeof decoded>((resolve) => {
+          resolveSecondDecode = () => resolve(decoded);
+        });
+      }
+
+      async close() {}
+    }
+    vi.stubGlobal("AudioContext", TestAudioContext);
+    const audio = {
+      currentTime: 0,
+      paused: false,
+      src: "",
+      load: vi.fn(),
+      pause: vi.fn(() => {
+        phases.push("pause");
+        audio.paused = true;
+      }),
+      play: vi.fn(),
+      removeAttribute: vi.fn(),
+    };
+    const firstFile = new File(["first"], "phase-first.mp3");
+    const secondFile = new File(["second"], "phase-second.mp3");
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <TrackWaveformPreview
+          active
+          file={firstFile}
+          fileId="phase-first"
+          fallbackDuration={60}
+          title="first"
+        />,
+        { createNodeMock: (element) => (element.type === "audio" ? audio : null) },
+      );
+    });
+    act(() => {
+      const audioElement = renderer!.root.findByType("audio");
+      audioElement.props.onPlay();
+      audioElement.props.onTimeUpdate({ currentTarget: { currentTime: 37 } });
+    });
+    expect(renderer!.root.findByProps({ role: "slider" }).props["aria-valuenow"]).toBe(37);
+    phases.length = 0;
+
+    await act(async () => {
+      renderer!.update(
+        <TrackWaveformPreview
+          active
+          file={secondFile}
+          fileId="phase-second"
+          fallbackDuration={60}
+          title="second"
+        />,
+      );
+    });
+
+    expect(phases[0]).toBe("pause");
+    expect(phases.indexOf("pause")).toBeLessThan(phases.indexOf("revoke"));
+    expect(audio.currentTime).toBe(0);
+    expect(renderer!.root.findByProps({ "aria-label": "play preview" })).toBeDefined();
+    expect(renderer!.root.findByProps({ role: "slider" }).props["aria-valuenow"]).toBe(0);
+    expect(renderer!.root.findByType("section").props["data-waveform-status"]).toBe("loading");
+    expect(
+      renderer!.root.findAll(
+        (node) => node.type === "svg" && node.props.preserveAspectRatio === "none",
+      ),
+    ).toHaveLength(0);
+
+    await act(async () => {
+      resolveSecondDecode();
+    });
+    act(() => renderer!.unmount());
+  });
+
+  it("discards a deferred decode when the File changes under the same track id", async () => {
+    vi.spyOn(URL, "createObjectURL").mockImplementation((file) => `blob:${(file as File).name}`);
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    const decodeResolvers: Array<() => void> = [];
+    class TestAudioContext {
+      async decodeAudioData() {
+        await new Promise<void>((resolve) => {
+          decodeResolvers.push(resolve);
+        });
+        return {
+          duration: 60,
+          length: 1,
+          numberOfChannels: 1,
+          getChannelData: () => new Float32Array([1]),
+        };
+      }
+
+      async close() {}
+    }
+    vi.stubGlobal("AudioContext", TestAudioContext);
+    const audio = {
+      currentTime: 0,
+      paused: true,
+      src: "",
+      load: vi.fn(),
+      pause: vi.fn(),
+      play: vi.fn(),
+      removeAttribute: vi.fn(),
+    };
+    const firstFile = new File(["first"], "same-id-first.mp3");
+    const secondFile = new File(["second"], "same-id-second.mp3");
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <TrackWaveformPreview
+          active
+          file={firstFile}
+          fileId="stable-id"
+          fallbackDuration={60}
+          title="first"
+        />,
+        { createNodeMock: (element) => (element.type === "audio" ? audio : null) },
+      );
+    });
+    await vi.waitFor(() => expect(decodeResolvers).toHaveLength(1));
+
+    await act(async () => {
+      renderer!.update(
+        <TrackWaveformPreview
+          active
+          file={secondFile}
+          fileId="stable-id"
+          fallbackDuration={60}
+          title="second"
+        />,
+      );
+    });
+    expect(renderer!.root.findByType("section").props["data-waveform-status"]).toBe("loading");
+    expect(
+      renderer!.root.findAll(
+        (node) => node.type === "svg" && node.props.preserveAspectRatio === "none",
+      ),
+    ).toHaveLength(0);
+
+    await act(async () => {
+      decodeResolvers.shift()?.();
+    });
+    await vi.waitFor(() => expect(decodeResolvers).toHaveLength(1));
+    expect(renderer!.root.findByType("section").props["data-waveform-status"]).toBe("loading");
+    expect(
+      renderer!.root.findAll(
+        (node) => node.type === "svg" && node.props.preserveAspectRatio === "none",
+      ),
+    ).toHaveLength(0);
+
+    await act(async () => {
+      decodeResolvers.shift()?.();
+    });
+    expect(renderer!.root.findByType("section").props["data-waveform-status"]).toBe("ready");
+    expect(
+      renderer!.root.findAll(
+        (node) => node.type === "svg" && node.props.preserveAspectRatio === "none",
+      ),
+    ).toHaveLength(2);
     act(() => renderer!.unmount());
   });
 

--- a/tests/unit/features/editor/trackMetadataEditor.test.tsx
+++ b/tests/unit/features/editor/trackMetadataEditor.test.tsx
@@ -279,13 +279,15 @@ describe("track metadata editor form seam", () => {
 
     expect(waveform.props.className).toContain("min-w-0");
     expect(waveform.props.className).toContain("w-full");
-    const waveformContainer = waveform.parent!.parent!;
-    let coverAncestor = cover.parent;
-    while (coverAncestor && coverAncestor !== waveformContainer) {
-      coverAncestor = coverAncestor.parent;
-    }
+    const waveformComponent = waveform.parent!;
+    const waveformContainer = waveformComponent.parent!;
+    const [detailsRow, waveformSibling] = waveformContainer.children;
 
-    expect(coverAncestor).toBe(waveformContainer);
+    expect(waveformContainer.children).toHaveLength(2);
+    expect(waveformSibling).toBe(waveformComponent);
+    expect(typeof detailsRow).not.toBe("string");
+    if (typeof detailsRow === "string") throw new Error("track details row missing");
+    expect(detailsRow.findByProps({ "data-testid": "cover-art" })).toBe(cover);
     expect(waveformContainer.props.className).toContain("min-h-full");
     expect(waveformContainer.props.className).not.toContain("flex-1");
 

--- a/tests/unit/features/editor/trackMetadataEditor.test.tsx
+++ b/tests/unit/features/editor/trackMetadataEditor.test.tsx
@@ -81,12 +81,14 @@ function EditorHarness({
   advancedMetadata = false,
   albumArtistLinked = true,
   inAlbum = false,
+  previewActive = true,
 }: {
   selectedFile?: TagiumFile | null;
   syncFilenames?: boolean;
   advancedMetadata?: boolean;
   albumArtistLinked?: boolean;
   inAlbum?: boolean;
+  previewActive?: boolean;
 }) {
   const { register, control, getValues, setError, clearErrors, setFocus } = useForm<AudioMetadata>({
     defaultValues: metadata,
@@ -95,6 +97,7 @@ function EditorHarness({
   return (
     <TooltipProvider>
       <TrackMetadataEditor
+        previewActive={previewActive}
         selectedFile={selectedFile}
         selectedFileId={selectedFile?.id ?? null}
         register={register}
@@ -260,6 +263,15 @@ describe("track metadata editor form seam", () => {
     expect(markup).toContain('role="slider"');
     expect(markup).toContain('aria-label="track position"');
     expect(markup).not.toContain(" controls=");
+  });
+
+  it("keeps selection rendered but disables playback when its editor is inaccessible", () => {
+    const markup = renderToStaticMarkup(<EditorHarness previewActive={false} />);
+
+    expect(markup).toContain('aria-label="preview track-1.mp3"');
+    expect(markup).toMatch(/<button[^>]*disabled=""[^>]*aria-label="play preview"/);
+    expect(markup).toContain('aria-label="track position"');
+    expect(markup).toContain('aria-disabled="true"');
   });
 
   it("describes a synced filename error from the title field", () => {

--- a/tests/unit/features/editor/trackMetadataEditor.test.tsx
+++ b/tests/unit/features/editor/trackMetadataEditor.test.tsx
@@ -53,6 +53,7 @@ const metadata: AudioMetadata = {
 const loadedTrack: TagiumFile = {
   id: "track-1",
   format: "mp3",
+  file: new File(["audio"], "track-1.mp3", { type: "audio/mpeg" }),
   filename: "track-1.mp3",
   status: "saved",
   downloadStatus: "ready",
@@ -249,6 +250,16 @@ describe("track metadata editor form seam", () => {
       expect(markup).toContain(`for="${id}"`);
       expect(markup).toContain(`id="${id}"`);
     }
+  });
+
+  it("exposes an accessible selected-track preview without native audio controls", () => {
+    const markup = renderToStaticMarkup(<EditorHarness />);
+
+    expect(markup).toContain('aria-label="preview track-1.mp3"');
+    expect(markup).toContain('aria-label="play preview"');
+    expect(markup).toContain('role="slider"');
+    expect(markup).toContain('aria-label="track position"');
+    expect(markup).not.toContain(" controls=");
   });
 
   it("describes a synced filename error from the title field", () => {

--- a/tests/unit/features/editor/trackMetadataEditor.test.tsx
+++ b/tests/unit/features/editor/trackMetadataEditor.test.tsx
@@ -176,6 +176,7 @@ function MountedEditorHarness({
   }, [exposeForm, form]);
   return (
     <TrackMetadataEditor
+      previewActive
       selectedFile={readyTrack}
       selectedFileId={readyTrack.id}
       register={form.register}
@@ -216,6 +217,18 @@ const createFormNodeMocks = () => {
     nodes,
     createNodeMock: (element: ReactElement) => {
       if (typeof element.type !== "string") return {};
+      if (element.type === "audio") {
+        return {
+          currentTime: 0,
+          duration: 0,
+          paused: true,
+          src: "",
+          load: vi.fn(),
+          pause: vi.fn(),
+          play: vi.fn(async () => undefined),
+          removeAttribute: vi.fn(),
+        };
+      }
       const props = element.props as Record<string, unknown>;
       const node = {
         focus: vi.fn(),

--- a/tests/unit/features/editor/trackMetadataEditor.test.tsx
+++ b/tests/unit/features/editor/trackMetadataEditor.test.tsx
@@ -268,6 +268,30 @@ describe("track metadata editor form seam", () => {
     }
   });
 
+  it("places the full-width waveform after the cover and metadata row", () => {
+    let renderer: ReactTestRenderer;
+    act(() => {
+      renderer = create(<EditorHarness />, createFormNodeMocks());
+    });
+
+    const waveform = renderer!.root.findByType("section");
+    const cover = renderer!.root.findByProps({ "data-testid": "cover-art" });
+
+    expect(waveform.props.className).toContain("min-w-0");
+    expect(waveform.props.className).toContain("w-full");
+    const waveformContainer = waveform.parent!.parent!;
+    let coverAncestor = cover.parent;
+    while (coverAncestor && coverAncestor !== waveformContainer) {
+      coverAncestor = coverAncestor.parent;
+    }
+
+    expect(coverAncestor).toBe(waveformContainer);
+    expect(waveformContainer.props.className).toContain("min-h-full");
+    expect(waveformContainer.props.className).not.toContain("flex-1");
+
+    act(() => renderer!.unmount());
+  });
+
   it("exposes an accessible selected-track preview without native audio controls", () => {
     const markup = renderToStaticMarkup(<EditorHarness />);
 

--- a/tests/unit/features/editor/waveformPreview.test.ts
+++ b/tests/unit/features/editor/waveformPreview.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  MAX_WAVEFORM_SAMPLES,
+  MAX_DECODED_PCM_BYTES,
+  MAX_WAVEFORM_DECODE_BYTES,
+  downsampleWaveform,
+  estimateDecodedPcmBytes,
+  formatPreviewTime,
+  getSeekTime,
+  loadWaveformPreview,
+  normalizePreviewDuration,
+} from "@/features/editor/waveformPreview";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("waveform preview", () => {
+  it("formats bounded transport time", () => {
+    expect(formatPreviewTime(0)).toBe("0:00");
+    expect(formatPreviewTime(125.9)).toBe("2:05");
+    expect(formatPreviewTime(-1)).toBe("0:00");
+    expect(formatPreviewTime(Number.NaN)).toBe("0:00");
+    expect(normalizePreviewDuration(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(normalizePreviewDuration(-10)).toBe(0);
+  });
+
+  it("maps pointer positions onto the track and clamps overflow", () => {
+    expect(getSeekTime(150, 100, 200, 120)).toBe(30);
+    expect(getSeekTime(50, 100, 200, 120)).toBe(0);
+    expect(getSeekTime(400, 100, 200, 120)).toBe(120);
+    expect(getSeekTime(150, 100, 0, 120)).toBe(0);
+    expect(getSeekTime(150, 100, 200, Number.POSITIVE_INFINITY)).toBe(0);
+  });
+
+  it("downsamples every channel into a fixed, normalized peak envelope", () => {
+    const channels = [
+      new Float32Array([0, 0.25, 0.5, 0.25, 0, 0, 0, 0]),
+      new Float32Array([0, 0, 0, 0, 0, -1, 0.5, 0]),
+    ];
+    const audio = {
+      duration: 1,
+      length: channels[0].length,
+      numberOfChannels: channels.length,
+      getChannelData: (index: number) => channels[index],
+    };
+
+    expect(downsampleWaveform(audio, 4)).toEqual([0.25, 0.5, 1, 0.5]);
+    expect(downsampleWaveform(audio, MAX_WAVEFORM_SAMPLES + 100)).toHaveLength(
+      MAX_WAVEFORM_SAMPLES,
+    );
+  });
+
+  it("represents silent and empty audio without invalid values", () => {
+    const silent = {
+      duration: 0,
+      length: 0,
+      numberOfChannels: 0,
+      getChannelData: () => new Float32Array(),
+    };
+
+    expect(downsampleWaveform(silent, 3)).toEqual([0, 0, 0]);
+  });
+
+  it("closes the decoding context after producing a bounded cached waveform", async () => {
+    const close = vi.fn(async () => undefined);
+    const decodeAudioData = vi.fn(async () => ({
+      duration: 1,
+      length: 2,
+      numberOfChannels: 1,
+      getChannelData: () => new Float32Array([0.5, 1]),
+    }));
+    class TestAudioContext {
+      close = close;
+      decodeAudioData = decodeAudioData;
+    }
+    vi.stubGlobal("AudioContext", TestAudioContext);
+    const file = new File(["audio"], "preview.mp3", { type: "audio/mpeg" });
+
+    const first = await loadWaveformPreview(file, new AbortController().signal, 1);
+    const second = await loadWaveformPreview(file, new AbortController().signal);
+
+    expect(first.samples).toHaveLength(MAX_WAVEFORM_SAMPLES);
+    expect(second).toBe(first);
+    expect(decodeAudioData).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start decoding after its caller has canceled", async () => {
+    const context = new AbortController();
+    context.abort();
+
+    await expect(
+      loadWaveformPreview(new File(["audio"], "canceled.mp3"), context.signal),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("never constructs a decoder without a finite positive duration", async () => {
+    const construct = vi.fn();
+    class TestAudioContext {
+      constructor() {
+        construct();
+      }
+    }
+    vi.stubGlobal("AudioContext", TestAudioContext);
+    const file = new File(["audio"], "unknown-duration.mp3");
+
+    await expect(loadWaveformPreview(file, new AbortController().signal, 0)).rejects.toThrow(
+      "duration is required",
+    );
+    await expect(
+      loadWaveformPreview(file, new AbortController().signal, Number.POSITIVE_INFINITY),
+    ).rejects.toThrow("duration is required");
+    expect(construct).not.toHaveBeenCalled();
+  });
+
+  it("rejects compressed-size and conservative duration budgets before decoding", async () => {
+    const construct = vi.fn();
+    class TestAudioContext {
+      constructor() {
+        construct();
+      }
+    }
+    vi.stubGlobal("AudioContext", TestAudioContext);
+    const oversized = new File(["audio"], "oversized.mp3");
+    Object.defineProperty(oversized, "size", { value: MAX_WAVEFORM_DECODE_BYTES + 1 });
+
+    await expect(loadWaveformPreview(oversized, new AbortController().signal, 1)).rejects.toThrow(
+      "too large",
+    );
+
+    const tooLong = MAX_DECODED_PCM_BYTES / estimateDecodedPcmBytes(1) + 1;
+    await expect(
+      loadWaveformPreview(new File(["audio"], "long.mp3"), new AbortController().signal, tooLong),
+    ).rejects.toThrow("duration exceeds");
+    expect(construct).not.toHaveBeenCalled();
+  });
+
+  it("rejects decoded PCM above budget and still closes its context", async () => {
+    const close = vi.fn(async () => undefined);
+    class TestAudioContext {
+      close = close;
+      async decodeAudioData() {
+        return {
+          duration: 1,
+          length: MAX_DECODED_PCM_BYTES / Float32Array.BYTES_PER_ELEMENT + 1,
+          numberOfChannels: 1,
+          getChannelData: vi.fn(),
+        };
+      }
+    }
+    vi.stubGlobal("AudioContext", TestAudioContext);
+
+    await expect(
+      loadWaveformPreview(
+        new File(["audio"], "decoded-large.mp3"),
+        new AbortController().signal,
+        1,
+      ),
+    ).rejects.toThrow("decoded audio exceeds");
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("closes and discards a decode that is canceled in flight", async () => {
+    let resolveDecode!: (audio: {
+      duration: number;
+      length: number;
+      numberOfChannels: number;
+      getChannelData: () => Float32Array;
+    }) => void;
+    const close = vi.fn(async () => undefined);
+    class TestAudioContext {
+      close = close;
+      decodeAudioData = vi.fn(
+        () =>
+          new Promise<{
+            duration: number;
+            length: number;
+            numberOfChannels: number;
+            getChannelData: () => Float32Array;
+          }>((resolve) => {
+            resolveDecode = resolve;
+          }),
+      );
+    }
+    vi.stubGlobal("AudioContext", TestAudioContext);
+    const controller = new AbortController();
+    const loading = loadWaveformPreview(
+      new File(["audio"], "cancel-running.mp3"),
+      controller.signal,
+      1,
+    );
+    await vi.waitFor(() => expect(resolveDecode).toBeTypeOf("function"));
+    controller.abort();
+    resolveDecode({
+      duration: 1,
+      length: 1,
+      numberOfChannels: 1,
+      getChannelData: () => new Float32Array([1]),
+    });
+
+    await expect(loading).rejects.toMatchObject({ name: "AbortError" });
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("serializes decode contexts and skips canceled queued work", async () => {
+    const resolvers: Array<() => void> = [];
+    let activeContexts = 0;
+    let maximumActiveContexts = 0;
+    const constructed = vi.fn();
+    class TestAudioContext {
+      constructor() {
+        constructed();
+        activeContexts += 1;
+        maximumActiveContexts = Math.max(maximumActiveContexts, activeContexts);
+      }
+
+      async decodeAudioData() {
+        await new Promise<void>((resolve) => resolvers.push(resolve));
+        return {
+          duration: 1,
+          length: 1,
+          numberOfChannels: 1,
+          getChannelData: () => new Float32Array([1]),
+        };
+      }
+
+      async close() {
+        activeContexts -= 1;
+      }
+    }
+    vi.stubGlobal("AudioContext", TestAudioContext);
+    const first = loadWaveformPreview(
+      new File(["first"], "first-queued.mp3"),
+      new AbortController().signal,
+      1,
+    );
+    const canceledController = new AbortController();
+    const canceledQueued = loadWaveformPreview(
+      new File(["second"], "second-queued.mp3"),
+      canceledController.signal,
+      1,
+    );
+    const third = loadWaveformPreview(
+      new File(["third"], "third-queued.mp3"),
+      new AbortController().signal,
+      1,
+    );
+    await vi.waitFor(() => expect(resolvers).toHaveLength(1));
+    canceledController.abort();
+    resolvers.shift()?.();
+    await first;
+    await expect(canceledQueued).rejects.toMatchObject({ name: "AbortError" });
+    await vi.waitFor(() => expect(resolvers).toHaveLength(1));
+    resolvers.shift()?.();
+    await third;
+
+    expect(constructed).toHaveBeenCalledTimes(2);
+    expect(maximumActiveContexts).toBe(1);
+  });
+});

--- a/tests/unit/features/workspace/trackPreviewVisibility.test.ts
+++ b/tests/unit/features/workspace/trackPreviewVisibility.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vite-plus/test";
+import { isTrackPreviewActive } from "@/features/workspace/trackPreviewVisibility";
+
+const visibleEditor = {
+  activeView: "editor" as const,
+  isMobile: true,
+  drawerOpen: false,
+};
+
+describe("track preview visibility", () => {
+  it("stops preview when settings opens", () => {
+    expect(isTrackPreviewActive({ ...visibleEditor, activeView: "settings" })).toBe(false);
+  });
+
+  it("stops preview while the mobile library drawer is open", () => {
+    expect(isTrackPreviewActive({ ...visibleEditor, drawerOpen: true })).toBe(false);
+  });
+
+  it("keeps a selected preview active in every accessible editor", () => {
+    expect(isTrackPreviewActive(visibleEditor)).toBe(true);
+    expect(isTrackPreviewActive({ ...visibleEditor, isMobile: false })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a SoundCloud-style waveform preview to the selected-track editor
- support play/pause, elapsed/duration, pointer drag seeking, keyboard seeking, and horizontal panning
- stop/reset before paint on selection replacement or whenever the editor becomes inaccessible
- pause when Settings opens, mobile Back returns to the library, or the sidebar sheet covers the editor
- degrade safely when playback or waveform construction is unavailable

## Resource and lifecycle safety
- serialize waveform decoding to one `AudioContext`
- reject compressed files over 96 MiB
- require finite positive duration and enforce a conservative 256 MiB decoded-PCM estimate before decoding
- retain an exact post-decode PCM gate as defense in depth
- use source generations so stale decode/media events cannot populate a replacement, including same-ID/new-File updates
- skip canceled queued work, discard canceled in-flight results, close contexts, and revoke object URLs
- document Web Audio's non-cancelable `decodeAudioData` behavior accurately

## Verification
- `vp check`
- `bun run typecheck`
- `bun run test` (428 tests on the mobile-navigation base)
- `bun run build`
- two fresh implementation reviews plus repeated rechecks after lifecycle fixes

## Dependency
Targets #125 (`codex/mobile-workspace-navigation`) because preview visibility must follow the mobile page/sheet accessibility state.

## Manual follow-up
The Playwright spec was not executed because project instructions say not to start a development server during manual-review workflows.