### PR TITLE
fix(export): normalize confirmation copy

### DIFF
--- a/src/features/export/ExportConfirmationDialog.tsx
+++ b/src/features/export/ExportConfirmationDialog.tsx
@@ -78,7 +78,7 @@ export default function ExportConfirmationDialog({
   onRestoreFocus,
 }: ExportConfirmationDialogProps) {
   const noun = plan?.trackCount === 1 ? "track" : "tracks";
-  const downloadLabel = plan ? `Download ~${formatMegabyteSize(plan.totalSizeBytes)}` : "Download";
+  const downloadLabel = plan ? `download ~${formatMegabyteSize(plan.totalSizeBytes)}` : "download";
 
   return (
     <Dialog open={Boolean(plan)} onOpenChange={(open) => !open && !busy && onCancel()}>
@@ -101,7 +101,7 @@ export default function ExportConfirmationDialog({
       >
         <DialogHeader>
           <DialogTitle>
-            Download {plan?.trackCount ?? 0} {noun}
+            download {plan?.trackCount ?? 0} {noun}
           </DialogTitle>
           {status !== "ready" && (
             <p
@@ -109,8 +109,8 @@ export default function ExportConfirmationDialog({
               className="rounded-md bg-accent px-3 py-2 text-sm text-accent-foreground"
             >
               {status === "changed"
-                ? "The download changed. Confirm the updated download again."
-                : "This download is no longer available. Cancel and try again when every track is ready."}
+                ? "the download changed. confirm the updated download again."
+                : "this download is no longer available. cancel and try again when every track is ready."}
             </p>
           )}
         </DialogHeader>
@@ -136,7 +136,7 @@ export default function ExportConfirmationDialog({
             disabled={busy}
             data-export-cancel
           >
-            Cancel
+            cancel
           </Button>
           <Button
             type="button"
@@ -145,7 +145,7 @@ export default function ExportConfirmationDialog({
             aria-busy={busy}
             className="min-w-44 justify-center tabular-nums"
           >
-            {busy ? "Preparing…" : downloadLabel}
+            {busy ? "preparing…" : downloadLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/features/export/exportConfirmation.ts
+++ b/src/features/export/exportConfirmation.ts
@@ -162,7 +162,7 @@ export const planExport = (
     if (looseTracks.length > 0) {
       groups.push({
         id: "loose",
-        title: "Loose tracks",
+        title: "singles",
         tracks: looseTracks.map(planTrack),
       });
     }
@@ -281,5 +281,5 @@ export const formatMegabyteSize = (sizeBytes: number) => {
         : megabytes < 100
           ? fractionalMegabyteFormatter.format(megabytes)
           : wholeMegabyteFormatter.format(megabytes);
-  return `${formatted} MB`;
+  return `${formatted.toLowerCase()} mb`;
 };

--- a/tests/e2e/export-confirmation.spec.ts
+++ b/tests/e2e/export-confirmation.spec.ts
@@ -20,9 +20,9 @@ test("bulk download confirmation owns focus, dismisses safely, and restores its 
   await expect(trigger).toBeEnabled();
 
   await trigger.click();
-  const dialog = page.getByRole("dialog", { name: "Download 1 track" });
+  const dialog = page.getByRole("dialog", { name: "download 1 track" });
   await expect(dialog).toBeVisible();
-  await expect(dialog.getByRole("button", { name: "Cancel" })).toBeFocused();
+  await expect(dialog.getByRole("button", { name: "cancel" })).toBeFocused();
 
   await page.keyboard.press("Escape");
   await expect(dialog).toBeHidden();
@@ -46,9 +46,9 @@ test("only the manifest scrolls in a constrained mobile dialog", async ({ page }
   await expect(drawer).toBeVisible();
   await downloadAllButton(page).click();
   await expect(drawer).toBeHidden();
-  const dialog = page.getByRole("dialog", { name: "Download 18 tracks" });
-  await expect(dialog.getByRole("button", { name: "Cancel" })).toBeFocused();
-  await dialog.getByRole("button", { name: "Loose tracks 18 tracks" }).click();
+  const dialog = page.getByRole("dialog", { name: "download 18 tracks" });
+  await expect(dialog.getByRole("button", { name: "cancel" })).toBeFocused();
+  await dialog.getByRole("button", { name: "singles 18 tracks" }).click();
 
   const manifest = dialog.getByTestId("export-manifest");
   const metrics = await manifest.evaluate((element) => ({
@@ -57,8 +57,8 @@ test("only the manifest scrolls in a constrained mobile dialog", async ({ page }
   }));
   expect(metrics.clientHeight).toBeGreaterThan(0);
   expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight);
-  await expect(dialog.getByRole("button", { name: "Cancel" })).toBeVisible();
-  await expect(dialog.getByRole("button", { name: /^Download ~/ })).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "cancel" })).toBeVisible();
+  await expect(dialog.getByRole("button", { name: /^download ~/ })).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(dialog).toBeHidden();
   await expect(menuButton).toBeFocused();

--- a/tests/unit/features/export/ExportConfirmationDialog.test.tsx
+++ b/tests/unit/features/export/ExportConfirmationDialog.test.tsx
@@ -55,8 +55,8 @@ describe("ExportConfirmationDialog", () => {
   it("shows only the locked manifest and approximate download copy", () => {
     const tree = render();
     const text = textContent(tree);
-    expect(text).toContain("Download 1 track");
-    expect(text).toContain("Download ~0.00 MB");
+    expect(text).toContain("download 1 track");
+    expect(text).toContain("download ~0.00 mb");
     expect(text).not.toMatch(/\bbytes?\b/i);
     expect(text).not.toMatch(/filename|format|artwork|path|setting/i);
     const disclosures = findAll(tree, (element) => element.type === ExportPlanDisclosure);
@@ -86,8 +86,8 @@ describe("ExportConfirmationDialog", () => {
     const onConfirm = vi.fn();
     const ready = render({ onCancel, onConfirm });
     const buttons = findAll(ready, (element) => element.type === Button);
-    const cancel = buttons.find((button) => textContent(button) === "Cancel");
-    const confirm = buttons.find((button) => textContent(button).startsWith("Download"));
+    const cancel = buttons.find((button) => textContent(button) === "cancel");
+    const confirm = buttons.find((button) => textContent(button).startsWith("download"));
     (cancel?.props.onClick as (() => void) | undefined)?.();
     (confirm?.props.onClick as (() => void) | undefined)?.();
     expect(onCancel).toHaveBeenCalledOnce();
@@ -96,7 +96,7 @@ describe("ExportConfirmationDialog", () => {
     const busy = render({ busy: true });
     const busyButtons = findAll(busy, (element) => element.type === Button);
     expect(busyButtons.every((button) => button.props.disabled === true)).toBe(true);
-    expect(textContent(busy)).toContain("Preparing…");
+    expect(textContent(busy)).toContain("preparing…");
     const content = findAll(busy, (element) => element.props["aria-busy"] === true)[0]!;
     const escapePrevent = vi.fn();
     const outsidePrevent = vi.fn();
@@ -113,7 +113,7 @@ describe("ExportConfirmationDialog", () => {
   it("announces changed and unavailable states and disables stale confirmation", () => {
     const changed = render({ status: "changed" });
     expect(textContent(findAll(changed, (element) => element.props.role === "alert")[0])).toBe(
-      "The download changed. Confirm the updated download again.",
+      "the download changed. confirm the updated download again.",
     );
 
     const unavailable = render({ status: "unavailable" });
@@ -121,12 +121,12 @@ describe("ExportConfirmationDialog", () => {
       textContent(findAll(unavailable, (element) => element.props.role === "alert")[0]),
     ).toContain("no longer available");
     const confirm = findAll(unavailable, (element) => element.type === Button).find((button) =>
-      textContent(button).startsWith("Download"),
+      textContent(button).startsWith("download"),
     );
     expect(confirm?.props.disabled).toBe(true);
   });
 
-  it("focuses Cancel, restores focus, and confines mobile scrolling to the manifest", () => {
+  it("focuses cancel, restores focus, and confines mobile scrolling to the manifest", () => {
     const onRestoreFocus = vi.fn();
     const tree = render({ onRestoreFocus });
     const content = findAll(

--- a/tests/unit/features/export/exportConfirmation.test.ts
+++ b/tests/unit/features/export/exportConfirmation.test.ts
@@ -89,7 +89,7 @@ describe("export confirmation planning", () => {
       },
       {
         id: "loose",
-        title: "Loose tracks",
+        title: "singles",
         tracks: [{ id: "orphan", title: "Orphan" }],
       },
     ]);
@@ -116,7 +116,7 @@ describe("export confirmation planning", () => {
       albums: [album("empty", "Empty", [])],
       looseTrackIds: ["ready"],
     });
-    expect(plan(looseOnly).groups.map(({ title }) => title)).toEqual(["Loose tracks"]);
+    expect(plan(looseOnly).groups.map(({ title }) => title)).toEqual(["singles"]);
   });
 
   it("invalidates every export-relevant file, path, metadata, patch, and setting change", () => {
@@ -216,9 +216,9 @@ describe("export confirmation planning", () => {
   });
 
   it("formats a compact MB-only estimate", () => {
-    expect(formatMegabyteSize(1)).toBe("0.00 MB");
-    expect(formatMegabyteSize(1_234_567)).toBe("1.2 MB");
-    expect(formatMegabyteSize(99_950_000)).toBe("100 MB");
-    expect(formatMegabyteSize(1_000_000_000)).toBe("1K MB");
+    expect(formatMegabyteSize(1)).toBe("0.00 mb");
+    expect(formatMegabyteSize(1_234_567)).toBe("1.2 mb");
+    expect(formatMegabyteSize(99_950_000)).toBe("100 mb");
+    expect(formatMegabyteSize(1_000_000_000)).toBe("1k mb");
   });
 });


### PR DESCRIPTION
## Summary

- renames the bulk-export manifest group from `loose tracks` to `singles`
- lowercases the confirmation title, buttons, loading state, alerts, and displayed size unit
- updates unit and Playwright assertions to match the visible copy

## Human review

Setup: import at least one loose audio file, then choose **download all**.

1. Verify the dialog title, `cancel`, `download`, and `preparing…` copy are lowercase.
2. Verify the ungrouped-track disclosure is labeled `singles`.
3. Verify the approximate size uses lowercase `mb`.
4. Confirm album and track titles retain their original capitalization; only product-owned interface copy changes.

The export behavior and ZIP structure are unchanged.

## Validation

- `bun run typecheck`
- `bun run lint`: 0 warnings/errors
- focused export tests: 2 files / 11 tests
- `git diff --check`
- Impeccable detector: no findings

The updated Playwright assertions were not run because the user-managed dev server was not running.