### PR TITLE
fix(analytics): use managed reverse proxy

### DIFF
--- a/docs/share-operations.md
+++ b/docs/share-operations.md
@@ -26,7 +26,7 @@ TAGIUM_DEPLOY_ENV=production bun run configure:share-artwork-lifecycle:productio
 
 There is one Worker service named `tagium`. Preview uses `wrangler versions upload` and production uses `wrangler deploy` against that same service; no named Wrangler environments are used, so production routes remain attached to `tagium`.
 
-Cloudflare Build variables still required: `WORKERS_CI_BRANCH`, `WORKERS_CI_COMMIT_SHA`, `VITE_PUBLIC_POSTHOG_HOST`, and `VITE_PUBLIC_POSTHOG_KEY`. Deploy credentials (`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`) are supplied by the operator or Workers Build environment.
+Cloudflare Build variables still required: `WORKERS_CI_BRANCH`, `WORKERS_CI_COMMIT_SHA`, `VITE_PUBLIC_POSTHOG_HOST=https://t.tagium.app`, and `VITE_PUBLIC_POSTHOG_KEY`. Deploy credentials (`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`) are supplied by the operator or Workers Build environment.
 
 ## Disable or takedown
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -621,6 +621,7 @@ export const createAnalytics = (
         .then((loadedClient) => {
           loadedClient.init(config.key!, {
             api_host: config.host,
+            ui_host: "https://us.posthog.com",
             defaults: "2026-05-30",
             capture_pageview: "history_change",
             capture_pageleave: true,

--- a/tests/e2e/analytics-isolation.spec.ts
+++ b/tests/e2e/analytics-isolation.spec.ts
@@ -5,7 +5,9 @@ test("unkeyed E2E builds make no PostHog requests", async ({ page, browserName }
   const postHogRequests: string[] = [];
   page.on("request", (request) => {
     const hostname = new URL(request.url()).hostname;
-    if (hostname.endsWith("posthog.com")) postHogRequests.push(request.url());
+    if (hostname.endsWith("posthog.com") || hostname === "t.tagium.app") {
+      postHogRequests.push(request.url());
+    }
   });
 
   await page.goto("/");

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -35,7 +35,7 @@ describe("analytics", () => {
     const analytics = createAnalytics(
       {
         key: "public-test-key",
-        host: "https://us.i.posthog.com",
+        host: "https://t.tagium.app",
         deployEnv: "production",
         releaseSha: "release-sha",
       },
@@ -64,7 +64,10 @@ describe("analytics", () => {
 
     expect(init).toHaveBeenCalledWith(
       "public-test-key",
-      expect.objectContaining({ api_host: "https://us.i.posthog.com" }),
+      expect.objectContaining({
+        api_host: "https://t.tagium.app",
+        ui_host: "https://us.posthog.com",
+      }),
     );
     expect(capture).toHaveBeenCalledWith("audio_upload_completed", {
       event_version: 1,


### PR DESCRIPTION
## review

- Before deploying production, set the Cloudflare Workers Build variable `VITE_PUBLIC_POSTHOG_HOST` to `https://t.tagium.app`; keep the existing project key.
- Deploy production, open the app, and complete an analytics-producing flow such as importing or uploading a track. In browser devtools, confirm the PostHog request goes to `t.tagium.app`, returns `200`, and the event appears in the PostHog project.
- Check an unkeyed or preview build and confirm it sends no requests to either `t.tagium.app` or `*.posthog.com`.
- The intended behavior is to proxy ingestion through `t.tagium.app` while keeping PostHog UI links pinned to the US cloud at `us.posthog.com`. Analytics remains production-only.
- Automatically verified: the 14 analytics unit tests, TypeScript typecheck, lint with zero warnings or errors, and the staged-file pre-commit checks. Production routing still requires the Cloudflare variable update and manual browser verification.