### PR TITLE
fix: address React Doctor warnings

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -36,16 +36,12 @@ jobs:
 
       - uses: millionco/react-doctor@v2
         with:
-          blocking: error
-        # Advisory by default: React Doctor reports findings on every PR — a
-        # sticky summary comment, inline review comments, and a commit status
-        # with the health score — but never fails the check, so it won't red-X
-        # a teammate's PR on day one. When your team trusts the signal, graduate
-        # the gate: uncomment the block below and set blocking to "error" (fail
-        # on new error-severity findings) or "warning" (fail on any finding).
+          blocking: warning
+        # React Doctor reports findings on every PR and fails the check on any
+        # warning or error introduced relative to the target branch.
         # Full reference: https://www.react.doctor/ci
-        # with:
-        #   blocking: error          # Gate level: "none" (advisory, the default) | "warning" | "error"
+        # Optional inputs:
+        #   blocking: warning        # Gate level: "none" (advisory, the default) | "warning" | "error"
         #   scope: full              # On PRs, scan the whole project instead of just changed files
         #   comment: false           # Disable the sticky PR summary comment
         #   review-comments: false   # Disable inline review comments on changed lines

--- a/doctor.config.json
+++ b/doctor.config.json
@@ -15,6 +15,10 @@
       {
         "files": ["server/api/track-metadata.get.ts"],
         "rules": ["deslop/unused-export"]
+      },
+      {
+        "files": ["cobalt-soundcloud.mjs"],
+        "rules": ["deslop/unused-file"]
       }
     ]
   }

--- a/src/features/audio/metadataEngine/binary.ts
+++ b/src/features/audio/metadataEngine/binary.ts
@@ -44,11 +44,3 @@ export const synchsafeToNumber = (bytes: Uint8Array, offset: number) =>
 
 export const numberToSynchsafe = (value: number) =>
   Uint8Array.of((value >>> 21) & 0x7f, (value >>> 14) & 0x7f, (value >>> 7) & 0x7f, value & 0x7f);
-
-export const bytesEqual = (left: Uint8Array, right: Uint8Array) => {
-  if (left.length !== right.length) return false;
-  for (let index = 0; index < left.length; index++) {
-    if (left[index] !== right[index]) return false;
-  }
-  return true;
-};

--- a/src/features/audio/metadataEngine/byteSource.ts
+++ b/src/features/audio/metadataEngine/byteSource.ts
@@ -56,14 +56,3 @@ export const makeBlobByteSource = (blob: Blob): ByteSource => {
     slice: (start, end) => blob.slice(start, end),
   };
 };
-
-export const readExactly = (source: ByteSource, offset: number, length: number, context: string) =>
-  source.read(offset, length).pipe(
-    Effect.mapError(
-      (error) =>
-        new AudioMetadataReadError({
-          message: `${context}: ${error.message}`,
-          cause: error,
-        }),
-    ),
-  );

--- a/src/features/editor/coverArt.tsx
+++ b/src/features/editor/coverArt.tsx
@@ -129,6 +129,8 @@ export default function CoverArt({
 
   useEffect(() => {
     if (uploadedCover) {
+      // The cleanup below revokes this exact URL when the cover changes or the component unmounts.
+      // react-doctor-disable-next-line react-doctor/no-create-object-url-without-revoke
       const url = URL.createObjectURL(uploadedCover);
       setCoverSrc(url);
       return () => URL.revokeObjectURL(url);
@@ -136,6 +138,8 @@ export default function CoverArt({
 
     if (picture && picture.length > 0) {
       const blob = new Blob([picture[0].data as unknown as BlobPart], { type: picture[0].format });
+      // The cleanup below revokes this exact URL when the picture changes or the component unmounts.
+      // react-doctor-disable-next-line react-doctor/no-create-object-url-without-revoke
       const url = URL.createObjectURL(blob);
       setCoverSrc(url);
       return () => URL.revokeObjectURL(url);


### PR DESCRIPTION
## Summary

- remove two unused audio metadata helpers
- document and suppress two object URL false positives where the exact URLs are already revoked by effect cleanup
- ignore the Docker-copied Cobalt SoundCloud adapter as an external entry point
- fail the React Doctor PR check on warnings as well as errors

## Root causes

React Doctor found two genuine unused exports and three paths its static entry-point/lifecycle analysis could not prove. The Cobalt adapter is copied into the production image by Dockerfile.cobalt, and both cover-art object URLs are revoked by their useEffect cleanup callbacks.

## Verification

- React Doctor full scan: 100/100, no issues
- React Doctor changed scope: 100/100, no issues
- lint: 0 warnings, 0 errors
- typecheck: passed
- tests: 86 files, 541 tests passed
- production build: passed