### PR TITLE
Restore the media URL transition and stabilize its empty state

### DIFF
--- a/src/features/import/MediaUrlEntry.tsx
+++ b/src/features/import/MediaUrlEntry.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { ArrowRight, Link2, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { MediaUrlEntryLayout } from "@/features/import/mediaUrlEntryPresentation";
+import { getMediaUrlEntryMotionKeyframes } from "@/features/import/mediaUrlEntryMotion";
 import {
   getSystemFailurePresentation,
   reportSystemFailure,
@@ -41,6 +42,17 @@ const validateMediaUrl = (value: string) => {
 const prefersReducedMotion = () =>
   typeof window !== "undefined" &&
   (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false);
+
+const clearMotionStyles = (anchor: HTMLDivElement | null, motion: HTMLDivElement | null) => {
+  if (anchor) anchor.style.height = "";
+  if (!motion) return;
+
+  motion.style.position = "";
+  motion.style.left = "";
+  motion.style.top = "";
+  motion.style.width = "";
+  motion.style.zIndex = "";
+};
 
 export function useMediaUrlEntryController(
   onUrlImport: (sourceUrl: string) => void | Promise<void>,
@@ -111,10 +123,76 @@ export default function MediaUrlEntry({
 }: MediaUrlEntryProps) {
   const internalController = useMediaUrlEntryController(onUrlImport);
   const controller = controlledController ?? internalController;
-  const feedbackRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const motionRef = useRef<HTMLDivElement>(null);
+  const previousRectRef = useRef<DOMRect | null>(null);
+  const previousLayoutRef = useRef(layout);
+  const animationRef = useRef<Animation | null>(null);
+
+  useLayoutEffect(() => {
+    const anchor = anchorRef.current;
+    const motion = motionRef.current;
+    if (!anchor || !motion) return;
+
+    const runningAnimation = animationRef.current;
+    const previousRect = runningAnimation
+      ? motion.getBoundingClientRect()
+      : previousRectRef.current;
+    const layoutChanged = previousLayoutRef.current !== layout;
+    runningAnimation?.cancel();
+    animationRef.current = null;
+    clearMotionStyles(anchor, motion);
+
+    const nextRect = motion.getBoundingClientRect();
+    if (
+      previousRect &&
+      layoutChanged &&
+      !prefersReducedMotion() &&
+      typeof motion.animate === "function"
+    ) {
+      anchor.style.height = `${nextRect.height}px`;
+      motion.style.position = "fixed";
+      motion.style.left = `${previousRect.left}px`;
+      motion.style.top = `${previousRect.top}px`;
+      motion.style.width = `${previousRect.width}px`;
+      motion.style.zIndex = "30";
+
+      const animation = motion.animate(getMediaUrlEntryMotionKeyframes(previousRect, nextRect), {
+        duration: 420,
+        easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+      });
+      animationRef.current = animation;
+      animation.onfinish = () => {
+        if (animationRef.current !== animation) return;
+        animationRef.current = null;
+        clearMotionStyles(anchorRef.current, motionRef.current);
+        previousRectRef.current = motion.getBoundingClientRect();
+      };
+    }
+
+    previousRectRef.current = nextRect;
+    previousLayoutRef.current = layout;
+  }, [layout]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const settleMotion = () => {
+      animationRef.current?.cancel();
+      animationRef.current = null;
+      clearMotionStyles(anchorRef.current, motionRef.current);
+      previousRectRef.current = motionRef.current?.getBoundingClientRect() ?? null;
+    };
+
+    window.addEventListener("resize", settleMotion);
+    return () => {
+      window.removeEventListener("resize", settleMotion);
+      settleMotion();
+    };
+  }, []);
 
   const showValidationFeedback = () => {
-    const feedback = feedbackRef.current;
+    const feedback = motionRef.current;
     if (!feedback || prefersReducedMotion() || typeof feedback.animate !== "function") return;
     feedback.animate(
       [
@@ -142,15 +220,18 @@ export default function MediaUrlEntry({
           "pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center border-t bg-background/95 p-3 lg:bottom-4 lg:border-t-0 lg:bg-transparent lg:px-4 lg:p-0",
       )}
     >
-      {layout !== "editor" && (
+      {layout === "landing" && (
         <div className="flex items-center gap-4 text-sm text-muted-foreground">
           <div className="h-px flex-1 bg-border" />
           <span>or import from a url</span>
           <div className="h-px flex-1 bg-border" />
         </div>
       )}
-      <div className={cn("w-full", layout === "editor" ? "max-w-3xl" : "max-w-md")}>
-        <div ref={feedbackRef} className="pointer-events-auto w-full bg-background">
+      <div
+        ref={anchorRef}
+        className={cn("w-full", layout === "landing" ? "max-w-md" : "max-w-3xl")}
+      >
+        <div ref={motionRef} className="pointer-events-auto w-full bg-background">
           <form
             noValidate
             onSubmit={async (event) => {

--- a/src/features/import/mediaUrlEntryMotion.ts
+++ b/src/features/import/mediaUrlEntryMotion.ts
@@ -1,0 +1,18 @@
+interface MotionRect {
+  left: number;
+  top: number;
+  width: number;
+}
+
+export const getMediaUrlEntryMotionKeyframes = (from: MotionRect, to: MotionRect): Keyframe[] => [
+  {
+    left: `${from.left}px`,
+    top: `${from.top}px`,
+    width: `${from.width}px`,
+  },
+  {
+    left: `${to.left}px`,
+    top: `${to.top}px`,
+    width: `${to.width}px`,
+  },
+];

--- a/src/features/workspace/audioTagger.tsx
+++ b/src/features/workspace/audioTagger.tsx
@@ -254,21 +254,14 @@ export default function AudioTagger() {
             inert={navigation.isMobile && navigation.drawerOpen}
             onAudioUpload={importing.commands.upload}
           >
-            {mediaUrlEntryPresentation?.layout === "landing" && (
+            {mediaUrlEntryPresentation && (
               <MediaUrlEntry
-                layout="landing"
+                layout={mediaUrlEntryPresentation.layout}
                 controller={mediaUrlEntryController}
                 onUrlImport={handleUrlImport}
               />
             )}
           </LandingScreen>
-          {mediaUrlEntryPresentation && mediaUrlEntryPresentation.layout !== "landing" && (
-            <MediaUrlEntry
-              layout={mediaUrlEntryPresentation.layout}
-              controller={mediaUrlEntryController}
-              onUrlImport={handleUrlImport}
-            />
-          )}
         </div>
       </div>
     </>

--- a/tests/e2e/settings-transition.spec.ts
+++ b/tests/e2e/settings-transition.spec.ts
@@ -12,7 +12,7 @@ const uploadTrack = async (page: Page) => {
     mimeType: "audio/mpeg",
     buffer: Buffer.from(mp3Bytes),
   });
-  await expect(page.getByRole("button", { name: "remove track" })).toBeAttached();
+  await expect(page.locator('[data-layout="editor"]')).toBeVisible();
 };
 
 const getPopulatedTrackList = (page: Page) => {
@@ -31,6 +31,74 @@ const clickBlankTrackList = async (page: Page) => {
     position: { x: bounds.width / 2, y: bounds.height - 8 },
   });
 };
+
+const clearSelectionWithEscape = async (page: Page) => {
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+  await page.keyboard.press("Escape");
+};
+
+test("moves the media URL entry continuously from landing to editor", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+
+  const mediaUrlForm = page.locator('form:has(input[name="media-url"])');
+  await expect(mediaUrlForm).toBeVisible();
+  const landingBox = await mediaUrlForm.boundingBox();
+  if (!landingBox) throw new Error("landing media URL form bounds were not found");
+
+  await page.evaluate(() => {
+    const motionWindow = window as Window & {
+      __mediaUrlMotionElement?: Element | null;
+      __mediaUrlMotionSamples?: Array<{ width: number; x: number; y: number }>;
+    };
+    const samples: Array<{ width: number; x: number; y: number }> = [];
+    motionWindow.__mediaUrlMotionElement = document.querySelector('input[name="media-url"]');
+    motionWindow.__mediaUrlMotionSamples = samples;
+    const deadline = performance.now() + 1_000;
+    const sample = () => {
+      const form = document.querySelector('input[name="media-url"]')?.closest("form");
+      if (form) {
+        const rect = form.getBoundingClientRect();
+        samples.push({ width: rect.width, x: rect.x, y: rect.y });
+      }
+      if (performance.now() < deadline) requestAnimationFrame(sample);
+    };
+    requestAnimationFrame(sample);
+  });
+
+  const mp3Bytes = new Uint8Array(834);
+  mp3Bytes.set([0xff, 0xfb, 0x90, 0x00], 0);
+  mp3Bytes.set([0xff, 0xfb, 0x90, 0x00], 417);
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "shared-element-track.mp3",
+    mimeType: "audio/mpeg",
+    buffer: Buffer.from(mp3Bytes),
+  });
+  await expect(page.locator('[data-layout="editor"]')).toBeVisible();
+  await page.waitForTimeout(1_000);
+
+  const editorBox = await mediaUrlForm.boundingBox();
+  if (!editorBox) throw new Error("editor media URL form bounds were not found");
+  const samples = await page.evaluate(
+    () =>
+      (
+        window as Window & {
+          __mediaUrlMotionSamples?: Array<{ width: number; x: number; y: number }>;
+        }
+      ).__mediaUrlMotionSamples ?? [],
+  );
+  const preservedElement = await page.evaluate(
+    () =>
+      (window as Window & { __mediaUrlMotionElement?: Element }).__mediaUrlMotionElement ===
+      document.querySelector('input[name="media-url"]'),
+  );
+  const minY = Math.min(landingBox.y, editorBox.y);
+  const maxY = Math.max(landingBox.y, editorBox.y);
+
+  expect(maxY - minY).toBeGreaterThan(20);
+  expect(preservedElement).toBe(true);
+  expect(samples.some((sample) => sample.y > minY + 1 && sample.y < maxY - 1)).toBe(true);
+});
 
 test("unmounts the media entry in settings and restores its source URL", async ({ page }) => {
   const shareLink = "https://tagium.app/share/abcdefghijklmnopqrstuv";
@@ -108,9 +176,10 @@ test("switches between the empty selection and track editor in both directions",
   page,
 }) => {
   await uploadTrack(page);
-  await page.getByRole("button", { name: "settings" }).focus();
-  await page.keyboard.press("Escape");
+  await clearSelectionWithEscape(page);
   await expect(page.getByRole("button", { name: /drop your audio here/ })).toBeVisible();
+  await expect(page.locator('input[name="media-url"]')).toBeEditable();
+  await expect(page.getByText("or import from a url", { exact: true })).not.toBeAttached();
   await expect(page.locator('[data-editor-state="empty-selection"]')).toHaveCSS("opacity", "1");
 
   await getPopulatedTrackList(page).getByRole("button").first().click();
@@ -126,30 +195,43 @@ for (const viewport of [
   { name: "mobile short", width: 390, height: 640 },
   { name: "medium", width: 900, height: 700 },
 ]) {
-  test(`keeps empty-editor imports usable without overlap at ${viewport.name} size`, async ({
-    page,
-  }) => {
+  test(`keeps the media bar stable and usable at ${viewport.name} size`, async ({ page }) => {
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
     await uploadTrack(page);
-    await page.getByRole("button", { name: "settings" }).focus();
-    await page.keyboard.press("Escape");
+    const selectedUrlForm = page.locator('[data-layout="editor"] form');
+    await expect(selectedUrlForm).toBeVisible();
+    await expect
+      .poll(() =>
+        selectedUrlForm.evaluate((form) => form.parentElement?.getAnimations().length ?? 0),
+      )
+      .toBe(0);
+    const selectedUrlFormBox = await selectedUrlForm.boundingBox();
+    await clearSelectionWithEscape(page);
 
     const dropzone = page.getByRole("button", { name: /drop your audio here/ });
     const urlEntry = page.locator('[data-layout="empty-editor"]');
+    const emptyUrlForm = urlEntry.locator("form");
     const urlInput = page.locator('input[name="media-url"]');
     await expect(dropzone).toBeVisible();
     await expect(dropzone).toBeEnabled();
     await expect(urlEntry).toBeVisible();
+    await expect(emptyUrlForm).toBeVisible();
+    await expect
+      .poll(() => emptyUrlForm.evaluate((form) => form.parentElement?.getAnimations().length ?? 0))
+      .toBe(0);
+    const emptyUrlFormBox = await emptyUrlForm.boundingBox();
     await expect(urlInput).toBeEditable();
+    await expect(page.getByText("or import from a url", { exact: true })).not.toBeAttached();
     await urlInput.fill("https://soundcloud.com/artist/track");
     await expect(urlInput).toHaveValue("https://soundcloud.com/artist/track");
 
     const dropzoneBox = await dropzone.boundingBox();
     const urlEntryBox = await urlEntry.boundingBox();
-    if (!dropzoneBox || !urlEntryBox) {
+    if (!dropzoneBox || !urlEntryBox || !selectedUrlFormBox || !emptyUrlFormBox) {
       throw new Error("empty editor import bounds were not found");
     }
     expect(dropzoneBox.y + dropzoneBox.height).toBeLessThanOrEqual(urlEntryBox.y + 1);
+    expect(emptyUrlFormBox.width).toBeCloseTo(selectedUrlFormBox.width, 5);
   });
 }
 

--- a/tests/unit/features/import/mediaUrlEntryMotion.test.ts
+++ b/tests/unit/features/import/mediaUrlEntryMotion.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vite-plus/test";
+import { getMediaUrlEntryMotionKeyframes } from "@/features/import/mediaUrlEntryMotion";
+
+describe("media URL entry motion", () => {
+  it("animates position and real width without scaling the form", () => {
+    const keyframes = getMediaUrlEntryMotionKeyframes(
+      { left: 100, top: 500, width: 448 },
+      { left: 300, top: 700, width: 768 },
+    );
+
+    expect(keyframes).toEqual([
+      { left: "100px", top: "500px", width: "448px" },
+      { left: "300px", top: "700px", width: "768px" },
+    ]);
+    expect(keyframes.every((keyframe) => keyframe.transform === undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Keeps URL importing fully available while refining the media bar across its visible states:

- Removes only the “or import from a url” divider from the populated-library empty-selection screen.
- Keeps the selected-track and empty-selection bars at the same width; the initial landing bar remains compact.
- Restores the shared-element transition so the same URL input glides and resizes between landing, loaded-editor, and empty-editor layouts.
- Preserves reduced-motion behavior and the intentional settings-screen unmount.

## Root cause

The transition regression landed in `f716382` through PR #135; its parent `412afb3` is the last known-good main commit. That refactor correctly lifted the URL-entry controller so text survived layout changes, but it also split one persistent `MediaUrlEntry` into mutually exclusive mounts and removed the geometry animation. There was no motion-related product decision in the PR, so this restores the lost behavior while keeping the lifted state.

## Human review

1. Start with an empty library. Confirm the compact URL import field and “or import from a url” divider are still present.
2. Add a track. The same URL field should glide to the wider media bar at the bottom of the editor instead of disappearing and reappearing.
3. Clear the track selection. Confirm the URL field remains editable, the divider is absent, and the media bar keeps the same width.
4. Enter text, open Settings, then return. The URL field should restore its text; it is intentionally unmounted while Settings is open.
5. Repeat at mobile and intermediate widths. Check that the bar fits without overlapping the dropzone.
6. With reduced motion enabled, state changes should settle immediately without the shared-element animation.

Review considerations: the landing layout intentionally remains narrower, while both editor states share the wider width. Motion animates real position and width rather than scaling the form, keeping text and controls crisp.

## Verification

- `bunx vp check`
- `bun run test` — 102 files, 631 tests passed
- `bun run build`
- `bun run test:e2e -- --project=chromium tests/e2e/settings-transition.spec.ts` — 10 passed
- Deterministic E2E coverage verifies DOM identity plus intermediate geometry during the landing-to-editor transition
- Unit coverage verifies real position/width keyframes without transform scaling
- Impeccable UI detector — no findings
