### PR TITLE
fix(e2e): stabilize landing transition selector

### DIFF
--- a/src/features/import/LandingScreen.tsx
+++ b/src/features/import/LandingScreen.tsx
@@ -47,6 +47,7 @@ export default function LandingScreen({ active, children, onAudioUpload }: Landi
 
   return (
     <div
+      data-view={active ? "landing" : undefined}
       className={cn(
         active
           ? "h-svh min-h-0 overflow-y-auto flex flex-col items-center justify-center p-8 transition-colors duration-200 max-lg:[@media(max-height:700px)]:p-4 md:h-auto md:flex-1"

--- a/tests/e2e/settings-transition.spec.ts
+++ b/tests/e2e/settings-transition.spec.ts
@@ -115,7 +115,7 @@ test("clicking blank space in the empty library closes settings", async ({ page 
   await page.getByRole("button", { name: "clear track selection and return to editor" }).click();
 
   await expect(page.getByRole("button", { name: "back to editor" })).not.toBeAttached();
-  await expect(page.getByRole("button", { name: /drop your mp3s here/ })).toBeVisible();
+  await expect(page.locator('[data-view="landing"]')).toBeVisible();
 });
 
 test("clicking blank space in a populated track list closes settings and clears the track", async ({


### PR DESCRIPTION
## Summary

- expose the active landing screen through the existing `data-view` convention
- assert the landing view rather than matching visible upload copy

## Root cause

The post-merge production workflow failed because `settings-transition.spec.ts` still matched “drop your mp3s here” after the multi-format UI changed that text to “drop your audio here.” All three browser projects failed, so the production deploy job was skipped.

## Impact

The transition test now verifies the navigation state it is responsible for and remains stable when upload copy or supported-format messaging changes. Merging this PR reruns the post-merge E2E gate and production deployment with the previously merged conformance work included.

## Verification

- red/green focused Chromium reproduction
- focused transition test: Chromium, Firefox, and WebKit passed
- `vp check`
- `vp test`: 424/424 passed
- `vp build`
- full Playwright suite: 37 passed, 5 skipped