### PR TITLE
fix: preserve late cover art during edits

### DIFF
--- a/src/features/editor/useTrackEditorSession.ts
+++ b/src/features/editor/useTrackEditorSession.ts
@@ -151,6 +151,7 @@ export const useTrackEditorSession = ({
   const lastResetFileIdRef = useRef<string | null>(null);
   const lastResetMetadataRef = useRef<AudioMetadata | null>(null);
   const formDirtyRef = useRef(false);
+  const latestMetadataWritesRef = useRef(new Map<string, symbol>());
   const [isCoverProcessing, setCoverProcessing] = useState(false);
   const {
     register,
@@ -327,6 +328,13 @@ export const useTrackEditorSession = ({
 
   const updateTags = useCallback(
     async (fileToUpdate: TagiumFile, newTags: AudioMetadata) => {
+      const writeToken = Symbol(fileToUpdate.id);
+      latestMetadataWritesRef.current.set(fileToUpdate.id, writeToken);
+      const isLatestWrite = () =>
+        latestMetadataWritesRef.current.get(fileToUpdate.id) === writeToken;
+      const finishWrite = () => {
+        if (isLatestWrite()) latestMetadataWritesRef.current.delete(fileToUpdate.id);
+      };
       const snapshot = library.getSnapshot();
       const latestFileToUpdate =
         snapshot.files.find((file) => file.id === fileToUpdate.id) ?? fileToUpdate;
@@ -363,6 +371,7 @@ export const useTrackEditorSession = ({
         );
         library.dispatch({ type: "content-replaced", files: nextFiles });
         if (library.getSnapshot().selectedFileId === fileToUpdate.id) reset(metadata);
+        finishWrite();
         return;
       }
 
@@ -397,6 +406,7 @@ export const useTrackEditorSession = ({
 
       try {
         const updatedFile = await runAudioBackendEffect(writeTags(latestFileToUpdate, metadata));
+        if (!isLatestWrite()) return;
         const { latestFile, latestMetadata, latestPendingPatch, latestSnapshot } =
           getLatestUpdateState();
         const remainingPatch = getMetadataPatchDifference(metadata, latestPendingPatch);
@@ -441,6 +451,7 @@ export const useTrackEditorSession = ({
         library.dispatch({ type: "content-replaced", files: nextFiles });
         if (library.getSnapshot().selectedFileId === fileToUpdate.id) reset(metadata);
       } catch (error) {
+        if (!isLatestWrite()) throw error;
         const message = getSystemFailurePresentation(error, "metadata").trackDescription;
         const { latestFile, latestMetadata, latestPendingPatch, latestSnapshot } =
           getLatestUpdateState();
@@ -469,6 +480,8 @@ export const useTrackEditorSession = ({
         );
         library.dispatch({ type: "content-replaced", files: nextFiles });
         throw error;
+      } finally {
+        finishWrite();
       }
     },
     [createCurrentMetadataPatch, getSubmittedMetadata, getValues, library, reset],

--- a/src/features/editor/useTrackEditorSession.ts
+++ b/src/features/editor/useTrackEditorSession.ts
@@ -25,6 +25,7 @@ import type {
   TagiumFile,
 } from "@/features/library/types";
 import { audioFilename, getAudioFormat } from "@/features/audio/audioFormat";
+import { EDITABLE_METADATA_FIELDS } from "@/features/audio/metadataFields";
 
 type PreviewField = "filename" | "title" | "artist";
 
@@ -77,6 +78,17 @@ const applyMetadataPatch = (metadata: AudioMetadata, patch: MetadataPatch): Audi
   ...(hasOwn(patch, "bpm") ? { bpm: getNullableNumericMetadataValue(patch.bpm) } : {}),
   ...(hasOwn(patch, "comment") ? { comment: patch.comment } : {}),
 });
+
+const getMetadataPatchDifference = (metadata: AudioMetadata, patch?: MetadataPatch) => {
+  if (!patch) return undefined;
+  const difference = { ...patch };
+  for (const field of EDITABLE_METADATA_FIELDS) {
+    if (hasOwn(difference, field) && Object.is(metadata[field], difference[field])) {
+      delete difference[field];
+    }
+  }
+  return sanitizePendingMetadataPatch(difference);
+};
 
 const getFilenameFromPatch = (file: TagiumFile, patch: MetadataPatch) =>
   hasOwn(patch, "filename") && patch.filename
@@ -137,6 +149,7 @@ export const useTrackEditorSession = ({
   const settingsRef = useRef(settings);
   const selectedFileIdRef = useRef<string | null>(library.state.selectedFileId);
   const lastResetFileIdRef = useRef<string | null>(null);
+  const lastResetMetadataRef = useRef<AudioMetadata | null>(null);
   const formDirtyRef = useRef(false);
   const [isCoverProcessing, setCoverProcessing] = useState(false);
   const {
@@ -172,11 +185,15 @@ export const useTrackEditorSession = ({
     let nextFormIsDirty = formIsDirty;
     if (selectedFile?.metadata) {
       const selectedFileChanged = lastResetFileIdRef.current !== selectedFile.id;
+      const selectedMetadataChanged = lastResetMetadataRef.current !== selectedFile.metadata;
       if (selectedFileChanged || !formIsDirty) {
         lastResetFileIdRef.current = selectedFile.id;
         reset(selectedFile.metadata);
         nextFormIsDirty = false;
+      } else if (selectedMetadataChanged) {
+        reset(selectedFile.metadata, { keepDirtyValues: true });
       }
+      lastResetMetadataRef.current = selectedFile.metadata;
     }
     selectedFileIdRef.current = library.state.selectedFileId;
     formDirtyRef.current = nextFormIsDirty;
@@ -349,9 +366,65 @@ export const useTrackEditorSession = ({
         return;
       }
 
+      const getLatestUpdateState = () => {
+        const latestSnapshot = library.getSnapshot();
+        const latestFile = latestSnapshot.files.find((file) => file.id === fileToUpdate.id);
+        const latestFormValues =
+          latestFile && selectedFileIdRef.current === fileToUpdate.id && formDirtyRef.current
+            ? getValues()
+            : undefined;
+        const latestFormMetadata =
+          latestFile?.metadata && latestFormValues
+            ? getProjectableAudioMetadata(
+                getSubmittedMetadata(latestFormValues),
+                latestFile.metadata,
+                latestFormValues,
+              )
+            : undefined;
+        const latestFormPatch = latestFormMetadata
+          ? createCurrentMetadataPatch(latestFormMetadata, dirtyFieldsRef.current)
+          : undefined;
+        const latestPendingPatch = sanitizePendingMetadataPatch({
+          ...latestFile?.pendingMetadataPatch,
+          ...latestFormPatch,
+        });
+        const latestMetadata = latestFile?.metadata
+          ? applyMetadataPatch(latestFile.metadata, latestPendingPatch ?? {})
+          : undefined;
+
+        return { latestFile, latestMetadata, latestPendingPatch, latestSnapshot };
+      };
+
       try {
         const updatedFile = await runAudioBackendEffect(writeTags(latestFileToUpdate, metadata));
-        const nextFiles = library.getSnapshot().files.map((file) =>
+        const { latestFile, latestMetadata, latestPendingPatch, latestSnapshot } =
+          getLatestUpdateState();
+        const remainingPatch = getMetadataPatchDifference(metadata, latestPendingPatch);
+
+        if (latestFile && latestMetadata && remainingPatch) {
+          const nextFile = withPendingMetadataPatch(
+            {
+              ...latestFile,
+              file: updatedFile,
+              originalFile: updatedFile,
+              filename: getFilenameFromPatch(latestFile, remainingPatch),
+              metadata: latestMetadata,
+              status: "pending",
+              downloadStatus: "ready",
+              downloadError: undefined,
+            },
+            remainingPatch,
+          );
+          library.dispatch({
+            type: "content-replaced",
+            files: latestSnapshot.files.map((file) =>
+              file.id === fileToUpdate.id ? nextFile : file,
+            ),
+          });
+          return;
+        }
+
+        const nextFiles = latestSnapshot.files.map((file) =>
           file.id === fileToUpdate.id
             ? clearPendingMetadataPatch({
                 ...file,
@@ -369,24 +442,28 @@ export const useTrackEditorSession = ({
         if (library.getSnapshot().selectedFileId === fileToUpdate.id) reset(metadata);
       } catch (error) {
         const message = getSystemFailurePresentation(error, "metadata").trackDescription;
-        const nextFiles = library.getSnapshot().files.map((file) =>
-          file.id === fileToUpdate.id
+        const { latestFile, latestMetadata, latestPendingPatch, latestSnapshot } =
+          getLatestUpdateState();
+        const failedPendingPatch = sanitizePendingMetadataPatch({
+          ...createSubmittedMetadataPatch(metadata),
+          ...latestPendingPatch,
+        });
+        const nextFiles = latestSnapshot.files.map((file) =>
+          file.id === fileToUpdate.id && latestFile
             ? withPendingMetadataPatch(
                 {
-                  ...file,
+                  ...latestFile,
                   status: "error" as const,
                   metadata: {
-                    ...metadata,
-                    duration: file.metadata?.duration || 0,
-                    bitrate: file.metadata?.bitrate || 0,
-                    sampleRate: file.metadata?.sampleRate || 0,
+                    ...(latestMetadata ?? metadata),
+                    duration: latestFile.metadata?.duration || 0,
+                    bitrate: latestFile.metadata?.bitrate || 0,
+                    sampleRate: latestFile.metadata?.sampleRate || 0,
                   },
-                  filename: metadata.filename
-                    ? audioFilename(metadata.filename, getAudioFormat(file))
-                    : file.filename,
+                  filename: getFilenameFromPatch(latestFile, failedPendingPatch ?? {}),
                   downloadError: message,
                 },
-                createSubmittedMetadataPatch(metadata),
+                failedPendingPatch,
               )
             : file,
         );
@@ -394,7 +471,7 @@ export const useTrackEditorSession = ({
         throw error;
       }
     },
-    [getSubmittedMetadata, library, reset],
+    [createCurrentMetadataPatch, getSubmittedMetadata, getValues, library, reset],
   );
 
   const hydrateDownloadedTrack = useCallback(

--- a/src/features/import/audioUrlImportSession.ts
+++ b/src/features/import/audioUrlImportSession.ts
@@ -125,7 +125,6 @@ export interface AudioUrlImportSession {
 export const createAudioUrlImportSession = ({
   library,
   getEditor,
-  resetEditorForm,
   getSettings,
   activateEditor,
   setUrlImporting,
@@ -133,7 +132,6 @@ export const createAudioUrlImportSession = ({
 }: {
   library: LibraryStore;
   getEditor: () => UrlImportEditor;
-  resetEditorForm: (metadata: Parameters<TrackEditorSession["form"]["reset"]>[0]) => void;
   getSettings: () => AppSettings;
   activateEditor: () => void;
   setUrlImporting: (importing: boolean) => void;
@@ -332,6 +330,7 @@ export const createAudioUrlImportSession = ({
       void (async () => {
         try {
           const cover = await fetchImportedCover(coverImport.coverUrl);
+          getEditor().flush(coverImport.trackIds);
           const current = library.getSnapshot();
           const covered = applyPlaylistImportedCover(
             current.files,
@@ -349,9 +348,6 @@ export const createAudioUrlImportSession = ({
             files: covered.files,
           });
           if (covered.files === current.files) return;
-          if (covered.selectedMetadata) {
-            resetEditorForm(covered.selectedMetadata);
-          }
           const trackIdSet = new Set(coverImport.trackIds);
           await Promise.all(
             covered.files.flatMap((file) => {

--- a/src/features/workspace/useAudioImportSession.ts
+++ b/src/features/workspace/useAudioImportSession.ts
@@ -11,7 +11,6 @@ import type { Manifest } from "@/features/share/shareManifest";
 
 type AudioImportEditor = {
   commands: Pick<TrackEditorSession["commands"], "flush" | "hydrateDownloadedTrack" | "updateTags">;
-  form: Pick<TrackEditorSession["form"], "reset">;
 };
 
 export interface AudioImportSession {
@@ -76,7 +75,6 @@ export const useAudioImportSession = ({
     createAudioUrlImportSession({
       library,
       getEditor: () => editorRef.current.commands,
-      resetEditorForm: (metadata) => editorRef.current.form.reset(metadata),
       getSettings: () => settingsRef.current,
       activateEditor: () => activateEditorRef.current(),
       setUrlImporting,

--- a/tests/unit/features/editor/useTrackEditorSession.test.ts
+++ b/tests/unit/features/editor/useTrackEditorSession.test.ts
@@ -153,6 +153,71 @@ describe("track editor session", () => {
     hook.unmount();
   });
 
+  it.each([
+    { field: "title", value: "Edited Title" },
+    { field: "album", value: "Edited Album" },
+  ] as const)("shows downloaded cover art while $field is dirty", async ({ field, value }) => {
+    const hook = renderHook(() => {
+      const library = useLibraryStore();
+      return { library, editor: useTrackEditorSession({ library, settings }) };
+    }, undefined);
+    const pending: TagiumFile = {
+      id: "remote",
+      filename: "remote.mp3",
+      status: "pending",
+      downloadStatus: "downloading",
+      metadata: metadata("Pending"),
+    };
+    act(() => {
+      hook.result.library.dispatch({
+        type: "content-replaced",
+        files: [pending],
+        looseTrackIds: [pending.id],
+        selection: { selectedAlbumId: null, selectedFileId: pending.id },
+      });
+    });
+    const registration = hook.result.editor.form.register(field);
+    act(() => {
+      void registration.onChange({ target: { name: field, value }, type: "change" });
+    });
+
+    const downloadedCover: AudioMetadata["picture"] = [
+      {
+        format: "image/jpeg",
+        type: 3,
+        description: "downloaded cover",
+        data: new Uint8Array([1, 2, 3]),
+      },
+    ];
+    const downloaded = new File(["download"], "downloaded.mp3");
+    const parsedFile: TagiumFile = {
+      ...readyFile("parsed", "Parsed"),
+      file: downloaded,
+      originalFile: downloaded,
+      filename: downloaded.name,
+      metadata: { ...metadata("Parsed"), picture: downloadedCover },
+    };
+    const backend = AudioBackend.of({
+      downloadFromCobalt: () => Effect.fail(new Error("unused")),
+      parseUploads: () =>
+        Effect.succeed([{ file: parsedFile, albumSeed: { title: "", artist: "", genre: "" } }]),
+      writeTags: () => Effect.succeed(new File(["written"], "edited.mp3")),
+    });
+
+    await act(async () => {
+      await Effect.runPromise(
+        hook.result.editor.commands
+          .hydrateDownloadedTrack(pending.id, downloaded)
+          .pipe(Effect.provideService(AudioBackend, backend)),
+      );
+    });
+
+    expect(hook.result.library.getSnapshot().files[0]?.metadata?.picture).toEqual(downloadedCover);
+    expect(hook.result.editor.form.getValues(field)).toBe(value);
+    expect(hook.result.editor.form.getValues("picture")).toEqual(downloadedCover);
+    hook.unmount();
+  });
+
   it.each(["success", "failure"] as const)(
     "merges dirty form values with the existing sparse pending patch through hydration %s",
     async (outcome) => {

--- a/tests/unit/features/editor/useTrackEditorSessionWriteOrdering.test.ts
+++ b/tests/unit/features/editor/useTrackEditorSessionWriteOrdering.test.ts
@@ -1,0 +1,225 @@
+import { act } from "react-test-renderer";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { AppSettings, AudioMetadata, TagiumFile } from "@/features/library/types";
+import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
+
+const mocks = vi.hoisted(() => ({
+  runAudioBackendEffect: vi.fn(),
+  writeTags: vi.fn(),
+}));
+
+vi.mock("@/features/audio/audioBackend", () => ({
+  parseUploads: vi.fn(),
+  runAudioBackendEffect: mocks.runAudioBackendEffect,
+  writeTags: mocks.writeTags,
+}));
+
+import { useTrackEditorSession } from "@/features/editor/useTrackEditorSession";
+import { useLibraryStore } from "@/features/library/useLibraryStore";
+import { renderHook } from "../../support/hookTestHarness";
+
+const settings: AppSettings = {
+  ...DEFAULT_APP_SETTINGS,
+  syncFilenames: false,
+};
+
+const metadata = (title: string): AudioMetadata => ({
+  filename: title.toLowerCase().replaceAll(" ", "-"),
+  title,
+  artist: "artist",
+  albumArtist: "artist",
+  album: "",
+  year: null,
+  genre: "",
+  duration: 120,
+  bitrate: 320,
+  sampleRate: 44_100,
+  picture: [],
+  trackNumber: null,
+  composer: "",
+  comment: "",
+  discNumber: null,
+  bpm: null,
+});
+
+const readyFile = (): TagiumFile => {
+  const file = new File(["initial"], "track.mp3", { type: "audio/mpeg" });
+  return {
+    id: "track",
+    filename: file.name,
+    file,
+    originalFile: file,
+    status: "saved",
+    downloadStatus: "ready",
+    metadata: metadata("initial"),
+  };
+};
+
+const deferred = <Value>() => {
+  let resolve!: (value: Value) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+};
+
+const createHarness = () => {
+  const hook = renderHook(() => {
+    const library = useLibraryStore();
+    return { library, editor: useTrackEditorSession({ library, settings }) };
+  }, undefined);
+  const initialFile = readyFile();
+  act(() => {
+    hook.result.library.dispatch({
+      type: "content-replaced",
+      files: [initialFile],
+      looseTrackIds: [initialFile.id],
+    });
+  });
+  return { hook, initialFile };
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("track editor metadata write ordering", () => {
+  it("ignores an older write that succeeds after a newer write", async () => {
+    const olderBackendWrite = deferred<File>();
+    const newerBackendWrite = deferred<File>();
+    mocks.runAudioBackendEffect
+      .mockReturnValueOnce(olderBackendWrite.promise)
+      .mockReturnValueOnce(newerBackendWrite.promise);
+    const { hook, initialFile } = createHarness();
+
+    let olderUpdate!: Promise<void>;
+    let newerUpdate!: Promise<void>;
+    act(() => {
+      olderUpdate = hook.result.editor.commands.updateTags(initialFile, metadata("older"));
+      newerUpdate = hook.result.editor.commands.updateTags(initialFile, metadata("newer"));
+    });
+    const newerFile = new File(["newer"], "newer.mp3", { type: "audio/mpeg" });
+    await act(async () => {
+      newerBackendWrite.resolve(newerFile);
+      await newerUpdate;
+    });
+
+    const olderFile = new File(["older"], "older.mp3", { type: "audio/mpeg" });
+    await act(async () => {
+      olderBackendWrite.resolve(olderFile);
+      await olderUpdate;
+    });
+
+    expect(hook.result.library.getSnapshot().files[0]).toMatchObject({
+      file: newerFile,
+      originalFile: newerFile,
+      filename: newerFile.name,
+      status: "saved",
+      metadata: { title: "newer" },
+    });
+    hook.unmount();
+  });
+
+  it("ignores an older write that fails after a newer write succeeds", async () => {
+    const olderBackendWrite = deferred<File>();
+    const newerBackendWrite = deferred<File>();
+    mocks.runAudioBackendEffect
+      .mockReturnValueOnce(olderBackendWrite.promise)
+      .mockReturnValueOnce(newerBackendWrite.promise);
+    const { hook, initialFile } = createHarness();
+
+    let olderUpdate!: Promise<void>;
+    let newerUpdate!: Promise<void>;
+    act(() => {
+      olderUpdate = hook.result.editor.commands.updateTags(initialFile, metadata("older"));
+      newerUpdate = hook.result.editor.commands.updateTags(initialFile, metadata("newer"));
+    });
+    const newerFile = new File(["newer"], "newer.mp3", { type: "audio/mpeg" });
+    await act(async () => {
+      newerBackendWrite.resolve(newerFile);
+      await newerUpdate;
+    });
+
+    await act(async () => {
+      olderBackendWrite.reject(new Error("older write failed"));
+      await expect(olderUpdate).rejects.toThrow("older write failed");
+    });
+
+    expect(hook.result.library.getSnapshot().files[0]).toMatchObject({
+      file: newerFile,
+      originalFile: newerFile,
+      filename: newerFile.name,
+      status: "saved",
+      hasBufferedChanges: false,
+      metadata: { title: "newer" },
+    });
+    expect(hook.result.library.getSnapshot().files[0]?.pendingMetadataPatch).toBeUndefined();
+    expect(hook.result.library.getSnapshot().files[0]?.downloadError).toBeUndefined();
+    hook.unmount();
+  });
+
+  it("ignores the older write when it finishes before the newer write", async () => {
+    const olderBackendWrite = deferred<File>();
+    const newerBackendWrite = deferred<File>();
+    mocks.runAudioBackendEffect
+      .mockReturnValueOnce(olderBackendWrite.promise)
+      .mockReturnValueOnce(newerBackendWrite.promise);
+    const { hook, initialFile } = createHarness();
+
+    let olderUpdate!: Promise<void>;
+    let newerUpdate!: Promise<void>;
+    act(() => {
+      olderUpdate = hook.result.editor.commands.updateTags(initialFile, metadata("older"));
+      newerUpdate = hook.result.editor.commands.updateTags(initialFile, metadata("newer"));
+    });
+    await act(async () => {
+      olderBackendWrite.resolve(new File(["older"], "older.mp3", { type: "audio/mpeg" }));
+      await olderUpdate;
+    });
+    expect(hook.result.library.getSnapshot().files[0]).toMatchObject({
+      file: initialFile.file,
+      filename: initialFile.filename,
+      status: "saved",
+      metadata: { title: "initial" },
+    });
+
+    const newerFile = new File(["newer"], "newer.mp3", { type: "audio/mpeg" });
+    await act(async () => {
+      newerBackendWrite.resolve(newerFile);
+      await newerUpdate;
+    });
+
+    expect(hook.result.library.getSnapshot().files[0]).toMatchObject({
+      file: newerFile,
+      filename: newerFile.name,
+      status: "saved",
+      metadata: { title: "newer" },
+    });
+    hook.unmount();
+  });
+
+  it("does not restore a track removed during a write", async () => {
+    const backendWrite = deferred<File>();
+    mocks.runAudioBackendEffect.mockReturnValueOnce(backendWrite.promise);
+    const { hook, initialFile } = createHarness();
+
+    let update!: Promise<void>;
+    act(() => {
+      update = hook.result.editor.commands.updateTags(initialFile, metadata("updated"));
+      hook.result.library.dispatch({
+        type: "content-replaced",
+        files: [],
+        looseTrackIds: [],
+      });
+    });
+    await act(async () => {
+      backendWrite.resolve(new File(["updated"], "updated.mp3", { type: "audio/mpeg" }));
+      await update;
+    });
+
+    expect(hook.result.library.getSnapshot().files).toEqual([]);
+    hook.unmount();
+  });
+});

--- a/tests/unit/features/import/audioUrlImportSession.test.ts
+++ b/tests/unit/features/import/audioUrlImportSession.test.ts
@@ -2,16 +2,19 @@ import { Effect } from "effect";
 import { act } from "react-test-renderer";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { CobaltAudioDownloadRequest } from "@/features/import/cobaltAudio";
-import type { AppSettings } from "@/features/library/types";
+import type { AppSettings, AudioMetadata } from "@/features/library/types";
 import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 import type { Manifest } from "@/features/share/shareManifest";
 
 const mocks = vi.hoisted(() => ({
   capture: vi.fn(),
   downloadFromCobalt: vi.fn((_request: CobaltAudioDownloadRequest) => Effect.never),
+  fetchImportedCover: vi.fn(),
+  runAudioBackendEffect: vi.fn(),
   resolveTrackMetadata: vi.fn(),
   resolveSoundCloudSet: vi.fn(),
   resolveYouTubePlaylist: vi.fn(),
+  writeTags: vi.fn(),
 }));
 
 vi.mock("@/analytics", async (importOriginal) => ({
@@ -22,8 +25,12 @@ vi.mock("@/features/audio/audioBackend", () => ({
   downloadFromCobalt: mocks.downloadFromCobalt,
   provideAudioBackend: (operation: unknown) => operation,
   parseUploads: vi.fn(),
-  runAudioBackendEffect: vi.fn(),
-  writeTags: vi.fn(),
+  runAudioBackendEffect: mocks.runAudioBackendEffect,
+  writeTags: mocks.writeTags,
+}));
+vi.mock("@/features/import/downloadTrack", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/features/import/downloadTrack")>()),
+  fetchImportedCover: mocks.fetchImportedCover,
 }));
 vi.mock("@/features/import/trackMetadata", () => ({
   resolveTrackMetadata: mocks.resolveTrackMetadata,
@@ -335,6 +342,150 @@ describe("audio URL import session", () => {
     expect(hook.result.library.getSnapshot().albums[0]?.sourceUrl).toBe(submittedUrl);
     hook.unmount();
   });
+
+  it.each(["success", "failure"] as const)(
+    "preserves dirty track metadata when a playlist cover write ends in %s",
+    async (outcome) => {
+      let resolveCover: ((cover: AudioMetadata["picture"]) => void) | undefined;
+      mocks.fetchImportedCover.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveCover = resolve;
+          }),
+      );
+      mocks.resolveSoundCloudSet.mockResolvedValue({
+        title: "Imported album",
+        artist: "Artist",
+        genre: "Electronic",
+        isAlbum: true,
+        coverUrl: "https://example.com/cover.jpg",
+        tracks: [
+          {
+            title: "Track",
+            url: "https://soundcloud.com/artist/track",
+            trackNumber: 1,
+          },
+          {
+            title: "Second track",
+            url: "https://soundcloud.com/artist/second-track",
+            trackNumber: 2,
+          },
+        ],
+      });
+      const coverSettings = {
+        ...settings("320"),
+        applySoundCloudAlbumCoverToTracks: true,
+      };
+      const hook = renderHook(() => {
+        const library = useLibraryStore();
+        const editor = useTrackEditorSession({ library, settings: coverSettings });
+        const importing = useAudioImportSession({
+          library,
+          editor,
+          settings: coverSettings,
+          activateEditor: vi.fn(),
+        });
+        return { editor, importing, library };
+      }, undefined);
+
+      await act(async () => {
+        await hook.result.importing.commands.importUrl(
+          "https://soundcloud.com/artist/sets/imported-album",
+        );
+      });
+      const downloaded = new File(["downloaded"], "track.mp3", { type: "audio/mpeg" });
+      act(() => {
+        const snapshot = hook.result.library.getSnapshot();
+        hook.result.library.dispatch({
+          type: "content-replaced",
+          files: snapshot.files.map((file, index) =>
+            index === 0
+              ? {
+                  ...file,
+                  file: downloaded,
+                  originalFile: downloaded,
+                  status: "saved",
+                  downloadStatus: "ready",
+                }
+              : file,
+          ),
+        });
+      });
+      const comment = hook.result.editor.form.register("comment");
+      act(() => {
+        void comment.onChange({
+          target: { name: "comment", value: "keep this edit" },
+          type: "change",
+        });
+      });
+      const cover: AudioMetadata["picture"] = [
+        {
+          format: "image/jpeg",
+          type: 3,
+          description: "playlist cover",
+          data: new Uint8Array([1, 2, 3]),
+        },
+      ];
+      const written = new File(["written"], "track.mp3", { type: "audio/mpeg" });
+      let resolveWrite: ((file: File) => void) | undefined;
+      let rejectWrite: ((error: Error) => void) | undefined;
+      mocks.writeTags.mockReturnValueOnce(undefined);
+      mocks.runAudioBackendEffect.mockImplementationOnce(
+        () =>
+          new Promise((resolve, reject) => {
+            resolveWrite = resolve;
+            rejectWrite = reject;
+          }),
+      );
+
+      await act(async () => {
+        resolveCover?.(cover);
+        await vi.waitFor(() => expect(mocks.writeTags).toHaveBeenCalled());
+      });
+
+      expect(mocks.writeTags).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ comment: "keep this edit", picture: cover }),
+      );
+      act(() => {
+        void comment.onChange({
+          target: { name: "comment", value: "keep the latest edit" },
+          type: "change",
+        });
+        hook.result.editor.commands.flush();
+        const snapshot = hook.result.library.getSnapshot();
+        hook.result.library.dispatch({
+          type: "track-selected",
+          albumId: snapshot.albums[0]?.id ?? null,
+          fileId: snapshot.files[1]?.id ?? null,
+          mode: "replace",
+        });
+      });
+      await act(async () => {
+        if (outcome === "success") {
+          resolveWrite?.(written);
+          await vi.waitFor(() =>
+            expect(hook.result.library.getSnapshot().files[0]?.file).toBe(written),
+          );
+        } else {
+          rejectWrite?.(new Error("write failed"));
+          await vi.waitFor(() =>
+            expect(hook.result.library.getSnapshot().files[0]?.status).toBe("error"),
+          );
+        }
+      });
+
+      expect(hook.result.editor.form.getValues("picture")).toEqual(cover);
+      expect(hook.result.library.getSnapshot().files[0]).toMatchObject({
+        status: outcome === "success" ? "pending" : "error",
+        hasBufferedChanges: true,
+        metadata: { comment: "keep the latest edit", picture: cover },
+        pendingMetadataPatch: { comment: "keep the latest edit" },
+      });
+      act(() => hook.result.importing.commands.cancelQueue());
+      hook.unmount();
+    },
+  );
 
   it("uses the latest settings and activation callback after asynchronous metadata resolution", async () => {
     let resolveMetadata: ((metadata: { title: string; artist: string }) => void) | undefined;


### PR DESCRIPTION
## review

- import a single youtube or soundcloud track with artwork, then edit the title and album before the download finishes. expect the typed values to remain and the cover to appear when download metadata arrives.
- enable automatic soundcloud album cover application, import an album or playlist, and edit the selected track while its cover is still loading. expect the cover to appear without replacing the edit.
- if possible, throttle the cover or tag write, keep editing, and switch to another track before it completes. expect the latest edit to remain pending on the original track after either a successful or failed write.
- exercise two overlapping saves on one track if practical. expect the newest-started write to remain authoritative regardless of completion order; an older success or failure must not replace its file, metadata, pending state, or error state.
- reviewer decision: a background write that finishes after a newer edit installs the written file bytes but keeps the newer metadata pending. overlapping writes use newest-started-wins ordering so stale completions still settle for callers without mutating track state.
- automatically verified: all 749 tests, production build and typecheck, lint, formatting and diff checks, plus the impeccable ui detector.
- manual verification: live provider timing and overlapping browser saves were not exercised locally; deferred download and write permutations are covered deterministically in unit and integration tests.

created with gpt-5.6-sol in the codex harness through t3 code.