### PR TITLE
Add workspace home navigation

### DIFF
--- a/src/features/editor/TrackMetadataEditor.tsx
+++ b/src/features/editor/TrackMetadataEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { ChangeEvent, ReactNode, RefObject, TransitionEvent } from "react";
 import {
   Controller,
@@ -43,6 +43,7 @@ import {
 type LoadedTrack = TagiumFile & { metadata: AudioMetadata };
 
 interface TrackMetadataEditorProps {
+  viewActive?: boolean;
   selectedFile: TagiumFile | null;
   selectedFileId: string | null;
   register: UseFormRegister<AudioMetadata>;
@@ -860,6 +861,12 @@ function LoadedTrackMetadataEditor({
 
 export default function TrackMetadataEditor(props: TrackMetadataEditorProps) {
   const focusedTitleFileIdRef = useRef<string | null>(null);
+  const viewActive = props.viewActive ?? true;
+  const wasViewActiveRef = useRef(viewActive);
+  const animateSelection = viewActive && wasViewActiveRef.current;
+  useLayoutEffect(() => {
+    wasViewActiveRef.current = viewActive;
+  }, [viewActive]);
   const { mode: editorMode, setMode: setEditorMode } = useMetadataEditorMode(
     props.advancedMetadata,
   );
@@ -905,7 +912,7 @@ export default function TrackMetadataEditor(props: TrackMetadataEditorProps) {
         data-editor-state="empty-selection"
         aria-hidden={trackIsSelected}
         inert={trackIsSelected}
-        className={`absolute inset-0 flex items-center justify-center bg-muted/5 px-4 pb-32 transition-opacity duration-200 motion-reduce:transition-none ${
+        className={`absolute inset-0 flex items-center justify-center bg-muted/5 px-4 pb-32 ${animateSelection ? "transition-opacity duration-200 motion-reduce:transition-none" : "transition-none"} ${
           trackIsSelected ? "pointer-events-none opacity-0" : "opacity-100"
         }`}
       >
@@ -916,7 +923,7 @@ export default function TrackMetadataEditor(props: TrackMetadataEditorProps) {
         aria-hidden={!trackIsSelected}
         inert={!trackIsSelected}
         onTransitionEnd={releaseExitedSelection}
-        className={`absolute inset-0 flex min-h-0 flex-col transition-opacity duration-200 motion-reduce:transition-none ${
+        className={`absolute inset-0 flex min-h-0 flex-col ${animateSelection ? "transition-opacity duration-200 motion-reduce:transition-none" : "transition-none"} ${
           trackIsSelected ? "opacity-100" : "pointer-events-none opacity-0"
         }`}
       >

--- a/src/features/editor/editorKeyboardShortcuts.ts
+++ b/src/features/editor/editorKeyboardShortcuts.ts
@@ -1,4 +1,5 @@
 export type EditorKeyboardShortcutActions = {
+  enabled?: boolean;
   selectedFileCount: number;
   isTrackCoverProcessing: boolean;
   selectAllFiles: () => void;
@@ -24,6 +25,7 @@ const handleEditorKeyboardShortcut = (
   event: KeyboardEvent,
   actions: EditorKeyboardShortcutActions,
 ) => {
+  if (actions.enabled === false) return;
   if (isEditableTarget(event.target)) return;
 
   if ((event.ctrlKey || event.metaKey) && event.key === "a") {

--- a/src/features/library/TagSidebarPanel.tsx
+++ b/src/features/library/TagSidebarPanel.tsx
@@ -58,6 +58,7 @@ export interface TagSidebarPanelProps {
   playlistDownloadQueue?: PlaylistDownloadQueuePanelState | null;
   onDownloadAll: () => void;
   onOpenSettings: () => void;
+  onGoHome: () => void;
   onCancelPlaylistDownloadQueue?: () => void;
   onRetryPlaylistDownloadQueue?: () => void;
 }
@@ -102,6 +103,7 @@ export default function TagSidebarPanel({
   playlistDownloadQueue = null,
   onDownloadAll,
   onOpenSettings,
+  onGoHome,
   onCancelPlaylistDownloadQueue,
   onRetryPlaylistDownloadQueue,
 }: TagSidebarPanelProps) {
@@ -178,7 +180,14 @@ export default function TagSidebarPanel({
       onDrop={handleSidebarFileDrop}
     >
       <div className="h-14 flex items-center px-5 border-b flex-shrink-0">
-        <span className="font-bold text-xl tracking-tight select-none">tagium</span>
+        <button
+          type="button"
+          aria-label="tagium, go to workspace home"
+          onClick={onGoHome}
+          className="font-bold text-xl tracking-tight select-none rounded-sm transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          tagium
+        </button>
         {mobileOpen && onMobileClose ? (
           <Button
             type="button"

--- a/src/features/library/TagSidebarPanel.tsx
+++ b/src/features/library/TagSidebarPanel.tsx
@@ -184,7 +184,7 @@ export default function TagSidebarPanel({
           type="button"
           aria-label="tagium, go to workspace home"
           onClick={onGoHome}
-          className="font-bold text-xl tracking-tight select-none rounded-sm transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="cursor-pointer font-bold text-xl tracking-tight select-none rounded-sm transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           tagium
         </button>

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -24,7 +24,7 @@ export default function SettingsPage({ settings, onChange, onBack }: SettingsPag
             type="button"
             className="inline-flex size-8 shrink-0 cursor-pointer items-center justify-center text-primary/80 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             onClick={onBack}
-            aria-label="back to editor"
+            aria-label="back to workspace"
           >
             <ArrowLeft className="size-5" />
           </button>

--- a/src/features/settings/useWorkspaceSettings.ts
+++ b/src/features/settings/useWorkspaceSettings.ts
@@ -4,31 +4,22 @@ import { saveAppSettings } from "@/features/settings/settings";
 import { getMetadataLinkState } from "@/features/library/metadataLinks";
 import type { SettingsPageProps } from "@/features/settings/SettingsPage";
 import { reportSystemFailure } from "@/features/workspace/systemFailure";
-import type { TrackEditorSession } from "@/features/editor/useTrackEditorSession";
-import type { LibraryStore } from "@/features/library/useLibraryStore";
 import type { AppSettings } from "@/features/library/types";
-import type { SetActiveView } from "@/features/workspace/audioWorkspaceTypes";
-
-type SettingsEditor = Pick<TrackEditorSession, "isCoverProcessing">;
+import type { WorkspaceNavigation } from "@/features/workspace/workspaceNavigation";
 
 export const useWorkspaceSettings = ({
-  editor,
   settings,
   setSettings,
-  setActiveView,
+  navigation,
 }: {
-  library: LibraryStore;
-  editor: SettingsEditor;
   settings: AppSettings;
   setSettings: (settings: AppSettings) => void;
-  setActiveView: SetActiveView;
+  navigation: Pick<WorkspaceNavigation, "goBack">;
 }): SettingsPageProps => {
-  const editorRef = useRef(editor);
   const settingsRef = useRef(settings);
   useLayoutEffect(() => {
-    editorRef.current = editor;
     settingsRef.current = settings;
-  }, [editor, settings]);
+  }, [settings]);
 
   const onChange = useCallback(
     (nextSettings: AppSettings) => {
@@ -65,11 +56,5 @@ export const useWorkspaceSettings = ({
     [setSettings],
   );
 
-  const onBack = useCallback(() => {
-    if (!editorRef.current.isCoverProcessing) {
-      setActiveView((current) => (current === "settings" ? "editor" : "settings"));
-    }
-  }, [setActiveView]);
-
-  return { settings, onChange, onBack };
+  return { settings, onChange, onBack: navigation.goBack };
 };

--- a/src/features/workspace/audioTagger.tsx
+++ b/src/features/workspace/audioTagger.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import AlbumMetadataDialog from "@/features/editor/AlbumMetadataDialog";
@@ -19,7 +19,7 @@ import {
 } from "@/features/workspace/sessionSafety";
 import { loadAppSettings } from "@/features/settings/settings";
 import { useAudioImportSession } from "@/features/workspace/useAudioImportSession";
-import { useAudioWorkspace, type ActiveView } from "@/features/workspace/useAudioWorkspace";
+import { useAudioWorkspace } from "@/features/workspace/useAudioWorkspace";
 import { useExportSession } from "@/features/export/useExportSession";
 import ExportConfirmationDialog from "@/features/export/ExportConfirmationDialog";
 import { useLibraryStore } from "@/features/library/useLibraryStore";
@@ -35,13 +35,17 @@ import {
 import { useShareWorkflow } from "@/features/share/useShareWorkflow";
 import { shareLinksEnabled } from "@/features/share/shareFeature";
 import { useAudioTaggerMobileNavigation } from "@/features/workspace/useAudioTaggerMobileNavigation";
+import { useWorkspaceNavigation } from "@/features/workspace/workspaceNavigation";
+
+const EMPTY_SELECTION = new Set<string>();
 
 export default function AudioTagger() {
   const library = useLibraryStore();
-  const [activeView, setActiveView] = useState<ActiveView>("editor");
   const [settings, setSettings] = useState<AppSettings>(loadAppSettings);
-  const activateEditor = useCallback(() => setActiveView("editor"), []);
   const editor = useTrackEditorSession({ library, settings });
+  const workspaceNavigation = useWorkspaceNavigation({ library, editor });
+  const activeView = workspaceNavigation.activeView;
+  const activateEditor = workspaceNavigation.showEditor;
   const exporting = useExportSession({ library, editor: editor.commands, settings });
   const importing = useAudioImportSession({
     library,
@@ -56,18 +60,18 @@ export default function AudioTagger() {
     editor,
     settings,
     setSettings,
-    activeView,
-    setActiveView,
+    navigation: workspaceNavigation,
     removeDownloads: importing.commands.removeTracks,
     busy,
   });
   const {
-    navigation,
+    navigation: mobileNavigation,
+    runPrimaryAction,
     drawerRef,
     menuButtonRef,
     sidebarProps: mobileSidebarProps,
     settingsPageProps: mobileSettingsProps,
-  } = useAudioTaggerMobileNavigation({ activeView, setActiveView, workspace });
+  } = useAudioTaggerMobileNavigation({ navigation: workspaceNavigation, workspace });
   const { files, albums, looseTrackIds, selectedFileId, selectedAlbumId, selectedFileIds } =
     library.state;
   const libraryIsEmpty = files.length === 0 && albums.length === 0 && looseTrackIds.length === 0;
@@ -137,61 +141,64 @@ export default function AudioTagger() {
         onConfirm={() => void exporting.confirmDownload()}
         onRestoreFocus={exporting.restoreConfirmationFocus}
       />
-      {navigation.isMobile && (
+      {mobileNavigation.isMobile && (
         <Button
           ref={menuButtonRef}
           type="button"
           size="icon"
           variant="outline"
-          className={`fixed left-3 top-3 z-30 size-11 bg-background/95 shadow-sm md:hidden ${navigation.drawerOpen ? "pointer-events-none opacity-0" : ""}`}
-          tabIndex={navigation.drawerOpen ? -1 : 0}
+          className={`fixed left-3 top-3 z-30 size-11 bg-background/95 shadow-sm md:hidden ${mobileNavigation.drawerOpen ? "pointer-events-none opacity-0" : ""}`}
+          tabIndex={mobileNavigation.drawerOpen ? -1 : 0}
           aria-label="open library"
           data-export-focus-fallback
-          onClick={(event) => navigation.openDrawer(event.currentTarget)}
+          onClick={(event) => mobileNavigation.openDrawer(event.currentTarget)}
         >
           <Menu />
         </Button>
       )}
       <div className="min-h-svh touch-pan-y flex flex-col overflow-x-hidden bg-background md:h-svh md:touch-auto md:flex-row md:overflow-hidden">
         <TagSidebarPanel
-          mobileOpen={navigation.drawerOpen}
+          mobileOpen={mobileNavigation.drawerOpen}
           mobileDrawerRef={drawerRef}
-          onMobileClose={navigation.closeDrawer}
+          onMobileClose={mobileNavigation.closeDrawer}
           loading={busy}
           files={files}
           albums={albums}
           looseTrackIds={looseTrackIds}
-          selectedAlbumId={selectedAlbumId}
-          selectedFileId={selectedFileId}
-          selectedFileIds={selectedFileIds}
+          selectedAlbumId={activeView === "settings" ? null : selectedAlbumId}
+          selectedFileId={activeView === "settings" ? null : selectedFileId}
+          selectedFileIds={activeView === "settings" ? EMPTY_SELECTION : selectedFileIds}
           {...mobileSidebarProps}
-          onAudioUpload={importing.commands.upload}
+          onAudioUpload={(filesToUpload) =>
+            runPrimaryAction(() => void importing.commands.upload(filesToUpload))
+          }
           onRetryDownload={importing.commands.retryTrack}
           onDownloadAlbum={(albumId) =>
-            navigation.runAfterDrawerClose(() => exporting.downloadAlbum(albumId))
+            mobileNavigation.runAfterDrawerClose(() => exporting.downloadAlbum(albumId))
           }
           onShareAlbum={
             shareLinksEnabled
-              ? (albumId) => navigation.runAfterDrawerClose(() => sharing.openCreator(albumId))
+              ? (albumId) =>
+                  mobileNavigation.runAfterDrawerClose(() => sharing.openCreator(albumId))
               : undefined
           }
           shareAlbumActions={shareLinksEnabled ? sharing.shareActions : undefined}
           onUploadToAlbum={(albumId, filesToUpload) =>
-            importing.commands.upload(filesToUpload, albumId)
+            runPrimaryAction(() => void importing.commands.upload(filesToUpload, albumId))
           }
           playlistDownloadQueue={importing.queue}
-          onDownloadAll={() => navigation.runAfterDrawerClose(exporting.downloadAll)}
+          onDownloadAll={() => mobileNavigation.runAfterDrawerClose(exporting.downloadAll)}
           onCancelPlaylistDownloadQueue={importing.commands.cancelQueue}
           onRetryPlaylistDownloadQueue={importing.commands.retryQueue}
         />
         <div
-          className={`relative order-1 flex-shrink-0 flex flex-col md:order-none md:min-h-0 md:flex-1 ${navigation.isMobile ? "transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-opacity" : ""} ${navigation.isMobile && navigation.drawerOpen ? "translate-x-[min(88vw,22rem)]" : navigation.isMobile ? "translate-x-0" : ""}`}
+          className={`relative order-1 flex-shrink-0 flex flex-col md:order-none md:min-h-0 md:flex-1 ${mobileNavigation.isMobile ? "transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-opacity" : ""} ${mobileNavigation.isMobile && mobileNavigation.drawerOpen ? "translate-x-[min(88vw,22rem)]" : mobileNavigation.isMobile ? "translate-x-0" : ""}`}
         >
-          {navigation.isMobile && (
+          {mobileNavigation.isMobile && (
             <div
-              className={`absolute inset-0 z-30 bg-black/25 transition-opacity duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:duration-100 ${navigation.drawerOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}
+              className={`absolute inset-0 z-30 bg-black/25 transition-opacity duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:duration-100 ${mobileNavigation.drawerOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}
               aria-hidden="true"
-              onClick={navigation.closeDrawer}
+              onClick={mobileNavigation.closeDrawer}
             />
           )}
           <div
@@ -200,7 +207,7 @@ export default function AudioTagger() {
                 ? "contents"
                 : "h-svh min-h-0 flex flex-col overflow-hidden md:h-auto md:min-h-0 md:flex-1"
             }
-            inert={navigation.isMobile && navigation.drawerOpen ? true : undefined}
+            inert={mobileNavigation.isMobile && mobileNavigation.drawerOpen ? true : undefined}
           >
             {!libraryIsEmpty ? (
               <div className="relative min-h-0 flex-1">
@@ -215,6 +222,7 @@ export default function AudioTagger() {
                   }`}
                 >
                   <TrackMetadataEditor
+                    viewActive={activeView === "editor"}
                     selectedFile={editor.selectedFile}
                     selectedFileId={selectedFileId}
                     register={editor.form.register}
@@ -256,7 +264,7 @@ export default function AudioTagger() {
           </div>
           <LandingScreen
             active={landingIsActive}
-            inert={navigation.isMobile && navigation.drawerOpen}
+            inert={mobileNavigation.isMobile && mobileNavigation.drawerOpen}
             onAudioUpload={importing.commands.upload}
           >
             {mediaUrlEntryPresentation && (

--- a/src/features/workspace/mobileWorkspaceNavigation.ts
+++ b/src/features/workspace/mobileWorkspaceNavigation.ts
@@ -36,6 +36,7 @@ export const useMobileWorkspaceNavigation = ({
   const openerRef = useRef<HTMLElement | null>(null);
   const mobileRef = useRef(false);
   const pendingActionRef = useRef<(() => void) | null>(null);
+  const popPendingRef = useRef(false);
   const currentWorkspaceNavRef = useRef<WorkspaceNavigationState["workspaceNav"]>(undefined);
 
   useEffect(() => {
@@ -55,6 +56,7 @@ export const useMobileWorkspaceNavigation = ({
       delete state.workspaceNav;
       history.replaceState(state, "", location.href);
       currentWorkspaceNavRef.current = undefined;
+      popPendingRef.current = false;
       setDrawerOpen(false);
       pendingActionRef.current = null;
     }
@@ -62,6 +64,7 @@ export const useMobileWorkspaceNavigation = ({
 
   useEffect(() => {
     const onPopState = (event: PopStateEvent) => {
+      popPendingRef.current = false;
       const nav = isWorkspaceNavigationState(event.state) ? event.state.workspaceNav : undefined;
       const previousNav = currentWorkspaceNavRef.current;
       currentWorkspaceNavRef.current = nav;
@@ -112,11 +115,12 @@ export const useMobileWorkspaceNavigation = ({
   );
 
   const closeDrawer = useCallback(() => {
-    if (!drawerOpen) return;
+    if (!drawerOpen || popPendingRef.current) return;
     if (
       isWorkspaceNavigationState(history.state) &&
       history.state.workspaceNav?.kind === "drawer"
     ) {
+      popPendingRef.current = true;
       history.back();
     } else {
       currentWorkspaceNavRef.current = undefined;
@@ -133,6 +137,7 @@ export const useMobileWorkspaceNavigation = ({
         action();
         return;
       }
+      if (popPendingRef.current) return;
       openerRef.current = null;
       pendingActionRef.current = action;
       closeDrawer();
@@ -150,13 +155,23 @@ export const useMobileWorkspaceNavigation = ({
     [activeView, setActiveView],
   );
 
-  const backWorkspace = useCallback(() => {
-    if (isWorkspaceNavigationState(history.state) && history.state.workspaceNav?.kind === "view") {
-      history.back();
-    } else {
-      setActiveView("editor");
-    }
-  }, [setActiveView]);
+  const backWorkspace = useCallback(
+    (afterBack?: () => void) => {
+      if (popPendingRef.current) return;
+      if (
+        isWorkspaceNavigationState(history.state) &&
+        history.state.workspaceNav?.kind === "view"
+      ) {
+        pendingActionRef.current = afterBack ?? null;
+        popPendingRef.current = true;
+        history.back();
+      } else {
+        setActiveView("editor");
+        afterBack?.();
+      }
+    },
+    [setActiveView],
+  );
 
   return useMemo(
     () => ({

--- a/src/features/workspace/useAudioTaggerMobileNavigation.ts
+++ b/src/features/workspace/useAudioTaggerMobileNavigation.ts
@@ -6,37 +6,42 @@ import {
   type SwipeDirection,
 } from "@/features/workspace/drawerSwipe";
 import { useMobileWorkspaceNavigation } from "@/features/workspace/mobileWorkspaceNavigation";
-import type { ActiveView, SetActiveView } from "@/features/workspace/audioWorkspaceTypes";
 import type { AudioWorkspace } from "@/features/workspace/useAudioWorkspace";
+import type { WorkspaceNavigation } from "@/features/workspace/workspaceNavigation";
 
 export const useAudioTaggerMobileNavigation = ({
-  activeView,
-  setActiveView,
+  navigation: workspaceNavigation,
   workspace,
 }: {
-  activeView: ActiveView;
-  setActiveView: SetActiveView;
+  navigation: WorkspaceNavigation;
   workspace: Pick<AudioWorkspace, "sidebarProps" | "settingsPageProps">;
 }) => {
-  const navigation = useMobileWorkspaceNavigation({ activeView, setActiveView });
+  const navigation = useMobileWorkspaceNavigation({
+    activeView: workspaceNavigation.activeView,
+    setActiveView: workspaceNavigation.syncView,
+  });
   const drawerRef = useRef<HTMLDivElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const wasDrawerOpenRef = useRef(false);
+  const runPrimaryAction = (action: () => void) => {
+    navigation.runAfterDrawerClose(() => {
+      if (workspace.sidebarProps.settingsOpen) navigation.backWorkspace(action);
+      else action();
+    });
+  };
   const sidebarProps = {
     ...workspace.sidebarProps,
     onSelectAlbum: (albumId: string, event?: ReactMouseEvent) => {
-      navigation.runAfterDrawerClose(() => workspace.sidebarProps.onSelectAlbum(albumId, event));
+      runPrimaryAction(() => workspace.sidebarProps.onSelectAlbum(albumId, event));
     },
     onSelectFile: (albumId: string, fileId: string, event?: ReactMouseEvent) => {
-      navigation.runAfterDrawerClose(() =>
-        workspace.sidebarProps.onSelectFile(albumId, fileId, event),
-      );
+      runPrimaryAction(() => workspace.sidebarProps.onSelectFile(albumId, fileId, event));
     },
     onSelectLooseTrack: (fileId: string, event?: ReactMouseEvent) => {
-      navigation.runAfterDrawerClose(() =>
-        workspace.sidebarProps.onSelectLooseTrack(fileId, event),
-      );
+      runPrimaryAction(() => workspace.sidebarProps.onSelectLooseTrack(fileId, event));
     },
+    onClearSelection: () => runPrimaryAction(workspace.sidebarProps.onClearSelection),
+    onGoHome: () => runPrimaryAction(workspace.sidebarProps.onGoHome),
     onEditAlbum: (albumId: string) =>
       navigation.runAfterDrawerClose(() => workspace.sidebarProps.onEditAlbum(albumId)),
     onAddAlbum: () => navigation.runAfterDrawerClose(workspace.sidebarProps.onAddAlbum),
@@ -172,6 +177,7 @@ export const useAudioTaggerMobileNavigation = ({
 
   return {
     navigation,
+    runPrimaryAction,
     drawerRef,
     menuButtonRef,
     sidebarProps,

--- a/src/features/workspace/useAudioWorkspace.ts
+++ b/src/features/workspace/useAudioWorkspace.ts
@@ -10,7 +10,7 @@ import { useWorkspaceAlbumDialog } from "@/features/workspace/useWorkspaceAlbumD
 import { useWorkspaceCleanup } from "@/features/workspace/useWorkspaceCleanup";
 import { useWorkspaceSelection } from "@/features/workspace/useWorkspaceSelection";
 import { useWorkspaceSettings } from "@/features/settings/useWorkspaceSettings";
-import type { ActiveView, SetActiveView } from "@/features/workspace/audioWorkspaceTypes";
+import type { WorkspaceNavigation } from "@/features/workspace/workspaceNavigation";
 
 export type { ActiveView } from "@/features/workspace/audioWorkspaceTypes";
 
@@ -36,6 +36,7 @@ type WorkspaceSidebarProps = Pick<
   | "onPromptCreateAlbumFromLooseTracks"
   | "onReorderAlbums"
   | "onOpenSettings"
+  | "onGoHome"
 >;
 
 export interface AudioWorkspace {
@@ -51,8 +52,7 @@ export const useAudioWorkspace = ({
   editor,
   settings,
   setSettings,
-  activeView,
-  setActiveView,
+  navigation,
   removeDownloads,
   busy,
 }: {
@@ -60,8 +60,7 @@ export const useAudioWorkspace = ({
   editor: WorkspaceEditor;
   settings: AppSettings;
   setSettings: (settings: AppSettings) => void;
-  activeView: ActiveView;
-  setActiveView: SetActiveView;
+  navigation: WorkspaceNavigation;
   removeDownloads: (trackIds: string[]) => void;
   busy: boolean;
 }): AudioWorkspace => {
@@ -70,16 +69,14 @@ export const useAudioWorkspace = ({
     library,
     editor,
     settings,
-    setActiveView,
+    navigation,
     removeDownloads,
   });
   const album = useWorkspaceAlbumDialog({ library, editor, settings, removeDownloads });
   const settingsPageProps = useWorkspaceSettings({
-    library,
-    editor,
     settings,
     setSettings,
-    setActiveView,
+    navigation,
   });
 
   return {
@@ -92,8 +89,10 @@ export const useAudioWorkspace = ({
       ...album.sidebarProps,
       cleanupSuggestionCountByAlbumId: cleanup.cleanupSuggestionCountByAlbumId,
       onReviewAlbumCleanup: cleanup.onReviewAlbum,
-      settingsOpen: activeView === "settings",
-      onOpenSettings: settingsPageProps.onBack,
+      settingsOpen: navigation.destination.kind === "settings",
+      onOpenSettings:
+        navigation.destination.kind === "settings" ? navigation.goBack : navigation.openSettings,
+      onGoHome: navigation.goHome,
     },
   };
 };

--- a/src/features/workspace/useWorkspaceSelection.ts
+++ b/src/features/workspace/useWorkspaceSelection.ts
@@ -17,7 +17,7 @@ import type { TagSidebarPanelProps } from "@/features/library/TagSidebarPanel";
 import type { TrackEditorSession } from "@/features/editor/useTrackEditorSession";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
 import type { AppSettings } from "@/features/library/types";
-import type { SetActiveView } from "@/features/workspace/audioWorkspaceTypes";
+import type { WorkspaceNavigation } from "@/features/workspace/workspaceNavigation";
 
 type SelectionEditor = Pick<TrackEditorSession, "isCoverProcessing"> & {
   commands: Pick<TrackEditorSession["commands"], "flush">;
@@ -39,13 +39,13 @@ export const useWorkspaceSelection = ({
   library,
   editor,
   settings,
-  setActiveView,
+  navigation,
   removeDownloads,
 }: {
   library: LibraryStore;
   editor: SelectionEditor;
   settings: AppSettings;
-  setActiveView: SetActiveView;
+  navigation: Pick<WorkspaceNavigation, "destination" | "showEditor" | "goHome">;
   removeDownloads: (trackIds: string[]) => void;
 }): {
   removalDialogProps: DestructiveActionDialogProps;
@@ -107,11 +107,8 @@ export const useWorkspaceSelection = ({
   );
 
   const clearSelection = useCallback(() => {
-    if (editorRef.current.isCoverProcessing) return;
-    setActiveView("editor");
-    editorRef.current.commands.flush();
-    library.dispatch({ type: "selection-cleared" });
-  }, [library, setActiveView]);
+    navigation.goHome();
+  }, [navigation]);
 
   const requestRemoveSelected = useCallback(() => {
     const snapshot = library.getSnapshot();
@@ -122,10 +119,12 @@ export const useWorkspaceSelection = ({
   const selectAll = useCallback(() => {
     if (editorRef.current.isCoverProcessing) return;
     editorRef.current.commands.flush();
+    navigation.showEditor();
     library.dispatch({ type: "all-tracks-selected" });
-  }, [library]);
+  }, [library, navigation]);
 
   const keyboardActionsRef = useRef<EditorKeyboardShortcutActions>({
+    enabled: navigation.destination.kind !== "settings",
     selectedFileCount: library.state.selectedFileIds.size,
     isTrackCoverProcessing: editor.isCoverProcessing,
     selectAllFiles: selectAll,
@@ -134,6 +133,7 @@ export const useWorkspaceSelection = ({
   });
   useLayoutEffect(() => {
     keyboardActionsRef.current = {
+      enabled: navigation.destination.kind !== "settings",
       selectedFileCount: library.state.selectedFileIds.size,
       isTrackCoverProcessing: editor.isCoverProcessing,
       selectAllFiles: selectAll,
@@ -144,6 +144,7 @@ export const useWorkspaceSelection = ({
     clearSelection,
     editor.isCoverProcessing,
     library.state.selectedFileIds.size,
+    navigation.destination.kind,
     requestRemoveSelected,
     selectAll,
   ]);
@@ -157,8 +158,8 @@ export const useWorkspaceSelection = ({
       referenceTrackId?: string,
     ) => {
       if (editorRef.current.isCoverProcessing) return;
-      setActiveView("editor");
       editorRef.current.commands.flush();
+      navigation.showEditor();
       const snapshot = library.getSnapshot();
       const target =
         destination.type === "loose"
@@ -200,14 +201,14 @@ export const useWorkspaceSelection = ({
         },
       });
     },
-    [library, setActiveView],
+    [library, navigation],
   );
 
   const selectTrack = useCallback(
     (albumId: string | null, fileId: string, event?: ReactMouseEvent) => {
       if (editorRef.current.isCoverProcessing) return;
-      setActiveView("editor");
       editorRef.current.commands.flush();
+      navigation.showEditor();
       const rangeSelection = Boolean(event?.shiftKey && library.getSnapshot().rangeAnchorFileId);
       library.dispatch({
         type: "track-selected",
@@ -216,7 +217,7 @@ export const useWorkspaceSelection = ({
         mode: rangeSelection ? "range" : event?.ctrlKey || event?.metaKey ? "toggle" : "replace",
       });
     },
-    [library, setActiveView],
+    [library, navigation],
   );
 
   return {
@@ -234,8 +235,8 @@ export const useWorkspaceSelection = ({
       onClearSelection: clearSelection,
       onSelectAlbum: (albumId, event) => {
         if (editorRef.current.isCoverProcessing) return;
-        setActiveView("editor");
         editorRef.current.commands.flush();
+        navigation.showEditor();
         library.dispatch({
           type: "album-selected",
           albumId,

--- a/src/features/workspace/workspaceNavigation.ts
+++ b/src/features/workspace/workspaceNavigation.ts
@@ -1,0 +1,113 @@
+import { useCallback, useLayoutEffect, useMemo, useReducer, useRef } from "react";
+import { flushSync } from "react-dom";
+import type { TrackEditorSession } from "@/features/editor/useTrackEditorSession";
+import type { LibraryStore } from "@/features/library/useLibraryStore";
+import type { ActiveView } from "@/features/workspace/audioWorkspaceTypes";
+
+type EditorDestination = "home" | "editor";
+
+export type WorkspaceDestination =
+  | { kind: EditorDestination }
+  | { kind: "settings"; returnTo: EditorDestination };
+
+export type WorkspaceNavigationAction =
+  | { type: "show-editor" }
+  | { type: "go-home" }
+  | { type: "open-settings" }
+  | { type: "go-back" };
+
+export const transitionWorkspaceDestination = (
+  destination: WorkspaceDestination,
+  action: WorkspaceNavigationAction,
+): WorkspaceDestination => {
+  switch (action.type) {
+    case "show-editor":
+      return { kind: "editor" };
+    case "go-home":
+      return { kind: "home" };
+    case "open-settings":
+      return destination.kind === "settings"
+        ? destination
+        : { kind: "settings", returnTo: destination.kind };
+    case "go-back":
+      return destination.kind === "settings" ? { kind: destination.returnTo } : destination;
+  }
+};
+
+type NavigationEditor = Pick<TrackEditorSession, "isCoverProcessing"> & {
+  commands: Pick<TrackEditorSession["commands"], "flush">;
+};
+
+export interface WorkspaceNavigation {
+  destination: WorkspaceDestination;
+  activeView: ActiveView;
+  showEditor: () => void;
+  goHome: () => void;
+  openSettings: () => void;
+  goBack: () => void;
+  syncView: (view: ActiveView) => void;
+}
+
+export const useWorkspaceNavigation = ({
+  library,
+  editor,
+  initialDestination = { kind: "home" },
+}: {
+  library: LibraryStore;
+  editor: NavigationEditor;
+  initialDestination?: WorkspaceDestination;
+}): WorkspaceNavigation => {
+  const [destination, dispatch] = useReducer(transitionWorkspaceDestination, initialDestination);
+  const destinationRef = useRef(destination);
+  const editorRef = useRef(editor);
+  const libraryRef = useRef(library);
+  useLayoutEffect(() => {
+    destinationRef.current = destination;
+    editorRef.current = editor;
+    libraryRef.current = library;
+  }, [destination, editor, library]);
+
+  const showEditor = useCallback(() => {
+    if (editorRef.current.isCoverProcessing) return;
+    dispatch({ type: "show-editor" });
+  }, []);
+
+  const goHome = useCallback(() => {
+    if (editorRef.current.isCoverProcessing) return;
+    const clearSelection = () => {
+      editorRef.current.commands.flush();
+      libraryRef.current.dispatch({ type: "selection-cleared" });
+    };
+
+    if (destinationRef.current.kind === "settings") flushSync(clearSelection);
+    else clearSelection();
+    dispatch({ type: "go-home" });
+  }, []);
+
+  const openSettings = useCallback(() => {
+    if (editorRef.current.isCoverProcessing) return;
+    dispatch({ type: "open-settings" });
+  }, []);
+
+  const goBack = useCallback(() => {
+    if (editorRef.current.isCoverProcessing) return;
+    dispatch({ type: "go-back" });
+  }, []);
+
+  const syncView = useCallback((view: ActiveView) => {
+    dispatch({ type: view === "settings" ? "open-settings" : "go-back" });
+  }, []);
+
+  return useMemo(
+    () => ({
+      destination,
+      activeView: destination.kind === "settings" ? "settings" : "editor",
+      showEditor,
+      goHome,
+      openSettings,
+      goBack,
+      syncView,
+    }),
+    [destination, goBack, goHome, openSettings, showEditor, syncView],
+  );
+};

--- a/src/features/workspace/workspaceNavigation.ts
+++ b/src/features/workspace/workspaceNavigation.ts
@@ -1,5 +1,4 @@
 import { useCallback, useLayoutEffect, useMemo, useReducer, useRef } from "react";
-import { flushSync } from "react-dom";
 import type { TrackEditorSession } from "@/features/editor/useTrackEditorSession";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
 import type { ActiveView } from "@/features/workspace/audioWorkspaceTypes";
@@ -74,13 +73,8 @@ export const useWorkspaceNavigation = ({
 
   const goHome = useCallback(() => {
     if (editorRef.current.isCoverProcessing) return;
-    const clearSelection = () => {
-      editorRef.current.commands.flush();
-      libraryRef.current.dispatch({ type: "selection-cleared" });
-    };
-
-    if (destinationRef.current.kind === "settings") flushSync(clearSelection);
-    else clearSelection();
+    editorRef.current.commands.flush();
+    libraryRef.current.dispatch({ type: "selection-cleared" });
     dispatch({ type: "go-home" });
   }, []);
 

--- a/tests/e2e/metadata-editor-layout.spec.ts
+++ b/tests/e2e/metadata-editor-layout.spec.ts
@@ -18,7 +18,7 @@ const uploadTrack = async (page: Page) => {
 const enableAdvancedMetadata = async (page: Page) => {
   await page.getByRole("button", { name: "settings" }).click();
   await page.getByRole("checkbox", { name: "enable advanced metadata" }).click();
-  await page.getByRole("button", { name: "back to editor" }).click();
+  await page.getByRole("button", { name: "back to workspace" }).click();
   await expect(page.getByRole("button", { name: "advanced" })).toBeVisible();
 };
 

--- a/tests/e2e/settings-transition.spec.ts
+++ b/tests/e2e/settings-transition.spec.ts
@@ -109,7 +109,7 @@ test("unmounts the media entry in settings and restores its source URL", async (
   await page.getByRole("button", { name: "settings" }).click();
   await expect(mediaUrl).not.toBeAttached();
 
-  await page.getByRole("button", { name: "back to editor" }).click();
+  await page.getByRole("button", { name: "back to workspace" }).click();
   await expect(mediaUrl).toHaveValue(shareLink);
 });
 
@@ -144,14 +144,142 @@ test("switches the metadata editor and settings without unmounting either panel"
   await expect(settings).toHaveCSS("opacity", "1");
 });
 
+test("treats settings as an exclusive destination and Back restores the selected track", async ({
+  page,
+}) => {
+  await uploadTrack(page);
+  const editor = page.locator('[data-view="metadata-editor"]');
+  const settings = page.locator('[data-view="settings"]');
+  const track = getPopulatedTrackList(page).getByRole("button").first();
+  await page.locator("#track-title").fill("Restored after settings");
+
+  expect(await track.evaluate((element) => element.classList.contains("bg-accent"))).toBe(true);
+  await page.getByRole("button", { name: "settings" }).click();
+
+  await expect(settings).toHaveAttribute("aria-hidden", "false");
+  await expect(editor).toHaveAttribute("aria-hidden", "true");
+  await expect(editor).toHaveAttribute("inert", "");
+  expect(await track.evaluate((element) => element.classList.contains("bg-accent"))).toBe(false);
+
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("Control+a");
+  await page.keyboard.press("Delete");
+  await expect(settings).toHaveAttribute("aria-hidden", "false");
+
+  await page.getByRole("button", { name: "back to workspace" }).click();
+
+  await expect(settings).toHaveAttribute("aria-hidden", "true");
+  await expect(editor).toHaveAttribute("aria-hidden", "false");
+  await expect(page.locator("#track-title")).toHaveValue("Restored after settings");
+  expect(await track.evaluate((element) => element.classList.contains("bg-accent"))).toBe(true);
+});
+
+test("uses the tagium nameplate as Home without discarding library work", async ({ page }) => {
+  await uploadTrack(page);
+  const title = page.locator("#track-title");
+  await title.fill("Preserved by Home");
+
+  await page.getByRole("button", { name: "tagium, go to workspace home" }).click();
+
+  await expect(page.getByText("library (1)", { exact: true })).toBeVisible();
+  await expect(page.locator('[data-editor-state="empty-selection"]')).toHaveCSS("opacity", "1");
+  await expect(page.getByRole("button", { name: "download track" })).not.toBeAttached();
+
+  await getPopulatedTrackList(page).getByRole("button").first().click();
+  await expect(title).toHaveValue("Preserved by Home");
+});
+
+test("goes directly from settings Home to the neutral editor without a nested track fade", async ({
+  page,
+}) => {
+  await uploadTrack(page);
+  await page.getByRole("button", { name: "settings" }).click();
+
+  await page.getByRole("button", { name: "tagium, go to workspace home" }).click();
+  await expect(page.locator('[data-view="settings"]')).toHaveAttribute("aria-hidden", "true");
+  await expect(page.locator('[data-view="metadata-editor"]')).toHaveAttribute(
+    "aria-hidden",
+    "false",
+  );
+  const animatedEditorStates = await page
+    .locator('[data-editor-state="empty-selection"], [data-editor-state="loaded-track"]')
+    .evaluateAll((elements) =>
+      elements
+        .filter((element) => element.getAnimations().length > 0)
+        .map((element) => element.getAttribute("data-editor-state")),
+    );
+
+  expect(animatedEditorStates).toEqual([]);
+  await expect(page.locator('[data-editor-state="empty-selection"]')).toHaveCSS("opacity", "1");
+});
+
+test("selecting a track from settings activates that editor destination", async ({ page }) => {
+  await uploadTrack(page);
+  await page.getByRole("button", { name: "settings" }).click();
+
+  await getPopulatedTrackList(page).getByRole("button").first().click();
+
+  await expect(page.locator('[data-view="settings"]')).toHaveAttribute("aria-hidden", "true");
+  await expect(page.locator('[data-view="metadata-editor"]')).toHaveAttribute(
+    "aria-hidden",
+    "false",
+  );
+  await expect(page.getByRole("button", { name: "download track" })).toBeVisible();
+});
+
+test("mobile sidebar actions leave settings and its history entry before navigating", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 700 });
+  await uploadTrack(page);
+
+  const openLibrary = page.getByRole("button", { name: "open library" });
+  await openLibrary.click();
+  await page
+    .getByRole("dialog", { name: "library" })
+    .getByRole("button", { name: "settings" })
+    .click();
+  await expect(page.locator('[data-view="settings"]')).toHaveAttribute("aria-hidden", "false");
+
+  await openLibrary.click();
+  await getPopulatedTrackList(page).getByRole("button").first().click();
+  await expect(page.locator('[data-view="metadata-editor"]')).toHaveAttribute(
+    "aria-hidden",
+    "false",
+  );
+  expect(
+    await page.evaluate(
+      () =>
+        (history.state as { workspaceNav?: { kind?: string } } | null)?.workspaceNav?.kind ?? null,
+    ),
+  ).toBeNull();
+
+  await openLibrary.click();
+  await page
+    .getByRole("dialog", { name: "library" })
+    .getByRole("button", { name: "settings" })
+    .click();
+  await expect(page.locator('[data-view="settings"]')).toHaveAttribute("aria-hidden", "false");
+
+  await openLibrary.click();
+  await page.getByRole("button", { name: "tagium, go to workspace home" }).click();
+  await expect(page.locator('[data-editor-state="empty-selection"]')).toHaveCSS("opacity", "1");
+  expect(
+    await page.evaluate(
+      () =>
+        (history.state as { workspaceNav?: { kind?: string } } | null)?.workspaceNav?.kind ?? null,
+    ),
+  ).toBeNull();
+});
+
 test("clicking blank space in the empty library closes settings", async ({ page }) => {
   await page.goto("/");
   await page.getByRole("button", { name: "settings" }).click();
-  await expect(page.getByRole("button", { name: "back to editor" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "back to workspace" })).toBeVisible();
 
   await page.getByRole("button", { name: "clear track selection and return to editor" }).click();
 
-  await expect(page.getByRole("button", { name: "back to editor" })).not.toBeAttached();
+  await expect(page.getByRole("button", { name: "back to workspace" })).not.toBeAttached();
   await expect(page.locator('[data-view="landing"]')).toBeVisible();
 });
 
@@ -279,7 +407,7 @@ test("gates advanced fields, retains their values, and reveals hidden validation
 
   await advancedSetting.click();
   await expect(page.getByText("link album artist to track artist")).toBeVisible();
-  await page.getByRole("button", { name: "back to editor" }).click();
+  await page.getByRole("button", { name: "back to workspace" }).click();
 
   await expect(page.getByRole("group", { name: "metadata fields" })).toBeVisible();
   await page.getByRole("button", { name: "advanced", exact: true }).click();
@@ -298,12 +426,12 @@ test("gates advanced fields, retains their values, and reveals hidden validation
 
   await page.getByRole("button", { name: "settings" }).click();
   await advancedSetting.click();
-  await page.getByRole("button", { name: "back to editor" }).click();
+  await page.getByRole("button", { name: "back to workspace" }).click();
   await expect(page.getByRole("group", { name: "metadata fields" })).not.toBeAttached();
 
   await page.getByRole("button", { name: "settings" }).click();
   await advancedSetting.click();
-  await page.getByRole("button", { name: "back to editor" }).click();
+  await page.getByRole("button", { name: "back to workspace" }).click();
   await expect(page.getByRole("button", { name: "advanced", exact: true })).toHaveAttribute(
     "aria-pressed",
     "true",

--- a/tests/unit/features/editor/editorKeyboardShortcuts.test.ts
+++ b/tests/unit/features/editor/editorKeyboardShortcuts.test.ts
@@ -139,6 +139,24 @@ describe("editor keyboard shortcuts", () => {
     expect(currentActions.clearSelection).toHaveBeenCalledOnce();
   });
 
+  it("leaves editor shortcuts inert outside the editor destination", () => {
+    const target = createKeyboardTarget();
+    const currentActions = actions({ enabled: false, selectedFileCount: 1 });
+    subscribeToEditorKeyboardShortcuts(target, () => currentActions);
+    const selectAllEvent = keyboardEvent("a", { ctrlKey: true });
+    const deleteEvent = keyboardEvent("Delete");
+
+    target.dispatch(selectAllEvent);
+    target.dispatch(deleteEvent);
+    target.dispatch(keyboardEvent("Escape"));
+
+    expect(preventDefaultFor(selectAllEvent)).not.toHaveBeenCalled();
+    expect(preventDefaultFor(deleteEvent)).not.toHaveBeenCalled();
+    expect(currentActions.selectAllFiles).not.toHaveBeenCalled();
+    expect(currentActions.requestRemoveSelectedFiles).not.toHaveBeenCalled();
+    expect(currentActions.clearSelection).not.toHaveBeenCalled();
+  });
+
   it.each([
     { tagName: "INPUT", isContentEditable: false },
     { tagName: "TEXTAREA", isContentEditable: false },

--- a/tests/unit/features/library/TagSidebarPanel.test.tsx
+++ b/tests/unit/features/library/TagSidebarPanel.test.tsx
@@ -50,11 +50,13 @@ describe("TagSidebarPanel", () => {
         onReorderAlbums={noOp}
         onDownloadAll={noOp}
         onOpenSettings={noOp}
+        onGoHome={noOp}
       />,
     );
 
     expect(markup).toContain("md:visible");
     expect(markup).toContain("md:opacity-100");
     expect(markup).toContain("md:translate-x-0");
+    expect(markup).toContain('aria-label="tagium, go to workspace home"');
   });
 });

--- a/tests/unit/features/settings/SettingsPage.test.tsx
+++ b/tests/unit/features/settings/SettingsPage.test.tsx
@@ -20,6 +20,7 @@ describe("settings page advanced metadata controls", () => {
     const normalMarkup = render(false);
     const advancedMarkup = render(true);
 
+    expect(normalMarkup).toContain('aria-label="back to workspace"');
     expect(normalMarkup).toContain("enable advanced metadata");
     expect(normalMarkup).not.toContain(getMetadataLinkDescriptor("albumArtist").label);
     expect(advancedMarkup).toContain(getMetadataLinkDescriptor("albumArtist").label);

--- a/tests/unit/features/settings/useWorkspaceSettings.test.ts
+++ b/tests/unit/features/settings/useWorkspaceSettings.test.ts
@@ -45,11 +45,9 @@ describe("workspace settings", () => {
       const library = useLibraryStore();
       const [settings, setSettings] = useState<AppSettings>(DEFAULT_APP_SETTINGS);
       const controls = useWorkspaceSettings({
-        library,
-        editor: { isCoverProcessing: false },
         settings,
         setSettings,
-        setActiveView: vi.fn(),
+        navigation: { goBack: vi.fn() },
       });
       return { library, settings, controls };
     }, undefined);

--- a/tests/unit/features/workspace/mobileWorkspaceNavigation.hook.test.tsx
+++ b/tests/unit/features/workspace/mobileWorkspaceNavigation.hook.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { act } from "react-test-renderer";
 import { describe, expect, it, vi } from "vitest";
 import { renderHook } from "../../support/hookTestHarness";
@@ -8,6 +9,7 @@ describe("mobile workspace navigation history integration", () => {
     const events = new EventTarget();
     let state: unknown = {};
     const stack: unknown[] = [state];
+    let backCalls = 0;
     const history = {
       get state() {
         return state;
@@ -21,6 +23,7 @@ describe("mobile workspace navigation history integration", () => {
         stack[stack.length - 1] = next;
       },
       back() {
+        backCalls++;
         stack.pop();
         state = stack.at(-1);
         queueMicrotask(() => {
@@ -41,22 +44,25 @@ describe("mobile workspace navigation history integration", () => {
         setTimeout,
       }),
     );
-    let activeView: "editor" | "settings" = "editor";
-    const hook = renderHook(
-      () =>
-        useMobileWorkspaceNavigation({
-          activeView,
-          setActiveView: (view) => {
-            activeView = view;
-          },
-        }),
-      undefined,
-    );
+    const hook = renderHook(() => {
+      const [activeView, setActiveView] = useState<"editor" | "settings">("editor");
+      const navigation = useMobileWorkspaceNavigation({
+        activeView,
+        setActiveView,
+      });
+      return { ...navigation, activeView };
+    }, undefined);
     act(() => hook.result.openDrawer());
     let ran = false;
+    let ignoredWhileClosing = false;
     act(() =>
       hook.result.runAfterDrawerClose(() => {
         ran = true;
+      }),
+    );
+    act(() =>
+      hook.result.runAfterDrawerClose(() => {
+        ignoredWhileClosing = true;
       }),
     );
     expect(ran).toBe(false);
@@ -64,16 +70,32 @@ describe("mobile workspace navigation history integration", () => {
       await Promise.resolve();
     });
     expect(ran).toBe(true);
+    expect(ignoredWhileClosing).toBe(false);
+    expect(backCalls).toBe(1);
 
     act(() => hook.result.navigateToView("settings"));
-    expect(activeView).toBe("settings");
+    expect(hook.result.activeView).toBe("settings");
+    let ranAfterBack = false;
+    let ignoredWhileGoingBack = false;
+    act(() => hook.result.backWorkspace(() => (ranAfterBack = true)));
+    act(() => hook.result.backWorkspace(() => (ignoredWhileGoingBack = true)));
+    expect(ranAfterBack).toBe(false);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(hook.result.activeView).toBe("editor");
+    expect(ranAfterBack).toBe(true);
+    expect(ignoredWhileGoingBack).toBe(false);
+    expect(backCalls).toBe(2);
+
+    act(() => hook.result.navigateToView("settings"));
     state = { shareSlug: "shared-album" };
     const sharePop = new Event("popstate");
     Object.defineProperty(sharePop, "state", { value: state });
     act(() => {
       events.dispatchEvent(sharePop);
     });
-    expect(activeView).toBe("settings");
+    expect(hook.result.activeView).toBe("settings");
     hook.unmount();
   });
 });

--- a/tests/unit/features/workspace/useAudioWorkspace.test.tsx
+++ b/tests/unit/features/workspace/useAudioWorkspace.test.tsx
@@ -15,6 +15,7 @@ import { renderHook } from "../../support/hookTestHarness";
 import { useAudioWorkspace } from "@/features/workspace/useAudioWorkspace";
 import { useLibraryStore } from "@/features/library/useLibraryStore";
 import { useTrackEditorSession } from "@/features/editor/useTrackEditorSession";
+import { useWorkspaceNavigation } from "@/features/workspace/workspaceNavigation";
 
 const initialSettings: AppSettings = {
   ...DEFAULT_APP_SETTINGS,
@@ -79,19 +80,18 @@ describe("audio workspace", () => {
     const hook = renderHook(() => {
       const library = useLibraryStore();
       const [settings, setSettings] = useState(initialSettings);
-      const [activeView, setActiveView] = useState<"editor" | "settings">("editor");
       const editor = useTrackEditorSession({ library, settings });
+      const navigation = useWorkspaceNavigation({ library, editor });
       const workspace = useAudioWorkspace({
         library,
         editor,
         settings,
         setSettings,
-        activeView,
-        setActiveView,
+        navigation,
         removeDownloads,
         busy: false,
       });
-      return { library, settings, activeView, workspace };
+      return { library, settings, activeView: navigation.activeView, workspace };
     }, undefined);
     const first = readyFile("first", "Artist - First (Official Audio)");
     const second = readyFile("second", "Second");

--- a/tests/unit/features/workspace/workspaceNavigation.test.tsx
+++ b/tests/unit/features/workspace/workspaceNavigation.test.tsx
@@ -1,0 +1,91 @@
+import { act } from "react-test-renderer";
+import { describe, expect, it, vi } from "vite-plus/test";
+import type { LibraryStore } from "@/features/library/useLibraryStore";
+import {
+  transitionWorkspaceDestination,
+  useWorkspaceNavigation,
+} from "@/features/workspace/workspaceNavigation";
+import { renderHook } from "../../support/hookTestHarness";
+
+describe("workspace destination transitions", () => {
+  it("remembers whether settings was opened from Home or the editor", () => {
+    const settingsFromHome = transitionWorkspaceDestination(
+      { kind: "home" },
+      { type: "open-settings" },
+    );
+    expect(settingsFromHome).toEqual({ kind: "settings", returnTo: "home" });
+    expect(transitionWorkspaceDestination(settingsFromHome, { type: "go-back" })).toEqual({
+      kind: "home",
+    });
+
+    const settingsFromEditor = transitionWorkspaceDestination(
+      { kind: "editor" },
+      { type: "open-settings" },
+    );
+    expect(settingsFromEditor).toEqual({ kind: "settings", returnTo: "editor" });
+    expect(transitionWorkspaceDestination(settingsFromEditor, { type: "go-back" })).toEqual({
+      kind: "editor",
+    });
+  });
+
+  it("keeps the original return destination when settings is opened twice", () => {
+    const settings = { kind: "settings", returnTo: "editor" } as const;
+    expect(transitionWorkspaceDestination(settings, { type: "open-settings" })).toBe(settings);
+  });
+});
+
+describe("workspace navigation", () => {
+  it("flushes editor work before Home clears selection", () => {
+    const calls: string[] = [];
+    const library = {
+      dispatch: vi.fn(() => {
+        calls.push("clear");
+      }),
+    } as unknown as LibraryStore;
+    const hook = renderHook(
+      () =>
+        useWorkspaceNavigation({
+          library,
+          editor: {
+            isCoverProcessing: false,
+            commands: {
+              flush: () => {
+                calls.push("flush");
+                return [];
+              },
+            },
+          },
+          initialDestination: { kind: "editor" },
+        }),
+      undefined,
+    );
+
+    act(() => hook.result.openSettings());
+    expect(hook.result.destination).toEqual({ kind: "settings", returnTo: "editor" });
+
+    act(() => hook.result.goHome());
+    expect(calls).toEqual(["flush", "clear"]);
+    expect(library.dispatch).toHaveBeenCalledWith({ type: "selection-cleared" });
+    expect(hook.result.destination).toEqual({ kind: "home" });
+    hook.unmount();
+  });
+
+  it("blocks destination changes while cover art is processing", () => {
+    const library = { dispatch: vi.fn() } as unknown as LibraryStore;
+    const hook = renderHook(
+      () =>
+        useWorkspaceNavigation({
+          library,
+          editor: { isCoverProcessing: true, commands: { flush: vi.fn() } },
+        }),
+      undefined,
+    );
+
+    act(() => hook.result.openSettings());
+    act(() => hook.result.showEditor());
+    act(() => hook.result.goHome());
+    expect(hook.result.destination).toEqual({ kind: "home" });
+    expect(library.dispatch).not.toHaveBeenCalled();
+    hook.unmount();
+  });
+});


### PR DESCRIPTION
## Summary

- Make the Tagium nameplate an accessible Home action that clears the active selection without deleting library work.
- Model Home, editor, and Settings as exclusive workspace destinations while preserving Settings Back context.
- Keep mobile history, keyboard shortcuts, and crossfade behavior aligned with the destination model.

## Why

Tagium has no separate home route, so the app name should return users to the neutral workspace. Previously, Settings visibility and track selection were independent, allowing both to appear active and causing confusing nested fades when returning to neutral.

## Human review

Setup: import one MP3 and change its title.

1. Click the Tagium nameplate. Expected: the neutral workspace appears, the track stays in the library, and reselecting it restores the edited title.
2. Select a track, open Settings, then use Back. Expected: the selection is visually inactive in Settings and the same track returns.
3. From Settings, click the Tagium nameplate. Expected: the app returns directly to neutral without a second track fade.
4. At a mobile width, open Settings from the drawer, reopen the drawer, then choose a track or Tagium. Expected: the drawer and Settings both close once, without requiring an extra browser Back.

Important edge cases:

- Escape, Cmd/Ctrl+A, and Delete should not invoke editor shortcuts while Settings is active.
- Repeated activation while the drawer/history transition is closing should not pop history twice.

## Decisions and tradeoffs

- Settings retains the prior selection only as inactive return context; it does not clear the library selection.
- Home flushes metadata before clearing selection and never deletes files.
- Dialogs and background work remain orthogonal to the workspace destination.

## Verification

- `bun run test` — 108 files, 680 tests passed
- `bun run build`
- `bun run lint`
- Vite+ formatting check
- Impeccable UI detector — no findings
- E2E coverage was added but not executed locally because the expected dev server was not running; manual UI review remains
