### PR TITLE
fix: make share publication awaitable

### DIFF
--- a/src/features/share/useShareWorkflow.ts
+++ b/src/features/share/useShareWorkflow.ts
@@ -597,7 +597,7 @@ export const useShareWorkflow = ({
     shareActions,
     importFromInput,
     openCreator,
-    publish: () => void publish(),
+    publish,
     closeDialog: () => setDialog({ status: "closed" }),
     stopDialogShare,
     stopPageShare,

--- a/tests/unit/features/share/shareWorkflowPreview.test.tsx
+++ b/tests/unit/features/share/shareWorkflowPreview.test.tsx
@@ -233,7 +233,7 @@ describe("share creator preview state", () => {
     });
 
     await act(async () => {
-      hook.result.publish();
+      void hook.result.publish();
       await Promise.resolve();
     });
     await vi.waitFor(() => expect(publishSharedAlbum).toHaveBeenCalledTimes(1));


### PR DESCRIPTION
## Human review

- With sharing enabled, open an eligible album's share dialog and create a link. Expect the dialog to show the publishing state and then the completed link normally.
- For an album whose previous publication is stopped, create another share link. Expect a fresh link rather than an update to the stopped publication.
- If practical, check a slow or failed publication. The publish button should remain disabled while work is pending, and failures should continue to appear in the dialog without an unhandled error.
- Reviewer decision: the workflow now exposes its existing completion promise to callers; the UI still treats the click as fire-and-forget, while tests can await the complete operation.
- Automatically verified with `bun run lint`, `bun run typecheck`, the focused regression, and `bun run test` (108 files, 680 tests). An independent review found no actionable issues and repeated both affected test files 20 times successfully. Manual browser verification remains.
