### PR TITLE
feat: track share link usage

### DIFF
--- a/server/api/manifests/[slug].get.ts
+++ b/server/api/manifests/[slug].get.ts
@@ -18,7 +18,11 @@ export default defineHandler(async (event) => {
     const result = await store.load(event.context.params?.slug ?? "");
     return result.kind === "available"
       ? Response.json(
-          { manifest: result.manifest, expiresAt: toShareExpiryIso(result.expiresAt) },
+          {
+            manifest: result.manifest,
+            expiresAt: toShareExpiryIso(result.expiresAt),
+            analyticsId: result.analyticsId,
+          },
           { headers: noStore },
         )
       : unavailable();

--- a/server/utils/share-manifest.ts
+++ b/server/utils/share-manifest.ts
@@ -76,7 +76,12 @@ export interface ShareManifestPersistence {
 }
 
 export type ShareManifestUnavailable = { kind: "unavailable" };
-export type ShareManifestLoaded = { kind: "available"; manifest: ShareManifest; expiresAt: number };
+export type ShareManifestLoaded = {
+  kind: "available";
+  manifest: ShareManifest;
+  expiresAt: number;
+  analyticsId: string;
+};
 export type ShareManifestRevokeResult = "revoked" | "unavailable" | "artwork_unavailable";
 export type ShareArtworkUpdate =
   | { kind: "retain" }
@@ -101,6 +106,10 @@ export const hashShareSecret = async (value: string) =>
   base64url(
     new Uint8Array(await crypto.subtle.digest("SHA-256", toArrayBuffer(utf8.encode(value)))),
   );
+
+/** Stable public identifier for analytics that does not expose the short share capability. */
+const shareAnalyticsId = (revocationTokenHash: string) =>
+  hashShareSecret(`tagium-share-analytics:${revocationTokenHash}`);
 
 const randomToken = (bytes = 32) => {
   const value = new Uint8Array(bytes);
@@ -313,6 +322,7 @@ export const createShareManifestStore = (
       const expiresAt = createdAt + SHARE_MANIFEST_LIFETIME_MS;
       const revocationToken = token();
       const revocationTokenHash = await hashShareSecret(revocationToken);
+      const analyticsId = await shareAnalyticsId(revocationTokenHash);
 
       for (let attempt = 0; attempt < 3; attempt++) {
         const slug = slugToken();
@@ -348,7 +358,7 @@ export const createShareManifestStore = (
             if (artworkKey) await persistence.deleteArtwork(artworkKey).catch(() => undefined);
             throw error;
           });
-        if (created === "created") return { slug, expiresAt, revocationToken };
+        if (created === "created") return { slug, expiresAt, revocationToken, analyticsId };
         if (artworkKey) await persistence.deleteArtwork(artworkKey).catch(() => undefined);
       }
       throw new Error("share_slug_collision");
@@ -483,7 +493,12 @@ export const createShareManifestStore = (
       if (!record) return unavailable();
       const manifest = decodeStored(record.payloadJson);
       return manifest
-        ? { kind: "available", manifest, expiresAt: record.expiresAt }
+        ? {
+            kind: "available",
+            manifest,
+            expiresAt: record.expiresAt,
+            analyticsId: await shareAnalyticsId(record.revocationTokenHash),
+          }
         : unavailable();
     },
     loadArtwork: async (slug: string) => {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -154,6 +154,19 @@ export type AnalyticsEvent =
       canceledCount: number;
       outcome: ImportOutcome;
       durationMs: number;
+    }
+  | {
+      type: "share_created" | "share_added";
+      shareId: string;
+      shareKind: "album" | "track";
+      trackCount: number;
+    }
+  | {
+      type: "share_opened";
+      shareId: string;
+      shareKind: "album" | "track";
+      trackCount: number;
+      viewer: "creator" | "recipient";
     };
 
 export interface AnalyticsConfig {
@@ -353,6 +366,15 @@ const CUSTOM_EVENT_PROPERTIES: Record<string, ReadonlySet<string>> = {
     "outcome",
     "duration_ms",
   ]),
+  share_created: new Set([...COMMON_CUSTOM_PROPERTIES, "share_id", "share_kind", "track_count"]),
+  share_opened: new Set([
+    ...COMMON_CUSTOM_PROPERTIES,
+    "share_id",
+    "share_kind",
+    "track_count",
+    "viewer",
+  ]),
+  share_added: new Set([...COMMON_CUSTOM_PROPERTIES, "share_id", "share_kind", "track_count"]),
 };
 const SAFE_SDK_EVENTS = new Set(["$pageview", "$pageleave", "$autocapture"]);
 const SAFE_SDK_PROPERTIES = new Set([
@@ -432,6 +454,8 @@ const isCobaltTunnelElapsedBucket = isOneOf([
   "5_to_15_seconds",
   "15_seconds_or_more",
 ] as const);
+const isShareKind = isOneOf(["album", "track"] as const);
+const isShareViewer = isOneOf(["creator", "recipient"] as const);
 
 const CUSTOM_PROPERTY_VALIDATORS: Record<
   string,
@@ -488,6 +512,22 @@ const CUSTOM_PROPERTY_VALIDATORS: Record<
     canceled_count: isNonNegativeInteger,
     outcome: isImportOutcome,
     duration_ms: isNonNegativeNumber,
+  },
+  share_created: {
+    share_id: isShareAnalyticsId,
+    share_kind: isShareKind,
+    track_count: isPositiveInteger,
+  },
+  share_opened: {
+    share_id: isShareAnalyticsId,
+    share_kind: isShareKind,
+    track_count: isPositiveInteger,
+    viewer: isShareViewer,
+  },
+  share_added: {
+    share_id: isShareAnalyticsId,
+    share_kind: isShareKind,
+    track_count: isPositiveInteger,
   },
 };
 
@@ -744,6 +784,28 @@ const serializeEvent = (event: AnalyticsEvent, config: AnalyticsConfig) => {
           duration_ms: event.durationMs,
         },
       };
+    case "share_created":
+    case "share_added":
+      return {
+        name: event.type,
+        properties: {
+          ...commonProperties,
+          share_id: event.shareId,
+          share_kind: event.shareKind,
+          track_count: event.trackCount,
+        },
+      };
+    case "share_opened":
+      return {
+        name: event.type,
+        properties: {
+          ...commonProperties,
+          share_id: event.shareId,
+          share_kind: event.shareKind,
+          track_count: event.trackCount,
+          viewer: event.viewer,
+        },
+      };
   }
 };
 
@@ -858,3 +920,4 @@ import {
   serializeMetadataLinkAnalytics,
   type MetadataLinkState,
 } from "@/features/library/metadataLinks";
+import { isShareAnalyticsId } from "@/features/share/shareManifest";

--- a/src/features/share/SharedAlbumPage.tsx
+++ b/src/features/share/SharedAlbumPage.tsx
@@ -26,7 +26,13 @@ export type SharedContentPageState =
       slug: string;
       reason: "unavailable" | "newer-version";
     }
-  | { status: "ready"; slug: string; manifest: Manifest; expiresAt: string };
+  | {
+      status: "ready";
+      slug: string;
+      manifest: Manifest;
+      expiresAt: string;
+      analyticsId: string;
+    };
 
 type ReadySharedContentPageState = Extract<SharedContentPageState, { status: "ready" }>;
 

--- a/src/features/share/shareClient.ts
+++ b/src/features/share/shareClient.ts
@@ -1,4 +1,9 @@
-import { decodeManifest, MANIFEST_VERSION, type Manifest } from "@/features/share/shareManifest";
+import {
+  decodeManifest,
+  isShareAnalyticsId,
+  MANIFEST_VERSION,
+  type Manifest,
+} from "@/features/share/shareManifest";
 
 const UNAVAILABLE_MESSAGE = "this share is no longer available";
 const SHARE_METADATA_TOO_LARGE_MESSAGE = "this share contains too much metadata to publish.";
@@ -24,6 +29,10 @@ export interface SharePublicationReceipt {
   revocationToken: string;
 }
 
+export interface CreatedSharePublicationReceipt extends SharePublicationReceipt {
+  analyticsId: string;
+}
+
 export type ShareUpdateReceipt = Omit<SharePublicationReceipt, "revocationToken">;
 
 const apiPath = (slug: string, suffix = "") =>
@@ -40,6 +49,7 @@ const readJson = async (response: Response) => {
 export interface FetchedSharedContent {
   manifest: Manifest;
   expiresAt: string;
+  analyticsId: string;
 }
 
 export const fetchSharedContent = async (
@@ -59,7 +69,9 @@ export const fetchSharedContent = async (
       payload === null ||
       !("manifest" in payload) ||
       !("expiresAt" in payload) ||
-      typeof payload.expiresAt !== "string"
+      typeof payload.expiresAt !== "string" ||
+      !("analyticsId" in payload) ||
+      !isShareAnalyticsId(payload.analyticsId)
     ) {
       throw new SharedContentUnavailableError();
     }
@@ -74,6 +86,7 @@ export const fetchSharedContent = async (
     return {
       manifest: decodeManifest(payload.manifest),
       expiresAt: payload.expiresAt,
+      analyticsId: payload.analyticsId,
     };
   } catch (error) {
     if (error instanceof SharedContentVersionError) throw error;
@@ -106,7 +119,7 @@ export const publishShare = async (
   manifest: Manifest,
   cover: File | null,
   dependencies: { fetch?: typeof globalThis.fetch } = {},
-): Promise<SharePublicationReceipt> => {
+): Promise<CreatedSharePublicationReceipt> => {
   const body = new FormData();
   body.set("manifest", JSON.stringify(manifest));
   if (cover) body.set("cover", cover);
@@ -128,11 +141,12 @@ export const publishShare = async (
     typeof receipt.slug !== "string" ||
     typeof receipt.url !== "string" ||
     typeof receipt.expiresAt !== "string" ||
-    typeof receipt.revocationToken !== "string"
+    typeof receipt.revocationToken !== "string" ||
+    !isShareAnalyticsId(receipt.analyticsId)
   ) {
     throw new Error("the share link could not be created");
   }
-  return receipt as SharePublicationReceipt;
+  return receipt as CreatedSharePublicationReceipt;
 };
 
 export const updateShare = async (

--- a/src/features/share/shareManifest.ts
+++ b/src/features/share/shareManifest.ts
@@ -112,17 +112,23 @@ export const manifestTracks = (manifest: Manifest): readonly ManifestTrack[] =>
 
 export const manifestTrackCount = (manifest: Manifest) => manifestTracks(manifest).length;
 
+export const SHARE_ANALYTICS_ID_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+export const isShareAnalyticsId = (value: unknown): value is string =>
+  typeof value === "string" && SHARE_ANALYTICS_ID_PATTERN.test(value);
+
 /** HTTP responses intentionally serialize dates; milliseconds are storage-only. */
 export interface SharePublicationResponse {
   slug: string;
   url: string;
   expiresAt: string;
   revocationToken: string;
+  analyticsId: string;
 }
 
 export interface ShareManifestResponse {
   manifest: Manifest;
   expiresAt: string;
+  analyticsId: string;
 }
 
 export const toShareExpiryIso = (expiresAt: number) => new Date(expiresAt).toISOString();

--- a/src/features/share/useShareWorkflow.ts
+++ b/src/features/share/useShareWorkflow.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { analytics } from "@/analytics";
 import { coverArtFileToPicture } from "@/features/editor/coverArtProcessing";
 import type { TrackEditorSession } from "@/features/editor/useTrackEditorSession";
 import type { AlbumGroup, SharePublication } from "@/features/library/types";
@@ -104,6 +105,7 @@ export const useShareWorkflow = ({
   const [anotherTabOpen, setAnotherTabOpen] = useState(false);
   const [, setExpiryTick] = useState(0);
   const loadingSlugRef = useRef<string | null>(null);
+  const pageLoadIdRef = useRef(0);
   const importingSlugRef = useRef<string | null>(null);
   const publicationReceiptsRef = useRef(
     new Map<string, { slug: string; expiresAt: string; token: string }>(),
@@ -265,25 +267,36 @@ export const useShareWorkflow = ({
     }),
   );
 
-  const loadSlug = useCallback(async (slug: string) => {
-    loadingSlugRef.current = slug;
-    setPage({ status: "loading", slug });
-    try {
-      const fetched = await fetchSharedContent(slug);
-      if (loadingSlugRef.current !== slug) return fetched;
-      setPage({ status: "ready", slug, ...fetched });
-      void detectAnotherTagiumTab().then(setAnotherTabOpen);
-      return fetched;
-    } catch (error) {
-      if (loadingSlugRef.current !== slug) throw error;
-      setPage({
-        status: "unavailable",
-        slug,
-        reason: error instanceof SharedContentVersionError ? "newer-version" : "unavailable",
-      });
-      throw error;
-    }
-  }, []);
+  const loadSlug = useCallback(
+    async (slug: string) => {
+      const loadId = ++pageLoadIdRef.current;
+      loadingSlugRef.current = slug;
+      setPage({ status: "loading", slug });
+      try {
+        const fetched = await fetchSharedContent(slug);
+        if (loadingSlugRef.current !== slug || pageLoadIdRef.current !== loadId) return fetched;
+        setPage({ status: "ready", slug, ...fetched });
+        analytics.capture({
+          type: "share_opened",
+          shareId: fetched.analyticsId,
+          shareKind: fetched.manifest.kind,
+          trackCount: manifestTrackCount(fetched.manifest),
+          viewer: getPublicationCapability(slug) ? "creator" : "recipient",
+        });
+        void detectAnotherTagiumTab().then(setAnotherTabOpen);
+        return fetched;
+      } catch (error) {
+        if (loadingSlugRef.current !== slug || pageLoadIdRef.current !== loadId) throw error;
+        setPage({
+          status: "unavailable",
+          slug,
+          reason: error instanceof SharedContentVersionError ? "newer-version" : "unavailable",
+        });
+        throw error;
+      }
+    },
+    [getPublicationCapability],
+  );
 
   useEffect(() => listenForTagiumPresence(), []);
 
@@ -347,6 +360,12 @@ export const useShareWorkflow = ({
             : entry,
         );
         await importing.commands.importSharedContent(fresh.manifest, slug, picture);
+        analytics.capture({
+          type: "share_added",
+          shareId: fresh.analyticsId,
+          shareKind: fresh.manifest.kind,
+          trackCount: manifestTrackCount(fresh.manifest),
+        });
         toast.success(`${fresh.manifest.kind} added to your library`, {
           description: sharedContentAddedDescription(fresh.manifest),
         });
@@ -533,6 +552,7 @@ export const useShareWorkflow = ({
       attemptedIntent = updating ? "update" : "create";
 
       let receipt;
+      let createdAnalyticsId: string | undefined;
       if (updating) {
         if (!existingPublication || !isActiveSharePublication(existingPublication)) {
           throw new Error(`the shared ${target.kind} can no longer be updated`);
@@ -553,6 +573,7 @@ export const useShareWorkflow = ({
         };
       } else {
         receipt = await publishShare(shareSnapshot.manifest, shareSnapshot.cover);
+        createdAnalyticsId = receipt.analyticsId;
         const capability = {
           slug: receipt.slug,
           expiresAt: receipt.expiresAt,
@@ -593,6 +614,14 @@ export const useShareWorkflow = ({
         status: "active",
       });
       setDialog({ status: "published", preview: currentDialog.preview, receipt });
+      if (createdAnalyticsId) {
+        analytics.capture({
+          type: "share_created",
+          shareId: createdAnalyticsId,
+          shareKind: shareSnapshot.manifest.kind,
+          trackCount: manifestTrackCount(shareSnapshot.manifest),
+        });
+      }
     } catch (error) {
       const createError = sharePublicationErrorMessage(error, target.kind).replace(/[.!?]+$/, "");
       setDialog({
@@ -687,6 +716,12 @@ export const useShareWorkflow = ({
             : entry,
         );
         await importing.commands.importSharedContent(fresh.manifest, page.slug, picture);
+        analytics.capture({
+          type: "share_added",
+          shareId: fresh.analyticsId,
+          shareKind: fresh.manifest.kind,
+          trackCount: manifestTrackCount(fresh.manifest),
+        });
         history.replaceState({}, "", "/");
         setPage(null);
         toast.success(`${fresh.manifest.kind} added to your library`, {

--- a/tests/server/manifests.test.ts
+++ b/tests/server/manifests.test.ts
@@ -194,8 +194,11 @@ describe("share manifest endpoints", () => {
       slug: string;
       revocationToken: string;
       expiresAt: string;
+      analyticsId: string;
     };
     expect(isShareExpiryIso(receipt.expiresAt)).toBe(true);
+    expect(receipt.analyticsId).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(receipt.analyticsId).not.toBe(receipt.slug);
 
     const loaded = await manifestHandler(
       event(
@@ -205,8 +208,9 @@ describe("share manifest endpoints", () => {
     );
     expect(loaded.status).toBe(200);
     expect(loaded.headers.get("cache-control")).toBe("no-store");
-    const payload = (await loaded.clone().json()) as { expiresAt: string };
+    const payload = (await loaded.clone().json()) as { expiresAt: string; analyticsId: string };
     expect(isShareExpiryIso(payload.expiresAt)).toBe(true);
+    expect(payload.analyticsId).toBe(receipt.analyticsId);
     await expect(loaded.json()).resolves.toMatchObject({ manifest });
 
     const cover = await artworkHandler(

--- a/tests/server/utils/share-manifest.test.ts
+++ b/tests/server/utils/share-manifest.test.ts
@@ -121,9 +121,12 @@ describe("share manifest store", () => {
     const published = await store.publish(manifest, undefined);
 
     expect(published.expiresAt).toBe(1_000 + SHARE_MANIFEST_LIFETIME_MS);
+    expect(published.analyticsId).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(published.analyticsId).not.toBe(published.slug);
     expect(await store.load(published.slug)).toMatchObject({
       kind: "available",
       expiresAt: published.expiresAt,
+      analyticsId: published.analyticsId,
     });
     now = published.expiresAt;
     expect(await store.load(published.slug)).toEqual({ kind: "unavailable" });

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -123,6 +123,63 @@ describe("analytics", () => {
     expect(JSON.stringify(capture.mock.calls)).not.toContain("internal.example");
   });
 
+  it("serializes privacy-safe share lifecycle events", async () => {
+    const capture = vi.fn();
+    const analytics = createAnalytics(
+      { key: "public-test-key", deployEnv: "production" },
+      {
+        loadClient: async () => ({ init: vi.fn(), capture }),
+        schedule: (load) => load(),
+      },
+    );
+    analytics.initialize();
+    await Promise.resolve();
+    await Promise.resolve();
+    const shareId = "a".repeat(43);
+
+    analytics.capture({
+      type: "share_created",
+      shareId,
+      shareKind: "album",
+      trackCount: 4,
+    });
+    analytics.capture({
+      type: "share_opened",
+      shareId,
+      shareKind: "album",
+      trackCount: 4,
+      viewer: "recipient",
+    });
+    analytics.capture({
+      type: "share_added",
+      shareId,
+      shareKind: "album",
+      trackCount: 4,
+    });
+
+    expect(capture.mock.calls).toEqual([
+      [
+        "share_created",
+        expect.objectContaining({ share_id: shareId, share_kind: "album", track_count: 4 }),
+      ],
+      [
+        "share_opened",
+        expect.objectContaining({
+          share_id: shareId,
+          share_kind: "album",
+          track_count: 4,
+          viewer: "recipient",
+        }),
+      ],
+      [
+        "share_added",
+        expect.objectContaining({ share_id: shareId, share_kind: "album", track_count: 4 }),
+      ],
+    ]);
+    expect(JSON.stringify(capture.mock.calls)).not.toContain("k7m4q2");
+    expect(JSON.stringify(capture.mock.calls)).not.toContain("/share/");
+  });
+
   it("serializes URL shape and tunnel readiness as privacy-safe categories", async () => {
     const init = vi.fn();
     const capture = vi.fn();
@@ -432,6 +489,35 @@ describe("analytics", () => {
     ).toEqual({
       event: "import_failure_category",
       properties: { provider: "soundcloud", import_kind: "set", track_count: 1 },
+    });
+    expect(
+      options.before_send({
+        event: "share_opened",
+        properties: {
+          share_id: "a".repeat(43),
+          share_kind: "album",
+          track_count: 4,
+          viewer: "recipient",
+          share_slug: "k7m4q2",
+        },
+      }),
+    ).toEqual({
+      event: "share_opened",
+      properties: {
+        share_id: "a".repeat(43),
+        share_kind: "album",
+        track_count: 4,
+        viewer: "recipient",
+      },
+    });
+    expect(
+      options.before_send({
+        event: "share_opened",
+        properties: { share_id: "k7m4q2", share_kind: "album", track_count: 4 },
+      }),
+    ).toEqual({
+      event: "share_opened",
+      properties: { share_kind: "album", track_count: 4 },
     });
     expect(
       options.before_send({

--- a/tests/unit/features/share/shareClient.test.ts
+++ b/tests/unit/features/share/shareClient.test.ts
@@ -26,13 +26,17 @@ const manifest = {
     },
   ],
 };
+const analyticsId = "a".repeat(43);
 
 describe("shared content client", () => {
   it("decodes the public response envelope without requesting audio", async () => {
-    const fetch = vi.fn(async () => Response.json({ manifest, expiresAt: "2026-10-20T12:00:00Z" }));
+    const fetch = vi.fn(async () =>
+      Response.json({ manifest, expiresAt: "2026-10-20T12:00:00Z", analyticsId }),
+    );
     await expect(fetchSharedContent("k7m4q2", { fetch })).resolves.toEqual({
       manifest,
       expiresAt: "2026-10-20T12:00:00Z",
+      analyticsId,
     });
     expect(fetch).toHaveBeenCalledWith(
       "/api/manifests/k7m4q2",
@@ -43,13 +47,27 @@ describe("shared content client", () => {
 
   it("distinguishes a future contract from a generic unavailable response", async () => {
     const futureFetch = vi.fn(async () =>
-      Response.json({ manifest: { ...manifest, version: 2 }, expiresAt: "2026-10-20T12:00:00Z" }),
+      Response.json({
+        manifest: { ...manifest, version: 2 },
+        expiresAt: "2026-10-20T12:00:00Z",
+        analyticsId,
+      }),
     );
     await expect(fetchSharedContent("k7m4q2", { fetch: futureFetch })).rejects.toBeInstanceOf(
       SharedContentVersionError,
     );
     const missingFetch = vi.fn(async () => new Response(null, { status: 404 }));
     await expect(fetchSharedContent("k7m4q2", { fetch: missingFetch })).rejects.toBeInstanceOf(
+      SharedContentUnavailableError,
+    );
+  });
+
+  it("rejects a response without a privacy-safe analytics identifier", async () => {
+    const fetch = vi.fn(async () =>
+      Response.json({ manifest, expiresAt: "2026-10-20T12:00:00Z", analyticsId: "k7m4q2" }),
+    );
+
+    await expect(fetchSharedContent("k7m4q2", { fetch })).rejects.toBeInstanceOf(
       SharedContentUnavailableError,
     );
   });

--- a/tests/unit/features/share/sharedAlbumPage.test.tsx
+++ b/tests/unit/features/share/sharedAlbumPage.test.tsx
@@ -35,6 +35,7 @@ const props = {
     status: "ready" as const,
     slug,
     expiresAt: "2026-10-20T12:00:00.000Z",
+    analyticsId: "a".repeat(43),
     manifest: {
       version: 1 as const,
       kind: "album" as const,

--- a/tests/unit/features/share/useShareWorkflow.test.tsx
+++ b/tests/unit/features/share/useShareWorkflow.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   removeRevocationReceipt: vi.fn(),
   importSharedContent: vi.fn(),
   coverArtFileToPicture: vi.fn(),
+  capture: vi.fn(),
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
 }));
@@ -21,6 +22,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("sonner", () => ({
   toast: { success: mocks.toastSuccess, error: mocks.toastError },
 }));
+vi.mock("@/analytics", () => ({ analytics: { capture: mocks.capture } }));
 vi.mock("@/features/editor/coverArtProcessing", () => ({
   coverArtFileToPicture: mocks.coverArtFileToPicture,
 }));
@@ -51,6 +53,7 @@ import {
 } from "@/features/share/sharePublication";
 
 const slug = "k7m4q2";
+const analyticsId = "a".repeat(43);
 const sharedManifest = {
   version: 1 as const,
   kind: "album" as const,
@@ -225,19 +228,29 @@ describe("share workflow pasted links", () => {
   it("imports a pasted link in place without changing browser history, and ignores a concurrent submit", async () => {
     const { hook } = workflow();
     let resolveFetch:
-      | ((value: { manifest: typeof sharedManifest; expiresAt: string }) => void)
+      | ((value: {
+          manifest: typeof sharedManifest;
+          expiresAt: string;
+          analyticsId: string;
+        }) => void)
       | undefined;
-    const pending = new Promise<{ manifest: typeof sharedManifest; expiresAt: string }>(
-      (resolve) => {
-        resolveFetch = resolve;
-      },
-    );
+    const pending = new Promise<{
+      manifest: typeof sharedManifest;
+      expiresAt: string;
+      analyticsId: string;
+    }>((resolve) => {
+      resolveFetch = resolve;
+    });
     mocks.fetchSharedContent.mockReturnValue(pending);
     const before = location.pathname;
 
     const first = hook.result.importFromInput(slug);
     const second = hook.result.importFromInput(slug);
-    resolveFetch?.({ manifest: sharedManifest, expiresAt: "2026-10-20T12:00:00.000Z" });
+    resolveFetch?.({
+      manifest: sharedManifest,
+      expiresAt: "2026-10-20T12:00:00.000Z",
+      analyticsId,
+    });
     await act(async () => {
       await Promise.all([first, second]);
     });
@@ -249,6 +262,12 @@ describe("share workflow pasted links", () => {
       description: "downloading 1 track — watch progress in the sidebar.",
     });
     expect(mocks.toastSuccess).not.toHaveBeenCalledWith(expect.stringContaining("at a time"));
+    expect(mocks.capture).toHaveBeenCalledWith({
+      type: "share_added",
+      shareId: analyticsId,
+      shareKind: "album",
+      trackCount: 1,
+    });
     hook.unmount();
   });
 
@@ -257,11 +276,20 @@ describe("share workflow pasted links", () => {
     mocks.fetchSharedContent.mockResolvedValue({
       manifest: sharedManifest,
       expiresAt: "2026-10-20T12:00:00.000Z",
+      analyticsId,
     });
     const { hook } = workflow();
 
     await vi.waitFor(() => expect(hook.result.page).toMatchObject({ status: "ready", slug }));
     expect(mocks.importSharedContent).not.toHaveBeenCalled();
+    expect(mocks.capture).toHaveBeenCalledOnce();
+    expect(mocks.capture).toHaveBeenCalledWith({
+      type: "share_opened",
+      shareId: analyticsId,
+      shareKind: "album",
+      trackCount: 1,
+      viewer: "recipient",
+    });
     hook.unmount();
   });
 
@@ -270,6 +298,7 @@ describe("share workflow pasted links", () => {
     mocks.fetchSharedContent.mockResolvedValue({
       manifest: sharedManifest,
       expiresAt: "2026-10-20T12:00:00.000Z",
+      analyticsId,
     });
     const { hook } = workflow();
 
@@ -278,6 +307,12 @@ describe("share workflow pasted links", () => {
 
     expect(mocks.toastSuccess).toHaveBeenCalledWith("album added to your library", {
       description: "downloading 1 track — watch progress in the sidebar.",
+    });
+    expect(mocks.capture).toHaveBeenNthCalledWith(2, {
+      type: "share_added",
+      shareId: analyticsId,
+      shareKind: "album",
+      trackCount: 1,
     });
     hook.unmount();
   });
@@ -309,10 +344,12 @@ describe("share workflow pasted links", () => {
       .mockResolvedValueOnce({
         manifest: sharedManifest,
         expiresAt: "2026-10-20T12:00:00.000Z",
+        analyticsId,
       })
       .mockResolvedValueOnce({
         manifest: freshManifest,
         expiresAt: "2026-10-20T12:00:00.000Z",
+        analyticsId,
       });
     mocks.fetchSharedArtwork.mockResolvedValue(artworkFile);
     mocks.coverArtFileToPicture.mockResolvedValue(convertedPicture);
@@ -380,6 +417,7 @@ describe("share workflow publication lifecycle", () => {
       url: "https://tagium.app/share/new-share",
       expiresAt: "2031-01-01T00:00:00.000Z",
       revocationToken: "new-token",
+      analyticsId,
     });
 
     await act(async () => hook.result.openCreator({ kind: "album", id: album.id }));
@@ -391,6 +429,12 @@ describe("share workflow publication lifecycle", () => {
     expect(album.sharePublication).toMatchObject({
       slug: "new-share",
       status: "active",
+    });
+    expect(mocks.capture).toHaveBeenCalledWith({
+      type: "share_created",
+      shareId: analyticsId,
+      shareKind: "album",
+      trackCount: 1,
     });
     hook.unmount();
   });
@@ -437,6 +481,7 @@ describe("share workflow publication lifecycle", () => {
         message: "the share link could not be created.",
       }),
     );
+    expect(mocks.capture).not.toHaveBeenCalled();
     hook.unmount();
   });
 
@@ -468,6 +513,7 @@ describe("share workflow publication lifecycle", () => {
       url: "https://tagium.app/share/track-share",
       expiresAt: "2031-01-01T00:00:00.000Z",
       revocationToken: "track-token",
+      analyticsId,
     });
 
     expect(hook.result.shareTrackActions[file.id]).toMatchObject({


### PR DESCRIPTION
## human review

- create an album share and a track share in a production-keyed deployment, then open each link in a separate browser profile and add it; expect sharing behavior to remain unchanged while PostHog receives `share_created`, `share_opened`, and `share_added`.
- in PostHog, break down those events by `share_id`; expect the same opaque 43-character id across one link's lifecycle, plus `share_kind`, `track_count`, and `viewer` on opens. Expect no raw six-character share code, URL, title, artist, or manifest content.
- open a created link in the creator browser and another profile; expect opens to be labeled `creator` and `recipient`. Refresh or click add; expect one opened event for the navigation and one added event only after the library add succeeds, not one event per manifest fetch.
- force unavailable or invalid manifest and failed publication/import paths; expect no created/opened/added success event and no change to existing share error behavior.
- reviewer decision: analytics remain PostHog-only; D1 stores no counters or event rows. A server-derived id based on the existing high-entropy revocation hash correlates events without exposing the short share capability and requires no migration.
- automated verification: `vp check`, all 743 tests, and the production build passed. React Doctor completed with only two pre-existing unrelated warnings. Manual verification still requires a production-keyed PostHog deployment because analytics are disabled outside production.
- authored by gpt-5.6-sol through the Codex harness.