### PR TITLE
fix(ui): lowercase user-facing copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Tagium is a web-based audio metadata editor. We allow users to save the tracks t
 - Grow the system in layers. Start from the smallest version that works end to end, and add each new capability on top of a product that already works. Never trade a working product for unfinished complexity.
 - Keep components modular and concerns clearly separated.
 - Prefer established, well-maintained libraries when they reduce overall complexity or improve reliability. Do not reimplement common functionality without a clear reason. e.g. modify shadcn components instead of creating custom solutions.
+- Keep all UI copy lowercase, including accessibility text, brands, acronyms, and units. Preserve placeholder casing and user/provider content; don't fake casing with CSS.
 
 ## Pull Requests
 

--- a/src/components/dev/DevPanel.tsx
+++ b/src/components/dev/DevPanel.tsx
@@ -180,7 +180,7 @@ export function DevPanel() {
 
           <div className="grid gap-4 p-4">
             <section className="grid gap-3">
-              <div className="flex items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
+              <div className="flex items-center gap-2 text-xs font-semibold text-muted-foreground">
                 <Zap className="size-3.5" />
                 rate limit
               </div>
@@ -250,7 +250,7 @@ export function DevPanel() {
             </section>
 
             <section className="grid gap-3">
-              <div className="flex items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
+              <div className="flex items-center gap-2 text-xs font-semibold text-muted-foreground">
                 <AlertTriangle className="size-3.5" />
                 next audio
               </div>
@@ -280,7 +280,7 @@ export function DevPanel() {
             </section>
 
             <section className="grid gap-3">
-              <div className="flex items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
+              <div className="flex items-center gap-2 text-xs font-semibold text-muted-foreground">
                 <AlertTriangle className="size-3.5" />
                 next tunnel
               </div>
@@ -310,7 +310,7 @@ export function DevPanel() {
             </section>
 
             <section className="grid gap-3">
-              <div className="flex items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
+              <div className="flex items-center gap-2 text-xs font-semibold text-muted-foreground">
                 <BellRing className="size-3.5" />
                 toasts
               </div>

--- a/src/components/dev/devToast.ts
+++ b/src/components/dev/devToast.ts
@@ -6,7 +6,7 @@ export const devToastKinds: DevToastKind[] = ["neutral", "success", "error", "in
 
 export const spawnDevToast = (kind: DevToastKind) => {
   const title = `${kind} toast`;
-  const options = { description: "previewing Tagium's notification styling" };
+  const options = { description: "previewing tagium's notification styling" };
 
   if (kind === "neutral") {
     toast(title, options);

--- a/src/features/audio/metadataFields.ts
+++ b/src/features/audio/metadataFields.ts
@@ -29,7 +29,7 @@ export type AdvancedNumericMetadataField = "discNumber" | "bpm";
 
 const advancedNumberLabels = {
   discNumber: "disc number",
-  bpm: "BPM",
+  bpm: "bpm",
 } as const satisfies Record<AdvancedNumericMetadataField, string>;
 
 export const validateAdvancedMetadataNumber = (

--- a/src/features/audio/mp3Compatibility.ts
+++ b/src/features/audio/mp3Compatibility.ts
@@ -119,7 +119,7 @@ const startsWithAscii = (bytes: Uint8Array, value: string, offset = 0) =>
   Array.from(value).every((character, index) => bytes[offset + index] === character.charCodeAt(0));
 
 export const getMp3AdmissionError = (file: File, bytes: Uint8Array) => {
-  if (bytes.length === 0) return `${file.name} is empty. Choose a valid mp3 file.`;
+  if (bytes.length === 0) return `${file.name} is empty. choose a valid mp3 file.`;
   if (!/\.mp3$/i.test(file.name)) {
     return `${file.name} is not an mp3. tagium currently supports mp3 files only.`;
   }
@@ -132,7 +132,7 @@ export const getMp3AdmissionError = (file: File, bytes: Uint8Array) => {
     return `${file.name} is not an mp3. tagium currently supports mp3 files only.`;
   }
   if (isMp3Bytes(bytes)) return null;
-  return `${file.name} is not a valid mp3. The file may be corrupt or renamed.`;
+  return `${file.name} is not a valid mp3. the file may be corrupt or renamed.`;
 };
 
 export const normalizeMp3Filename = (filename: string) => {

--- a/src/features/editor/TrackMetadataEditor.tsx
+++ b/src/features/editor/TrackMetadataEditor.tsx
@@ -256,7 +256,7 @@ function TrackDetailsFields({
     },
     [active, focusedTitleFileIdRef, selectedFileId, titleRegistrationRef],
   );
-  const albumFieldReason = "Album title is synced with the album.";
+  const albumFieldReason = "album title is synced with the album.";
 
   return (
     <>
@@ -546,10 +546,10 @@ function TrackFileSummary({ selectedFile }: { selectedFile: LoadedTrack }) {
         <span className="font-medium">size: </span>
         {selectedFile.file &&
           selectedFile.status !== "error" &&
-          `${(selectedFile.file.size / (1024 * 1024)).toFixed(2)} MB`}
+          `${(selectedFile.file.size / (1024 * 1024)).toFixed(2)} mb`}
         {selectedFile.file &&
           selectedFile.status === "error" &&
-          `${(selectedFile.file.size / (1024 * 1024)).toFixed(2)} MB (metadata failed)`}
+          `${(selectedFile.file.size / (1024 * 1024)).toFixed(2)} mb (metadata failed)`}
         {!selectedFile.file && selectedFile.downloadStatus === "downloading" && "downloading"}
         {!selectedFile.file && selectedFile.downloadStatus === "error" && "download failed"}
         {!selectedFile.file && selectedFile.downloadStatus === "canceled" && "download canceled"}

--- a/src/features/editor/audioTaggerUtils.ts
+++ b/src/features/editor/audioTaggerUtils.ts
@@ -36,7 +36,10 @@ export const getAcceptedUploadParseResult = (uploads: UploadedTrack[]) => {
 
 export const getUploadRejectionMessage = (rejectedUploads: UploadedTrack[]) =>
   rejectedUploads
-    .map((upload) => upload.file.downloadError ?? `${upload.file.filename} could not be imported.`)
+    .map(
+      (upload) =>
+        `${upload.file.filename} could not be imported. try a valid mp3, flac, or unencrypted m4a/mp4 file.`,
+    )
     .join("\n");
 
 export const getNullableNumericMetadataValue = (

--- a/src/features/editor/coverArtProcessing.ts
+++ b/src/features/editor/coverArtProcessing.ts
@@ -37,7 +37,7 @@ export const validateCoverArtUpload = (file: File) => {
     throw new Error("cover art image must be a jpeg or png.");
   }
   if (file.size > MAX_COVER_ART_UPLOAD_BYTES) {
-    throw new Error("cover art must be 25 MB or smaller.");
+    throw new Error("cover art must be 25 mb or smaller.");
   }
 };
 

--- a/src/features/import/AudioImportDropzone.tsx
+++ b/src/features/import/AudioImportDropzone.tsx
@@ -120,7 +120,7 @@ export default function AudioImportDropzone({
             {isDragging ? "drop to import" : "drop your audio here"}
           </p>
           <p className="mt-1 text-sm text-muted-foreground">
-            MP3, FLAC, and M4A/MP4 · or click to browse
+            mp3, flac, and m4a/mp4 · or click to browse
           </p>
         </div>
       </button>

--- a/src/features/import/audioUpload.tsx
+++ b/src/features/import/audioUpload.tsx
@@ -47,7 +47,7 @@ export default function AudioUpload({ onAudioUpload }: AudioUploadProps) {
         aria-label="upload audio files"
       >
         <Upload className="h-6 w-6 text-muted-foreground" />
-        <span className="text-xs text-muted-foreground">upload MP3, FLAC, or M4A/MP4 files</span>
+        <span className="text-xs text-muted-foreground">upload mp3, flac, or m4a/mp4 files</span>
       </Button>
     </div>
   );

--- a/src/features/import/downloadTrack.ts
+++ b/src/features/import/downloadTrack.ts
@@ -184,7 +184,7 @@ interface FetchImportedCoverDependencies {
 const readCoverResponseFile = async (response: Response, contentType: string) => {
   const declaredLength = Number(response.headers.get("content-length"));
   if (Number.isFinite(declaredLength) && declaredLength > MAX_COVER_ART_UPLOAD_BYTES) {
-    throw new Error("cover art must be 25 MB or smaller.");
+    throw new Error("cover art must be 25 mb or smaller.");
   }
   if (!response.body) throw new Error("album cover response body is unavailable.");
 
@@ -199,7 +199,7 @@ const readCoverResponseFile = async (response: Response, contentType: string) =>
       receivedBytes += value.byteLength;
       if (receivedBytes > MAX_COVER_ART_UPLOAD_BYTES) {
         await reader.cancel();
-        throw new Error("cover art must be 25 MB or smaller.");
+        throw new Error("cover art must be 25 mb or smaller.");
       }
       chunks.push(Uint8Array.from(value));
     }

--- a/src/features/import/playlistDownloadQueue.ts
+++ b/src/features/import/playlistDownloadQueue.ts
@@ -148,7 +148,7 @@ export const derivePlaylistDownloadQueueSummary = (
   const failedCount = queue.items.filter((item) => item.status === "failed").length;
   const canceledCount = queue.items.filter((item) => item.status === "canceled").length;
   return {
-    label: `Downloading ${completedCount}/${queue.items.length}`,
+    label: `downloading ${completedCount}/${queue.items.length}`,
     totalCount: queue.items.length,
     completedCount,
     activeCount: activeItems.length,

--- a/src/features/library/albumOps.ts
+++ b/src/features/library/albumOps.ts
@@ -50,7 +50,7 @@ export function mergeUploadedTracksIntoAlbums(
     const firstSeed =
       albumSeedUploads.find((upload) => upload.albumSeed.title.trim())?.albumSeed ??
       albumSeedUploads[0].albumSeed;
-    const albumTitle = firstSeed.title || `Album ${nextAlbums.length + 1}`;
+    const albumTitle = firstSeed.title || `album ${nextAlbums.length + 1}`;
 
     const createdAlbum: AlbumGroup = {
       id: crypto.randomUUID(),

--- a/src/features/settings/SettingsPageSections.tsx
+++ b/src/features/settings/SettingsPageSections.tsx
@@ -213,7 +213,7 @@ export function DownloadsSettingsSection({ settings, onChange }: SettingsSection
           className="mt-0.5"
         />
         <span className="text-sm font-medium">
-          automatically apply SoundCloud album cover to all tracks
+          automatically apply soundcloud album cover to all tracks
         </span>
       </label>
     </section>
@@ -235,7 +235,7 @@ export function AboutSettingsSection() {
           <h3 className="text-base font-semibold">ethics</h3>
           <p className="text-sm leading-6 text-muted-foreground">
             tagium is not a piracy tool and cannot be used as one. it only works with free, publicly
-            accessible audio. It cannot be used to bypass paywalls or access private content.
+            accessible audio. it cannot be used to bypass paywalls or access private content.
           </p>
           <p className="text-sm leading-6 text-muted-foreground">
             you are responsible for the content you download and how you use it. credit original
@@ -276,7 +276,7 @@ export function AboutSettingsSection() {
           href="https://github.com/flamboh/tagium"
           target="_blank"
           rel="noreferrer"
-          aria-label="GitHub"
+          aria-label="github"
           className="inline-flex size-12 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none"
         >
           <svg
@@ -298,7 +298,7 @@ export function AboutSettingsSection() {
           href="https://x.com/flambohh"
           target="_blank"
           rel="noreferrer"
-          aria-label="Twitter"
+          aria-label="twitter"
           className="inline-flex size-12 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none"
         >
           <svg

--- a/src/features/workspace/DestructiveActionDialog.tsx
+++ b/src/features/workspace/DestructiveActionDialog.tsx
@@ -30,7 +30,7 @@ export default function DestructiveActionDialog({
         <DialogHeader>
           <DialogTitle>{`remove ${plural ? `${itemCount} ` : ""}${noun}?`}</DialogTitle>
           <DialogDescription>
-            {`This removes the ${noun} from the current session. This cannot be undone.`}
+            {`this removes the ${noun} from the current session. this cannot be undone.`}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/src/features/workspace/systemFailure.ts
+++ b/src/features/workspace/systemFailure.ts
@@ -38,7 +38,7 @@ const KNOWN_FAILURES = {
   capacity: {
     code: "capacity",
     title: "downloads are busy",
-    description: "Too many downloads are running right now. Try again in a moment.",
+    description: "too many downloads are running right now. try again in a moment.",
     trackDescription: "downloads are busy. try again in a moment.",
     retryable: true,
     dedupeKey: "system-download-capacity",
@@ -46,7 +46,7 @@ const KNOWN_FAILURES = {
   rate_limited: {
     code: "rate_limited",
     title: "too many download requests",
-    description: "Wait a moment, then try the download again.",
+    description: "wait a moment, then try the download again.",
     trackDescription: "too many download requests. try again shortly.",
     retryable: true,
     dedupeKey: "system-download-rate-limited",
@@ -54,7 +54,7 @@ const KNOWN_FAILURES = {
   timeout: {
     code: "timeout",
     title: "the download took too long",
-    description: "Try again. If it keeps failing, try another link.",
+    description: "try again. if it keeps failing, try another link.",
     trackDescription: "download timed out. try again.",
     retryable: true,
     dedupeKey: "system-download-timeout",
@@ -62,7 +62,7 @@ const KNOWN_FAILURES = {
   service_unavailable: {
     code: "service_unavailable",
     title: "downloads are temporarily unavailable",
-    description: "tagium could not reach the download service. Try again soon.",
+    description: "tagium could not reach the download service. try again soon.",
     trackDescription: "audio downloads are temporarily unavailable.",
     retryable: true,
     dedupeKey: "system-download-service-unavailable",
@@ -70,7 +70,7 @@ const KNOWN_FAILURES = {
   unsupported_source: {
     code: "unsupported_source",
     title: "this link is not supported",
-    description: "Try a public SoundCloud or YouTube track URL.",
+    description: "try a public soundcloud or youtube track url.",
     trackDescription: "this link is not supported.",
     retryable: false,
     dedupeKey: "system-download-unsupported-source",
@@ -78,7 +78,7 @@ const KNOWN_FAILURES = {
   private_or_missing: {
     code: "private_or_missing",
     title: "we could not access this media",
-    description: "Check that the link is public and still available, then try again.",
+    description: "check that the link is public and still available, then try again.",
     trackDescription: "media is private, unavailable, or no longer exists.",
     retryable: false,
     dedupeKey: "system-download-private-or-missing",
@@ -86,7 +86,7 @@ const KNOWN_FAILURES = {
   invalid_response: {
     code: "invalid_response",
     title: "we could not read this media",
-    description: "The provider returned an unexpected response. Try again or use another link.",
+    description: "the provider returned an unexpected response. try again or use another link.",
     trackDescription: "the media provider returned an unexpected response.",
     retryable: true,
     dedupeKey: "system-download-invalid-response",
@@ -96,43 +96,43 @@ const KNOWN_FAILURES = {
 const FALLBACKS = {
   download: {
     title: "download failed",
-    description: "tagium could not download this track. Try again or use another link.",
+    description: "tagium could not download this track. try again or use another link.",
     trackDescription: "download failed. try again or use another link.",
   },
   import: {
     title: "import failed",
-    description: "tagium could not import this media. Try again in a moment.",
+    description: "tagium could not import this media. try again in a moment.",
     trackDescription: "import failed. try again.",
   },
   upload: {
     title: "some files could not be imported",
     description:
-      "tagium could not read one or more audio files. Try a valid MP3, FLAC, or M4A file.",
+      "tagium could not read one or more audio files. try a valid mp3, flac, or m4a file.",
     trackDescription: "one or more audio files could not be read.",
   },
   export: {
     title: "export failed",
-    description: "tagium could not prepare your download. Your tracks are still in the library.",
+    description: "tagium could not prepare your download. your tracks are still in the library.",
     trackDescription: "export failed. your tracks are still in the library.",
   },
   "cover-art": {
     title: "cover art failed",
-    description: "tagium could not process this cover image. Try another jpeg or png.",
+    description: "tagium could not process this cover image. try another jpeg or png.",
     trackDescription: "cover art could not be processed.",
   },
   "cover-import": {
     title: "cover art was not imported",
-    description: "The tracks were imported without cover art. Upload a jpeg or png manually.",
+    description: "the tracks were imported without cover art. upload a jpeg or png manually.",
     trackDescription: "cover art was not imported. upload an image manually.",
   },
   metadata: {
     title: "metadata could not be saved",
-    description: "Your edits are still visible. Try the action again.",
+    description: "your edits are still visible. try the action again.",
     trackDescription: "metadata could not be saved. try again.",
   },
   storage: {
     title: "settings could not be saved",
-    description: "Your browser did not allow tagium to store these settings.",
+    description: "your browser did not allow tagium to store these settings.",
     trackDescription: "settings could not be saved.",
   },
 } as const satisfies Record<

--- a/tests/e2e/settings-transition.spec.ts
+++ b/tests/e2e/settings-transition.spec.ts
@@ -118,7 +118,7 @@ test("prevents checkbox label text selection", async ({ page }) => {
   await page.getByRole("button", { name: "settings" }).click();
 
   const checkboxLabel = page
-    .getByText("automatically apply SoundCloud album cover to all tracks", {
+    .getByText("automatically apply soundcloud album cover to all tracks", {
       exact: true,
     })
     .locator("..");

--- a/tests/unit/components/dev/devToast.test.ts
+++ b/tests/unit/components/dev/devToast.test.ts
@@ -26,7 +26,7 @@ describe("dev toast controls", () => {
     spawnDevToast(kind);
 
     expect(toastMocks[kind]).toHaveBeenCalledWith(`${kind} toast`, {
-      description: "previewing Tagium's notification styling",
+      description: "previewing tagium's notification styling",
     });
   });
 
@@ -34,7 +34,7 @@ describe("dev toast controls", () => {
     spawnDevToast("neutral" satisfies DevToastKind);
 
     expect(toastMocks).toHaveBeenCalledWith("neutral toast", {
-      description: "previewing Tagium's notification styling",
+      description: "previewing tagium's notification styling",
     });
   });
 });

--- a/tests/unit/features/editor/audioTagger.test.ts
+++ b/tests/unit/features/editor/audioTagger.test.ts
@@ -59,23 +59,24 @@ describe("audioTagger metadata patches", () => {
     });
   });
 
-  it("consolidates every rejected file error into one presentation", () => {
-    const rejectedUploads = ["empty.mp3 is empty.", "song.wav is not an mp3."].map(
-      (downloadError, index) =>
+  it("presents lowercase recovery copy without changing filename casing", () => {
+    const rejectedUploads = ["EMPTY.MP3", "song.wav"].map(
+      (filename, index) =>
         ({
           file: {
             id: `rejected-${index}`,
-            filename: index === 0 ? "empty.mp3" : "song.wav",
+            filename,
             status: "error",
             downloadStatus: "ready",
-            downloadError,
+            downloadError: "private CODEC diagnostic",
           },
           albumSeed: { title: "", artist: "", genre: "" },
         }) satisfies UploadedTrack,
     );
 
     expect(getUploadRejectionMessage(rejectedUploads)).toBe(
-      "empty.mp3 is empty.\nsong.wav is not an mp3.",
+      "EMPTY.MP3 could not be imported. try a valid mp3, flac, or unencrypted m4a/mp4 file.\n" +
+        "song.wav could not be imported. try a valid mp3, flac, or unencrypted m4a/mp4 file.",
     );
   });
 

--- a/tests/unit/features/editor/coverArtProcessing.test.ts
+++ b/tests/unit/features/editor/coverArtProcessing.test.ts
@@ -31,7 +31,7 @@ describe("cover art processing", () => {
           type: "image/jpeg",
         }),
       ),
-    ).toThrow("25 MB");
+    ).toThrow("25 mb");
     expect(() =>
       validateCoverArtUpload(new File(["text"], "cover.txt", { type: "text/plain" })),
     ).toThrow("image");

--- a/tests/unit/features/import/downloadTrack.test.ts
+++ b/tests/unit/features/import/downloadTrack.test.ts
@@ -73,7 +73,7 @@ describe("imported cover downloads", () => {
 
     await expect(
       fetchImportedCover("https://example.com/cover", { fetch, optimize }),
-    ).rejects.toThrow("25 MB");
+    ).rejects.toThrow("25 mb");
     expect(optimize).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/features/import/playlistDownloadQueue.test.ts
+++ b/tests/unit/features/import/playlistDownloadQueue.test.ts
@@ -33,7 +33,7 @@ describe("playlistDownloadQueue", () => {
 
     const summary = derivePlaylistDownloadQueueSummary(queue, 12_000);
 
-    expect(summary.label).toBe("Downloading 1/3");
+    expect(summary.label).toBe("downloading 1/3");
     expect(summary.completedCount).toBe(1);
     expect(summary.activeCount).toBe(1);
     expect(summary.pendingCount).toBe(1);

--- a/tests/unit/features/workspace/systemFailure.test.ts
+++ b/tests/unit/features/workspace/systemFailure.test.ts
@@ -38,7 +38,7 @@ describe("system failure reporting", () => {
     expect(presentation).toMatchObject({
       code: "unknown",
       title: "export failed",
-      description: "tagium could not prepare your download. Your tracks are still in the library.",
+      description: "tagium could not prepare your download. your tracks are still in the library.",
     });
     expect(JSON.stringify(presentation)).not.toContain("private upstream");
   });
@@ -49,7 +49,7 @@ describe("system failure reporting", () => {
 
     expect(toastMocks.error).toHaveBeenCalledTimes(2);
     expect(toastMocks.error).toHaveBeenLastCalledWith("export failed", {
-      description: "tagium could not prepare your download. Your tracks are still in the library.",
+      description: "tagium could not prepare your download. your tracks are still in the library.",
     });
   });
 
@@ -91,7 +91,7 @@ describe("system failure reporting", () => {
     ).toMatchObject({
       code: "unknown",
       title: "metadata could not be saved",
-      description: "Your edits are still visible. Try the action again.",
+      description: "your edits are still visible. try the action again.",
     });
 
     expect(
@@ -108,7 +108,7 @@ describe("system failure reporting", () => {
     ).toMatchObject({
       code: "unknown",
       title: "cover art was not imported",
-      description: "The tracks were imported without cover art. Upload a jpeg or png manually.",
+      description: "the tracks were imported without cover art. upload a jpeg or png manually.",
     });
   });
 });


### PR DESCRIPTION
## Review

- Open the workspace, settings, a track removal dialog, and the dev panel. Confirm all product-authored copy is lowercase, including format names, units, accessibility labels, notifications, and dev-panel headings.
- Upload an invalid audio file and confirm the error preserves the filename casing while showing lowercase recovery guidance.
- Confirm existing placeholders and imported track, album, artist, filename, and provider content retain their original casing.

## Edge cases

- Check uppercase filenames and metadata values to ensure only the surrounding product copy is lowercase.
- Check failed imports, cover-size errors, validation errors, and download-service errors.

## Decisions

- Detailed codec diagnostics remain internal; rejected uploads use concise public recovery copy.
- Placeholder and user/provider casing is intentionally preserved.

## Verification

- Automated: `bun run lint`, `bun run typecheck`, and `bun run test` passed; 108 test files and 680 tests passed. The UI detector reported no findings.
- Manual: the deployment preview and end-to-end browser flows still need review.