### PR TITLE
feat: normalize YouTube and SoundCloud links

### DIFF
--- a/server/api/cobalt/tunnel.get.ts
+++ b/server/api/cobalt/tunnel.get.ts
@@ -30,6 +30,8 @@ type TunnelObservabilityContext = {
 };
 
 const COBALT_TUNNEL_TIMEOUT_MS = 300_000;
+const EMPTY_BODY_RETRY_DELAYS_MS = [100, 250, 500] as const;
+const EMPTY_BODY_RETRY_ATTEMPTS = EMPTY_BODY_RETRY_DELAYS_MS.length + 1;
 
 const createTunnelRequestId = () => `tagium-tunnel-${crypto.randomUUID()}`;
 
@@ -51,9 +53,15 @@ const streamNonEmptyBody = async (response: Response) => {
   if (!reader) {
     return undefined;
   }
-
-  const firstChunk = await reader.read();
+  let firstChunk: ReadableStreamReadResult<Uint8Array>;
+  try {
+    firstChunk = await reader.read();
+  } catch (error) {
+    reader.releaseLock();
+    throw error;
+  }
   if (firstChunk.done) {
+    reader.releaseLock();
     return undefined;
   }
 
@@ -62,16 +70,29 @@ const streamNonEmptyBody = async (response: Response) => {
       controller.enqueue(firstChunk.value);
     },
     async pull(controller) {
-      const chunk = await reader.read();
-      if (chunk.done) {
-        controller.close();
-        return;
+      try {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          controller.close();
+          reader.releaseLock();
+          return;
+        }
+        controller.enqueue(chunk.value);
+      } catch (error) {
+        try {
+          await reader.cancel(error);
+        } finally {
+          reader.releaseLock();
+        }
+        controller.error(error);
       }
-
-      controller.enqueue(chunk.value);
     },
     async cancel(reason) {
-      await reader.cancel(reason);
+      try {
+        await reader.cancel(reason);
+      } finally {
+        reader.releaseLock();
+      }
     },
   });
 };
@@ -275,10 +296,36 @@ export default defineHandler(async (event) => {
       requestHeaders.set("Fly-Force-Instance-Id", tunnelRequest.machineId);
     }
 
-    const response = await fetch(tunnelRequest.tunnelUrl, {
-      headers: requestHeaders,
-      signal: AbortSignal.timeout(COBALT_TUNNEL_TIMEOUT_MS),
-    });
+    const fetchSignal = AbortSignal.timeout(COBALT_TUNNEL_TIMEOUT_MS);
+    let response: Response | undefined;
+    let body: ReadableStream<Uint8Array> | undefined;
+    for (let attempt = 1; attempt <= EMPTY_BODY_RETRY_ATTEMPTS; attempt++) {
+      response = await fetch(tunnelRequest.tunnelUrl, {
+        headers: requestHeaders,
+        signal: fetchSignal,
+      });
+      if (!response.ok) break;
+      body = await streamNonEmptyBody(response);
+      if (body || attempt === EMPTY_BODY_RETRY_ATTEMPTS) break;
+      await new Promise<void>((resolve, reject) => {
+        const onAbort = () => {
+          clearTimeout(timer);
+          done(fetchSignal.reason);
+        };
+        const done = (error?: unknown) => {
+          fetchSignal.removeEventListener("abort", onAbort);
+          if (error === undefined) resolve();
+          else reject(error);
+        };
+        const timer = setTimeout(() => done(), EMPTY_BODY_RETRY_DELAYS_MS[attempt - 1]);
+        if (fetchSignal.aborted) {
+          onAbort();
+          return;
+        }
+        fetchSignal.addEventListener("abort", onAbort, { once: true });
+      });
+    }
+    if (!response) throw new Error("tunnel.fetch_missing");
 
     if (!response.ok) {
       const responseText = await response.text();
@@ -304,7 +351,6 @@ export default defineHandler(async (event) => {
       return new Response(`Cobalt tunnel request failed (${response.status}).`, { status: 502 });
     }
 
-    const body = await streamNonEmptyBody(response);
     if (!body) {
       logTunnelFailure("upstream empty body", {
         ...getTunnelLogContext(requestId, tunnelUrl, machineId, observability),

--- a/server/api/cobalt/tunnel.get.ts
+++ b/server/api/cobalt/tunnel.get.ts
@@ -32,6 +32,16 @@ type TunnelObservabilityContext = {
 const COBALT_TUNNEL_TIMEOUT_MS = 300_000;
 const EMPTY_BODY_RETRY_DELAYS_MS = [100, 250, 500] as const;
 const EMPTY_BODY_RETRY_ATTEMPTS = EMPTY_BODY_RETRY_DELAYS_MS.length + 1;
+type TunnelOutcome = "ready" | "recovered" | "exhausted" | "non_retryable";
+
+const withTunnelTelemetry = (headers: Headers, outcome: TunnelOutcome, attempts: number) => {
+  headers.set("X-Tagium-Tunnel-Outcome", outcome);
+  headers.set("X-Tagium-Tunnel-Attempts", String(attempts));
+  return headers;
+};
+
+const tunnelTelemetryHeaders = (outcome: TunnelOutcome, attempts: number) =>
+  withTunnelTelemetry(new Headers(), outcome, attempts);
 
 const createTunnelRequestId = () => `tagium-tunnel-${crypto.randomUUID()}`;
 
@@ -168,10 +178,17 @@ const tryParseCobaltCapacityError = (responseText: string) => {
   return undefined;
 };
 
-const cobaltCapacityErrorResponse = (body: unknown, retryAfter: string | null) => {
+const cobaltCapacityErrorResponse = (
+  body: unknown,
+  retryAfter: string | null,
+  attempts?: number,
+) => {
   const headers = new Headers({ "Content-Type": "application/json" });
   if (retryAfter) {
     headers.set("Retry-After", retryAfter);
+  }
+  if (attempts !== undefined) {
+    withTunnelTelemetry(headers, "non_retryable", attempts);
   }
 
   return new Response(JSON.stringify(body), {
@@ -182,7 +199,10 @@ const cobaltCapacityErrorResponse = (body: unknown, retryAfter: string | null) =
 
 const cobaltDevTunnelFaultResponse = (fault: ReturnType<typeof consumeTunnelDevFault>) => {
   if (fault === "rate-limit") {
-    return new Response("Cobalt tunnel request failed (429).", { status: 502 });
+    return new Response("Cobalt tunnel request failed (429).", {
+      status: 502,
+      headers: tunnelTelemetryHeaders("non_retryable", 1),
+    });
   }
 
   if (fault === "capacity") {
@@ -192,15 +212,24 @@ const cobaltDevTunnelFaultResponse = (fault: ReturnType<typeof consumeTunnelDevF
         error: { code: "error.api.capacity_exceeded" },
       },
       "2",
+      1,
     );
   }
 
   if (fault === "timeout") {
-    return new Response("Cobalt tunnel request timed out.", { status: 502 });
+    // Dev faults happen before an upstream fetch. Use one synthetic attempt so
+    // their telemetry has the same bounded shape as real tunnel responses.
+    return new Response("Cobalt tunnel request timed out.", {
+      status: 502,
+      headers: tunnelTelemetryHeaders("non_retryable", 1),
+    });
   }
 
   if (fault === "empty-body") {
-    return new Response("Cobalt tunnel response was empty.", { status: 502 });
+    return new Response("Cobalt tunnel response was empty.", {
+      status: 502,
+      headers: tunnelTelemetryHeaders("exhausted", EMPTY_BODY_RETRY_ATTEMPTS),
+    });
   }
 
   return undefined;
@@ -260,6 +289,7 @@ export default defineHandler(async (event) => {
   let tunnelUrl: URL | undefined;
   let machineId: string | null | undefined;
   let observability: TunnelObservabilityContext = {};
+  let upstreamAttempts = 0;
 
   try {
     const runtimeEnv = getRuntimeEnv(event.req);
@@ -300,6 +330,7 @@ export default defineHandler(async (event) => {
     let response: Response | undefined;
     let body: ReadableStream<Uint8Array> | undefined;
     for (let attempt = 1; attempt <= EMPTY_BODY_RETRY_ATTEMPTS; attempt++) {
+      upstreamAttempts = attempt;
       response = await fetch(tunnelRequest.tunnelUrl, {
         headers: requestHeaders,
         signal: fetchSignal,
@@ -338,7 +369,11 @@ export default defineHandler(async (event) => {
           status: response.status,
           retryAfter: response.headers.get("Retry-After") ?? undefined,
         });
-        return cobaltCapacityErrorResponse(capacityError, response.headers.get("Retry-After"));
+        return cobaltCapacityErrorResponse(
+          capacityError,
+          response.headers.get("Retry-After"),
+          upstreamAttempts,
+        );
       }
 
       logTunnelFailure("upstream non-ok", {
@@ -348,7 +383,10 @@ export default defineHandler(async (event) => {
         responseBytes: new TextEncoder().encode(responseText).byteLength,
         contentType: response.headers.get("content-type") ?? undefined,
       });
-      return new Response(`Cobalt tunnel request failed (${response.status}).`, { status: 502 });
+      return new Response(`Cobalt tunnel request failed (${response.status}).`, {
+        status: 502,
+        headers: tunnelTelemetryHeaders("non_retryable", upstreamAttempts),
+      });
     }
 
     if (!body) {
@@ -358,7 +396,10 @@ export default defineHandler(async (event) => {
         status: response.status,
         contentLength: response.headers.get("content-length") ?? undefined,
       });
-      return new Response("Cobalt tunnel response was empty.", { status: 502 });
+      return new Response("Cobalt tunnel response was empty.", {
+        status: 502,
+        headers: tunnelTelemetryHeaders("exhausted", upstreamAttempts),
+      });
     }
 
     const responseHeaders = new Headers();
@@ -367,6 +408,11 @@ export default defineHandler(async (event) => {
       responseHeaders.set("Content-Type", contentType);
     }
 
+    withTunnelTelemetry(
+      responseHeaders,
+      upstreamAttempts > 1 ? "recovered" : "ready",
+      upstreamAttempts,
+    );
     return new Response(body, { headers: responseHeaders });
   } catch (error) {
     if (error instanceof Error) {
@@ -376,15 +422,30 @@ export default defineHandler(async (event) => {
         errorName: error.name,
       });
       if (error.name === "TimeoutError" || error.name === "AbortError") {
-        return new Response("Cobalt tunnel request timed out.", { status: 502 });
+        return new Response("Cobalt tunnel request timed out.", {
+          status: 502,
+          ...(upstreamAttempts > 0
+            ? { headers: tunnelTelemetryHeaders("non_retryable", upstreamAttempts) }
+            : {}),
+        });
       }
-      return new Response(error.message, { status: 502 });
+      return new Response(error.message, {
+        status: 502,
+        ...(upstreamAttempts > 0
+          ? { headers: tunnelTelemetryHeaders("non_retryable", upstreamAttempts) }
+          : {}),
+      });
     }
 
     logTunnelFailure("fetch threw non-error", {
       ...getTunnelLogContext(requestId, tunnelUrl, machineId, observability),
       elapsedMs: Date.now() - startedAt,
     });
-    return new Response("Cobalt tunnel request failed.", { status: 502 });
+    return new Response("Cobalt tunnel request failed.", {
+      status: 502,
+      ...(upstreamAttempts > 0
+        ? { headers: tunnelTelemetryHeaders("non_retryable", upstreamAttempts) }
+        : {}),
+    });
   }
 });

--- a/server/api/soundcloud-link.get.ts
+++ b/server/api/soundcloud-link.get.ts
@@ -1,0 +1,8 @@
+import { defineHandler } from "nitro";
+import { resolveSoundCloudShortLink } from "../utils/soundcloud-link";
+
+export default defineHandler(async (event) => {
+  const input = new URL(event.req.url, "http://tagium.local").searchParams.get("url");
+  if (!input) throw new Error("soundcloud.url_required");
+  return resolveSoundCloudShortLink(input, { signal: event.req.signal });
+});

--- a/server/api/soundcloud-set.get.ts
+++ b/server/api/soundcloud-set.get.ts
@@ -12,6 +12,7 @@ import {
   type SoundCloudLogContext,
 } from "../utils/soundcloud-observability";
 import { urlStringSchema } from "../utils/schema";
+import { parseMediaLink } from "../../src/lib/media-link";
 
 const TRACK_RESOLVE_CONCURRENCY = 4;
 
@@ -208,11 +209,15 @@ export default defineHandler(async (event) => {
   if (!sourceUrl) {
     throw new Error("soundcloud.url_required");
   }
+  const parsedSource = parseMediaLink(sourceUrl);
+  if (parsedSource.provider !== "soundcloud" || parsedSource.kind !== "playlist") {
+    throw new Error("soundcloud.set_url_required");
+  }
 
   const context = getSoundCloudLogContext(event.req, sourceUrl ?? undefined);
   const clientId = await getSoundCloudClientId(globalThis.fetch, context);
   const resolveUrl = new URL("https://api-v2.soundcloud.com/resolve");
-  resolveUrl.searchParams.set("url", sourceUrl);
+  resolveUrl.searchParams.set("url", parsedSource.canonicalUrl);
   resolveUrl.searchParams.set("client_id", clientId);
 
   const playlistStartedAt = Date.now();

--- a/server/api/track-metadata.get.ts
+++ b/server/api/track-metadata.get.ts
@@ -2,6 +2,7 @@ import { Effect, Schema } from "effect";
 import { defineHandler } from "nitro";
 import { getSoundCloudClientId } from "../utils/soundcloud";
 import { urlStringSchema } from "../utils/schema";
+import { parseMediaLink } from "../../src/lib/media-link";
 
 const nonEmptyStringSchema = Schema.String.check(Schema.isNonEmpty());
 
@@ -16,8 +17,10 @@ const soundCloudTrackSchema = Schema.Struct({
   user: Schema.optionalKey(Schema.Struct({ username: Schema.optionalKey(Schema.String) })),
 });
 
-const isSoundCloudUrl = (url: URL) =>
-  url.hostname === "soundcloud.com" || url.hostname.endsWith(".soundcloud.com");
+const isSoundCloudUrl = (url: URL) => {
+  const parsed = parseMediaLink(url.toString());
+  return parsed.provider === "soundcloud" && parsed.kind === "track";
+};
 
 export const resolveSoundCloudTrackMetadata = async (
   sourceUrl: string,
@@ -45,12 +48,9 @@ export const resolveSoundCloudTrackMetadata = async (
 };
 
 export const getTrackMetadataEndpoint = (sourceUrl: string) => {
-  const url = new URL(sourceUrl);
-  const isYouTube =
-    url.hostname === "youtu.be" ||
-    url.hostname === "youtube.com" ||
-    url.hostname.endsWith(".youtube.com");
-  if (isYouTube) {
+  const parsed = parseMediaLink(sourceUrl);
+  if (parsed.provider !== "youtube" || parsed.kind !== "track") return undefined;
+  if (parsed.provider === "youtube") {
     const endpoint = new URL("https://www.youtube.com/oembed");
     endpoint.searchParams.set("url", sourceUrl);
     endpoint.searchParams.set("format", "json");

--- a/server/api/youtube-playlist.get.ts
+++ b/server/api/youtube-playlist.get.ts
@@ -9,6 +9,7 @@ import {
   YOUTUBE_USER_AGENT,
 } from "../utils/youtube";
 import { urlStringSchema } from "../utils/schema";
+import { parseMediaLink } from "../../src/lib/media-link";
 
 const MAX_CONTINUATION_REQUESTS = 100;
 
@@ -249,14 +250,11 @@ const fetchContinuation = async (token: string, config: JsonRecord, signal: Abor
 };
 
 const parseSourceUrl = (sourceUrl: string) => {
-  const parsed = new URL(sourceUrl);
-  const isYouTubeHost =
-    parsed.hostname === "youtube.com" || parsed.hostname.endsWith(".youtube.com");
-  const playlistId = parsed.searchParams.get("list");
-  if (!isYouTubeHost || parsed.pathname.replace(/\/+$/, "") !== "/playlist" || !playlistId) {
+  const parsed = parseMediaLink(sourceUrl);
+  if (parsed.provider !== "youtube" || parsed.kind !== "playlist") {
     throw new Error("youtube.playlist_url_required");
   }
-  return playlistId;
+  return parsed.playlistId;
 };
 
 export default defineHandler(async (event) => {

--- a/server/utils/soundcloud-link.ts
+++ b/server/utils/soundcloud-link.ts
@@ -1,0 +1,62 @@
+import { parseMediaLink, isSoundCloudHost } from "../../src/lib/media-link";
+
+const SHORT_HOSTS = new Set(["on.soundcloud.com", "snd.sc"]);
+const MAX_HOPS = 4;
+const TIMEOUT_MS = 5_000;
+
+export async function resolveSoundCloudShortLink(
+  input: string,
+  options: { fetch?: typeof fetch; signal?: AbortSignal } = {},
+) {
+  let current: URL;
+  try {
+    current = new URL(input);
+  } catch {
+    throw new Error("soundcloud.short.invalid");
+  }
+  if (
+    current.protocol !== "https:" &&
+    !(current.protocol === "http:" && current.hostname === "snd.sc")
+  )
+    throw new Error("soundcloud.short.invalid");
+  if (current.protocol === "http:") current.protocol = "https:";
+  if (!SHORT_HOSTS.has(current.hostname.toLowerCase())) throw new Error("soundcloud.short.invalid");
+  const fetchImpl = options.fetch ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  if (options.signal?.aborted) controller.abort();
+  const abort = () => controller.abort();
+  if (options.signal) options.signal.addEventListener("abort", abort, { once: true });
+  try {
+    for (let hop = 0; hop <= MAX_HOPS; hop++) {
+      const response = await fetchImpl(current, { redirect: "manual", signal: controller.signal });
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get("location");
+        if (!location || hop === MAX_HOPS) throw new Error("soundcloud.short.too_many_redirects");
+        const next = new URL(location, current);
+        if (next.protocol === "http:" && next.hostname.toLowerCase() === "snd.sc")
+          next.protocol = "https:";
+        const nextHost = next.hostname.toLowerCase();
+        if (
+          next.protocol !== "https:" ||
+          next.username ||
+          next.password ||
+          next.port ||
+          next.hash ||
+          (!SHORT_HOSTS.has(nextHost) && !isSoundCloudHost(nextHost))
+        )
+          throw new Error("soundcloud.short.off_provider");
+        current = next;
+        continue;
+      }
+      if (!response.ok) throw new Error("soundcloud.short.unavailable");
+      const parsed = parseMediaLink(current.toString());
+      if (parsed.provider !== "soundcloud") throw new Error("soundcloud.short.unsupported");
+      return parsed;
+    }
+    throw new Error("soundcloud.short.too_many_redirects");
+  } finally {
+    clearTimeout(timeout);
+    options.signal?.removeEventListener("abort", abort);
+  }
+}

--- a/server/utils/youtube.ts
+++ b/server/utils/youtube.ts
@@ -144,7 +144,12 @@ export const getYouTubeVideoId = (sourceUrl: string) => {
     if (url.hostname === "youtu.be") {
       videoId = pathParts[0];
     } else {
-      const isYouTubeHost = url.hostname === "youtube.com" || url.hostname.endsWith(".youtube.com");
+      const isYouTubeHost = [
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com",
+        "music.youtube.com",
+      ].includes(url.hostname.toLowerCase());
       if (!isYouTubeHost) return undefined;
 
       if (pathParts[0] === "watch") {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -3,6 +3,14 @@ export type ImportKind = "single" | "set";
 export type ImportOutcome = "completed" | "partial" | "failed" | "canceled";
 export type ExportKind = "track" | "album" | "library";
 export type TrackSourceMix = "local" | "imported" | "mixed" | "unknown";
+export type AnalyticsProvider = "youtube" | "soundcloud" | "other";
+export type MediaLinkShape = "canonical" | "short" | "mobile" | "nocookie" | "other";
+export type CobaltTunnelOutcome = "ready" | "recovered" | "exhausted" | "non_retryable";
+export type CobaltTunnelElapsedBucket =
+  | "under_1_second"
+  | "1_to_5_seconds"
+  | "5_to_15_seconds"
+  | "15_seconds_or_more";
 export type AnalyticsErrorCode =
   | "capacity"
   | "rate_limited"
@@ -21,6 +29,23 @@ export type AnalyticsEvent =
       duplicateCount: number;
       parseRejectedCount: number;
       targetKind: AudioUploadTargetKind;
+    }
+  | {
+      type: "media_link_processed";
+      sourceUrl: string;
+      mediaKind: "track" | "playlist" | "unsupported";
+      shape: MediaLinkShape;
+      normalized: boolean;
+      redirected: boolean;
+      outcome: "accepted" | "rejected";
+      failureReason?: "invalid" | "unsupported" | "resolution_failed";
+    }
+  | {
+      type: "cobalt_tunnel_readiness";
+      sourceUrl: string;
+      outcome: CobaltTunnelOutcome;
+      attempts: number;
+      elapsedBucket: CobaltTunnelElapsedBucket;
     }
   | {
       type: "import_started";
@@ -121,7 +146,7 @@ export interface Analytics {
   capture: (event: AnalyticsEvent) => void;
 }
 
-const providerFromUrl = (sourceUrl: string) => {
+export const analyticsProviderFromUrl = (sourceUrl: string): AnalyticsProvider => {
   try {
     const url = new URL(sourceUrl);
     const host = url.hostname.toLowerCase();
@@ -150,7 +175,7 @@ const providerFromUrl = (sourceUrl: string) => {
   } catch {
     // Invalid and non-web URLs are intentionally grouped with other providers.
   }
-  return "other" as const;
+  return "other";
 };
 
 const errorCodeFrom = (
@@ -190,6 +215,23 @@ type BeforeSendEvent = {
 
 const COMMON_CUSTOM_PROPERTIES = ["event_version", "deploy_env", "release_sha"];
 const CUSTOM_EVENT_PROPERTIES: Record<string, ReadonlySet<string>> = {
+  media_link_processed: new Set([
+    ...COMMON_CUSTOM_PROPERTIES,
+    "provider",
+    "media_kind",
+    "shape",
+    "normalized",
+    "redirected",
+    "outcome",
+    "failure_reason",
+  ]),
+  cobalt_tunnel_readiness: new Set([
+    ...COMMON_CUSTOM_PROPERTIES,
+    "provider",
+    "outcome",
+    "attempts",
+    "elapsed_bucket",
+  ]),
   audio_upload_completed: new Set([
     ...COMMON_CUSTOM_PROPERTIES,
     "requested_count",
@@ -289,9 +331,55 @@ const SAFE_SDK_PROPERTIES = new Set([
 const SENSITIVE_PROPERTY_NAME =
   /(?:url|href|referrer|pathname|host|filename|artist|album|artwork|message|response|body|tunnel|text|elements)/i;
 const URL_VALUE = /https?:\/\//i;
+const isOneOf =
+  <Value extends string>(values: readonly Value[]) =>
+  (value: unknown): value is Value =>
+    typeof value === "string" && values.includes(value as Value);
+const isBoolean = (value: unknown) => typeof value === "boolean";
+const isBoundedTunnelAttempt = (value: unknown) =>
+  typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 4;
+const isAnalyticsProvider = isOneOf(["youtube", "soundcloud", "other"] as const);
+const isMediaKind = isOneOf(["track", "playlist", "unsupported"] as const);
+const isMediaLinkShape = isOneOf(["canonical", "short", "mobile", "nocookie", "other"] as const);
+const isMediaLinkOutcome = isOneOf(["accepted", "rejected"] as const);
+const isMediaLinkFailure = isOneOf(["invalid", "unsupported", "resolution_failed"] as const);
+const isCobaltTunnelOutcome = isOneOf([
+  "ready",
+  "recovered",
+  "exhausted",
+  "non_retryable",
+] as const);
+const isCobaltTunnelElapsedBucket = isOneOf([
+  "under_1_second",
+  "1_to_5_seconds",
+  "5_to_15_seconds",
+  "15_seconds_or_more",
+] as const);
+
+const CUSTOM_PROPERTY_VALIDATORS: Record<
+  string,
+  Readonly<Record<string, (value: unknown) => boolean>>
+> = {
+  media_link_processed: {
+    provider: isAnalyticsProvider,
+    media_kind: isMediaKind,
+    shape: isMediaLinkShape,
+    normalized: isBoolean,
+    redirected: isBoolean,
+    outcome: isMediaLinkOutcome,
+    failure_reason: isMediaLinkFailure,
+  },
+  cobalt_tunnel_readiness: {
+    provider: isAnalyticsProvider,
+    outcome: isCobaltTunnelOutcome,
+    attempts: isBoundedTunnelAttempt,
+    elapsed_bucket: isCobaltTunnelElapsedBucket,
+  },
+};
 
 const redactAndValidateEvent = (event: BeforeSendEvent): BeforeSendEvent | null => {
   const customAllowedProperties = CUSTOM_EVENT_PROPERTIES[event.event];
+  const customPropertyValidators = CUSTOM_PROPERTY_VALIDATORS[event.event];
   const isSdkEvent = SAFE_SDK_EVENTS.has(event.event);
   if (!customAllowedProperties && !isSdkEvent) return null;
 
@@ -300,6 +388,8 @@ const redactAndValidateEvent = (event: BeforeSendEvent): BeforeSendEvent | null 
     const isAllowedCustomProperty = customAllowedProperties?.has(property) ?? false;
     const isAllowedSdkProperty = SAFE_SDK_PROPERTIES.has(property);
     if (!isAllowedCustomProperty && !isAllowedSdkProperty) continue;
+    const customValidator = customPropertyValidators?.[property];
+    if (customValidator && !customValidator(value)) continue;
     if (!isAllowedCustomProperty && SENSITIVE_PROPERTY_NAME.test(property)) continue;
     if (!isAllowedCustomProperty && typeof value === "string" && URL_VALUE.test(value)) continue;
     properties[property] = value;
@@ -330,6 +420,33 @@ const serializeEvent = (event: AnalyticsEvent, config: AnalyticsConfig) => {
   };
 
   switch (event.type) {
+    case "media_link_processed": {
+      return {
+        name: event.type,
+        properties: {
+          ...commonProperties,
+          provider: analyticsProviderFromUrl(event.sourceUrl),
+          media_kind: event.mediaKind,
+          shape: event.shape,
+          normalized: event.normalized,
+          redirected: event.redirected,
+          outcome: event.outcome,
+          ...(event.failureReason ? { failure_reason: event.failureReason } : {}),
+        },
+      };
+    }
+    case "cobalt_tunnel_readiness": {
+      return {
+        name: event.type,
+        properties: {
+          ...commonProperties,
+          provider: analyticsProviderFromUrl(event.sourceUrl),
+          outcome: event.outcome,
+          attempts: Math.max(1, Math.min(4, Math.trunc(event.attempts))),
+          elapsed_bucket: event.elapsedBucket,
+        },
+      };
+    }
     case "audio_upload_completed":
       return {
         name: event.type,
@@ -347,7 +464,7 @@ const serializeEvent = (event: AnalyticsEvent, config: AnalyticsConfig) => {
         name: event.type,
         properties: {
           ...commonProperties,
-          provider: providerFromUrl(event.sourceUrl),
+          provider: analyticsProviderFromUrl(event.sourceUrl),
           import_kind: event.importKind,
         },
       };
@@ -356,7 +473,7 @@ const serializeEvent = (event: AnalyticsEvent, config: AnalyticsConfig) => {
         name: event.type,
         properties: {
           ...commonProperties,
-          provider: providerFromUrl(event.sourceUrl),
+          provider: analyticsProviderFromUrl(event.sourceUrl),
           import_kind: event.importKind,
           resolved_count: event.resolvedCount,
           has_cover: event.hasCover,
@@ -367,7 +484,7 @@ const serializeEvent = (event: AnalyticsEvent, config: AnalyticsConfig) => {
         name: event.type,
         properties: {
           ...commonProperties,
-          provider: providerFromUrl(event.sourceUrl),
+          provider: analyticsProviderFromUrl(event.sourceUrl),
           import_kind: event.importKind,
           outcome: event.outcome,
           total_count: event.totalCount,

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -123,17 +123,30 @@ export interface Analytics {
 
 const providerFromUrl = (sourceUrl: string) => {
   try {
-    const hostname = new URL(sourceUrl).hostname.toLowerCase();
+    const url = new URL(sourceUrl);
+    const host = url.hostname.toLowerCase();
     if (
-      hostname === "youtube.com" ||
-      hostname.endsWith(".youtube.com") ||
-      hostname === "youtu.be"
-    ) {
-      return "youtube" as const;
-    }
-    if (hostname === "soundcloud.com" || hostname.endsWith(".soundcloud.com")) {
-      return "soundcloud" as const;
-    }
+      [
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com",
+        "music.youtube.com",
+        "youtu.be",
+        "youtube-nocookie.com",
+        "www.youtube-nocookie.com",
+      ].includes(host)
+    )
+      return "youtube";
+    if (
+      [
+        "soundcloud.com",
+        "www.soundcloud.com",
+        "m.soundcloud.com",
+        "on.soundcloud.com",
+        "snd.sc",
+      ].includes(host)
+    )
+      return "soundcloud";
   } catch {
     // Invalid and non-web URLs are intentionally grouped with other providers.
   }

--- a/src/features/import/audioUrlImportSession.ts
+++ b/src/features/import/audioUrlImportSession.ts
@@ -14,15 +14,16 @@ import {
   type PlaylistDownloadControllerSnapshot,
 } from "@/features/import/playlistDownloadController";
 import type { Playlist } from "@/features/import/playlist";
-import { isSoundCloudSetUrl, resolveSoundCloudSet } from "@/features/import/soundcloudSet";
+import { resolveSoundCloudSet } from "@/features/import/soundcloudSet";
 import { reportSystemFailure } from "@/features/workspace/systemFailure";
 import { resolveTrackMetadata, type TrackMetadata } from "@/features/import/trackMetadata";
 import type { TrackEditorSession } from "@/features/editor/useTrackEditorSession";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
 import type { AppSettings, AudioMetadata, TagiumFile } from "@/features/library/types";
-import { isYouTubePlaylistUrl, resolveYouTubePlaylist } from "@/features/import/youtubePlaylist";
+import { resolveYouTubePlaylist } from "@/features/import/youtubePlaylist";
 import type { Manifest } from "@/features/share/shareManifest";
 import { createSharedAlbumDownloadPlan } from "@/features/share/sharedAlbumDownload";
+import { parseMediaLink } from "@/lib/media-link";
 
 type ManagedDownloadTrack = QueuedDownloadTrack & { importOperationId?: string };
 const retryProvider = (
@@ -31,10 +32,10 @@ const retryProvider = (
   const providers = new Set(
     tracks.map((track) => {
       try {
-        const host = new URL(track.downloadRequest.sourceUrl).hostname.toLowerCase();
-        return host === "youtu.be" || host.includes("youtube")
+        const parsed = parseMediaLink(track.downloadRequest.sourceUrl);
+        return parsed.provider === "youtube"
           ? "youtube"
-          : host.includes("soundcloud")
+          : parsed.provider === "soundcloud"
             ? "soundcloud"
             : "other";
       } catch {
@@ -330,13 +331,50 @@ export const createAudioUrlImportSession = ({
     importUrl: async (sourceUrl) => {
       const trimmedUrl = sourceUrl.trim();
       if (!trimmedUrl) return;
-      const playlistProvider = isSoundCloudSetUrl(trimmedUrl)
-        ? "soundcloud"
-        : isYouTubePlaylistUrl(trimmedUrl)
-          ? "youtube"
-          : null;
+      let parsed = parseMediaLink(trimmedUrl);
+      if (parsed.kind === "unsupported") {
+        try {
+          const candidate = new URL(trimmedUrl);
+          if (candidate.hostname === "on.soundcloud.com" || candidate.hostname === "snd.sc") {
+            const endpoint = new URL("/api/soundcloud-link", window.location.origin);
+            endpoint.searchParams.set("url", trimmedUrl);
+            const response = await fetch(endpoint);
+            if (response.ok) {
+              const candidateResult = await response.json();
+              if (
+                candidateResult &&
+                typeof candidateResult === "object" &&
+                typeof candidateResult.canonicalUrl === "string"
+              ) {
+                const reparsed = parseMediaLink(candidateResult.canonicalUrl);
+                if (reparsed.kind !== "unsupported") parsed = reparsed;
+              }
+            }
+          }
+        } catch {
+          /* handled by unsupported guard below */
+        }
+      }
+      if (parsed.kind === "unsupported") {
+        const host = (() => {
+          try {
+            return new URL(trimmedUrl).hostname.toLowerCase();
+          } catch {
+            return "";
+          }
+        })();
+        const exactProvider =
+          host.includes("youtube") ||
+          host.includes("soundcloud") ||
+          host === "youtu.be" ||
+          host === "snd.sc";
+        if (exactProvider) throw new Error("unsupported_media_link");
+        parsed = { provider: "other", kind: "unsupported", canonicalUrl: trimmedUrl };
+      }
+      const normalizedUrl = parsed.canonicalUrl;
+      const playlistProvider = parsed.kind === "playlist" ? parsed.provider : null;
       const importOperationId = importLifecycleTracker.start({
-        sourceUrl: trimmedUrl,
+        sourceUrl: normalizedUrl,
         importKind: playlistProvider ? "set" : "single",
       });
       setUrlImporting(true);
@@ -345,11 +383,11 @@ export const createAudioUrlImportSession = ({
           try {
             const playlist =
               playlistProvider === "soundcloud"
-                ? await resolveSoundCloudSet(trimmedUrl, importOperationId)
-                : await resolveYouTubePlaylist(trimmedUrl);
-            // Preserve the exact validated URL submitted by the user; provider
-            // responses intentionally do not carry request provenance.
-            handlePlaylistDownload({ ...playlist, sourceUrl: trimmedUrl }, importOperationId);
+                ? await resolveSoundCloudSet(normalizedUrl, importOperationId)
+                : await resolveYouTubePlaylist(normalizedUrl);
+            // Preserve the canonical URL; provider responses intentionally do
+            // not carry request provenance.
+            handlePlaylistDownload({ ...playlist, sourceUrl: normalizedUrl }, importOperationId);
           } catch (error) {
             importLifecycleTracker.fail(importOperationId, error, "resolve");
             throw error;
@@ -358,11 +396,11 @@ export const createAudioUrlImportSession = ({
         }
         let trackMetadata: TrackMetadata | undefined;
         try {
-          trackMetadata = await resolveTrackMetadata(trimmedUrl);
+          trackMetadata = await resolveTrackMetadata(normalizedUrl);
         } catch {
           // Metadata enrichment is optional; URL-derived metadata remains available.
         }
-        handleAudioDownload(trimmedUrl, importOperationId, trackMetadata);
+        handleAudioDownload(normalizedUrl, importOperationId, trackMetadata);
       } finally {
         setUrlImporting(false);
       }

--- a/src/features/import/audioUrlImportSession.ts
+++ b/src/features/import/audioUrlImportSession.ts
@@ -1,4 +1,8 @@
-import { analytics } from "@/analytics";
+import { analytics, analyticsProviderFromUrl, type MediaLinkShape } from "@/analytics";
+import type {
+  CobaltAudioDownloadLifecycleEvent,
+  CobaltAudioDownloadRequest,
+} from "@/features/import/cobaltAudio";
 import { downloadFromCobalt, provideAudioBackend } from "@/features/audio/audioBackend";
 import { applyPlaylistImportedCover } from "@/features/library/fileMetadataOps";
 import {
@@ -65,6 +69,43 @@ const createPlaylistDownloadModelTrack = (track: ManagedDownloadTrack) => ({
   sourceUrl: track.downloadRequest.sourceUrl,
 });
 
+const mediaLinkShapeFromUrl = (sourceUrl: string): MediaLinkShape => {
+  try {
+    const host = new URL(sourceUrl).hostname.toLowerCase();
+    if (host === "youtu.be" || host === "on.soundcloud.com" || host === "snd.sc") {
+      return "short";
+    }
+    if (host === "m.youtube.com" || host === "music.youtube.com" || host === "m.soundcloud.com") {
+      return "mobile";
+    }
+    if (host === "youtube-nocookie.com" || host === "www.youtube-nocookie.com") {
+      return "nocookie";
+    }
+    if (
+      host === "youtube.com" ||
+      host === "www.youtube.com" ||
+      host === "soundcloud.com" ||
+      host === "www.soundcloud.com"
+    ) {
+      return "canonical";
+    }
+  } catch {
+    // Invalid and generic inputs share the non-identifying "other" shape.
+  }
+  return "other";
+};
+
+const captureTunnelReadiness = (sourceUrl: string, event: CobaltAudioDownloadLifecycleEvent) => {
+  if (event.type !== "tunnel-readiness") return;
+  analytics.capture({
+    type: "cobalt_tunnel_readiness",
+    sourceUrl,
+    outcome: event.outcome,
+    attempts: event.attempts,
+    elapsedBucket: event.elapsedBucket,
+  });
+};
+
 export interface AudioUrlImportSession {
   importUrl: (sourceUrl: string) => Promise<void>;
   retryTrack: (fileId: string) => void;
@@ -122,7 +163,21 @@ export const createAudioUrlImportSession = ({
     if (controller) return controller;
     controller = createPlaylistDownloadController<ManagedDownloadTrack>({
       createModelTrack: createPlaylistDownloadModelTrack,
-      downloadTrack: (track) => provideAudioBackend(downloadFromCobalt(track.downloadRequest)),
+      downloadTrack: (track) => {
+        const request: CobaltAudioDownloadRequest = track.downloadRequest;
+        return provideAudioBackend(
+          downloadFromCobalt({
+            ...request,
+            onLifecycle: (event) => {
+              try {
+                request.onLifecycle?.(event);
+              } finally {
+                captureTunnelReadiness(request.sourceUrl, event);
+              }
+            },
+          }),
+        );
+      },
       hydrateTrack: (track, downloadedFile) =>
         provideAudioBackend(getEditor().hydrateDownloadedTrack(track.fileId, downloadedFile)),
       hasTrack: (trackId) => library.getSnapshot().files.some((file) => file.id === trackId),
@@ -332,10 +387,13 @@ export const createAudioUrlImportSession = ({
       const trimmedUrl = sourceUrl.trim();
       if (!trimmedUrl) return;
       let parsed = parseMediaLink(trimmedUrl);
+      let shortLinkResolutionAttempted = false;
+      let redirected = false;
       if (parsed.kind === "unsupported") {
         try {
           const candidate = new URL(trimmedUrl);
           if (candidate.hostname === "on.soundcloud.com" || candidate.hostname === "snd.sc") {
+            shortLinkResolutionAttempted = true;
             const endpoint = new URL("/api/soundcloud-link", window.location.origin);
             endpoint.searchParams.set("url", trimmedUrl);
             const response = await fetch(endpoint);
@@ -347,7 +405,10 @@ export const createAudioUrlImportSession = ({
                 typeof candidateResult.canonicalUrl === "string"
               ) {
                 const reparsed = parseMediaLink(candidateResult.canonicalUrl);
-                if (reparsed.kind !== "unsupported") parsed = reparsed;
+                if (reparsed.kind !== "unsupported") {
+                  parsed = reparsed;
+                  redirected = true;
+                }
               }
             }
           }
@@ -355,22 +416,32 @@ export const createAudioUrlImportSession = ({
           /* handled by unsupported guard below */
         }
       }
+      const provider = analyticsProviderFromUrl(trimmedUrl);
       if (parsed.kind === "unsupported") {
-        const host = (() => {
-          try {
-            return new URL(trimmedUrl).hostname.toLowerCase();
-          } catch {
-            return "";
-          }
-        })();
-        const exactProvider =
-          host.includes("youtube") ||
-          host.includes("soundcloud") ||
-          host === "youtu.be" ||
-          host === "snd.sc";
-        if (exactProvider) throw new Error("unsupported_media_link");
+        if (provider !== "other") {
+          analytics.capture({
+            type: "media_link_processed",
+            sourceUrl: trimmedUrl,
+            mediaKind: "unsupported",
+            shape: mediaLinkShapeFromUrl(trimmedUrl),
+            normalized: false,
+            redirected: false,
+            outcome: "rejected",
+            failureReason: shortLinkResolutionAttempted ? "resolution_failed" : "unsupported",
+          });
+          throw new Error("unsupported_media_link");
+        }
         parsed = { provider: "other", kind: "unsupported", canonicalUrl: trimmedUrl };
       }
+      analytics.capture({
+        type: "media_link_processed",
+        sourceUrl: trimmedUrl,
+        mediaKind: parsed.kind === "unsupported" ? "unsupported" : parsed.kind,
+        shape: mediaLinkShapeFromUrl(trimmedUrl),
+        normalized: parsed.canonicalUrl !== trimmedUrl,
+        redirected,
+        outcome: "accepted",
+      });
       const normalizedUrl = parsed.canonicalUrl;
       const playlistProvider = parsed.kind === "playlist" ? parsed.provider : null;
       const importOperationId = importLifecycleTracker.start({

--- a/src/features/import/cobaltAudio.ts
+++ b/src/features/import/cobaltAudio.ts
@@ -5,6 +5,7 @@ import {
   LocalAudioProcessor,
   LocalAudioProcessorLive,
 } from "@/features/import/localAudioProcessor";
+import type { CobaltTunnelElapsedBucket, CobaltTunnelOutcome } from "@/analytics";
 
 export type AudioDownloadBitrate = "320" | "256" | "128" | "96" | "64";
 
@@ -14,6 +15,12 @@ export type CobaltAudioDownloadLifecycleEvent =
     }
   | {
       type: "tunnel-budget-wait-ended";
+    }
+  | {
+      type: "tunnel-readiness";
+      outcome: CobaltTunnelOutcome;
+      attempts: number;
+      elapsedBucket: CobaltTunnelElapsedBucket;
     };
 
 export type CobaltAudioDownloadLifecycleCallback = (
@@ -32,6 +39,7 @@ export interface CobaltAudioDownloadRequest {
 
 const MAX_CONCURRENT_COBALT_DOWNLOADS = 4;
 const COBALT_TUNNEL_START_INTERVAL_MS = 1_600;
+const MAX_TUNNEL_ATTEMPTS = 4;
 let activeCobaltDownloads = 0;
 const pendingCobaltDownloads: (() => void)[] = [];
 let nextCobaltTunnelStartAt = 0;
@@ -180,6 +188,42 @@ const getStableLastModified = (sourceUrl: string) =>
     return (hash * 31 + character.charCodeAt(0)) % 2_147_483_647;
   }, 1);
 
+const tunnelElapsedBucket = (elapsedMs: number): CobaltTunnelElapsedBucket => {
+  if (elapsedMs < 1_000) return "under_1_second";
+  if (elapsedMs < 5_000) return "1_to_5_seconds";
+  if (elapsedMs < 15_000) return "5_to_15_seconds";
+  return "15_seconds_or_more";
+};
+
+const tunnelReadinessFromResponse = (
+  response: Response,
+  elapsedMs: number,
+): Extract<CobaltAudioDownloadLifecycleEvent, { type: "tunnel-readiness" }> | undefined => {
+  const outcome = response.headers.get("X-Tagium-Tunnel-Outcome");
+  const rawAttempts = response.headers.get("X-Tagium-Tunnel-Attempts");
+  if (
+    outcome !== "ready" &&
+    outcome !== "recovered" &&
+    outcome !== "exhausted" &&
+    outcome !== "non_retryable"
+  ) {
+    return undefined;
+  }
+  if (!rawAttempts || !/^\d+$/.test(rawAttempts)) return undefined;
+
+  const attempts = Number(rawAttempts);
+  if (!Number.isInteger(attempts) || attempts < 1 || attempts > MAX_TUNNEL_ATTEMPTS) {
+    return undefined;
+  }
+
+  return {
+    type: "tunnel-readiness",
+    outcome,
+    attempts,
+    elapsedBucket: tunnelElapsedBucket(elapsedMs),
+  };
+};
+
 const decodeCobaltDownloadPlan = Effect.fn("decodeCobaltDownloadPlan")(function* (input: unknown) {
   return yield* decodeCobaltDownloadPlanEffect(input).pipe(
     Effect.mapError(
@@ -243,7 +287,12 @@ const makeCobaltAudio = Effect.fn("makeCobaltAudio")(function* () {
       try: async () => {
         await waitForCobaltTunnelStart(onLifecycle, signal);
 
+        const startedAt = Date.now();
         const response = await fetch(url, { signal });
+        const readiness = tunnelReadinessFromResponse(response, Date.now() - startedAt);
+        if (readiness) {
+          onLifecycle?.(readiness);
+        }
         if (!response.ok) {
           throw new Error(await response.text());
         }

--- a/src/features/import/soundcloudSet.ts
+++ b/src/features/import/soundcloudSet.ts
@@ -1,17 +1,10 @@
 import { decodePlaylist, type Playlist } from "@/features/import/playlist";
+import { parseMediaLink } from "@/lib/media-link";
 
 export type SoundCloudSet = Playlist;
 
-export const isSoundCloudSetUrl = (url: string) => {
-  try {
-    const parsedUrl = new URL(url);
-    const isSoundCloudHost =
-      parsedUrl.hostname === "soundcloud.com" || parsedUrl.hostname.endsWith(".soundcloud.com");
-    return isSoundCloudHost && parsedUrl.pathname.includes("/sets/");
-  } catch {
-    return false;
-  }
-};
+export const isSoundCloudSetUrl = (url: string) =>
+  parseMediaLink(url).provider === "soundcloud" && parseMediaLink(url).kind === "playlist";
 
 export const resolveSoundCloudSet = async (url: string, importId?: string) => {
   const endpoint = new URL("/api/soundcloud-set", window.location.origin);

--- a/src/features/import/youtubePlaylist.ts
+++ b/src/features/import/youtubePlaylist.ts
@@ -1,21 +1,10 @@
 import { decodePlaylist, type Playlist } from "@/features/import/playlist";
+import { parseMediaLink } from "@/lib/media-link";
 
 export type YouTubePlaylist = Playlist;
 
-export const isYouTubePlaylistUrl = (url: string) => {
-  try {
-    const parsedUrl = new URL(url);
-    const isYouTubeHost =
-      parsedUrl.hostname === "youtube.com" || parsedUrl.hostname.endsWith(".youtube.com");
-    return (
-      isYouTubeHost &&
-      parsedUrl.pathname.replace(/\/+$/, "") === "/playlist" &&
-      Boolean(parsedUrl.searchParams.get("list"))
-    );
-  } catch {
-    return false;
-  }
-};
+export const isYouTubePlaylistUrl = (url: string) =>
+  parseMediaLink(url).provider === "youtube" && parseMediaLink(url).kind === "playlist";
 
 export const resolveYouTubePlaylist = async (url: string) => {
   const endpoint = new URL("/api/youtube-playlist", window.location.origin);

--- a/src/features/share/shareEligibility.ts
+++ b/src/features/share/shareEligibility.ts
@@ -1,20 +1,9 @@
 import type { AlbumGroup, TagiumFile } from "@/features/library/types";
+import { parseMediaLink } from "@/lib/media-link";
 
 const supportedSource = (value: string) => {
   try {
-    const url = new URL(value);
-    const host = url.hostname.toLowerCase();
-    return (
-      url.protocol === "https:" &&
-      !url.username &&
-      !url.password &&
-      !url.hash &&
-      (host === "youtu.be" ||
-        host === "youtube.com" ||
-        host.endsWith(".youtube.com") ||
-        host === "soundcloud.com" ||
-        host.endsWith(".soundcloud.com"))
-    );
+    return parseMediaLink(value).kind !== "unsupported";
   } catch {
     return false;
   }

--- a/src/features/share/shareManifest.ts
+++ b/src/features/share/shareManifest.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect";
+import { parseMediaLink } from "@/lib/media-link";
 
 /** The largest persisted JSON manifest. Artwork bytes are deliberately not part of it. */
 export const MAX_MANIFEST_PAYLOAD_BYTES = 256 * 1024;
@@ -23,16 +24,10 @@ const positiveInteger = (minimum: number, maximum: number) =>
 const isSupportedSourceUrl = (value: string) => {
   try {
     const url = new URL(value);
-    if (url.protocol !== "https:" || url.username || url.password || url.hash) return false;
+    if (url.protocol !== "https:" || url.username || url.password) return false;
 
-    const hostname = url.hostname.toLowerCase();
-    return (
-      hostname === "youtu.be" ||
-      hostname === "youtube.com" ||
-      hostname.endsWith(".youtube.com") ||
-      hostname === "soundcloud.com" ||
-      hostname.endsWith(".soundcloud.com")
-    );
+    const parsed = parseMediaLink(value);
+    return parsed.kind !== "unsupported";
   } catch {
     return false;
   }
@@ -193,7 +188,7 @@ export interface ManifestAlbumProjection {
 
 const supportedProvenance = (value: string | undefined) =>
   value !== undefined && value.length > 0 && value.length <= 2_048 && isSupportedSourceUrl(value)
-    ? value
+    ? parseMediaLink(value).canonicalUrl
     : undefined;
 
 export interface ManifestTrackProjection {
@@ -247,7 +242,8 @@ export const projectAlbumManifest = (
       }
       const metadata = { ...file.metadata, ...file.pendingMetadataPatch };
       return {
-        sourceUrl: file.downloadRequest.sourceUrl,
+        sourceUrl:
+          supportedProvenance(file.downloadRequest.sourceUrl) ?? file.downloadRequest.sourceUrl,
         audioBitrate: file.downloadRequest.audioBitrate,
         metadata: {
           filename: metadata.filename || file.filename.replace(/\.mp3$/i, ""),

--- a/src/lib/media-link.ts
+++ b/src/lib/media-link.ts
@@ -1,0 +1,138 @@
+export const YOUTUBE_HOSTS = [
+  "youtube.com",
+  "www.youtube.com",
+  "m.youtube.com",
+  "music.youtube.com",
+] as const;
+export const SOUNDCLOUD_HOSTS = [
+  "soundcloud.com",
+  "www.soundcloud.com",
+  "m.soundcloud.com",
+] as const;
+const youtubeSet = new Set<string>(YOUTUBE_HOSTS);
+const soundcloudSet = new Set<string>(SOUNDCLOUD_HOSTS);
+const videoId = /^[A-Za-z0-9_-]{11}$/;
+
+export type ParsedMediaLink =
+  | { provider: "youtube"; kind: "track"; canonicalUrl: string; videoId: string }
+  | { provider: "youtube"; kind: "playlist"; canonicalUrl: string; playlistId: string }
+  | { provider: "soundcloud"; kind: "track" | "playlist"; canonicalUrl: string }
+  | { provider: "other"; kind: "unsupported"; canonicalUrl: string };
+
+const unsupported = (url: URL): ParsedMediaLink => ({
+  provider: "other",
+  kind: "unsupported",
+  canonicalUrl: url.toString(),
+});
+const youtubeTrack = (id: string): ParsedMediaLink | undefined =>
+  videoId.test(id)
+    ? {
+        provider: "youtube",
+        kind: "track",
+        videoId: id,
+        canonicalUrl: `https://www.youtube.com/watch?v=${id}`,
+      }
+    : undefined;
+
+export function parseMediaLink(input: string): ParsedMediaLink {
+  let url: URL;
+  try {
+    url = new URL(input.trim());
+  } catch {
+    return { provider: "other", kind: "unsupported", canonicalUrl: input.trim() };
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.port)
+    return unsupported(url);
+  const host = url.hostname.toLowerCase();
+  if (host === "youtube-nocookie.com" || host === "www.youtube-nocookie.com") {
+    const parts = url.pathname.split("/").filter(Boolean);
+    const list = url.searchParams.get("list");
+    if (
+      parts[0] === "embed" &&
+      list &&
+      (parts[1] === "videoseries" || url.searchParams.get("listType") === "playlist")
+    )
+      return {
+        provider: "youtube",
+        kind: "playlist",
+        playlistId: list,
+        canonicalUrl: `https://www.youtube.com/playlist?list=${encodeURIComponent(list)}`,
+      };
+    if (parts[0] === "embed" && parts[1] && !parts[1].includes("videoseries"))
+      return youtubeTrack(parts[1]) ?? unsupported(url);
+    return unsupported(url);
+  }
+  if (host === "youtu.be" || youtubeSet.has(host)) {
+    const parts = url.pathname.split("/").filter(Boolean);
+    const list = url.searchParams.get("list");
+    if (
+      youtubeSet.has(host) &&
+      (parts[0] === "playlist" ||
+        (parts[0] === "embed" &&
+          (parts[1] === "videoseries" || url.searchParams.get("listType") === "playlist"))) &&
+      list
+    ) {
+      return {
+        provider: "youtube",
+        kind: "playlist",
+        playlistId: list,
+        canonicalUrl: `https://www.youtube.com/playlist?list=${encodeURIComponent(list)}`,
+      };
+    }
+    let id: string | undefined;
+    if (host === "youtu.be") id = parts[0];
+    else if (parts[0] === "watch") id = url.searchParams.get("v") ?? parts[1];
+    else if (["shorts", "live", "embed", "v"].includes(parts[0] ?? "")) id = parts[1];
+    else if (parts[0] === "attribution_link") {
+      const raw = url.searchParams.get("u");
+      if (raw?.startsWith("/") && !raw.startsWith("//"))
+        return parseMediaLink(`https://${host}${raw}`);
+    }
+    return (id ? youtubeTrack(id) : undefined) ?? unsupported(url);
+  }
+  if (soundcloudSet.has(host)) {
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (
+      parts.length >= 3 &&
+      parts.length <= 4 &&
+      parts[1] === "sets" &&
+      (parts.length === 3 || parts[3]?.startsWith("s-"))
+    ) {
+      const token =
+        (parts[3]?.startsWith("s-") ? parts[3] : undefined) ??
+        (url.searchParams.get("secret_token")?.startsWith("s-")
+          ? url.searchParams.get("secret_token")!
+          : undefined);
+      const base = `https://soundcloud.com/${parts[0]}/sets/${parts[2]}`;
+      return {
+        provider: "soundcloud",
+        kind: "playlist",
+        canonicalUrl: token ? `${base}/${token}` : base,
+      };
+    }
+    if (
+      parts.length >= 2 &&
+      parts.length <= 3 &&
+      parts[0] &&
+      !["stream", "discover", "you", "likes", "stations", "search", "sets"].includes(parts[0]) &&
+      (parts.length === 2 || parts[2]?.startsWith("s-"))
+    ) {
+      const token =
+        (parts[2]?.startsWith("s-") ? parts[2] : undefined) ??
+        (url.searchParams.get("secret_token")?.startsWith("s-")
+          ? url.searchParams.get("secret_token")!
+          : undefined);
+      const base = `https://soundcloud.com/${parts[0]}/${parts[1]}`;
+      return {
+        provider: "soundcloud",
+        kind: "track",
+        canonicalUrl: token ? `${base}/${token}` : base,
+      };
+    }
+    return unsupported(url);
+  }
+  return unsupported(url);
+}
+
+export const isYouTubeHost = (host: string) => youtubeSet.has(host.toLowerCase());
+export const isSoundCloudHost = (host: string) => soundcloudSet.has(host.toLowerCase());

--- a/tests/server/cobalt/tunnel.get.test.ts
+++ b/tests/server/cobalt/tunnel.get.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import handler from "../../../server/api/cobalt/tunnel.get";
+import { setDevFault } from "../../../server/utils/dev-controls";
 
 type RuntimeRequest = Request & {
   runtime: {
@@ -7,6 +8,7 @@ type RuntimeRequest = Request & {
       env: {
         COBALT_API_URL: string;
         COBALT_MACHINE_AFFINITY_SECRET: string;
+        TAGIUM_DEPLOY_ENV?: string;
       };
     };
   };
@@ -64,6 +66,7 @@ describe("cobalt tunnel endpoint", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    setDevFault({ target: "tunnel", fault: null });
   });
 
   it("streams successful tunnel bodies even when upstream reports content-length zero", async () => {
@@ -84,6 +87,8 @@ describe("cobalt tunnel endpoint", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("audio/mpeg");
     expect(response.headers.get("Content-Length")).toBeNull();
+    expect(response.headers.get("X-Tagium-Tunnel-Outcome")).toBe("ready");
+    expect(response.headers.get("X-Tagium-Tunnel-Attempts")).toBe("1");
     expect(await response.text()).toBe("audio-bytes");
   });
 
@@ -96,6 +101,8 @@ describe("cobalt tunnel endpoint", () => {
     vi.stubGlobal("fetch", fetchMock);
     const response = await handler(makeEvent(makeTunnelRequest()));
     expect(response.status).toBe(200);
+    expect(response.headers.get("X-Tagium-Tunnel-Outcome")).toBe("recovered");
+    expect(response.headers.get("X-Tagium-Tunnel-Attempts")).toBe("4");
     expect(await response.text()).toBe("audio-bytes");
     expect(fetchMock).toHaveBeenCalledTimes(4);
   });
@@ -105,6 +112,8 @@ describe("cobalt tunnel endpoint", () => {
     vi.stubGlobal("fetch", fetchMock);
     const response = await handler(makeEvent(makeTunnelRequest()));
     expect(response.status).toBe(502);
+    expect(response.headers.get("X-Tagium-Tunnel-Outcome")).toBe("exhausted");
+    expect(response.headers.get("X-Tagium-Tunnel-Attempts")).toBe("4");
     expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
@@ -113,6 +122,8 @@ describe("cobalt tunnel endpoint", () => {
     vi.stubGlobal("fetch", fetchMock);
     const response = await handler(makeEvent(makeTunnelRequest()));
     expect(response.status).toBe(502);
+    expect(response.headers.get("X-Tagium-Tunnel-Outcome")).toBe("non_retryable");
+    expect(response.headers.get("X-Tagium-Tunnel-Attempts")).toBe("1");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -208,7 +219,10 @@ describe("cobalt tunnel endpoint", () => {
     const response = await handler(makeEvent(makeTunnelRequestForMachine()));
 
     expect(response.status).toBe(503);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
     expect(response.headers.get("Retry-After")).toBe("2");
+    expect(response.headers.get("X-Tagium-Tunnel-Outcome")).toBe("non_retryable");
+    expect(response.headers.get("X-Tagium-Tunnel-Attempts")).toBe("1");
     expect(await response.json()).toEqual({
       status: "error",
       error: {
@@ -287,8 +301,30 @@ describe("cobalt tunnel endpoint", () => {
     const response = await handler(makeEvent(makeTunnelRequest()));
 
     expect(response.status).toBe(502);
+    expect(response.headers.get("X-Tagium-Tunnel-Outcome")).toBe("non_retryable");
+    expect(response.headers.get("X-Tagium-Tunnel-Attempts")).toBe("1");
     expect(await response.text()).toBe("private upstream detail");
     expect(JSON.stringify(warnMock.mock.calls)).not.toContain("private upstream detail");
+  });
+
+  it("reports the number of attempts begun before a retry fetch throws", async () => {
+    let attempts = 0;
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        attempts += 1;
+        if (attempts === 1) return new Response(null, { status: 200 });
+        throw new TypeError("second fetch failed");
+      }),
+    );
+
+    const response = await handler(makeEvent(makeTunnelRequest()));
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("X-Tagium-Tunnel-Outcome")).toBe("non_retryable");
+    expect(response.headers.get("X-Tagium-Tunnel-Attempts")).toBe("2");
+    expect(await response.text()).toBe("second fetch failed");
   });
 
   it("preserves the established timeout wording for aborted upstream fetches", async () => {
@@ -302,6 +338,24 @@ describe("cobalt tunnel endpoint", () => {
     const response = await handler(makeEvent(makeTunnelRequest()));
 
     expect(response.status).toBe(502);
+    expect(response.headers.get("X-Tagium-Tunnel-Outcome")).toBe("non_retryable");
+    expect(response.headers.get("X-Tagium-Tunnel-Attempts")).toBe("1");
     expect(await response.text()).toBe("Cobalt tunnel request timed out.");
+  });
+
+  it("annotates a pre-fetch dev timeout with one synthetic attempt", async () => {
+    const request = makeTunnelRequest();
+    request.runtime.cloudflare.env.TAGIUM_DEPLOY_ENV = "local";
+    setDevFault({ target: "tunnel", fault: "timeout" });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handler(makeEvent(request));
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("X-Tagium-Tunnel-Outcome")).toBe("non_retryable");
+    expect(response.headers.get("X-Tagium-Tunnel-Attempts")).toBe("1");
+    expect(await response.text()).toBe("Cobalt tunnel request timed out.");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/server/cobalt/tunnel.get.test.ts
+++ b/tests/server/cobalt/tunnel.get.test.ts
@@ -87,6 +87,54 @@ describe("cobalt tunnel endpoint", () => {
     expect(await response.text()).toBe("audio-bytes");
   });
 
+  it("retries a bounded empty 200 tunnel response", async () => {
+    let attempt = 0;
+    const fetchMock = vi.fn(async () => {
+      attempt++;
+      return attempt < 4 ? new Response(null, { status: 200 }) : new Response("audio-bytes");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const response = await handler(makeEvent(makeTunnelRequest()));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("audio-bytes");
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("stops after four empty responses", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const response = await handler(makeEvent(makeTunnelRequest()));
+    expect(response.status).toBe(502);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not retry non-ok responses", async () => {
+    const fetchMock = vi.fn(async () => new Response("missing", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const response = await handler(makeEvent(makeTunnelRequest()));
+    expect(response.status).toBe(502);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels an upstream stream when a later read fails", async () => {
+    let reads = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        reads++;
+        if (reads === 1) controller.enqueue(new TextEncoder().encode("first"));
+        else controller.error(new Error("upstream read failed"));
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(stream)),
+    );
+    const response = await handler(makeEvent(makeTunnelRequest()));
+    expect(response.status).toBe(200);
+    await expect(response.arrayBuffer()).rejects.toThrow();
+    expect(reads).toBeGreaterThanOrEqual(2);
+  });
+
   it("forwards Fly machine affinity when machine param is present", async () => {
     const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => {
       return new Response("audio-bytes", {

--- a/tests/server/utils/media-link.test.ts
+++ b/tests/server/utils/media-link.test.ts
@@ -4,6 +4,7 @@ import { resolveSoundCloudShortLink } from "../../../server/utils/soundcloud-lin
 
 describe("media link contract", () => {
   it.each([
+    ["https://youtu.be/qEIbFhBzfvA", "https://www.youtube.com/watch?v=qEIbFhBzfvA", "track"],
     ["https://youtu.be/dQw4w9WgXcQ?si=x", "https://www.youtube.com/watch?v=dQw4w9WgXcQ", "track"],
     [
       "https://m.youtube.com/shorts/dQw4w9WgXcQ",

--- a/tests/server/utils/media-link.test.ts
+++ b/tests/server/utils/media-link.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { parseMediaLink } from "../../../src/lib/media-link";
+import { resolveSoundCloudShortLink } from "../../../server/utils/soundcloud-link";
+
+describe("media link contract", () => {
+  it.each([
+    ["https://youtu.be/dQw4w9WgXcQ?si=x", "https://www.youtube.com/watch?v=dQw4w9WgXcQ", "track"],
+    [
+      "https://m.youtube.com/shorts/dQw4w9WgXcQ",
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "track",
+    ],
+    [
+      "https://www.youtube.com/embed/videoseries?list=PL123",
+      "https://www.youtube.com/playlist?list=PL123",
+      "playlist",
+    ],
+    [
+      "https://www.youtube-nocookie.com/embed?listType=playlist&list=PL123",
+      "https://www.youtube.com/playlist?list=PL123",
+      "playlist",
+    ],
+    [
+      "https://youtube-nocookie.com/embed/dQw4w9WgXcQ",
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "track",
+    ],
+    [
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ#t=2",
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "track",
+    ],
+    [
+      "https://m.soundcloud.com/a/t?secret_token=s-abc&utm_source=x",
+      "https://soundcloud.com/a/t/s-abc",
+      "track",
+    ],
+    [
+      "https://www.soundcloud.com/a/sets/mix?secret_token=s-xyz&utm_medium=x",
+      "https://soundcloud.com/a/sets/mix/s-xyz",
+      "playlist",
+    ],
+  ])("normalizes %s", (input, canonical, kind) => {
+    const result = parseMediaLink(input);
+    expect(result.canonicalUrl).toBe(canonical);
+    expect(result.kind).toBe(kind);
+  });
+
+  it.each([
+    "https://foo.youtube.com/watch?v=dQw4w9WgXcQ",
+    "https://youtube.com.example/watch?v=dQw4w9WgXcQ",
+    "http://youtube.com/watch?v=dQw4w9WgXcQ",
+    "https://soundcloud.com.evil/a/t",
+  ])("rejects %s", (input) => {
+    expect(parseMediaLink(input).kind).toBe("unsupported");
+  });
+  it.each(["https://soundcloud.com/a/t/extra", "https://soundcloud.com/a/sets/mix/extra"])(
+    "rejects malformed SoundCloud path %s",
+    (input) => expect(parseMediaLink(input).kind).toBe("unsupported"),
+  );
+});
+
+describe("bounded SoundCloud short links", () => {
+  const response = (status: number, location?: string) =>
+    new Response(null, { status, headers: location ? { location } : undefined });
+  it("resolves a relative redirect to a track", async () => {
+    let first = true;
+    const result = await resolveSoundCloudShortLink("https://on.soundcloud.com/x", {
+      fetch: async () =>
+        first
+          ? ((first = false), response(302, "https://soundcloud.com/artist/track"))
+          : response(200),
+    });
+    expect(result.kind).toBe("track");
+  });
+  it("upgrades legacy snd.sc before fetching", async () => {
+    let seen = "";
+    await expect(
+      resolveSoundCloudShortLink("http://snd.sc/x", {
+        fetch: async (url) => {
+          seen = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+          return response(200);
+        },
+      }),
+    ).rejects.toThrow();
+    expect(seen.startsWith("https://snd.sc/")).toBe(true);
+  });
+  it("rejects off-provider destinations and excessive hops", async () => {
+    await expect(
+      resolveSoundCloudShortLink("https://on.soundcloud.com/x", {
+        fetch: async () => response(302, "https://example.com"),
+      }),
+    ).rejects.toThrow("off_provider");
+    let count = 0;
+    await expect(
+      resolveSoundCloudShortLink("https://on.soundcloud.com/x", {
+        fetch: async () => {
+          count++;
+          return response(302, `https://on.soundcloud.com/${count}`);
+        },
+      }),
+    ).rejects.toThrow("too_many_redirects");
+  });
+});

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -120,6 +120,129 @@ describe("analytics", () => {
     expect(JSON.stringify(capture.mock.calls)).not.toContain("internal.example");
   });
 
+  it("serializes URL shape and tunnel readiness as privacy-safe categories", async () => {
+    const init = vi.fn();
+    const capture = vi.fn();
+    const analytics = createAnalytics(
+      { key: "public-test-key", deployEnv: "production" },
+      {
+        loadClient: async () => ({ init, capture }),
+        schedule: (load) => load(),
+      },
+    );
+    analytics.initialize();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const linkCases = [
+      ["https://youtube.com/watch?v=private-id", "youtube", "canonical"],
+      ["https://youtu.be/private-id", "youtube", "short"],
+      ["https://music.youtube.com/watch?v=private-id", "youtube", "mobile"],
+      ["https://www.youtube-nocookie.com/embed/private-id", "youtube", "nocookie"],
+      ["https://on.soundcloud.com/private-token", "soundcloud", "short"],
+      ["https://foo.youtube.com/private-id", "other", "other"],
+      ["https://youtube.com.evil/private-id", "other", "other"],
+    ] as const;
+
+    for (const [sourceUrl, provider, shape] of linkCases) {
+      analytics.capture({
+        type: "media_link_processed",
+        sourceUrl,
+        mediaKind: "track",
+        shape,
+        normalized: shape !== "canonical",
+        redirected: shape === "short",
+        outcome: "accepted",
+      });
+      expect(capture.mock.calls.at(-1)).toEqual([
+        "media_link_processed",
+        expect.objectContaining({
+          provider,
+          media_kind: "track",
+          shape,
+          normalized: shape !== "canonical",
+          redirected: shape === "short",
+          outcome: "accepted",
+        }),
+      ]);
+    }
+
+    analytics.capture({
+      type: "media_link_processed",
+      sourceUrl: "https://on.soundcloud.com/private-token",
+      mediaKind: "unsupported",
+      shape: "short",
+      normalized: false,
+      redirected: false,
+      outcome: "rejected",
+      failureReason: "resolution_failed",
+    });
+    analytics.capture({
+      type: "cobalt_tunnel_readiness",
+      sourceUrl: "https://soundcloud.com/private-artist/private-track?secret=query",
+      outcome: "recovered",
+      attempts: 3,
+      elapsedBucket: "1_to_5_seconds",
+    });
+
+    expect(capture.mock.calls.at(-2)?.[1]).toEqual(
+      expect.objectContaining({
+        provider: "soundcloud",
+        failure_reason: "resolution_failed",
+      }),
+    );
+    expect(capture.mock.calls.at(-1)).toEqual([
+      "cobalt_tunnel_readiness",
+      expect.objectContaining({
+        provider: "soundcloud",
+        outcome: "recovered",
+        attempts: 3,
+        elapsed_bucket: "1_to_5_seconds",
+      }),
+    ]);
+
+    const serialized = JSON.stringify(capture.mock.calls);
+    for (const sensitiveValue of [
+      "private-id",
+      "private-token",
+      "private-artist",
+      "private-track",
+      "secret",
+      "query",
+      "youtube.com.evil",
+      "foo.youtube.com",
+    ]) {
+      expect(serialized).not.toContain(sensitiveValue);
+    }
+
+    const options = init.mock.calls[0]?.[1] as {
+      before_send: (event: {
+        event: string;
+        properties: Record<string, unknown>;
+      }) => { properties: Record<string, unknown> } | null;
+    };
+    const redacted = options.before_send({
+      event: "cobalt_tunnel_readiness",
+      properties: {
+        event_version: 1,
+        deploy_env: "production",
+        provider: "https://soundcloud.com/private-track",
+        outcome: "private-title",
+        attempts: 999,
+        elapsed_bucket: "request-signature",
+        source_url: "https://soundcloud.com/private-track",
+        request_id: "private-request-id",
+        machine_id: "private-machine-id",
+        tunnel_signature: "private-signature",
+      },
+    });
+
+    expect(redacted?.properties).toEqual({
+      event_version: 1,
+      deploy_env: "production",
+    });
+  });
+
   it("maps import failures to stable codes without serializing exception details", async () => {
     const capture = vi.fn();
     const analytics = createAnalytics(

--- a/tests/unit/features/import/audioUrlImportSession.test.ts
+++ b/tests/unit/features/import/audioUrlImportSession.test.ts
@@ -1,16 +1,23 @@
 import { Effect } from "effect";
 import { act } from "react-test-renderer";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { CobaltAudioDownloadRequest } from "@/features/import/cobaltAudio";
 import type { AppSettings } from "@/features/library/types";
 
 const mocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  downloadFromCobalt: vi.fn((_request: CobaltAudioDownloadRequest) => Effect.never),
   resolveTrackMetadata: vi.fn(),
   resolveSoundCloudSet: vi.fn(),
   resolveYouTubePlaylist: vi.fn(),
 }));
 
+vi.mock("@/analytics", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/analytics")>()),
+  analytics: { capture: mocks.capture },
+}));
 vi.mock("@/features/audio/audioBackend", () => ({
-  downloadFromCobalt: () => Effect.never,
+  downloadFromCobalt: mocks.downloadFromCobalt,
   provideAudioBackend: (operation: unknown) => operation,
   parseUploads: vi.fn(),
   runAudioBackendEffect: vi.fn(),
@@ -40,9 +47,161 @@ const settings = (audioBitrate: AppSettings["audioBitrate"]): AppSettings => ({
   applySoundCloudAlbumCoverToTracks: false,
 });
 
-afterEach(() => vi.clearAllMocks());
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe("audio URL import session", () => {
+  it("records accepted and rejected URL processing after resolution", async () => {
+    mocks.resolveTrackMetadata.mockResolvedValue(undefined);
+    const hook = renderHook(() => {
+      const library = useLibraryStore();
+      const editor = useTrackEditorSession({ library, settings: settings("320") });
+      const importing = useAudioImportSession({
+        library,
+        editor,
+        settings: settings("320"),
+        activateEditor: vi.fn(),
+      });
+      return { library, importing };
+    }, undefined);
+
+    await act(async () => {
+      await hook.result.importing.commands.importUrl("https://www.youtube.com/watch?v=abcdefghijk");
+    });
+    expect(mocks.capture).toHaveBeenCalledWith({
+      type: "media_link_processed",
+      sourceUrl: "https://www.youtube.com/watch?v=abcdefghijk",
+      mediaKind: "track",
+      shape: "canonical",
+      normalized: false,
+      redirected: false,
+      outcome: "accepted",
+    });
+
+    await expect(
+      hook.result.importing.commands.importUrl("https://soundcloud.com/discover"),
+    ).rejects.toThrow("unsupported_media_link");
+    expect(mocks.capture).toHaveBeenCalledWith({
+      type: "media_link_processed",
+      sourceUrl: "https://soundcloud.com/discover",
+      mediaKind: "unsupported",
+      shape: "canonical",
+      normalized: false,
+      redirected: false,
+      outcome: "rejected",
+      failureReason: "unsupported",
+    });
+    hook.unmount();
+  });
+
+  it("records failed short-link resolution as rejected", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("unavailable", { status: 503 })),
+    );
+    const hook = renderHook(() => {
+      const library = useLibraryStore();
+      const editor = useTrackEditorSession({ library, settings: settings("320") });
+      const importing = useAudioImportSession({
+        library,
+        editor,
+        settings: settings("320"),
+        activateEditor: vi.fn(),
+      });
+      return importing;
+    }, undefined);
+
+    await expect(
+      hook.result.commands.importUrl("https://on.soundcloud.com/private-token"),
+    ).rejects.toThrow("unsupported_media_link");
+
+    expect(mocks.capture).toHaveBeenCalledWith({
+      type: "media_link_processed",
+      sourceUrl: "https://on.soundcloud.com/private-token",
+      mediaKind: "unsupported",
+      shape: "short",
+      normalized: false,
+      redirected: false,
+      outcome: "rejected",
+      failureReason: "resolution_failed",
+    });
+    expect(
+      mocks.capture.mock.calls.some(
+        ([event]) =>
+          event.type === "media_link_processed" &&
+          "sourceUrl" in event &&
+          event.sourceUrl === "https://on.soundcloud.com/private-token" &&
+          event.outcome === "accepted",
+      ),
+    ).toBe(false);
+    hook.unmount();
+  });
+
+  it("wires recovery and exhaustion lifecycle events to tunnel analytics", async () => {
+    mocks.resolveTrackMetadata.mockResolvedValue(undefined);
+    const hook = renderHook(() => {
+      const library = useLibraryStore();
+      const editor = useTrackEditorSession({ library, settings: settings("320") });
+      const importing = useAudioImportSession({
+        library,
+        editor,
+        settings: settings("320"),
+        activateEditor: vi.fn(),
+      });
+      return importing;
+    }, undefined);
+
+    await act(async () => {
+      await hook.result.commands.importUrl("https://youtu.be/abcdefghijk");
+    });
+    await vi.waitFor(() => expect(mocks.downloadFromCobalt).toHaveBeenCalled());
+    const request = mocks.downloadFromCobalt.mock.calls[0]?.[0];
+
+    request?.onLifecycle?.({
+      type: "tunnel-readiness",
+      outcome: "recovered",
+      attempts: 3,
+      elapsedBucket: "under_1_second",
+    });
+    request?.onLifecycle?.({
+      type: "tunnel-readiness",
+      outcome: "exhausted",
+      attempts: 4,
+      elapsedBucket: "1_to_5_seconds",
+    });
+    request?.onLifecycle?.({
+      type: "tunnel-readiness",
+      outcome: "non_retryable",
+      attempts: 1,
+      elapsedBucket: "5_to_15_seconds",
+    });
+
+    expect(mocks.capture).toHaveBeenCalledWith({
+      type: "cobalt_tunnel_readiness",
+      sourceUrl: "https://www.youtube.com/watch?v=abcdefghijk",
+      outcome: "recovered",
+      attempts: 3,
+      elapsedBucket: "under_1_second",
+    });
+    expect(mocks.capture).toHaveBeenCalledWith({
+      type: "cobalt_tunnel_readiness",
+      sourceUrl: "https://www.youtube.com/watch?v=abcdefghijk",
+      outcome: "exhausted",
+      attempts: 4,
+      elapsedBucket: "1_to_5_seconds",
+    });
+    expect(mocks.capture).toHaveBeenCalledWith({
+      type: "cobalt_tunnel_readiness",
+      sourceUrl: "https://www.youtube.com/watch?v=abcdefghijk",
+      outcome: "non_retryable",
+      attempts: 1,
+      elapsedBucket: "5_to_15_seconds",
+    });
+    hook.unmount();
+  });
+
   it.each([
     ["https://soundcloud.com/artist/sets/exact-set", "resolveSoundCloudSet"],
     ["https://www.youtube.com/playlist?list=PL_exact", "resolveYouTubePlaylist"],

--- a/tests/unit/features/import/cobaltAudio.test.ts
+++ b/tests/unit/features/import/cobaltAudio.test.ts
@@ -108,6 +108,112 @@ describe("CobaltAudio download", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    {
+      outcome: "recovered",
+      attempts: "3",
+      status: 200,
+      expectedError: undefined,
+    },
+    {
+      outcome: "exhausted",
+      attempts: "4",
+      status: 502,
+      expectedError: "Cobalt tunnel response was empty.",
+    },
+    {
+      outcome: "non_retryable",
+      attempts: "1",
+      status: 502,
+      expectedError: "Cobalt tunnel request timed out.",
+    },
+    {
+      outcome: "non_retryable",
+      attempts: "2",
+      status: 502,
+      expectedError: "upstream fetch failed.",
+    },
+  ] as const)(
+    "reports $outcome tunnel readiness without tunnel details",
+    async ({ outcome, attempts, status, expectedError }) => {
+      const onLifecycle = vi.fn();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) => {
+          if (url === "/api/cobalt/audio") {
+            return Response.json({
+              status: "tunnel",
+              url: "/api/cobalt/tunnel?private=signature",
+              filename: "private-title.mp3",
+            });
+          }
+
+          return new Response(status === 200 ? "audio-bytes" : expectedError, {
+            status,
+            headers: {
+              "Content-Type": "audio/mpeg",
+              "X-Tagium-Tunnel-Outcome": outcome,
+              "X-Tagium-Tunnel-Attempts": attempts,
+            },
+          });
+        }),
+      );
+
+      const download = runCobaltDownload({
+        sourceUrl: "https://soundcloud.com/private-artist/private-track",
+        audioBitrate: "128",
+        onLifecycle,
+      });
+
+      if (expectedError) {
+        await expect(download).rejects.toThrow(expectedError);
+      } else {
+        await download;
+      }
+
+      expect(onLifecycle).toHaveBeenCalledWith({
+        type: "tunnel-readiness",
+        outcome,
+        attempts: Number(attempts),
+        elapsedBucket: "under_1_second",
+      });
+      expect(JSON.stringify(onLifecycle.mock.calls)).not.toContain("private");
+      expect(JSON.stringify(onLifecycle.mock.calls)).not.toContain("signature");
+    },
+  );
+
+  it("ignores malformed tunnel telemetry headers", async () => {
+    const onLifecycle = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === "/api/cobalt/audio") {
+          return Response.json({
+            status: "tunnel",
+            url: "/api/cobalt/tunnel",
+            filename: "track.mp3",
+          });
+        }
+        return new Response("audio-bytes", {
+          headers: {
+            "X-Tagium-Tunnel-Outcome": "recovered",
+            "X-Tagium-Tunnel-Attempts": "999",
+          },
+        });
+      }),
+    );
+
+    await runCobaltDownload({
+      sourceUrl: "https://soundcloud.com/artist/track",
+      audioBitrate: "128",
+      onLifecycle,
+    });
+
+    expect(onLifecycle).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "tunnel-readiness" }),
+    );
+  });
+
   it("paces Cobalt tunnel download starts", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
@@ -147,7 +253,8 @@ describe("CobaltAudio download", () => {
     await vi.advanceTimersByTimeAsync(7_000);
     await downloads;
 
-    expect(tunnelStartTimes).toEqual([0, 1_600, 3_200, 4_800]);
+    const firstStart = tunnelStartTimes[0] ?? 0;
+    expect(tunnelStartTimes.map((time) => time - firstStart)).toEqual([0, 1_600, 3_200, 4_800]);
   });
 
   it("reports Cobalt tunnel budget waits", async () => {


### PR DESCRIPTION
## What changed

YouTube and SoundCloud source links are now parsed through one compatibility layer. The app recognizes common YouTube forms and canonicalizes provider tracking/fragments, accepts canonical YouTube playlists and embeds, normalizes SoundCloud tracks/sets while preserving private set tokens, and resolves bounded `on.soundcloud.com` / `snd.sc` redirects. Existing v1 share links remain compatible, while generic non-provider Cobalt URLs continue to pass through. Cobalt tunnel reads now retry a bounded number of empty successful responses.

## Root cause

Link handling was implemented as several independent hostname/path checks. Those checks disagreed across import routing, metadata lookup, playlist endpoints, analytics, and share manifests, so valid mobile, short, embed, and redirect forms could be rejected or saved inconsistently. Exact-host parsing and canonical provenance now keep those paths aligned and prevent lookalike hosts from being treated as providers. For the follow-up tunnel fix, YouTube `youtu.be` canonicalization and metadata lookup were succeeding, but the immediate signed audio tunnel could return upstream HTTP 200 with an empty body before the audio was ready. The tunnel now retries those empty 200 responses with bounded delays; non-OK responses are not retried.

## Human review

Setup: use the existing app/dev server with configured Cobalt and SoundCloud services. Real provider links still need manual verification; this PR does not claim that manual verification was completed.

Exercise these flows:

- Import a `youtu.be` track and YouTube `m`, `/music`, `/shorts`, `/live`, and privacy-enhanced forms. Try a canonical playlist and playlist embed; expect correct single/playlist routing and a canonical saved source.
- Import a direct SoundCloud track/set from `m.soundcloud.com`, plus `on.soundcloud.com` short links that resolve to a track/set; expect the correct importer. `snd.sc` support is best-effort.
- Import/download [https://youtu.be/qEIbFhBzfvA](https://youtu.be/qEIbFhBzfvA); expect the canonical source to resolve and the audio import/download to succeed.

Check edge failures:

- YouTube clip/channel URLs and malformed SoundCloud pages are rejected clearly.
- Lookalike hosts are not treated as providers.
- Generic non-provider Cobalt URLs still pass through.
- A Cobalt tunnel that returns empty 200 responses four times ends with a bounded 502; a non-OK upstream response is returned without retries.

Decisions to review:

- `watch?v=...&list=...` remains a single track.
- Provider fragments and tracking parameters are removed from canonical saved sources.
- Private SoundCloud tokens are preserved.
- Redirects use exact hosts and bounded hop safety.
- Existing v1 share compatibility is retained.

Telemetry review:

- PostHog emits privacy-safe categorical `media_link_processed` and `cobalt_tunnel_readiness` events only.
- Events contain categorical provider/link-shape/media-kind/outcome signals plus bounded attempts and elapsed-time buckets; they do not contain raw URLs, media IDs, tunnel URLs, signatures, machine IDs, request IDs, or other media/request data.
- Provider classification uses the exact YouTube/SoundCloud allowlists, so lookalike hosts remain `other` and are never labeled as providers.

## Automated verification

- `bun run test` — 94 files, 597 tests passed
- `bun run typecheck`
- `bun run lint`
- `git diff --check`
- Focused tunnel/media-link tests: 31 tests passed

Real provider links still need manual verification as described above.
