### PR TITLE
Fix dialog content flash during exit

### DIFF
--- a/src/features/export/ExportConfirmationDialog.tsx
+++ b/src/features/export/ExportConfirmationDialog.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown } from "lucide-react";
-import { useId, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -69,19 +69,22 @@ export function ExportPlanDisclosure({ group }: { group: ExportPlanGroup }) {
   );
 }
 
-export default function ExportConfirmationDialog({
+type ExportConfirmationDialogViewProps = ExportConfirmationDialogProps & { open: boolean };
+
+export function ExportConfirmationDialogView({
   plan,
   status,
   busy,
   onCancel,
   onConfirm,
   onRestoreFocus,
-}: ExportConfirmationDialogProps) {
+  open,
+}: ExportConfirmationDialogViewProps) {
   const noun = plan?.trackCount === 1 ? "track" : "tracks";
   const downloadLabel = plan ? `download ~${formatMegabyteSize(plan.totalSizeBytes)}` : "download";
 
   return (
-    <Dialog open={Boolean(plan)} onOpenChange={(open) => !open && !busy && onCancel()}>
+    <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && !busy && onCancel()}>
       <DialogContent
         showCloseButton={false}
         aria-describedby={undefined}
@@ -150,5 +153,18 @@ export default function ExportConfirmationDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+export default function ExportConfirmationDialog(props: ExportConfirmationDialogProps) {
+  const visiblePlanRef = useRef(props.plan);
+  if (props.plan) visiblePlanRef.current = props.plan;
+
+  return (
+    <ExportConfirmationDialogView
+      {...props}
+      open={Boolean(props.plan)}
+      plan={props.plan ?? visiblePlanRef.current}
+    />
   );
 }

--- a/src/features/export/ExportConfirmationDialog.tsx
+++ b/src/features/export/ExportConfirmationDialog.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown } from "lucide-react";
-import { useId, useRef, useState } from "react";
+import { useId, useLayoutEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -158,7 +158,9 @@ export function ExportConfirmationDialogView({
 
 export default function ExportConfirmationDialog(props: ExportConfirmationDialogProps) {
   const visiblePlanRef = useRef(props.plan);
-  if (props.plan) visiblePlanRef.current = props.plan;
+  useLayoutEffect(() => {
+    if (props.plan) visiblePlanRef.current = props.plan;
+  }, [props.plan]);
 
   return (
     <ExportConfirmationDialogView

--- a/src/features/library/MetadataCleanupDialog.tsx
+++ b/src/features/library/MetadataCleanupDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -32,11 +32,14 @@ function MetadataCleanupDialogSession({
   onOpenChange,
   onApply,
 }: MetadataCleanupDialogSessionProps) {
+  const visibleSuggestionsRef = useRef(suggestions);
+  if (open) visibleSuggestionsRef.current = suggestions;
+  const visibleSuggestions = open ? suggestions : visibleSuggestionsRef.current;
   const [selectedIds, setSelectedIds] = useState(
     () => new Set(suggestions.map((suggestion) => suggestion.trackId)),
   );
 
-  const selectedSuggestions = suggestions.filter((suggestion) =>
+  const selectedSuggestions = visibleSuggestions.filter((suggestion) =>
     selectedIds.has(suggestion.trackId),
   );
 
@@ -62,13 +65,13 @@ function MetadataCleanupDialogSession({
           </DialogDescription>
         </DialogHeader>
         <div className="min-h-0 flex-1 overflow-y-auto border-y px-6">
-          {suggestions.length === 0 ? (
+          {visibleSuggestions.length === 0 ? (
             <p className="py-8 text-center text-sm text-muted-foreground">
               nothing left to clean up
             </p>
           ) : (
             <div className="divide-y">
-              {suggestions.map((suggestion) => (
+              {visibleSuggestions.map((suggestion) => (
                 <label
                   key={suggestion.trackId}
                   className="flex cursor-pointer select-none items-start gap-3 py-4"

--- a/src/features/library/MetadataCleanupDialog.tsx
+++ b/src/features/library/MetadataCleanupDialog.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -33,7 +33,9 @@ function MetadataCleanupDialogSession({
   onApply,
 }: MetadataCleanupDialogSessionProps) {
   const visibleSuggestionsRef = useRef(suggestions);
-  if (open) visibleSuggestionsRef.current = suggestions;
+  useLayoutEffect(() => {
+    if (open) visibleSuggestionsRef.current = suggestions;
+  }, [open, suggestions]);
   const visibleSuggestions = open ? suggestions : visibleSuggestionsRef.current;
   const [selectedIds, setSelectedIds] = useState(
     () => new Set(suggestions.map((suggestion) => suggestion.trackId)),

--- a/tests/unit/features/export/ExportConfirmationDialog.test.tsx
+++ b/tests/unit/features/export/ExportConfirmationDialog.test.tsx
@@ -1,7 +1,19 @@
 import type { ReactElement, ReactNode } from "react";
-import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
 import { describe, expect, it, vi } from "vite-plus/test";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children?: ReactNode }) => <footer>{children}</footer>,
+  DialogHeader: ({ children }: { children?: ReactNode }) => <header>{children}</header>,
+  DialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+}));
+
 import ExportConfirmationDialog, {
+  ExportConfirmationDialogView,
   ExportPlanDisclosure,
 } from "@/features/export/ExportConfirmationDialog";
 import { Button } from "@/components/ui/button";
@@ -26,6 +38,8 @@ const textContent = (node: ReactNode): string => {
   if (!isElement(node)) return "";
   return childrenOf(node).map(textContent).join("");
 };
+const renderedText = (node: ReactTestInstance): string =>
+  node.children.map((child) => (typeof child === "string" ? child : renderedText(child))).join("");
 
 const plan = {
   target: { kind: "library" as const },
@@ -41,17 +55,39 @@ const plan = {
 };
 
 const render = (overrides: Partial<Parameters<typeof ExportConfirmationDialog>[0]> = {}) =>
-  ExportConfirmationDialog({
+  ExportConfirmationDialogView({
     plan,
     status: "ready",
     busy: false,
     onCancel: vi.fn(),
     onConfirm: vi.fn(),
     onRestoreFocus: vi.fn(),
+    open: true,
     ...overrides,
   });
 
 describe("ExportConfirmationDialog", () => {
+  it("keeps the populated plan rendered while the dialog closes", () => {
+    const props = {
+      plan,
+      status: "ready" as const,
+      busy: false,
+      onCancel: vi.fn(),
+      onConfirm: vi.fn(),
+      onRestoreFocus: vi.fn(),
+    };
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<ExportConfirmationDialog {...props} />);
+    });
+
+    act(() => renderer.update(<ExportConfirmationDialog {...props} plan={null} />));
+
+    expect(renderedText(renderer.root)).toContain("download 1 track");
+    expect(renderedText(renderer.root)).not.toContain("download 0 tracks");
+    act(() => renderer.unmount());
+  });
+
   it("shows only the locked manifest and approximate download copy", () => {
     const tree = render();
     const text = textContent(tree);

--- a/tests/unit/features/library/MetadataCleanupDialog.test.tsx
+++ b/tests/unit/features/library/MetadataCleanupDialog.test.tsx
@@ -45,6 +45,29 @@ const textContent = (node: ReactTestInstance): string =>
   node.children.map((child) => (typeof child === "string" ? child : textContent(child))).join("");
 
 describe("MetadataCleanupDialog", () => {
+  it("keeps populated suggestions rendered while the dialog closes", () => {
+    const props = {
+      open: true,
+      selectionSessionKey: 1,
+      suggestions: [suggestion("one"), suggestion("two")],
+      returnFocusTarget: null,
+      onOpenChange: vi.fn(),
+      onApply: vi.fn(),
+    };
+    let renderer: ReturnType<typeof create>;
+    act(() => {
+      renderer = create(<MetadataCleanupDialog {...props} />);
+    });
+
+    act(() => {
+      renderer!.update(<MetadataCleanupDialog {...props} open={false} suggestions={[]} />);
+    });
+
+    expect(textContent(renderer!.root)).toContain("apply 2 changes");
+    expect(textContent(renderer!.root)).not.toContain("nothing left to clean up");
+    act(() => renderer!.unmount());
+  });
+
   it("preserves equivalent unchecked choices live and resets them on a new session", () => {
     const onApply = vi.fn();
     const props = {


### PR DESCRIPTION
## Review instructions

- Load multiple ready tracks, choose **download all**, and close the confirmation with Cancel, Escape, and the backdrop. Expected: the dialog closes while continuing to show the original track count; it never flashes “download 0 tracks.”
- Reopen the download confirmation and complete the download. Expected: the original count remains visible until the success close animation finishes.
- Create an album with cleanup suggestions, open **clean up tracks**, and dismiss it. Then reopen and apply the cleanup. Expected: the selected changes remain visible during either close animation; the dialog does not flash “apply 0 changes” or “nothing left to clean up.”
- Check both one-track and multi-track cases. Live changes while a dialog remains open should still update normally; only the departing render is frozen.
- The implementation retains the last populated display snapshot during exit while allowing the underlying export/cleanup state to clear immediately.
- Automatically verified with `bun run typecheck`, `bun run lint`, and `bun run test` (108 files, 682 tests). The 200 ms visual exit animation still needs manual verification.