### PR TITLE
fix(ui): center cleanup checkboxes

### DIFF
--- a/src/features/library/MetadataCleanupDialog.tsx
+++ b/src/features/library/MetadataCleanupDialog.tsx
@@ -76,7 +76,7 @@ function MetadataCleanupDialogSession({
               {visibleSuggestions.map((suggestion) => (
                 <label
                   key={suggestion.trackId}
-                  className="flex cursor-pointer select-none items-start gap-3 py-4"
+                  className="flex cursor-pointer select-none items-center gap-3 py-4"
                 >
                   <Checkbox
                     checked={selectedIds.has(suggestion.trackId)}
@@ -88,7 +88,6 @@ function MetadataCleanupDialogSession({
                         return next;
                       })
                     }
-                    className="mt-1"
                   />
                   <div className="min-w-0 flex-1 space-y-1.5">
                     <p className="truncate text-sm text-foreground/70 line-through decoration-2 decoration-foreground/80">


### PR DESCRIPTION
## review

- open the [preview deploy](https://t3code-center-cleanup-checkboxes-tagium.oliver-boorstein.workers.dev/), load or download an album with track-title cleanup suggestions, and launch `track title clean up`
- confirm each checkbox is vertically centered against its two-line before/after title comparison, including rows with long truncated titles
- toggle individual rows and `clear all`; selection behavior and the apply-count button should remain unchanged
- the intended tradeoff is alignment only: checkbox size, row density, title spacing, and mobile behavior are unchanged
- automated verification: `bun run typecheck`, `bun run lint`, the three dialog unit tests, and the impeccable layout detector all pass
- manual verification: check the linked preview at narrow and wide viewport sizes