### PR TITLE
feat: shorten share links

### DIFF
--- a/docs/share-operations.md
+++ b/docs/share-operations.md
@@ -34,7 +34,7 @@ Use a maintainer credential with access only to the intended environment. This c
 
 ```sh
 TAGIUM_DEPLOY_ENV=production SHARE_MAINTAINER_CONFIRM=disable \
-  bun run disable:share-manifest -- <22-character-slug>
+  bun run disable:share-manifest -- <6-character-slug>
 ```
 
 It validates the environment and server-derived key, disables the D1 row first, then deletes the corresponding R2 object. A missing or previously-disabled row is safe to retry. If R2 deletion fails, the link remains disabled; repeat the exact command once R2 is available. Never use preview resource values for production (or vice versa).

--- a/scripts/disable-share-manifest.ts
+++ b/scripts/disable-share-manifest.ts
@@ -13,7 +13,7 @@ if (
   !SHARE_SLUG_PATTERN.test(slug)
 ) {
   console.error(
-    "usage: TAGIUM_DEPLOY_ENV=preview|production SHARE_MAINTAINER_CONFIRM=disable bun run disable:share-manifest -- <22-char-slug>",
+    "usage: TAGIUM_DEPLOY_ENV=preview|production SHARE_MAINTAINER_CONFIRM=disable bun run disable:share-manifest -- <6-character-slug>",
   );
   exit(1);
 }

--- a/server/middleware/02-share-noindex.ts
+++ b/server/middleware/02-share-noindex.ts
@@ -1,8 +1,11 @@
 import { defineHandler } from "nitro";
+import { SHARE_SLUG_PATTERN } from "../../src/features/share/shareSlug";
 
 // This middleware is the Nitro seam before the SPA fallback serves /share/:slug.
 export default defineHandler((event) => {
-  if (/^\/share\/[A-Za-z0-9_-]{22}\/?$/.test(new URL(event.req.url).pathname)) {
+  const pathname = new URL(event.req.url).pathname;
+  const match = pathname.match(/^\/share\/([^/]+)\/?$/);
+  if (SHARE_SLUG_PATTERN.test(match?.[1] ?? "")) {
     event.res.headers.set("X-Robots-Tag", "noindex, nofollow");
   }
 });

--- a/server/utils/share-manifest.ts
+++ b/server/utils/share-manifest.ts
@@ -5,6 +5,7 @@ import {
   type Manifest,
   type ManifestArtwork,
 } from "../../src/features/share/shareManifest";
+import { createShareSlug, SHARE_SLUG_PATTERN } from "../../src/features/share/shareSlug";
 
 /**
  * The share-manifest module is the server seam for publishing, reading, and
@@ -17,7 +18,7 @@ export const SHARE_ARTWORK_MAX_BYTES = 5 * 1024 * 1024;
 export const SHARE_ARTWORK_MAX_EDGE = 1_600;
 export const SHARE_ARTWORK_MAX_PIXELS = 16_000_000;
 export const SHARE_MANIFEST_MAX_BYTES = 256 * 1024;
-export const SHARE_SLUG_PATTERN = /^[A-Za-z0-9_-]{22}$/;
+export { SHARE_SLUG_PATTERN } from "../../src/features/share/shareSlug";
 
 export type ShareManifest = Manifest;
 
@@ -293,10 +294,15 @@ const samePublishedValue = (left: StoredShareManifest, right: StoredShareManifes
 
 export const createShareManifestStore = (
   persistence: ShareManifestPersistence,
-  options: { now?: () => number; randomToken?: (bytes?: number) => string } = {},
+  options: {
+    now?: () => number;
+    randomToken?: (bytes?: number) => string;
+    randomSlug?: () => string;
+  } = {},
 ) => {
   const clock = options.now ?? nowMs;
   const token = options.randomToken ?? randomToken;
+  const slugToken = options.randomSlug ?? createShareSlug;
   return {
     publish: async (manifest: ShareManifest, artwork: ShareArtwork | undefined) => {
       const payload = JSON.stringify(withArtwork(manifest, artwork));
@@ -309,7 +315,7 @@ export const createShareManifestStore = (
       const revocationTokenHash = await hashShareSecret(revocationToken);
 
       for (let attempt = 0; attempt < 3; attempt++) {
-        const slug = token(16);
+        const slug = slugToken();
         // An attempt-specific key prevents a slug collision from overwriting an existing cover.
         const artworkKey = artwork
           ? `shares/${slug}/${token(8)}.${artwork.type === "image/png" ? "png" : "jpg"}`

--- a/src/features/share/shareLink.ts
+++ b/src/features/share/shareLink.ts
@@ -1,4 +1,5 @@
-const SHARE_SLUG_PATTERN = /^[A-Za-z0-9_-]{22}$/;
+import { SHARE_SLUG_PATTERN } from "@/features/share/shareSlug";
+
 const PRODUCTION_ORIGINS = new Set(["https://tagium.app", "https://www.tagium.app"]);
 
 export type ShareLinkClassification =
@@ -31,8 +32,9 @@ export const classifyShareLink = (
 };
 
 export const shareSlugFromPathname = (pathname: string) => {
-  const match = pathname.match(/^\/share\/([A-Za-z0-9_-]{22})\/?$/);
-  return match?.[1] ?? null;
+  const match = pathname.match(/^\/share\/([^/]+)\/?$/);
+  const slug = match?.[1] ?? "";
+  return SHARE_SLUG_PATTERN.test(slug) ? slug : null;
 };
 
 export const shareLinkForSlug = (

--- a/src/features/share/shareSlug.ts
+++ b/src/features/share/shareSlug.ts
@@ -1,0 +1,21 @@
+export const SHARE_SLUG_ALPHABET = "23456789abcdefghjkmnpqrstvwxyz";
+export const SHARE_SLUG_LENGTH = 6;
+export const SHARE_SLUG_PATTERN = /^[23456789abcdefghjkmnpqrstvwxyz]{6}$/;
+
+const RANDOM_BYTE_LIMIT = Math.floor(256 / SHARE_SLUG_ALPHABET.length) * SHARE_SLUG_ALPHABET.length;
+
+export const createShareSlug = () => {
+  const bytes = new Uint8Array(SHARE_SLUG_LENGTH);
+  let slug = "";
+
+  while (slug.length < SHARE_SLUG_LENGTH) {
+    crypto.getRandomValues(bytes);
+    for (const byte of bytes) {
+      if (byte >= RANDOM_BYTE_LIMIT) continue;
+      slug += SHARE_SLUG_ALPHABET[byte % SHARE_SLUG_ALPHABET.length];
+      if (slug.length === SHARE_SLUG_LENGTH) return slug;
+    }
+  }
+
+  return slug;
+};

--- a/tests/server/manifests.test.ts
+++ b/tests/server/manifests.test.ts
@@ -257,7 +257,7 @@ describe("share manifest endpoints", () => {
 
   it("uses one unavailable response for missing manifests, artwork, and invalid revocation", async () => {
     const runtime = createRuntime();
-    const slug = "a".repeat(22);
+    const slug = "aaaaaa";
     for (const response of await Promise.all([
       manifestHandler(
         event(request(`https://tagium.test/api/manifests/${slug}`, {}, runtime.env), slug),
@@ -311,10 +311,7 @@ describe("share manifest endpoints", () => {
       ),
     );
     const read = await manifestHandler(
-      event(
-        request(`https://tagium.test/api/manifests/${"a".repeat(22)}`, {}, runtime.env),
-        "a".repeat(22),
-      ),
+      event(request("https://tagium.test/api/manifests/aaaaaa", {}, runtime.env), "aaaaaa"),
     );
     expect(create.status).toBe(429);
     expect(read.status).toBe(429);
@@ -448,7 +445,7 @@ describe("share manifest endpoints", () => {
   it("rate-limits updates and rejects cross-site or ambiguous update bodies", async () => {
     const runtime = createRuntime();
     runtime.env.SHARE_UPDATE_RATE_LIMITER = { limit: async () => ({ success: false }) };
-    const slug = "a".repeat(22);
+    const slug = "aaaaaa";
     const limitedForm = new FormData();
     limitedForm.set("manifest", JSON.stringify(manifest));
     const limited = await updateHandler(
@@ -605,11 +602,11 @@ describe("share manifest endpoints", () => {
     const limited = await revokeHandler(
       event(
         request(
-          `https://tagium.test/api/manifests/${"a".repeat(22)}`,
+          "https://tagium.test/api/manifests/aaaaaa",
           { method: "DELETE", headers: { authorization: `Bearer ${"x".repeat(10_000)}` } },
           runtime.env,
         ),
-        "a".repeat(22),
+        "aaaaaa",
       ),
     );
     expect(limited.status).toBe(429);
@@ -618,16 +615,18 @@ describe("share manifest endpoints", () => {
   it("marks shared-album routes as noindex without affecting other routes", () => {
     const headers = new Headers();
     noindexMiddleware({
-      req: new Request(`https://tagium.test/share/${"a".repeat(22)}`),
+      req: new Request("https://tagium.test/share/aaaaaa"),
       res: { headers },
     } as Parameters<typeof noindexMiddleware>[0]);
     expect(headers.get("x-robots-tag")).toBe("noindex, nofollow");
 
-    const otherHeaders = new Headers();
-    noindexMiddleware({
-      req: new Request("https://tagium.test/share/not-a-slug"),
-      res: { headers: otherHeaders },
-    } as Parameters<typeof noindexMiddleware>[0]);
-    expect(otherHeaders.get("x-robots-tag")).toBeNull();
+    for (const pathname of ["/share/not-a-slug", `/share/${"a".repeat(22)}`]) {
+      const otherHeaders = new Headers();
+      noindexMiddleware({
+        req: new Request(`https://tagium.test${pathname}`),
+        res: { headers: otherHeaders },
+      } as Parameters<typeof noindexMiddleware>[0]);
+      expect(otherHeaders.get("x-robots-tag")).toBeNull();
+    }
   });
 });

--- a/tests/server/utils/share-manifest.test.ts
+++ b/tests/server/utils/share-manifest.test.ts
@@ -6,6 +6,11 @@ import {
   type ShareManifestPersistence,
   type StoredShareManifest,
 } from "../../../server/utils/share-manifest";
+import {
+  createShareSlug,
+  SHARE_SLUG_ALPHABET,
+  SHARE_SLUG_PATTERN,
+} from "../../../src/features/share/shareSlug";
 
 const manifest = {
   version: 1 as const,
@@ -99,6 +104,16 @@ const createFakePersistence = () => {
 };
 
 describe("share manifest store", () => {
+  it("generates six-character slugs from the 30-character ambiguity-free alphabet", () => {
+    expect(SHARE_SLUG_ALPHABET).toHaveLength(30);
+    expect(new Set(SHARE_SLUG_ALPHABET).size).toBe(30);
+    expect(SHARE_SLUG_PATTERN.test("a".repeat(22))).toBe(false);
+    expect(SHARE_SLUG_PATTERN.test("K7M4Q2")).toBe(false);
+    for (let attempt = 0; attempt < 100; attempt++) {
+      expect(createShareSlug()).toMatch(SHARE_SLUG_PATTERN);
+    }
+  });
+
   it("publishes a single record and makes it unavailable at exactly 90 days", async () => {
     const fake = createFakePersistence();
     let now = 1_000;
@@ -216,9 +231,11 @@ describe("share manifest store", () => {
       fake.records.set(record.slug, record);
       return "created";
     };
-    const tokens = ["revocation", "a".repeat(22), "first-owner", "b".repeat(22), "second-owner"];
+    const tokens = ["revocation", "first-owner", "second-owner"];
+    const slugs = ["aaaaaa", "bbbbbb"];
     const store = createShareManifestStore(fake.persistence, {
       randomToken: () => tokens.shift()!,
+      randomSlug: () => slugs.shift()!,
     });
     await store.publish(manifest, await parseShareArtwork(new File([png], "cover.png")));
 

--- a/tests/unit/features/share/revocationReceipt.test.ts
+++ b/tests/unit/features/share/revocationReceipt.test.ts
@@ -32,7 +32,7 @@ describe("local sharing permission", () => {
     vi.setSystemTime(new Date("2026-07-22T12:00:00Z"));
     const storage = new MemoryStorage();
     const receipt = {
-      slug: "AbcdEFGHijklmno_123-45",
+      slug: "k7m4q2",
       expiresAt: "2026-10-20T12:00:00Z",
       token: "private-revocation-secret",
     };

--- a/tests/unit/features/share/shareClient.test.ts
+++ b/tests/unit/features/share/shareClient.test.ts
@@ -30,12 +30,12 @@ const manifest = {
 describe("shared content client", () => {
   it("decodes the public response envelope without requesting audio", async () => {
     const fetch = vi.fn(async () => Response.json({ manifest, expiresAt: "2026-10-20T12:00:00Z" }));
-    await expect(fetchSharedContent("AbcdEFGHijklmno_123-45", { fetch })).resolves.toEqual({
+    await expect(fetchSharedContent("k7m4q2", { fetch })).resolves.toEqual({
       manifest,
       expiresAt: "2026-10-20T12:00:00Z",
     });
     expect(fetch).toHaveBeenCalledWith(
-      "/api/manifests/AbcdEFGHijklmno_123-45",
+      "/api/manifests/k7m4q2",
       expect.objectContaining({ cache: "no-store" }),
     );
     expect(fetch).toHaveBeenCalledOnce();
@@ -45,20 +45,20 @@ describe("shared content client", () => {
     const futureFetch = vi.fn(async () =>
       Response.json({ manifest: { ...manifest, version: 2 }, expiresAt: "2026-10-20T12:00:00Z" }),
     );
-    await expect(
-      fetchSharedContent("AbcdEFGHijklmno_123-45", { fetch: futureFetch }),
-    ).rejects.toBeInstanceOf(SharedContentVersionError);
+    await expect(fetchSharedContent("k7m4q2", { fetch: futureFetch })).rejects.toBeInstanceOf(
+      SharedContentVersionError,
+    );
     const missingFetch = vi.fn(async () => new Response(null, { status: 404 }));
-    await expect(
-      fetchSharedContent("AbcdEFGHijklmno_123-45", { fetch: missingFetch }),
-    ).rejects.toBeInstanceOf(SharedContentUnavailableError);
+    await expect(fetchSharedContent("k7m4q2", { fetch: missingFetch })).rejects.toBeInstanceOf(
+      SharedContentUnavailableError,
+    );
   });
 
   it("sends the private revocation permission only in the delete authorization header", async () => {
     const fetch = vi.fn(
       async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(null, { status: 204 }),
     );
-    await revokeShare("AbcdEFGHijklmno_123-45", "private-secret", { fetch });
+    await revokeShare("k7m4q2", "private-secret", { fetch });
     const [url, request] = fetch.mock.calls[0]!;
     expect(url).not.toContain("private-secret");
     expect(request).toEqual(
@@ -71,26 +71,26 @@ describe("shared content client", () => {
 
   it("accepts only a 204 revocation response", async () => {
     const fetch = vi.fn(async () => new Response(null, { status: 404 }));
-    await expect(
-      revokeShare("AbcdEFGHijklmno_123-45", "private-secret", { fetch }),
-    ).rejects.toThrow("sharing could not be stopped");
+    await expect(revokeShare("k7m4q2", "private-secret", { fetch })).rejects.toThrow(
+      "sharing could not be stopped",
+    );
   });
 
   it("updates the same link with a bearer capability and never posts", async () => {
     const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
       Response.json({
-        slug: "AbcdEFGHijklmno_123-45",
-        url: "https://tagium.app/share/AbcdEFGHijklmno_123-45",
+        slug: "k7m4q2",
+        url: "https://tagium.app/share/k7m4q2",
         expiresAt: "2026-10-20T12:00:00Z",
       }),
     );
     await expect(
-      updateShare("AbcdEFGHijklmno_123-45", "private-secret", manifest as never, null, {
+      updateShare("k7m4q2", "private-secret", manifest as never, null, {
         fetch,
       }),
-    ).resolves.toMatchObject({ slug: "AbcdEFGHijklmno_123-45" });
+    ).resolves.toMatchObject({ slug: "k7m4q2" });
     const [url, request] = fetch.mock.calls[0]!;
-    expect(url).toBe("/api/manifests/AbcdEFGHijklmno_123-45");
+    expect(url).toBe("/api/manifests/k7m4q2");
     expect(request).toMatchObject({
       method: "PATCH",
       headers: expect.objectContaining({ Authorization: "Bearer private-secret" }),

--- a/tests/unit/features/share/shareLink.test.ts
+++ b/tests/unit/features/share/shareLink.test.ts
@@ -5,7 +5,7 @@ import {
   shareSlugFromPathname,
 } from "@/features/share/shareLink";
 
-const slug = "AbcdEFGHijklmno_123-45";
+const slug = "k7m4q2";
 
 describe("share link classification", () => {
   it("builds the canonical link used for copying into another workspace", () => {
@@ -37,5 +37,7 @@ describe("share link classification", () => {
     });
     expect(shareSlugFromPathname(`/share/${slug}`)).toBe(slug);
     expect(shareSlugFromPathname("/share/short")).toBeNull();
+    expect(shareSlugFromPathname("/share/abcdefg")).toBeNull();
+    expect(shareSlugFromPathname("/share/old_code-123456789012")).toBeNull();
   });
 });

--- a/tests/unit/features/share/sharedAlbumDownload.test.ts
+++ b/tests/unit/features/share/sharedAlbumDownload.test.ts
@@ -59,20 +59,15 @@ describe("shared album download planning", () => {
         data: new Uint8Array(new ArrayBuffer(3)),
       },
     ];
-    const plan = createSharedAlbumDownloadPlan(
-      manifest,
-      "AbcdEFGHijklmno_123-45",
-      () => `id-${++id}`,
-      cover,
-    );
+    const plan = createSharedAlbumDownloadPlan(manifest, "k7m4q2", () => `id-${++id}`, cover);
 
-    expect(plan.album.sourceManifestSlug).toBe("AbcdEFGHijklmno_123-45");
+    expect(plan.album.sourceManifestSlug).toBe("k7m4q2");
     expect(plan.album.sourceUrl).toBe(manifest.album.sourceUrl);
     expect(plan.album.cover).toBe(cover);
     expect(plan.album.cover?.[0]).toMatchObject({ type: 3, description: "shared cover" });
     expect(plan.pendingFiles[0]).toMatchObject({
       filename: "a custom filename.mp3",
-      sourceManifestSlug: "AbcdEFGHijklmno_123-45",
+      sourceManifestSlug: "k7m4q2",
       metadata: {
         title: "One",
         artist: "Track artist",

--- a/tests/unit/features/share/sharedAlbumPage.test.tsx
+++ b/tests/unit/features/share/sharedAlbumPage.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@/components/ui/dialog", () => {
   };
 });
 
-const slug = "AbcdEFGHijklmno_123-45";
+const slug = "k7m4q2";
 const props = {
   state: {
     status: "ready" as const,

--- a/tests/unit/features/share/useShareWorkflow.test.tsx
+++ b/tests/unit/features/share/useShareWorkflow.test.tsx
@@ -50,7 +50,7 @@ import {
   projectTrackShareSnapshot,
 } from "@/features/share/sharePublication";
 
-const slug = "AbcdEFGHijklmno_123-45";
+const slug = "k7m4q2";
 const sharedManifest = {
   version: 1 as const,
   kind: "album" as const,


### PR DESCRIPTION
## human review

- create both an album share and a track share; expect each generated URL to end in exactly six lowercase characters, for example `/share/k7m4q2`.
- open the new links and exercise add, update, and stop sharing; expect the full sharing lifecycle to continue working.
- try an existing 22-character URL plus uppercase, punctuation, and ambiguous-character variants; expect them to be unavailable rather than accepted through a compatibility path.
- reviewer decision: codes use the 30-character alphabet `23456789abcdefghjkmnpqrstvwxyz`, providing 729 million combinations. Database uniqueness and three generation attempts remain the collision safeguard.
- reviewer decision: this intentionally breaks the single existing production album link to keep the contract and implementation clean; recreate that share after deployment if it is still needed.
- automated verification: 741 tests, typecheck, lint, production build, and focused legacy-format rejection tests passed. Manually verify the visible copied URL on a deployed preview.
