### PR TITLE
fix: improve import resilience and telemetry

### DIFF
--- a/docs/cobalt-audio-downloads.md
+++ b/docs/cobalt-audio-downloads.md
@@ -57,10 +57,14 @@ Run the checked-in load tester only against a disposable Fly clone:
 
 ```sh
 flyctl apps create tagium-cobalt-loadtest
-flyctl deploy --config fly.cobalt.toml --app tagium-cobalt-loadtest
+flyctl deploy --config fly.cobalt.toml --app tagium-cobalt-loadtest \
+  --env API_URL=https://tagium-cobalt-loadtest.fly.dev/
 bun run load-test:cobalt -- --target https://tagium-cobalt-loadtest.fly.dev
 flyctl apps destroy tagium-cobalt-loadtest
 ```
 
 Never target the production Cobalt deployment. The script deliberately exercises real provider
 downloads and increasing concurrency; use its curated URL list or an explicitly supplied safe list.
+It refuses the production origin and aborts before fetching any tunnel whose origin differs from
+the disposable target. Keep the explicit `API_URL` override: without it, the shared production Fly
+configuration would make the clone return production tunnel URLs.

--- a/scripts/load-test-cobalt-safety.ts
+++ b/scripts/load-test-cobalt-safety.ts
@@ -1,0 +1,46 @@
+const PRODUCTION_COBALT_ORIGINS = new Set(["https://tagium-cobalt.fly.dev"]);
+
+export const parseLoadTestTarget = (value: string) => {
+  let target: URL;
+  try {
+    target = new URL(value);
+  } catch {
+    throw new Error(`Invalid load-test target: ${JSON.stringify(value)}.`);
+  }
+
+  if (target.protocol !== "https:") {
+    throw new Error("Load-test target must use HTTPS.");
+  }
+  if (
+    target.username ||
+    target.password ||
+    target.pathname !== "/" ||
+    target.search ||
+    target.hash
+  ) {
+    throw new Error("Load-test target must be an origin URL without credentials, path, or query.");
+  }
+  if (PRODUCTION_COBALT_ORIGINS.has(target.origin)) {
+    throw new Error(`Refusing to load-test production Cobalt at ${target.origin}.`);
+  }
+
+  return target;
+};
+
+export const assertTunnelMatchesLoadTestTarget = (target: URL, tunnelValue: string) => {
+  let tunnel: URL;
+  try {
+    tunnel = new URL(tunnelValue);
+  } catch {
+    throw new Error("Cobalt returned an invalid tunnel URL; aborting the load test.");
+  }
+
+  if (tunnel.origin !== target.origin) {
+    throw new Error(
+      `Cobalt returned tunnel origin ${tunnel.origin}, expected ${target.origin}; ` +
+        "aborting before the tunnel is fetched.",
+    );
+  }
+
+  return tunnel.href;
+};

--- a/scripts/load-test-cobalt.ts
+++ b/scripts/load-test-cobalt.ts
@@ -8,7 +8,8 @@
  * against the Machine real users depend on will degrade the app for them.
  *
  *   flyctl apps create tagium-cobalt-loadtest
- *   flyctl deploy --config fly.cobalt.toml --app tagium-cobalt-loadtest
+ *   flyctl deploy --config fly.cobalt.toml --app tagium-cobalt-loadtest \
+ *     --env API_URL=https://tagium-cobalt-loadtest.fly.dev/
  *   bun run scripts/load-test-cobalt.ts --target https://tagium-cobalt-loadtest.fly.dev
  *   flyctl apps destroy tagium-cobalt-loadtest   # when you're done
  *
@@ -41,6 +42,7 @@
 import { readFileSync } from "node:fs";
 import { argv, env, exit } from "node:process";
 import { fileURLToPath } from "node:url";
+import { assertTunnelMatchesLoadTestTarget, parseLoadTestTarget } from "./load-test-cobalt-safety";
 
 // Last-resort fallback if scripts/load-test-urls.txt is missing or unreadable.
 const FALLBACK_URLS = ["https://www.youtube.com/watch?v=YE7VzlLtp-4"];
@@ -76,7 +78,7 @@ interface WaveSummary {
 }
 
 interface CliOptions {
-  target: string;
+  target: URL;
   urls: string[];
   waves: number[];
   requestsPerWave: number;
@@ -133,10 +135,11 @@ const parseArgs = (argv: string[]): CliOptions => {
     }
   }
 
-  const target = flags.get("target");
-  if (!target) {
+  const targetValue = flags.get("target");
+  if (!targetValue) {
     throw new Error("Missing required --target <cobalt-origin-url>.");
   }
+  const target = parseLoadTestTarget(targetValue);
 
   return {
     target,
@@ -201,7 +204,7 @@ const describeError = (error: unknown) => {
 };
 
 const performOneDownload = async (
-  target: string,
+  target: URL,
   sourceUrl: string,
   bitrate: string,
   apiKey: string | undefined,
@@ -254,7 +257,9 @@ const performOneDownload = async (
     return { ok: false, errorCode: plan.error.code, resolveMs };
   }
 
-  const tunnelUrls = pickTunnelUrls(plan);
+  const tunnelUrls = pickTunnelUrls(plan).map((url) =>
+    assertTunnelMatchesLoadTestTarget(target, url),
+  );
   if (tunnelUrls.length === 0) {
     return {
       ok: false,
@@ -393,7 +398,7 @@ const main = async () => {
     );
   }
 
-  console.log(`Target: ${options.target}`);
+  console.log(`Target: ${options.target.origin}`);
   console.log(`URLs: ${options.urls.join(", ")}`);
   console.log(`Waves (concurrency): ${options.waves.join(", ")}`);
   console.log(`Requests per wave: ${options.requestsPerWave}`);

--- a/server/api/cobalt/tunnel.get.ts
+++ b/server/api/cobalt/tunnel.get.ts
@@ -30,9 +30,22 @@ type TunnelObservabilityContext = {
 };
 
 const COBALT_TUNNEL_TIMEOUT_MS = 300_000;
-const EMPTY_BODY_RETRY_DELAYS_MS = [100, 250, 500] as const;
+const EMPTY_BODY_RETRY_DELAYS_MS = [100, 250, 500, 1_000, 2_000, 4_000] as const;
 const EMPTY_BODY_RETRY_ATTEMPTS = EMPTY_BODY_RETRY_DELAYS_MS.length + 1;
+const EMPTY_BODY_RETRY_JITTER_RATIO = 0.2;
 type TunnelOutcome = "ready" | "recovered" | "exhausted" | "non_retryable";
+
+const getEmptyBodyRetryDelayMs = (baseDelayMs: number, tunnelUrl: URL, attempt: number) => {
+  let hash = 0;
+  for (const character of `${tunnelUrl.href}:${attempt}`) {
+    hash = (Math.imul(hash, 31) + character.charCodeAt(0)) | 0;
+  }
+
+  const unitInterval = (hash >>> 0) / 0xffff_ffff;
+  const jitterMultiplier =
+    1 - EMPTY_BODY_RETRY_JITTER_RATIO + unitInterval * EMPTY_BODY_RETRY_JITTER_RATIO * 2;
+  return Math.round(baseDelayMs * jitterMultiplier);
+};
 
 const withTunnelTelemetry = (headers: Headers, outcome: TunnelOutcome, attempts: number) => {
   headers.set("X-Tagium-Tunnel-Outcome", outcome);
@@ -326,7 +339,10 @@ export default defineHandler(async (event) => {
       requestHeaders.set("Fly-Force-Instance-Id", tunnelRequest.machineId);
     }
 
-    const fetchSignal = AbortSignal.timeout(COBALT_TUNNEL_TIMEOUT_MS);
+    const fetchSignal = AbortSignal.any([
+      AbortSignal.timeout(COBALT_TUNNEL_TIMEOUT_MS),
+      event.req.signal,
+    ]);
     let response: Response | undefined;
     let body: ReadableStream<Uint8Array> | undefined;
     for (let attempt = 1; attempt <= EMPTY_BODY_RETRY_ATTEMPTS; attempt++) {
@@ -348,7 +364,12 @@ export default defineHandler(async (event) => {
           if (error === undefined) resolve();
           else reject(error);
         };
-        const timer = setTimeout(() => done(), EMPTY_BODY_RETRY_DELAYS_MS[attempt - 1]);
+        const retryDelayMs = getEmptyBodyRetryDelayMs(
+          EMPTY_BODY_RETRY_DELAYS_MS[attempt - 1],
+          tunnelRequest.tunnelUrl,
+          attempt,
+        );
+        const timer = setTimeout(() => done(), retryDelayMs);
         if (fetchSignal.aborted) {
           onAbort();
           return;

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -4,6 +4,18 @@ export type ImportOutcome = "completed" | "partial" | "failed" | "canceled";
 export type ExportKind = "track" | "album" | "library";
 export type TrackSourceMix = "local" | "imported" | "mixed" | "unknown";
 export type AnalyticsProvider = "youtube" | "soundcloud" | "other";
+export type AnalyticsProviderScope = AnalyticsProvider | "mixed";
+export type ImportFailureStage = "plan" | "tunnel" | "processing" | "hydration";
+export type ImportFailureCode =
+  | "capacity"
+  | "rate_limited"
+  | "service_unavailable"
+  | "timeout"
+  | "fetch_failed"
+  | "empty_response"
+  | "parse_failed"
+  | "metadata_write_failed"
+  | "unknown";
 export type MediaLinkShape = "canonical" | "short" | "mobile" | "nocookie" | "other";
 export type CobaltTunnelOutcome = "ready" | "recovered" | "exhausted" | "non_retryable";
 export type CobaltTunnelElapsedBucket =
@@ -16,7 +28,6 @@ export type AnalyticsErrorCode =
   | "rate_limited"
   | "service_unavailable"
   | "timeout"
-  | "resolve_failed"
   | "parse_failed"
   | "metadata_write_failed"
   | "unknown";
@@ -69,8 +80,20 @@ export type AnalyticsEvent =
       failedCount: number;
       canceledCount: number;
       durationMs: number;
-      error?: unknown;
-      failureStage?: "resolve";
+    }
+  | {
+      type: "import_resolution_failed";
+      sourceUrl: string;
+      importKind: ImportKind;
+      code: ImportFailureCode;
+    }
+  | {
+      type: "import_failure_category";
+      sourceUrl: string;
+      importKind: ImportKind;
+      stage: ImportFailureStage;
+      code: ImportFailureCode;
+      trackCount: number;
     }
   | {
       type: "export_started";
@@ -117,10 +140,20 @@ export type AnalyticsEvent =
     }
   | {
       type: "import_retry_started";
-      provider: "youtube" | "soundcloud" | "other";
+      provider: AnalyticsProviderScope;
       retryCount: number;
       previousFailedCount: number;
       previousCanceledCount: number;
+    }
+  | {
+      type: "import_retry_finished";
+      provider: AnalyticsProviderScope;
+      retryCount: number;
+      completedCount: number;
+      failedCount: number;
+      canceledCount: number;
+      outcome: ImportOutcome;
+      durationMs: number;
     };
 
 export interface AnalyticsConfig {
@@ -179,11 +212,7 @@ export const analyticsProviderFromUrl = (sourceUrl: string): AnalyticsProvider =
   return "other";
 };
 
-const errorCodeFrom = (
-  error: unknown,
-  failureStage?: Extract<AnalyticsEvent, { type: "import_finished" }>["failureStage"],
-): AnalyticsErrorCode => {
-  if (failureStage === "resolve") return "resolve_failed";
+const errorCodeFrom = (error: unknown): AnalyticsErrorCode => {
   const message = error instanceof Error ? error.message : "";
   if (message.includes("error.api.capacity_exceeded")) return "capacity";
   if (
@@ -259,7 +288,20 @@ const CUSTOM_EVENT_PROPERTIES: Record<string, ReadonlySet<string>> = {
     "failed_count",
     "canceled_count",
     "duration_ms",
-    "error_code",
+  ]),
+  import_failure_category: new Set([
+    ...COMMON_CUSTOM_PROPERTIES,
+    "provider",
+    "import_kind",
+    "stage",
+    "code",
+    "track_count",
+  ]),
+  import_resolution_failed: new Set([
+    ...COMMON_CUSTOM_PROPERTIES,
+    "provider",
+    "import_kind",
+    "code",
   ]),
   export_started: new Set([
     ...COMMON_CUSTOM_PROPERTIES,
@@ -301,6 +343,16 @@ const CUSTOM_EVENT_PROPERTIES: Record<string, ReadonlySet<string>> = {
     "previous_failed_count",
     "previous_canceled_count",
   ]),
+  import_retry_finished: new Set([
+    ...COMMON_CUSTOM_PROPERTIES,
+    "provider",
+    "retry_count",
+    "completed_count",
+    "failed_count",
+    "canceled_count",
+    "outcome",
+    "duration_ms",
+  ]),
 };
 const SAFE_SDK_EVENTS = new Set(["$pageview", "$pageleave", "$autocapture"]);
 const SAFE_SDK_PROPERTIES = new Set([
@@ -315,6 +367,7 @@ const SAFE_SDK_PROPERTIES = new Set([
   "$sent_at",
   "$lib",
   "$lib_version",
+  "$user_agent",
   "$browser",
   "$browser_version",
   "$os",
@@ -340,8 +393,29 @@ const isOneOf =
     typeof value === "string" && values.includes(value as Value);
 const isBoolean = (value: unknown) => typeof value === "boolean";
 const isBoundedTunnelAttempt = (value: unknown) =>
-  typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 4;
+  typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 7;
 const isAnalyticsProvider = isOneOf(["youtube", "soundcloud", "other"] as const);
+const isAnalyticsProviderScope = isOneOf(["youtube", "soundcloud", "other", "mixed"] as const);
+const isImportKind = isOneOf(["single", "set"] as const);
+const isImportOutcome = isOneOf(["completed", "partial", "failed", "canceled"] as const);
+const isImportFailureStage = isOneOf(["plan", "tunnel", "processing", "hydration"] as const);
+const isImportFailureCode = isOneOf([
+  "capacity",
+  "rate_limited",
+  "service_unavailable",
+  "timeout",
+  "fetch_failed",
+  "empty_response",
+  "parse_failed",
+  "metadata_write_failed",
+  "unknown",
+] as const);
+const isNonNegativeInteger = (value: unknown) =>
+  typeof value === "number" && Number.isInteger(value) && value >= 0;
+const isPositiveInteger = (value: unknown) =>
+  typeof value === "number" && Number.isInteger(value) && value > 0;
+const isNonNegativeNumber = (value: unknown) =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0;
 const isMediaKind = isOneOf(["track", "playlist", "unsupported"] as const);
 const isMediaLinkShape = isOneOf(["canonical", "short", "mobile", "nocookie", "other"] as const);
 const isMediaLinkOutcome = isOneOf(["accepted", "rejected"] as const);
@@ -378,6 +452,43 @@ const CUSTOM_PROPERTY_VALIDATORS: Record<
     attempts: isBoundedTunnelAttempt,
     elapsed_bucket: isCobaltTunnelElapsedBucket,
   },
+  import_finished: {
+    provider: isAnalyticsProvider,
+    import_kind: isImportKind,
+    outcome: isImportOutcome,
+    total_count: isNonNegativeInteger,
+    completed_count: isNonNegativeInteger,
+    failed_count: isNonNegativeInteger,
+    canceled_count: isNonNegativeInteger,
+    duration_ms: isNonNegativeNumber,
+  },
+  import_failure_category: {
+    provider: isAnalyticsProvider,
+    import_kind: isImportKind,
+    stage: isImportFailureStage,
+    code: isImportFailureCode,
+    track_count: isPositiveInteger,
+  },
+  import_resolution_failed: {
+    provider: isAnalyticsProvider,
+    import_kind: isImportKind,
+    code: isImportFailureCode,
+  },
+  import_retry_started: {
+    provider: isAnalyticsProviderScope,
+    retry_count: isPositiveInteger,
+    previous_failed_count: isNonNegativeInteger,
+    previous_canceled_count: isNonNegativeInteger,
+  },
+  import_retry_finished: {
+    provider: isAnalyticsProviderScope,
+    retry_count: isPositiveInteger,
+    completed_count: isNonNegativeInteger,
+    failed_count: isNonNegativeInteger,
+    canceled_count: isNonNegativeInteger,
+    outcome: isImportOutcome,
+    duration_ms: isNonNegativeNumber,
+  },
 };
 
 const redactAndValidateEvent = (event: BeforeSendEvent): BeforeSendEvent | null => {
@@ -396,6 +507,23 @@ const redactAndValidateEvent = (event: BeforeSendEvent): BeforeSendEvent | null 
     if (!isAllowedCustomProperty && SENSITIVE_PROPERTY_NAME.test(property)) continue;
     if (!isAllowedCustomProperty && typeof value === "string" && URL_VALUE.test(value)) continue;
     properties[property] = value;
+  }
+
+  if (event.event === "import_retry_finished" || event.event === "import_finished") {
+    const expectedCount =
+      event.event === "import_retry_finished" ? properties.retry_count : properties.total_count;
+    const completedCount = properties.completed_count;
+    const failedCount = properties.failed_count;
+    const canceledCount = properties.canceled_count;
+    if (
+      typeof expectedCount !== "number" ||
+      typeof completedCount !== "number" ||
+      typeof failedCount !== "number" ||
+      typeof canceledCount !== "number" ||
+      completedCount + failedCount + canceledCount !== expectedCount
+    ) {
+      return null;
+    }
   }
 
   if (isSdkEvent) properties.app_view = "tagium";
@@ -445,7 +573,7 @@ const serializeEvent = (event: AnalyticsEvent, config: AnalyticsConfig) => {
           ...commonProperties,
           provider: analyticsProviderFromUrl(event.sourceUrl),
           outcome: event.outcome,
-          attempts: Math.max(1, Math.min(4, Math.trunc(event.attempts))),
+          attempts: Math.max(1, Math.min(7, Math.trunc(event.attempts))),
           elapsed_bucket: event.elapsedBucket,
         },
       };
@@ -495,9 +623,28 @@ const serializeEvent = (event: AnalyticsEvent, config: AnalyticsConfig) => {
           failed_count: event.failedCount,
           canceled_count: event.canceledCount,
           duration_ms: event.durationMs,
-          ...(event.error === undefined
-            ? {}
-            : { error_code: errorCodeFrom(event.error, event.failureStage) }),
+        },
+      };
+    case "import_failure_category":
+      return {
+        name: event.type,
+        properties: {
+          ...commonProperties,
+          provider: analyticsProviderFromUrl(event.sourceUrl),
+          import_kind: event.importKind,
+          stage: event.stage,
+          code: event.code,
+          track_count: event.trackCount,
+        },
+      };
+    case "import_resolution_failed":
+      return {
+        name: event.type,
+        properties: {
+          ...commonProperties,
+          provider: analyticsProviderFromUrl(event.sourceUrl),
+          import_kind: event.importKind,
+          code: event.code,
         },
       };
     case "export_started":
@@ -581,6 +728,20 @@ const serializeEvent = (event: AnalyticsEvent, config: AnalyticsConfig) => {
           retry_count: event.retryCount,
           previous_failed_count: event.previousFailedCount,
           previous_canceled_count: event.previousCanceledCount,
+        },
+      };
+    case "import_retry_finished":
+      return {
+        name: event.type,
+        properties: {
+          ...commonProperties,
+          provider: event.provider,
+          retry_count: event.retryCount,
+          completed_count: event.completedCount,
+          failed_count: event.failedCount,
+          canceled_count: event.canceledCount,
+          outcome: event.outcome,
+          duration_ms: event.durationMs,
         },
       };
   }

--- a/src/features/import/audioUrlImportSession.ts
+++ b/src/features/import/audioUrlImportSession.ts
@@ -1,4 +1,4 @@
-import { analytics, analyticsProviderFromUrl, type MediaLinkShape } from "@/analytics";
+import { analytics, type MediaLinkShape } from "@/analytics";
 import type {
   CobaltAudioDownloadLifecycleEvent,
   CobaltAudioDownloadRequest,
@@ -32,7 +32,7 @@ import { parseMediaLink } from "@/lib/media-link";
 type ManagedDownloadTrack = QueuedDownloadTrack & { importOperationId?: string };
 const retryProvider = (
   tracks: readonly ManagedDownloadTrack[],
-): "youtube" | "soundcloud" | "other" => {
+): "youtube" | "soundcloud" | "other" | "mixed" => {
   const providers = new Set(
     tracks.map((track) => {
       try {
@@ -47,7 +47,7 @@ const retryProvider = (
       }
     }),
   );
-  return providers.size === 1 ? providers.values().next().value! : "other";
+  return providers.size === 1 ? providers.values().next().value! : "mixed";
 };
 type UrlImportEditor = Pick<
   TrackEditorSession["commands"],
@@ -61,6 +61,9 @@ const managedDownloadTrackFromFile = (file: TagiumFile): ManagedDownloadTrack | 
         fileId: file.id,
         title: file.metadata?.title || file.filename,
         downloadRequest: file.downloadRequest,
+        ...(file.downloadRequest.importId
+          ? { importOperationId: file.downloadRequest.importId }
+          : {}),
       }
     : null;
 const createPlaylistDownloadModelTrack = (track: ManagedDownloadTrack) => ({
@@ -214,12 +217,15 @@ export const createAudioUrlImportSession = ({
         library.dispatch({ type: "content-replaced", files: nextFiles });
       },
       markFailed: markDownloadError,
-      onTrackSettled: ({ track, outcome, error }) => {
+      onTrackSettled: (event) => {
+        const { track, outcome } = event;
         if (!track.importOperationId) return;
         importLifecycleTracker.settle(track.importOperationId, {
           trackId: track.fileId,
           outcome,
-          ...(error === undefined ? {} : { error }),
+          ...(event.outcome === "failed"
+            ? { error: event.error, failureStage: event.failureStage }
+            : {}),
         });
       },
       onAction: (event) => {
@@ -233,12 +239,25 @@ export const createAudioUrlImportSession = ({
           });
           return;
         }
+        if (event.type === "retry_started") {
+          analytics.capture({
+            type: "import_retry_started",
+            provider: retryProvider(event.tracks),
+            retryCount: event.tracks.length,
+            previousFailedCount: event.previousSnapshot.failed,
+            previousCanceledCount: event.previousSnapshot.canceledCount,
+          });
+          return;
+        }
         analytics.capture({
-          type: "import_retry_started",
+          type: "import_retry_finished",
           provider: retryProvider(event.tracks),
-          retryCount: event.tracks.length,
-          previousFailedCount: event.previousSnapshot.failed,
-          previousCanceledCount: event.previousSnapshot.canceledCount,
+          retryCount: event.retryCount,
+          completedCount: event.completedCount,
+          failedCount: event.failedCount,
+          canceledCount: event.canceledCount,
+          outcome: event.outcome,
+          durationMs: event.durationMs,
         });
       },
       emitSnapshot: (snapshot) => {
@@ -416,27 +435,42 @@ export const createAudioUrlImportSession = ({
           /* handled by unsupported guard below */
         }
       }
-      const provider = analyticsProviderFromUrl(trimmedUrl);
       if (parsed.kind === "unsupported") {
-        if (provider !== "other") {
-          analytics.capture({
-            type: "media_link_processed",
-            sourceUrl: trimmedUrl,
-            mediaKind: "unsupported",
-            shape: mediaLinkShapeFromUrl(trimmedUrl),
-            normalized: false,
-            redirected: false,
-            outcome: "rejected",
-            failureReason: shortLinkResolutionAttempted ? "resolution_failed" : "unsupported",
-          });
-          throw new Error("unsupported_media_link");
+        let isValidHttpsUrl = false;
+        try {
+          const candidate = new URL(trimmedUrl);
+          isValidHttpsUrl =
+            candidate.protocol === "https:" &&
+            candidate.username === "" &&
+            candidate.password === "" &&
+            candidate.port === "";
+        } catch {
+          // Invalid text is reported separately from a valid unsupported provider URL.
         }
-        parsed = { provider: "other", kind: "unsupported", canonicalUrl: trimmedUrl };
+        analytics.capture({
+          type: "media_link_processed",
+          sourceUrl: trimmedUrl,
+          mediaKind: "unsupported",
+          shape: mediaLinkShapeFromUrl(trimmedUrl),
+          normalized: false,
+          redirected: false,
+          outcome: "rejected",
+          failureReason: shortLinkResolutionAttempted
+            ? "resolution_failed"
+            : isValidHttpsUrl
+              ? "unsupported"
+              : "invalid",
+        });
+        throw new Error(
+          shortLinkResolutionAttempted
+            ? "soundcloud short-link resolution failed"
+            : "unsupported url",
+        );
       }
       analytics.capture({
         type: "media_link_processed",
         sourceUrl: trimmedUrl,
-        mediaKind: parsed.kind === "unsupported" ? "unsupported" : parsed.kind,
+        mediaKind: parsed.kind,
         shape: mediaLinkShapeFromUrl(trimmedUrl),
         normalized: parsed.canonicalUrl !== trimmedUrl,
         redirected,
@@ -460,7 +494,7 @@ export const createAudioUrlImportSession = ({
             // not carry request provenance.
             handlePlaylistDownload({ ...playlist, sourceUrl: normalizedUrl }, importOperationId);
           } catch (error) {
-            importLifecycleTracker.fail(importOperationId, error, "resolve");
+            importLifecycleTracker.fail(importOperationId, error);
             throw error;
           }
           return;

--- a/src/features/import/cobaltAudio.ts
+++ b/src/features/import/cobaltAudio.ts
@@ -6,6 +6,7 @@ import {
   LocalAudioProcessorLive,
 } from "@/features/import/localAudioProcessor";
 import type { CobaltTunnelElapsedBucket, CobaltTunnelOutcome } from "@/analytics";
+import { ImportStageError } from "@/features/import/importLifecycle";
 
 export type AudioDownloadBitrate = "320" | "256" | "128" | "96" | "64";
 
@@ -39,7 +40,7 @@ export interface CobaltAudioDownloadRequest {
 
 const MAX_CONCURRENT_COBALT_DOWNLOADS = 4;
 const COBALT_TUNNEL_START_INTERVAL_MS = 1_600;
-const MAX_TUNNEL_ATTEMPTS = 4;
+const MAX_TUNNEL_ATTEMPTS = 7;
 let activeCobaltDownloads = 0;
 const pendingCobaltDownloads: (() => void)[] = [];
 let nextCobaltTunnelStartAt = 0;
@@ -274,6 +275,7 @@ const makeCobaltAudio = Effect.fn("makeCobaltAudio")(function* () {
     }).pipe(
       Effect.flatMap((responseJson) => decodeCobaltDownloadPlan(responseJson)),
       Effect.mapError(toPublicAudioError),
+      Effect.mapError((error) => new ImportStageError("plan", error)),
     );
 
   const fetchTunnelFile = (
@@ -311,7 +313,7 @@ const makeCobaltAudio = Effect.fn("makeCobaltAudio")(function* () {
           lastModified,
         });
       },
-      catch: toPublicAudioError,
+      catch: (error) => new ImportStageError("tunnel", toPublicAudioError(error)),
     });
 
   const runDownload = (request: CobaltAudioDownloadRequest) =>
@@ -320,13 +322,19 @@ const makeCobaltAudio = Effect.fn("makeCobaltAudio")(function* () {
       const lastModified = getStableLastModified(request.sourceUrl);
 
       if (plan.status === "local-processing") {
-        return yield* localAudioProcessor.processLocalAudio({
-          plan,
-          lastModified,
-          fetchTunnelFile: (url, filename) =>
-            fetchTunnelFile(url, filename, lastModified, request.onLifecycle, request.signal),
-          signal: request.signal,
-        });
+        return yield* localAudioProcessor
+          .processLocalAudio({
+            plan,
+            lastModified,
+            fetchTunnelFile: (url, filename) =>
+              fetchTunnelFile(url, filename, lastModified, request.onLifecycle, request.signal),
+            signal: request.signal,
+          })
+          .pipe(
+            Effect.mapError((error) =>
+              error instanceof ImportStageError ? error : new ImportStageError("processing", error),
+            ),
+          );
       }
 
       return yield* fetchTunnelFile(

--- a/src/features/import/importLifecycle.ts
+++ b/src/features/import/importLifecycle.ts
@@ -1,13 +1,36 @@
-import type { Analytics, ImportKind, ImportOutcome } from "@/analytics";
+import type {
+  Analytics,
+  ImportFailureCode,
+  ImportFailureStage,
+  ImportKind,
+  ImportOutcome,
+} from "@/analytics";
 
 export type ImportTrackOutcome = "completed" | "failed" | "canceled";
+
+export class ImportStageError extends Error {
+  readonly stage: Exclude<ImportFailureStage, "hydration">;
+
+  constructor(stage: ImportStageError["stage"], cause: unknown) {
+    super(errorMessage(cause), { cause });
+    this.name = "ImportStageError";
+    this.stage = stage;
+  }
+}
 
 interface ImportOperation {
   sourceUrl: string;
   importKind: ImportKind;
   startedAt: number;
   trackIds: Set<string>;
-  settledTracks: Map<string, { outcome: ImportTrackOutcome; error?: unknown }>;
+  settledTracks: Map<
+    string,
+    {
+      outcome: ImportTrackOutcome;
+      error?: unknown;
+      failureStage?: ImportFailureStage;
+    }
+  >;
 }
 
 interface ImportLifecycleDependencies {
@@ -19,12 +42,63 @@ interface ImportLifecycleDependencies {
 export interface ImportLifecycleTracker {
   start: (input: { sourceUrl: string; importKind: ImportKind }) => string;
   resolve: (operationId: string, resolution: { trackIds: string[]; hasCover: boolean }) => void;
-  fail: (operationId: string, error: unknown, failureStage: "resolve") => void;
+  fail: (operationId: string, error: unknown) => void;
   settle: (
     operationId: string,
-    settlement: { trackId: string; outcome: ImportTrackOutcome; error?: unknown },
+    settlement: {
+      trackId: string;
+      outcome: ImportTrackOutcome;
+      error?: unknown;
+      failureStage?: ImportFailureStage;
+    },
   ) => void;
 }
+
+const errorMessage = (error: unknown) => {
+  if (error instanceof Error) return error.message;
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  return "";
+};
+
+export const importFailureCodeFrom = (error: unknown): ImportFailureCode => {
+  const message = errorMessage(error).toLowerCase();
+  if (message.includes("error.api.capacity_exceeded")) return "capacity";
+  if (
+    message.includes("error.api.rate_exceeded") ||
+    message.includes("rate limit") ||
+    /\b429\b/.test(message)
+  ) {
+    return "rate_limited";
+  }
+  if (
+    message.includes("error.api.unreachable") ||
+    message.includes("cobalt_api_url is not configured") ||
+    message.includes("networkerror") ||
+    message.includes("failed to fetch")
+  ) {
+    return "service_unavailable";
+  }
+  if (message.includes("error.api.timed_out") || /\btimed?\s*out\b/.test(message)) {
+    return "timeout";
+  }
+  if (message.includes("error.api.fetch.empty") || message.includes("response was empty")) {
+    return "empty_response";
+  }
+  if (message.includes("error.api.fetch.fail")) return "fetch_failed";
+  if (/metadata.*(?:write|appl)|write.*metadata/.test(message)) return "metadata_write_failed";
+  if (/could not be parsed|decode|malformed|metadata read/.test(message)) return "parse_failed";
+  return "unknown";
+};
+
+export const importFailureStageFromDownloadError = (error: unknown): ImportFailureStage =>
+  error instanceof ImportStageError ? error.stage : "plan";
 
 const deriveOutcome = (counts: {
   completed: number;
@@ -69,10 +143,16 @@ export const createImportLifecycleTracker = (
         });
       }
     },
-    fail: (operationId, error, failureStage) => {
+    fail: (operationId, error) => {
       const operation = operations.get(operationId);
       if (!operation) return;
       operations.delete(operationId);
+      dependencies.capture({
+        type: "import_resolution_failed",
+        sourceUrl: operation.sourceUrl,
+        importKind: operation.importKind,
+        code: importFailureCodeFrom(error),
+      });
       dependencies.capture({
         type: "import_finished",
         sourceUrl: operation.sourceUrl,
@@ -83,8 +163,6 @@ export const createImportLifecycleTracker = (
         failedCount: 0,
         canceledCount: 0,
         durationMs: Math.max(0, dependencies.now() - operation.startedAt),
-        error,
-        failureStage,
       });
     },
     settle: (operationId, settlement) => {
@@ -98,16 +176,34 @@ export const createImportLifecycleTracker = (
       let completed = 0;
       let failed = 0;
       let canceled = 0;
-      let firstError: unknown;
+      const failures = new Map<
+        string,
+        { stage: ImportFailureStage; code: ImportFailureCode; count: number }
+      >();
       for (const result of operation.settledTracks.values()) {
         if (result.outcome === "completed") completed += 1;
         if (result.outcome === "failed") {
           failed += 1;
-          firstError ??= result.error;
+          const stage = result.failureStage ?? "plan";
+          const code = importFailureCodeFrom(result.error);
+          const key = `${stage}:${code}`;
+          const aggregate = failures.get(key);
+          if (aggregate) aggregate.count += 1;
+          else failures.set(key, { stage, code, count: 1 });
         }
         if (result.outcome === "canceled") canceled += 1;
       }
       operations.delete(operationId);
+      for (const failure of failures.values()) {
+        dependencies.capture({
+          type: "import_failure_category",
+          sourceUrl: operation.sourceUrl,
+          importKind: operation.importKind,
+          stage: failure.stage,
+          code: failure.code,
+          trackCount: failure.count,
+        });
+      }
       dependencies.capture({
         type: "import_finished",
         sourceUrl: operation.sourceUrl,
@@ -118,7 +214,6 @@ export const createImportLifecycleTracker = (
         failedCount: failed,
         canceledCount: canceled,
         durationMs: Math.max(0, dependencies.now() - operation.startedAt),
-        ...(firstError === undefined ? {} : { error: firstError }),
       });
     },
   };

--- a/src/features/import/playlistDownloadController.ts
+++ b/src/features/import/playlistDownloadController.ts
@@ -10,31 +10,40 @@ import {
   markPlaylistDownloadTrackCanceled,
   markPlaylistDownloadTrackCompleted,
   markPlaylistDownloadTrackFailed,
-  removeActivePlaylistDownloadTrack,
   removePlaylistDownloadTracks,
   reserveNextPlaylistDownloadTrack,
+  type ActivePlaylistDownload,
   type PlaylistDownloadQueueRun,
   type PlaylistDownloadQueueRuntimeSnapshot,
   type PlaylistDownloadRuntimeTrack,
 } from "@/features/import/playlistDownloadQueueRuntime";
 import type { PlaylistDownloadQueueTrack as PlaylistDownloadQueueModelTrack } from "@/features/import/playlistDownloadQueue";
 import { createDownloadAdmissionWindow } from "@/features/import/downloadAdmissionWindow";
+import {
+  importFailureStageFromDownloadError,
+  type ImportTrackOutcome,
+} from "@/features/import/importLifecycle";
+import type { ImportFailureStage, ImportOutcome } from "@/analytics";
 
 export const PLAYLIST_DOWNLOAD_CONCURRENCY = 3;
 
 type PlaylistDownloadControllerRun<Track extends PlaylistDownloadRuntimeTrack> =
   PlaylistDownloadQueueRun<Track> & {
-    activeFibers: Map<string, Fiber.Fiber<void, unknown>>;
+    activeFibers: Map<ActivePlaylistDownload, Fiber.Fiber<void, unknown>>;
+    currentExecutions: Map<string, ActivePlaylistDownload>;
     budgetWakeFiber?: Fiber.Fiber<void>;
   };
 
 export type PlaylistDownloadControllerSnapshot = PlaylistDownloadQueueRuntimeSnapshot;
 
-export interface PlaylistDownloadTrackSettled<Track extends PlaylistDownloadRuntimeTrack> {
-  track: Track;
-  outcome: "completed" | "failed" | "canceled";
-  error?: unknown;
-}
+export type PlaylistDownloadTrackSettled<Track extends PlaylistDownloadRuntimeTrack> =
+  | { track: Track; outcome: "completed" | "canceled" }
+  | {
+      track: Track;
+      outcome: "failed";
+      error: unknown;
+      failureStage: ImportFailureStage;
+    };
 
 export type PlaylistDownloadControllerAction<Track extends PlaylistDownloadRuntimeTrack> =
   | {
@@ -43,8 +52,20 @@ export type PlaylistDownloadControllerAction<Track extends PlaylistDownloadRunti
     }
   | {
       type: "retry_started";
+      retryAttemptId: number;
       tracks: Track[];
       previousSnapshot: PlaylistDownloadControllerSnapshot;
+    }
+  | {
+      type: "retry_finished";
+      retryAttemptId: number;
+      tracks: Track[];
+      retryCount: number;
+      completedCount: number;
+      failedCount: number;
+      canceledCount: number;
+      outcome: ImportOutcome;
+      durationMs: number;
     };
 
 export interface PlaylistDownloadControllerDeps<Track extends PlaylistDownloadRuntimeTrack> {
@@ -72,7 +93,10 @@ export interface PlaylistDownloadController<Track extends PlaylistDownloadRuntim
 
 const isPlaylistDownloadAbort = (error: unknown) => {
   if (error instanceof DOMException && error.name === "AbortError") return true;
-  if (error instanceof Error && error.name === "AbortError") return true;
+  if (error instanceof Error) {
+    if (error.name === "AbortError") return true;
+    if (error.cause !== undefined) return isPlaylistDownloadAbort(error.cause);
+  }
   return false;
 };
 
@@ -89,14 +113,95 @@ const firstCauseError = (cause: Cause.Cause<unknown>) => {
   return cause;
 };
 
+type StagedDownloadFailure = { stage: ImportFailureStage; error: unknown };
+
+const isStagedDownloadFailure = (failure: unknown): failure is StagedDownloadFailure =>
+  typeof failure === "object" && failure !== null && "stage" in failure && "error" in failure;
+
+const retryOutcomeFrom = (counts: {
+  completedCount: number;
+  failedCount: number;
+  canceledCount: number;
+}): ImportOutcome => {
+  if (counts.canceledCount > 0) return "canceled";
+  if (counts.failedCount === 0) return "completed";
+  if (counts.completedCount > 0) return "partial";
+  return "failed";
+};
+
 export const createPlaylistDownloadController = <Track extends PlaylistDownloadRuntimeTrack>(
   deps: PlaylistDownloadControllerDeps<Track>,
 ): PlaylistDownloadController<Track> => {
   let currentRun: PlaylistDownloadControllerRun<Track> | null = null;
   let nextRunId = 0;
   let currentSnapshot: PlaylistDownloadControllerSnapshot | null = null;
+  let nextRetryAttemptId = 0;
+  const retryAttempts = new Map<
+    number,
+    {
+      runId: number;
+      tracks: Track[];
+      trackIds: Set<string>;
+      outcomes: Map<string, ImportTrackOutcome>;
+      startedAt: number;
+    }
+  >();
+  const pendingRetryAttemptIds = new Map<number, Map<string, number>>();
   const downloadAdmission = createDownloadAdmissionWindow();
   const now = deps.now ?? (() => Date.now());
+
+  const notifyTrackSettled = (
+    run: PlaylistDownloadControllerRun<Track>,
+    event: PlaylistDownloadTrackSettled<Track>,
+    retryAttemptId?: number,
+  ) => {
+    deps.onTrackSettled?.(event);
+    if (retryAttemptId === undefined) return;
+
+    const attempt = retryAttempts.get(retryAttemptId);
+    if (!attempt || attempt.runId !== run.id) return;
+    if (!attempt.trackIds.has(event.track.fileId)) return;
+    if (attempt.outcomes.has(event.track.fileId)) return;
+    attempt.outcomes.set(event.track.fileId, event.outcome);
+    if (attempt.outcomes.size !== attempt.trackIds.size) return;
+
+    let completedCount = 0;
+    let failedCount = 0;
+    let canceledCount = 0;
+    for (const outcome of attempt.outcomes.values()) {
+      if (outcome === "completed") completedCount += 1;
+      if (outcome === "failed") failedCount += 1;
+      if (outcome === "canceled") canceledCount += 1;
+    }
+    retryAttempts.delete(retryAttemptId);
+    const counts = { completedCount, failedCount, canceledCount };
+    deps.onAction?.({
+      type: "retry_finished",
+      retryAttemptId,
+      tracks: attempt.tracks,
+      retryCount: attempt.trackIds.size,
+      ...counts,
+      outcome: retryOutcomeFrom(counts),
+      durationMs: Math.max(0, now() - attempt.startedAt),
+    });
+  };
+
+  const takePendingRetryAttemptIdFor = (
+    run: PlaylistDownloadControllerRun<Track>,
+    trackId: string,
+  ) => {
+    const runAttempts = pendingRetryAttemptIds.get(run.id);
+    const retryAttemptId = runAttempts?.get(trackId);
+    runAttempts?.delete(trackId);
+    if (runAttempts?.size === 0) pendingRetryAttemptIds.delete(run.id);
+    return retryAttemptId;
+  };
+
+  const isCurrentExecution = (
+    run: PlaylistDownloadControllerRun<Track>,
+    trackId: string,
+    execution: ActivePlaylistDownload,
+  ) => run.currentExecutions.get(trackId) === execution;
 
   const createSnapshot = (run: PlaylistDownloadControllerRun<Track>) =>
     derivePlaylistDownloadQueueState(run, now());
@@ -140,15 +245,19 @@ export const createPlaylistDownloadController = <Track extends PlaylistDownloadR
     const canceledTrackIds = cancelPendingPlaylistDownloadTracks(run, now());
     deps.markCanceled(canceledTrackIds);
     for (const track of pendingTracks) {
-      deps.onTrackSettled?.({ track, outcome: "canceled" });
+      notifyTrackSettled(
+        run,
+        { track, outcome: "canceled" },
+        takePendingRetryAttemptIdFor(run, track.fileId),
+      );
     }
   };
 
   const cancelActive = (run: PlaylistDownloadControllerRun<Track>) => {
     if (run.active.length === 0) return;
     const canceledTrackIds = cancelActivePlaylistDownloadTracks(run, now());
-    for (const trackId of canceledTrackIds) {
-      const fiber = run.activeFibers.get(trackId);
+    for (const execution of run.active) {
+      const fiber = run.activeFibers.get(execution);
       if (fiber) {
         Effect.runFork(Fiber.interrupt(fiber));
       }
@@ -156,68 +265,105 @@ export const createPlaylistDownloadController = <Track extends PlaylistDownloadR
     deps.markCanceled(canceledTrackIds);
   };
 
-  const runDownloadEffect = (run: PlaylistDownloadControllerRun<Track>, track: Track) =>
+  const runDownloadEffect = (
+    run: PlaylistDownloadControllerRun<Track>,
+    track: Track,
+    execution: ActivePlaylistDownload,
+    retryAttemptId: number | undefined,
+  ) =>
     Effect.gen(function* () {
+      if (!isCurrentExecution(run, track.fileId, execution)) return;
       if (!deps.hasTrack(track.fileId)) {
         yield* Effect.sync(() => {
+          if (!isCurrentExecution(run, track.fileId, execution)) return;
           markPlaylistDownloadTrackCanceled(run, track.fileId, now());
           deps.markCanceled([track.fileId]);
-          deps.onTrackSettled?.({ track, outcome: "canceled" });
+          notifyTrackSettled(run, { track, outcome: "canceled" }, retryAttemptId);
         });
         return;
       }
 
-      const downloadedFile = yield* deps.downloadTrack(track);
-      if (currentRun !== run) return;
+      const downloadedFile = yield* deps.downloadTrack(track).pipe(
+        Effect.mapError(
+          (error): StagedDownloadFailure => ({
+            stage: importFailureStageFromDownloadError(error),
+            error,
+          }),
+        ),
+      );
+      if (currentRun !== run || !isCurrentExecution(run, track.fileId, execution)) return;
 
-      yield* deps.hydrateTrack(track, downloadedFile);
-      if (currentRun !== run) return;
+      yield* deps
+        .hydrateTrack(track, downloadedFile)
+        .pipe(Effect.mapError((error): StagedDownloadFailure => ({ stage: "hydration", error })));
+      if (currentRun !== run || !isCurrentExecution(run, track.fileId, execution)) return;
 
       yield* Effect.sync(() => {
+        if (!isCurrentExecution(run, track.fileId, execution)) return;
         markPlaylistDownloadTrackCompleted(run, track.fileId, now());
-        deps.onTrackSettled?.({ track, outcome: "completed" });
+        notifyTrackSettled(run, { track, outcome: "completed" }, retryAttemptId);
       });
     });
 
   const handleDownloadExit = (
     run: PlaylistDownloadControllerRun<Track>,
     track: Track,
+    execution: ActivePlaylistDownload,
+    retryAttemptId: number | undefined,
     exit: Exit.Exit<void, unknown>,
   ) => {
-    run.activeFibers.delete(track.fileId);
-    const trackWasRemoved = !run.model.items.some((item) => item.id === track.fileId);
+    run.activeFibers.delete(execution);
+    const executionIsCurrent = isCurrentExecution(run, track.fileId, execution);
+    if (executionIsCurrent) run.currentExecutions.delete(track.fileId);
+    const trackWasRemoved =
+      !executionIsCurrent || !run.model.items.some((item) => item.id === track.fileId);
 
     if (Exit.isFailure(exit)) {
-      const error = firstCauseError(exit.cause);
+      const failure = firstCauseError(exit.cause);
+      const stagedFailure = isStagedDownloadFailure(failure) ? failure : undefined;
+      const error = stagedFailure?.error ?? failure;
       if (trackWasRemoved) {
-        deps.onTrackSettled?.({ track, outcome: "canceled" });
+        notifyTrackSettled(run, { track, outcome: "canceled" }, retryAttemptId);
       } else if (Exit.hasInterrupts(exit) || isPlaylistDownloadAbort(error)) {
         markPlaylistDownloadTrackCanceled(run, track.fileId, now());
-        deps.onTrackSettled?.({ track, outcome: "canceled" });
+        notifyTrackSettled(run, { track, outcome: "canceled" }, retryAttemptId);
         if (currentRun === run) {
           deps.markCanceled([track.fileId]);
         }
       } else {
         markPlaylistDownloadTrackFailed(run, track.fileId, toErrorMessage(error), now());
-        deps.onTrackSettled?.({ track, outcome: "failed", error });
+        notifyTrackSettled(
+          run,
+          {
+            track,
+            outcome: "failed",
+            error,
+            failureStage: stagedFailure?.stage ?? "plan",
+          },
+          retryAttemptId,
+        );
         if (currentRun === run) {
           deps.markFailed(track.fileId, error);
         }
       }
+    } else if (trackWasRemoved) {
+      notifyTrackSettled(run, { track, outcome: "canceled" }, retryAttemptId);
     }
 
-    removeActivePlaylistDownloadTrack(run, track.fileId);
+    run.active = run.active.filter((active) => active !== execution);
     publish(run);
     pump(run);
   };
 
   const startDownload = (run: PlaylistDownloadControllerRun<Track>, track: Track) => {
-    markPlaylistDownloadTrackActive(run, track, now());
+    const execution = markPlaylistDownloadTrackActive(run, track, now());
+    run.currentExecutions.set(track.fileId, execution);
+    const retryAttemptId = takePendingRetryAttemptIdFor(run, track.fileId);
     publish(run);
 
-    const fiber = Effect.runFork(runDownloadEffect(run, track));
-    run.activeFibers.set(track.fileId, fiber);
-    fiber.addObserver((exit) => handleDownloadExit(run, track, exit));
+    const fiber = Effect.runFork(runDownloadEffect(run, track, execution, retryAttemptId));
+    run.activeFibers.set(execution, fiber);
+    fiber.addObserver((exit) => handleDownloadExit(run, track, execution, retryAttemptId, exit));
   };
 
   const pump = (run: PlaylistDownloadControllerRun<Track>) => {
@@ -250,7 +396,7 @@ export const createPlaylistDownloadController = <Track extends PlaylistDownloadR
     finishIfIdle(run);
   };
 
-  const enqueue = (tracks: Track[]) => {
+  const enqueue = (tracks: Track[], startImmediately = true) => {
     if (tracks.length === 0) return [];
 
     if (currentRun && !currentRun.done && !currentRun.canceled) {
@@ -265,18 +411,19 @@ export const createPlaylistDownloadController = <Track extends PlaylistDownloadR
 
       deps.markQueued(queuedTracks);
       publish(currentRun);
-      pump(currentRun);
+      if (startImmediately) pump(currentRun);
       return queuedTracks;
     }
 
     const run: PlaylistDownloadControllerRun<Track> = {
       ...createPlaylistDownloadQueueRun(++nextRunId, tracks, now(), deps.createModelTrack),
       activeFibers: new Map(),
+      currentExecutions: new Map(),
     };
     currentRun = run;
     deps.markQueued(tracks);
     publish(run);
-    pump(run);
+    if (startImmediately) pump(run);
     return tracks;
   };
 
@@ -296,26 +443,61 @@ export const createPlaylistDownloadController = <Track extends PlaylistDownloadR
     },
     remove: (trackIds) => {
       if (!currentRun || trackIds.length === 0) return;
+      const run = currentRun;
 
-      const removed = removePlaylistDownloadTracks(currentRun, trackIds);
+      const removed = removePlaylistDownloadTracks(run, trackIds);
       if (removed.removedTrackIds.length === 0) return;
 
       for (const track of removed.pendingTracks) {
-        deps.onTrackSettled?.({ track, outcome: "canceled" });
+        notifyTrackSettled(
+          run,
+          { track, outcome: "canceled" },
+          takePendingRetryAttemptIdFor(run, track.fileId),
+        );
       }
-      for (const trackId of removed.activeTrackIds) {
-        const fiber = currentRun.activeFibers.get(trackId);
+      const removedActiveTrackIds = new Set(removed.activeTrackIds);
+      for (const execution of run.active) {
+        if (!removedActiveTrackIds.has(execution.fileId)) continue;
+        if (isCurrentExecution(run, execution.fileId, execution)) {
+          run.currentExecutions.delete(execution.fileId);
+        }
+        const fiber = run.activeFibers.get(execution);
         if (fiber) Effect.runFork(Fiber.interrupt(fiber));
       }
 
-      publish(currentRun);
-      pump(currentRun);
+      publish(run);
+      pump(run);
     },
     retry: (tracks) => {
       const previousSnapshot = currentSnapshot;
-      const queuedTracks = enqueue(tracks);
-      if (!previousSnapshot || queuedTracks.length === 0) return;
-      deps.onAction?.({ type: "retry_started", tracks: queuedTracks, previousSnapshot });
+      const queuedTracks = enqueue(tracks, false);
+      if (queuedTracks.length === 0 || !currentRun) return;
+      const retryRun = currentRun;
+      if (!previousSnapshot) {
+        pump(retryRun);
+        return;
+      }
+      const retryAttemptId = ++nextRetryAttemptId;
+      retryAttempts.set(retryAttemptId, {
+        runId: retryRun.id,
+        tracks: queuedTracks,
+        trackIds: new Set(queuedTracks.map((track) => track.fileId)),
+        outcomes: new Map(),
+        startedAt: now(),
+      });
+      const runPendingRetryAttemptIds =
+        pendingRetryAttemptIds.get(retryRun.id) ?? new Map<string, number>();
+      for (const track of queuedTracks) {
+        runPendingRetryAttemptIds.set(track.fileId, retryAttemptId);
+      }
+      pendingRetryAttemptIds.set(retryRun.id, runPendingRetryAttemptIds);
+      deps.onAction?.({
+        type: "retry_started",
+        retryAttemptId,
+        tracks: queuedTracks,
+        previousSnapshot,
+      });
+      pump(retryRun);
     },
     getSnapshot: () => currentSnapshot,
   };

--- a/tests/server/cobalt/tunnel.get.test.ts
+++ b/tests/server/cobalt/tunnel.get.test.ts
@@ -47,6 +47,18 @@ const makeTunnelRequestForMachine = () => {
   return machineRequest;
 };
 
+const makeTunnelRequestWithId = (id: string) => {
+  const request = makeTunnelRequest();
+  const requestUrl = new URL(request.url);
+  const upstreamUrl = new URL(requestUrl.searchParams.get("url") ?? "");
+  upstreamUrl.searchParams.set("id", id);
+  requestUrl.searchParams.set("url", upstreamUrl.href);
+  const updatedRequest = new Request(requestUrl, request) as RuntimeRequest;
+  updatedRequest.runtime = request.runtime;
+
+  return updatedRequest;
+};
+
 const withObservability = (request: RuntimeRequest) => {
   const url = new URL(request.url);
   url.searchParams.set("parentRequestId", "plan-request-1");
@@ -107,14 +119,131 @@ describe("cobalt tunnel endpoint", () => {
     expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
-  it("stops after four empty responses", async () => {
+  it("recovers when a tunnel becomes ready after the original retry window", async () => {
+    vi.useFakeTimers();
+    let attempt = 0;
+    const fetchMock = vi.fn(async () => {
+      attempt++;
+      return attempt < 7 ? new Response(null, { status: 200 }) : new Response("audio-bytes");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const responsePromise = handler(makeEvent(makeTunnelRequest()));
+      await vi.advanceTimersByTimeAsync(10_000);
+      const response = await responsePromise;
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("X-Tagium-Tunnel-Outcome")).toBe("recovered");
+      expect(response.headers.get("X-Tagium-Tunnel-Attempts")).toBe("7");
+      expect(await response.text()).toBe("audio-bytes");
+      expect(fetchMock).toHaveBeenCalledTimes(7);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("deterministically staggers retries for different tunnel urls", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const attemptsByUrl = new Map<string, number>();
+    const startTimesByUrl = new Map<string, number[]>();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = input instanceof Request ? input.url : input.toString();
+        const attempts = (attemptsByUrl.get(url) ?? 0) + 1;
+        attemptsByUrl.set(url, attempts);
+        startTimesByUrl.set(url, [...(startTimesByUrl.get(url) ?? []), Date.now()]);
+        return attempts === 1 ? new Response(null, { status: 200 }) : new Response("audio-bytes");
+      }),
+    );
+
+    try {
+      const first = handler(makeEvent(makeTunnelRequestWithId("tunnel-a")));
+      const second = handler(makeEvent(makeTunnelRequestWithId("tunnel-b")));
+      await vi.advanceTimersByTimeAsync(200);
+      await Promise.all([first, second]);
+
+      const retryDelays = [...startTimesByUrl.values()].map(
+        ([startedAt = 0, retriedAt = 0]) => retriedAt - startedAt,
+      );
+      expect(retryDelays).toHaveLength(2);
+      expect(retryDelays.every((delay) => delay >= 80 && delay <= 120)).toBe(true);
+      expect(new Set(retryDelays).size).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops after the bounded extended retry window", async () => {
+    vi.useFakeTimers();
     const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
-    const response = await handler(makeEvent(makeTunnelRequest()));
-    expect(response.status).toBe(502);
-    expect(response.headers.get("X-Tagium-Tunnel-Outcome")).toBe("exhausted");
-    expect(response.headers.get("X-Tagium-Tunnel-Attempts")).toBe("4");
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    try {
+      const responsePromise = handler(makeEvent(makeTunnelRequest()));
+      await vi.advanceTimersByTimeAsync(10_000);
+      const response = await responsePromise;
+
+      expect(response.status).toBe(502);
+      expect(response.headers.get("X-Tagium-Tunnel-Outcome")).toBe("exhausted");
+      expect(response.headers.get("X-Tagium-Tunnel-Attempts")).toBe("7");
+      expect(fetchMock).toHaveBeenCalledTimes(7);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops retrying when the shared tunnel timeout aborts a backoff", async () => {
+    vi.useFakeTimers();
+    const timeout = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const responsePromise = handler(makeEvent(makeTunnelRequest()));
+      await vi.advanceTimersByTimeAsync(0);
+      timeout.abort(new DOMException("timed out", "TimeoutError"));
+      const response = await responsePromise;
+
+      expect(response.status).toBe(502);
+      expect(response.headers.get("X-Tagium-Tunnel-Outcome")).toBe("non_retryable");
+      expect(response.headers.get("X-Tagium-Tunnel-Attempts")).toBe("1");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops retrying when the downstream tunnel request is aborted", async () => {
+    vi.useFakeTimers();
+    const downstream = new AbortController();
+    const request = makeTunnelRequest();
+    const abortableRequest = new Request(request, { signal: downstream.signal }) as RuntimeRequest;
+    abortableRequest.runtime = request.runtime;
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const responsePromise = handler(makeEvent(abortableRequest));
+      await vi.advanceTimersByTimeAsync(0);
+      downstream.abort(new DOMException("cancelled", "AbortError"));
+      const result = await Promise.race([
+        responsePromise,
+        vi.advanceTimersByTimeAsync(1).then(() => "pending" as const),
+      ]);
+
+      expect(result).not.toBe("pending");
+      if (result === "pending") return;
+      expect(result.status).toBe(502);
+      expect(result.headers.get("X-Tagium-Tunnel-Outcome")).toBe("non_retryable");
+      expect(result.headers.get("X-Tagium-Tunnel-Attempts")).toBe("1");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not retry non-ok responses", async () => {
@@ -272,6 +401,7 @@ describe("cobalt tunnel endpoint", () => {
   });
 
   it("rejects empty successful Cobalt tunnel responses", async () => {
+    vi.useFakeTimers();
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => {
@@ -283,10 +413,16 @@ describe("cobalt tunnel endpoint", () => {
       }),
     );
 
-    const response = await handler(makeEvent(makeTunnelRequest()));
+    try {
+      const responsePromise = handler(makeEvent(makeTunnelRequest()));
+      await vi.advanceTimersByTimeAsync(10_000);
+      const response = await responsePromise;
 
-    expect(response.status).toBe(502);
-    expect(await response.text()).toBe("Cobalt tunnel response was empty.");
+      expect(response.status).toBe(502);
+      expect(await response.text()).toBe("Cobalt tunnel response was empty.");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns a safe compatibility response when the upstream fetch throws", async () => {

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -187,14 +187,21 @@ describe("analytics", () => {
       attempts: 3,
       elapsedBucket: "1_to_5_seconds",
     });
+    analytics.capture({
+      type: "cobalt_tunnel_readiness",
+      sourceUrl: "https://soundcloud.com/private-artist/private-track",
+      outcome: "exhausted",
+      attempts: 7,
+      elapsedBucket: "5_to_15_seconds",
+    });
 
-    expect(capture.mock.calls.at(-2)?.[1]).toEqual(
+    expect(capture.mock.calls.at(-3)?.[1]).toEqual(
       expect.objectContaining({
         provider: "soundcloud",
         failure_reason: "resolution_failed",
       }),
     );
-    expect(capture.mock.calls.at(-1)).toEqual([
+    expect(capture.mock.calls.at(-2)).toEqual([
       "cobalt_tunnel_readiness",
       expect.objectContaining({
         provider: "soundcloud",
@@ -203,6 +210,9 @@ describe("analytics", () => {
         elapsed_bucket: "1_to_5_seconds",
       }),
     ]);
+    expect(capture.mock.calls.at(-1)?.[1]).toEqual(
+      expect.objectContaining({ outcome: "exhausted", attempts: 7 }),
+    );
 
     const serialized = JSON.stringify(capture.mock.calls);
     for (const sensitiveValue of [
@@ -246,7 +256,7 @@ describe("analytics", () => {
     });
   });
 
-  it("maps import failures to stable codes without serializing exception details", async () => {
+  it("serializes typed import failure categories without private details", async () => {
     const capture = vi.fn();
     const analytics = createAnalytics(
       { key: "public-test-key", deployEnv: "production" },
@@ -259,36 +269,28 @@ describe("analytics", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    const cases = [
-      [new Error("error.api.capacity_exceeded private upstream detail"), "capacity"],
-      [new Error("Cobalt tunnel request failed (429): private body"), "rate_limited"],
-      [new Error("error.api.unreachable internal hostname"), "service_unavailable"],
-      [new Error("error.api.timed_out after private URL"), "timeout"],
-      [new Error("downloaded track could not be parsed: private filename"), "parse_failed"],
-      [new Error("unexpected private detail"), "unknown"],
-    ] as const;
+    analytics.capture({
+      type: "import_failure_category",
+      sourceUrl: "https://soundcloud.com/private-path",
+      importKind: "set",
+      stage: "tunnel",
+      code: "empty_response",
+      trackCount: 2,
+    });
 
-    for (const [error, expectedCode] of cases) {
-      analytics.capture({
-        type: "import_finished",
-        sourceUrl: "https://soundcloud.com/private-path",
-        importKind: "single",
-        outcome: "failed",
-        totalCount: 1,
-        completedCount: 0,
-        failedCount: 1,
-        canceledCount: 0,
-        durationMs: 250,
-        error,
-      });
-      expect(capture.mock.calls.at(-1)?.[1]).toEqual(
-        expect.objectContaining({ error_code: expectedCode }),
-      );
-    }
+    expect(capture.mock.calls.at(-1)?.[1]).toEqual(
+      expect.objectContaining({
+        provider: "soundcloud",
+        import_kind: "set",
+        stage: "tunnel",
+        code: "empty_response",
+        track_count: 2,
+      }),
+    );
 
     const payloads = JSON.stringify(capture.mock.calls);
     expect(payloads).not.toContain("private");
-    expect(payloads).not.toContain("error.api");
+    expect(payloads).not.toContain("soundcloud.com");
   });
 
   it("initializes PostHog with explicit privacy-preserving collection settings", async () => {
@@ -381,6 +383,7 @@ describe("analytics", () => {
       event: "$pageview",
       properties: {
         $browser: "Chrome",
+        $user_agent: "Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36",
         $current_url: "https://tagium.example/?private=query",
         $referrer: "https://internal.example/user-name",
         $pathname: "/private-path",
@@ -406,10 +409,41 @@ describe("analytics", () => {
     });
     expect(pageview).toEqual({
       event: "$pageview",
-      properties: { $browser: "Chrome", app_view: "tagium" },
+      properties: {
+        $browser: "Chrome",
+        $user_agent: "Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36",
+        app_view: "tagium",
+      },
     });
     expect(
       options.before_send({ event: "made_up_event", properties: { private: "value" } }),
+    ).toBeNull();
+    expect(
+      options.before_send({
+        event: "import_failure_category",
+        properties: {
+          provider: "soundcloud",
+          import_kind: "set",
+          stage: "private-url",
+          code: "private-request-id",
+          track_count: 1,
+        },
+      }),
+    ).toEqual({
+      event: "import_failure_category",
+      properties: { provider: "soundcloud", import_kind: "set", track_count: 1 },
+    });
+    expect(
+      options.before_send({
+        event: "import_retry_finished",
+        properties: {
+          provider: "mixed",
+          retry_count: 2,
+          completed_count: 1,
+          failed_count: 0,
+          canceled_count: 0,
+        },
+      }),
     ).toBeNull();
   });
 
@@ -588,6 +622,16 @@ describe("analytics", () => {
       previousFailedCount: 1,
       previousCanceledCount: 1,
     });
+    analytics.capture({
+      type: "import_retry_finished",
+      provider: "youtube",
+      retryCount: 3,
+      completedCount: 1,
+      failedCount: 1,
+      canceledCount: 1,
+      outcome: "canceled",
+      durationMs: 400,
+    });
 
     expect(capture.mock.calls.map(([name, properties]) => [name, properties])).toEqual([
       [
@@ -624,6 +668,18 @@ describe("analytics", () => {
           retry_count: 2,
           previous_failed_count: 1,
           previous_canceled_count: 1,
+        }),
+      ],
+      [
+        "import_retry_finished",
+        expect.objectContaining({
+          provider: "youtube",
+          retry_count: 3,
+          completed_count: 1,
+          failed_count: 1,
+          canceled_count: 1,
+          outcome: "canceled",
+          duration_ms: 400,
         }),
       ],
     ]);

--- a/tests/unit/features/import/audioUrlImportSession.test.ts
+++ b/tests/unit/features/import/audioUrlImportSession.test.ts
@@ -84,7 +84,7 @@ describe("audio URL import session", () => {
 
     await expect(
       hook.result.importing.commands.importUrl("https://soundcloud.com/discover"),
-    ).rejects.toThrow("unsupported_media_link");
+    ).rejects.toThrow("unsupported url");
     expect(mocks.capture).toHaveBeenCalledWith({
       type: "media_link_processed",
       sourceUrl: "https://soundcloud.com/discover",
@@ -117,7 +117,7 @@ describe("audio URL import session", () => {
 
     await expect(
       hook.result.commands.importUrl("https://on.soundcloud.com/private-token"),
-    ).rejects.toThrow("unsupported_media_link");
+    ).rejects.toThrow("soundcloud short-link resolution failed");
 
     expect(mocks.capture).toHaveBeenCalledWith({
       type: "media_link_processed",
@@ -140,6 +140,50 @@ describe("audio URL import session", () => {
     ).toBe(false);
     hook.unmount();
   });
+
+  it.each([
+    ["not a url", "invalid", "other"],
+    ["https://example.com/private-track", "unsupported", "other"],
+    ["http://youtube.com/watch?v=abcdefghijk", "invalid", "canonical"],
+    ["https://user:secret@youtube.com/watch?v=abcdefghijk", "invalid", "canonical"],
+    ["https://youtube.com:444/watch?v=abcdefghijk", "invalid", "canonical"],
+  ] as const)(
+    "rejects unsupported providers before starting an import (%s)",
+    async (sourceUrl, failureReason, shape) => {
+      const hook = renderHook(() => {
+        const library = useLibraryStore();
+        const editor = useTrackEditorSession({ library, settings: settings("320") });
+        const importing = useAudioImportSession({
+          library,
+          editor,
+          settings: settings("320"),
+          activateEditor: vi.fn(),
+        });
+        return { library, importing };
+      }, undefined);
+
+      await expect(hook.result.importing.commands.importUrl(sourceUrl)).rejects.toThrow(
+        "unsupported url",
+      );
+      expect(mocks.capture).toHaveBeenCalledWith({
+        type: "media_link_processed",
+        sourceUrl,
+        mediaKind: "unsupported",
+        shape,
+        normalized: false,
+        redirected: false,
+        outcome: "rejected",
+        failureReason,
+      });
+      expect(mocks.capture.mock.calls.some(([event]) => event.type === "import_started")).toBe(
+        false,
+      );
+      expect(mocks.resolveTrackMetadata).not.toHaveBeenCalled();
+      expect(mocks.downloadFromCobalt).not.toHaveBeenCalled();
+      expect(hook.result.library.getSnapshot().files).toEqual([]);
+      hook.unmount();
+    },
+  );
 
   it("wires recovery and exhaustion lifecycle events to tunnel analytics", async () => {
     mocks.resolveTrackMetadata.mockResolvedValue(undefined);
@@ -261,7 +305,9 @@ describe("audio URL import session", () => {
 
     let importing: Promise<void> | undefined;
     act(() => {
-      importing = hook.result.importing.commands.importUrl("https://example.com/latest-track");
+      importing = hook.result.importing.commands.importUrl(
+        "https://www.youtube.com/watch?v=abcdefghijk",
+      );
     });
     await vi.waitFor(() => expect(resolveMetadata).toBeTypeOf("function"));
     hook.rerender({ currentSettings: settings("128"), activateEditor: latestActivation });

--- a/tests/unit/features/import/cobaltAudio.test.ts
+++ b/tests/unit/features/import/cobaltAudio.test.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect";
 import { downloadFromCobalt, runAudioBackendEffect } from "@/features/audio/audioBackend";
 import { runAudioEffectWithoutServices } from "@/features/audio/audioRuntime";
 import type { CobaltAudioDownloadRequest } from "@/features/import/cobaltAudio";
+import { ImportStageError } from "@/features/import/importLifecycle";
 import type { CobaltDownloadPlan } from "@/features/import/cobaltAudioSchemas";
 import { decodeCobaltDownloadPlanEffect } from "@/features/import/cobaltAudioSchemas";
 import {
@@ -117,7 +118,7 @@ describe("CobaltAudio download", () => {
     },
     {
       outcome: "exhausted",
-      attempts: "4",
+      attempts: "7",
       status: 502,
       expectedError: "Cobalt tunnel response was empty.",
     },
@@ -166,7 +167,12 @@ describe("CobaltAudio download", () => {
       });
 
       if (expectedError) {
-        await expect(download).rejects.toThrow(expectedError);
+        const error = await download.then(
+          () => undefined,
+          (cause: unknown) => cause,
+        );
+        expect(error).toBeInstanceOf(ImportStageError);
+        expect(error).toMatchObject({ stage: "tunnel", message: expectedError });
       } else {
         await download;
       }
@@ -390,12 +396,15 @@ describe("CobaltAudio download", () => {
       }),
     );
 
-    await expect(
-      runCobaltDownload({
-        sourceUrl: "https://soundcloud.com/artist/malformed",
-        audioBitrate: "128",
-      }),
-    ).rejects.toThrow();
+    const error = await runCobaltDownload({
+      sourceUrl: "https://soundcloud.com/artist/malformed",
+      audioBitrate: "128",
+    }).then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
+    expect(error).toBeInstanceOf(ImportStageError);
+    expect(error).toMatchObject({ stage: "plan" });
     expect(fetchedUrls).toEqual(["/api/cobalt/audio"]);
   });
 

--- a/tests/unit/features/import/importLifecycle.test.ts
+++ b/tests/unit/features/import/importLifecycle.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, it } from "vite-plus/test";
 import type { AnalyticsEvent } from "@/analytics";
-import { createImportLifecycleTracker } from "@/features/import/importLifecycle";
+import {
+  createImportLifecycleTracker,
+  ImportStageError,
+  importFailureStageFromDownloadError,
+} from "@/features/import/importLifecycle";
 
 describe("import lifecycle", () => {
+  it.each([
+    [new Error("error.api.fetch.fail"), "plan"],
+    [new ImportStageError("plan", new Error("malformed cobalt audio plan")), "plan"],
+    [new ImportStageError("tunnel", new Error("error.api.capacity_exceeded")), "tunnel"],
+    [new ImportStageError("processing", new Error("arbitrary worker failure")), "processing"],
+  ] as const)("preserves the typed download failure stage", (error, stage) => {
+    expect(importFailureStageFromDownloadError(error)).toBe(stage);
+  });
   it("emits one completed outcome after every resolved track completes", () => {
     const captured: AnalyticsEvent[] = [];
     let now = 100;
@@ -67,23 +79,29 @@ describe("import lifecycle", () => {
     });
     now = 1_125;
 
-    tracker.fail(operationId, new Error("private resolver response"), "resolve");
-    tracker.fail(operationId, new Error("duplicate failure"), "resolve");
+    tracker.fail(operationId, new Error("error.api.fetch.fail private resolver response"));
+    tracker.fail(operationId, new Error("duplicate failure"));
 
-    expect(captured.at(-1)).toEqual({
-      type: "import_finished",
-      sourceUrl: "https://soundcloud.com/artist/sets/private-set",
-      importKind: "set",
-      outcome: "failed",
-      totalCount: 0,
-      completedCount: 0,
-      failedCount: 0,
-      canceledCount: 0,
-      durationMs: 125,
-      error: expect.any(Error),
-      failureStage: "resolve",
-    });
-    expect(captured).toHaveLength(2);
+    expect(captured.slice(-2)).toEqual([
+      {
+        type: "import_resolution_failed",
+        sourceUrl: "https://soundcloud.com/artist/sets/private-set",
+        importKind: "set",
+        code: "fetch_failed",
+      },
+      {
+        type: "import_finished",
+        sourceUrl: "https://soundcloud.com/artist/sets/private-set",
+        importKind: "set",
+        outcome: "failed",
+        totalCount: 0,
+        completedCount: 0,
+        failedCount: 0,
+        canceledCount: 0,
+        durationMs: 125,
+      },
+    ]);
+    expect(captured).toHaveLength(3);
   });
 
   it.each([
@@ -123,4 +141,67 @@ describe("import lifecycle", () => {
       );
     },
   );
+
+  it("aggregates stable failure categories across a playlist", () => {
+    const captured: AnalyticsEvent[] = [];
+    const tracker = createImportLifecycleTracker({
+      capture: (event) => captured.push(event),
+      createId: () => "operation",
+      now: () => 100,
+    });
+    const operationId = tracker.start({
+      sourceUrl: "https://soundcloud.com/artist/sets/set",
+      importKind: "set",
+    });
+    tracker.resolve(operationId, {
+      trackIds: ["track-1", "track-2", "track-3"],
+      hasCover: false,
+    });
+
+    tracker.settle(operationId, {
+      trackId: "track-1",
+      outcome: "failed",
+      failureStage: "tunnel",
+      error: new Error("Cobalt tunnel response was empty."),
+    });
+    tracker.settle(operationId, {
+      trackId: "track-2",
+      outcome: "failed",
+      failureStage: "plan",
+      error: new Error("error.api.fetch.empty request-id=private"),
+    });
+    tracker.settle(operationId, {
+      trackId: "track-3",
+      outcome: "failed",
+      failureStage: "hydration",
+      error: new Error("downloaded track could not be parsed: /private/file.mp3"),
+    });
+
+    expect(captured.slice(-4, -1)).toEqual([
+      expect.objectContaining({
+        type: "import_failure_category",
+        stage: "tunnel",
+        code: "empty_response",
+        trackCount: 1,
+      }),
+      expect.objectContaining({
+        type: "import_failure_category",
+        stage: "plan",
+        code: "empty_response",
+        trackCount: 1,
+      }),
+      expect.objectContaining({
+        type: "import_failure_category",
+        stage: "hydration",
+        code: "parse_failed",
+        trackCount: 1,
+      }),
+    ]);
+    expect(
+      captured
+        .filter((event) => event.type === "import_failure_category")
+        .reduce((sum, event) => sum + event.trackCount, 0),
+    ).toBe(3);
+    expect(JSON.stringify(captured.slice(-4))).not.toContain("private");
+  });
 });

--- a/tests/unit/features/import/playlistDownloadController.test.ts
+++ b/tests/unit/features/import/playlistDownloadController.test.ts
@@ -6,6 +6,7 @@ import {
   type PlaylistDownloadControllerSnapshot,
 } from "@/features/import/playlistDownloadController";
 import type { PlaylistDownloadRuntimeTrack } from "@/features/import/playlistDownloadQueueRuntime";
+import { ImportStageError } from "@/features/import/importLifecycle";
 
 type Track = PlaylistDownloadRuntimeTrack & {
   sourceUrl: string;
@@ -302,6 +303,7 @@ describe("playlistDownloadController", () => {
     expect(harness.actions).toEqual([
       {
         type: "retry_started",
+        retryAttemptId: 1,
         tracks: tracks(3),
         previousSnapshot: expect.objectContaining({
           total: 3,
@@ -331,6 +333,144 @@ describe("playlistDownloadController", () => {
       completed: 0,
       active: [{ fileId: "track-2" }],
     });
+  });
+
+  it("does not let a canceled run settle an immediate retry with the same track id", async () => {
+    const harness = createControllerHarness();
+    harness.controller.enqueue([tracks(1)[0]]);
+    await flushEffects();
+
+    harness.controller.cancel();
+    harness.controller.retry([tracks(1)[0]]);
+
+    expect(harness.actions.map((action) => action.type)).toEqual([
+      "cancel_requested",
+      "retry_started",
+    ]);
+
+    await flushEffects();
+
+    expect(harness.lifecycle).toEqual([{ track: tracks(1)[0], outcome: "canceled" }]);
+    expect(harness.actions.map((action) => action.type)).toEqual([
+      "cancel_requested",
+      "retry_started",
+    ]);
+
+    harness.downloads.get("track-1")?.resolve(audioFile("retry.mp3"));
+    await flushEffects();
+
+    expect(harness.actions.at(-1)).toEqual(
+      expect.objectContaining({
+        type: "retry_finished",
+        retryCount: 1,
+        completedCount: 1,
+        failedCount: 0,
+        canceledCount: 0,
+        outcome: "completed",
+      }),
+    );
+  });
+
+  it("does not let a removed execution settle its same-run replacement", async () => {
+    const harness = createControllerHarness();
+    harness.controller.enqueue([tracks(1)[0]]);
+    await flushEffects();
+
+    harness.controller.remove(["track-1"]);
+    harness.controller.retry([tracks(1)[0]]);
+
+    expect(harness.actions.map((action) => action.type)).toEqual(["retry_started"]);
+
+    await flushEffects();
+
+    expect(harness.lifecycle).toEqual([{ track: tracks(1)[0], outcome: "canceled" }]);
+    expect(harness.actions.map((action) => action.type)).toEqual(["retry_started"]);
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      active: [{ fileId: "track-1" }],
+      pending: 0,
+      completed: 0,
+      canceledCount: 0,
+      done: false,
+    });
+
+    harness.downloads.get("track-1")?.resolve(audioFile("replacement.mp3"));
+    await flushEffects();
+
+    expect(harness.actions.at(-1)).toEqual(
+      expect.objectContaining({
+        type: "retry_finished",
+        retryCount: 1,
+        completedCount: 1,
+        failedCount: 0,
+        canceledCount: 0,
+        outcome: "completed",
+      }),
+    );
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      active: [],
+      completed: 1,
+      done: true,
+    });
+  });
+
+  it("keeps retry generations separate when a retry is removed and retried again", async () => {
+    const harness = createControllerHarness();
+    harness.controller.enqueue([tracks(1)[0]]);
+    await flushEffects();
+    harness.downloads.get("track-1")?.reject(new Error("initial failure"));
+    await flushEffects();
+
+    harness.controller.retry([tracks(1)[0]]);
+    await flushEffects();
+    harness.controller.remove(["track-1"]);
+    harness.controller.retry([tracks(1)[0]]);
+    await flushEffects();
+
+    expect(harness.actions).toEqual([
+      expect.objectContaining({ type: "retry_started", retryAttemptId: 1 }),
+      expect.objectContaining({
+        type: "retry_finished",
+        retryAttemptId: 1,
+        canceledCount: 1,
+      }),
+      expect.objectContaining({ type: "retry_started", retryAttemptId: 2 }),
+    ]);
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      active: [{ fileId: "track-1" }],
+      done: false,
+    });
+
+    harness.downloads.get("track-1")?.resolve(audioFile("second-retry.mp3"));
+    await flushEffects();
+
+    expect(harness.actions.at(-1)).toEqual(
+      expect.objectContaining({
+        type: "retry_finished",
+        retryAttemptId: 2,
+        completedCount: 1,
+        canceledCount: 0,
+        outcome: "completed",
+      }),
+    );
+  });
+
+  it("pumps retry work without emitting telemetry when there is no baseline snapshot", async () => {
+    const harness = createControllerHarness();
+
+    harness.controller.retry([tracks(1)[0]]);
+    await flushEffects();
+
+    expect(harness.downloadStarts).toEqual(["track-1"]);
+    expect(harness.actions).toEqual([]);
+
+    harness.downloads.get("track-1")?.resolve(audioFile("track-1.mp3"));
+    await flushEffects();
+
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      completed: 1,
+      done: true,
+    });
+    expect(harness.actions).toEqual([]);
   });
 
   it("does not let stale pending hydration complete an old run after cancel and retry", async () => {
@@ -396,6 +536,142 @@ describe("playlistDownloadController", () => {
     ]);
   });
 
+  it("reports typed failure stages and a terminal outcome for each retry batch", async () => {
+    const harness = createControllerHarness();
+    harness.controller.enqueue(tracks(3));
+    await flushEffects();
+    harness.downloads.get("track-1")?.reject(new Error("initial failure"));
+    harness.downloads.get("track-2")?.reject(new Error("initial failure"));
+    harness.downloads.get("track-3")?.reject(new Error("initial failure"));
+    await flushEffects();
+
+    harness.hydrations.set("track-2", deferred<void>());
+    harness.controller.retry(tracks(3));
+    harness.controller.retry(tracks(3));
+    await flushEffects();
+    harness.downloads.get("track-1")?.reject(new Error("error.api.fetch.fail private-id"));
+    harness.downloads.get("track-2")?.resolve(audioFile("track-2.mp3"));
+    harness.downloads.get("track-3")?.resolve(audioFile("track-3.mp3"));
+    await flushEffects();
+    harness.hydrations.get("track-2")?.reject(new Error("private parse failure"));
+    await flushEffects();
+
+    expect(harness.lifecycle.slice(-3)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          track: tracks(3)[0],
+          outcome: "failed",
+          failureStage: "plan",
+        }),
+        expect.objectContaining({
+          track: tracks(3)[1],
+          outcome: "failed",
+          failureStage: "hydration",
+        }),
+        { track: tracks(3)[2], outcome: "completed" },
+      ]),
+    );
+    expect(harness.actions.at(-1)).toEqual({
+      type: "retry_finished",
+      retryAttemptId: 1,
+      tracks: tracks(3),
+      retryCount: 3,
+      completedCount: 1,
+      failedCount: 2,
+      canceledCount: 0,
+      outcome: "partial",
+      durationMs: expect.any(Number),
+    });
+    expect(harness.actions.map((action) => action.type).slice(-2)).toEqual([
+      "retry_started",
+      "retry_finished",
+    ]);
+    expect(harness.actions.filter((action) => action.type === "retry_started")).toHaveLength(1);
+  });
+
+  it("registers the accepted retry set before fast settlement", async () => {
+    const harness = createControllerHarness({ hasTrack: () => false });
+    harness.controller.enqueue([tracks(1)[0]]);
+    await flushEffects();
+
+    harness.controller.retry([tracks(1)[0], tracks(2)[1]]);
+    harness.controller.retry([tracks(1)[0]]);
+    await flushEffects();
+
+    expect(harness.actions.map((action) => action.type)).toEqual([
+      "retry_started",
+      "retry_finished",
+      "retry_started",
+      "retry_finished",
+    ]);
+    expect(harness.actions).toEqual([
+      expect.objectContaining({
+        type: "retry_started",
+        retryAttemptId: 1,
+        tracks: [tracks(1)[0], tracks(2)[1]],
+      }),
+      expect.objectContaining({
+        type: "retry_finished",
+        retryAttemptId: 1,
+        retryCount: 2,
+        completedCount: 0,
+        failedCount: 0,
+        canceledCount: 2,
+      }),
+      expect.objectContaining({ type: "retry_started", retryAttemptId: 2 }),
+      expect.objectContaining({ type: "retry_finished", retryAttemptId: 2 }),
+    ]);
+  });
+
+  it("finishes a retry as canceled when its accepted track is removed", async () => {
+    const harness = createControllerHarness();
+    harness.controller.enqueue([tracks(1)[0]]);
+    await flushEffects();
+    harness.downloads.get("track-1")?.reject(new Error("initial failure"));
+    await flushEffects();
+
+    harness.controller.retry([tracks(1)[0]]);
+    await flushEffects();
+    harness.controller.remove(["track-1"]);
+    await flushEffects();
+
+    expect(harness.actions.at(-1)).toEqual(
+      expect.objectContaining({
+        type: "retry_finished",
+        retryCount: 1,
+        completedCount: 0,
+        failedCount: 0,
+        canceledCount: 1,
+        outcome: "canceled",
+      }),
+    );
+  });
+
+  it("finishes every accepted retry track when the retry run is canceled", async () => {
+    const harness = createControllerHarness();
+    harness.controller.enqueue(tracks(2));
+    await flushEffects();
+    harness.downloads.get("track-1")?.reject(new Error("initial failure"));
+    harness.downloads.get("track-2")?.reject(new Error("initial failure"));
+    await flushEffects();
+
+    harness.controller.retry(tracks(2));
+    await flushEffects();
+    harness.controller.cancel();
+    await flushEffects();
+
+    expect(harness.actions.at(-1)).toEqual(
+      expect.objectContaining({
+        type: "retry_finished",
+        retryCount: 2,
+        completedCount: 0,
+        failedCount: 0,
+        canceledCount: 2,
+        outcome: "canceled",
+      }),
+    );
+  });
+
   it("settles a track removed before work starts as canceled", async () => {
     const harness = createControllerHarness({ hasTrack: () => false });
 
@@ -411,5 +687,18 @@ describe("playlistDownloadController", () => {
       canceledCount: 1,
       done: true,
     });
+  });
+
+  it("preserves cancellation through a typed download-stage error", async () => {
+    const harness = createControllerHarness();
+    harness.controller.enqueue([tracks(1)[0]]);
+    await flushEffects();
+    harness.downloads
+      .get("track-1")
+      ?.reject(new ImportStageError("tunnel", new DOMException("aborted", "AbortError")));
+    await flushEffects();
+
+    expect(harness.failed).toEqual([]);
+    expect(harness.lifecycle).toEqual([{ track: tracks(1)[0], outcome: "canceled" }]);
   });
 });

--- a/tests/unit/features/workspace/systemFailure.test.ts
+++ b/tests/unit/features/workspace/systemFailure.test.ts
@@ -43,6 +43,24 @@ describe("system failure reporting", () => {
     expect(JSON.stringify(presentation)).not.toContain("private upstream");
   });
 
+  it("presents the import gateway's unsupported source token as non-retryable", () => {
+    expect(getSystemFailurePresentation(new Error("unsupported url"), "import")).toMatchObject({
+      code: "unsupported_source",
+      retryable: false,
+      description: "try a public soundcloud or youtube track url.",
+    });
+  });
+
+  it("keeps failed SoundCloud short-link resolution retryable", () => {
+    expect(
+      getSystemFailurePresentation(new Error("soundcloud short-link resolution failed"), "import"),
+    ).toMatchObject({
+      code: "unknown",
+      retryable: true,
+      title: "import failed",
+    });
+  });
+
   it("reports every explicit export failure", () => {
     reportSystemFailure(new Error("first private cause"), "export");
     reportSystemFailure(new Error("second private cause"), "export");

--- a/tests/unit/scripts/loadTestCobaltSafety.test.ts
+++ b/tests/unit/scripts/loadTestCobaltSafety.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertTunnelMatchesLoadTestTarget,
+  parseLoadTestTarget,
+} from "../../../scripts/load-test-cobalt-safety";
+
+describe("Cobalt load-test safety", () => {
+  it("accepts an HTTPS disposable origin", () => {
+    expect(parseLoadTestTarget("https://tagium-cobalt-loadtest.fly.dev").origin).toBe(
+      "https://tagium-cobalt-loadtest.fly.dev",
+    );
+  });
+
+  it("refuses the production Cobalt origin", () => {
+    expect(() => parseLoadTestTarget("https://tagium-cobalt.fly.dev")).toThrow(
+      "Refusing to load-test production Cobalt",
+    );
+  });
+
+  it.each([
+    "http://tagium-cobalt-loadtest.fly.dev",
+    "https://user:password@tagium-cobalt-loadtest.fly.dev",
+    "https://tagium-cobalt-loadtest.fly.dev/tunnel",
+    "https://tagium-cobalt-loadtest.fly.dev/?target=production",
+  ])("refuses unsafe target %s", (target) => {
+    expect(() => parseLoadTestTarget(target)).toThrow();
+  });
+
+  it("accepts tunnels from the disposable origin", () => {
+    const target = parseLoadTestTarget("https://tagium-cobalt-loadtest.fly.dev");
+
+    expect(
+      assertTunnelMatchesLoadTestTarget(
+        target,
+        "https://tagium-cobalt-loadtest.fly.dev/tunnel?id=safe",
+      ),
+    ).toBe("https://tagium-cobalt-loadtest.fly.dev/tunnel?id=safe");
+  });
+
+  it("aborts before a cross-origin tunnel can be fetched", () => {
+    const target = parseLoadTestTarget("https://tagium-cobalt-loadtest.fly.dev");
+
+    expect(() =>
+      assertTunnelMatchesLoadTestTarget(
+        target,
+        "https://tagium-cobalt.fly.dev/tunnel?id=production",
+      ),
+    ).toThrow("aborting before the tunnel is fetched");
+  });
+});


### PR DESCRIPTION
## human review

- Open Tagium and import one public YouTube track and one public SoundCloud track. Expect both to finish normally and remain editable.
- Try a generic HTTPS URL, a malformed URL, and a supported SoundCloud short link whose resolution fails. Expect generic URLs to show the non-retryable supported-provider message; the short-link resolution failure should remain retryable.
- In a non-production environment, inject an empty tunnel response and cancel during backoff. Expect at most seven bounded attempts, cancellation without further fetches, and no stale retry completion.
- Retry failed tracks, including canceling or removing and immediately retrying the same track. Expect one start and one matching finish event per accepted retry, with no duplicate or stale result.
- Review the PostHog Import Health dashboard after deployment. Track failure remains failed tracks / attempted tracks; resolution failure, typed stage/code counts, retry recovery, and tunnel attempts are separate. The new typed tiles are expected to be empty before this release receives traffic.
- For the load-test guard, run `bun run load-test:cobalt -- --target https://tagium-cobalt.fly.dev --waves 1 --requests-per-wave 1 --max-requests 1`. Expect it to refuse before making a request. A disposable clone must be deployed with its own `API_URL`.
- Reviewer decision: the retry window now reaches roughly 9.4 seconds in the worst empty-body case. Fresh-plan fallback is intentionally deferred to avoid duplicate downloads/local processing.
- Automatically verified: 715 tests, typecheck, lint, production build, and diff checks pass. Manual production verification and the disposable Fly load test remain.