### PR TITLE
docs: relax pull request guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Every PR must include brief, plain-language instructions for human review that p
 - Business-logic decisions, assumptions, or tradeoffs that need reviewer consideration.
 - What was verified automatically and anything that still requires manual verification.
 
-Keep this guidance focused on observable behavior and decisions rather than an exhaustive summary of the implementation. Do not include anything else in PRs.
+Keep this guidance focused on observable behavior and decisions rather than an exhaustive summary of the implementation.
 
 ## References
 


### PR DESCRIPTION
The project-level guidance currently says PRs may contain only human-review information, which conflicts with broader PR conventions. This removes that restriction while preserving the required human-review fast path.

## Human review

- Open `AGENTS.md` and read the **Pull Requests** section; no setup or test data is required.
- Confirm the four review requirements remain unchanged and the final sentence no longer prohibits other useful PR content.
- Check that no unrelated guidance changed.
- Decision to review: this intentionally relaxes only the exclusivity rule; human-review instructions remain mandatory.
- Automatically verified with `git diff --check`; only wording review remains manual.

Made by GPT-5.6 Sol through the Codex harness.