### PR TITLE
feat: add share link previews

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "tagium",
       "dependencies": {
         "@cf-wasm/resvg": "^0.4.0",
+        "@expo-google-fonts/inter": "^0.4.2",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@imput/libav.js-encode-cli": "6.8.7",
@@ -29,7 +30,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
-        "@expo-google-fonts/inter": "^0.4.2",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^24.12.2",

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,10 @@
     "": {
       "name": "tagium",
       "dependencies": {
+        "@cf-wasm/resvg": "^0.4.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
+        "@expo-google-fonts/inter": "^0.4.2",
         "@imput/libav.js-encode-cli": "6.8.7",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.15",
@@ -112,6 +114,8 @@
 
     "@bundled-es-modules/tough-cookie": ["@bundled-es-modules/tough-cookie@0.1.6", "", { "dependencies": { "@types/tough-cookie": "4.0.5", "tough-cookie": "4.1.4" } }, "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw=="],
 
+    "@cf-wasm/resvg": ["@cf-wasm/resvg@0.4.0", "", { "dependencies": { "@resvg/resvg-wasm": "2.6.2", "@resvg/resvg-wasm-legacy": "npm:@resvg/resvg-wasm@2.4.1" } }, "sha512-p45IjI5EDYPTsJzhoqJ48f/TcNhR3/F9l2CCFomEHBJ0jbedQQMFB9CQfRaqcqdhDTNy4fSjN8hvOeKDMnz3zA=="],
+
     "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
 
     "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
@@ -147,6 +151,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.6", "", {}, "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.3.5", "", { "dependencies": { "@eslint/core": "0.15.2", "levn": "0.4.1" } }, "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w=="],
+
+    "@expo-google-fonts/inter": ["@expo-google-fonts/inter@0.4.2", "", {}, "sha512-syfiImMaDmq7cFi0of+waE2M4uSCyd16zgyWxdPOY7fN2VBmSLKEzkfbZgeOjJq61kSqPBNNtXjggiQiSD6gMQ=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
 
@@ -445,6 +451,10 @@
     "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "optionalDependencies": { "@types/react": "19.1.12", "@types/react-dom": "19.1.9" }, "peerDependencies": { "react": "19.1.0", "react-dom": "19.1.0" } }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
+
+    "@resvg/resvg-wasm": ["@resvg/resvg-wasm@2.6.2", "", {}, "sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw=="],
+
+    "@resvg/resvg-wasm-legacy": ["@resvg/resvg-wasm@2.4.1", "", {}, "sha512-yi6R0HyHtsoWTRA06Col4WoDs7SvlXU3DLMNP2bdAgs7HK18dTEVl1weXgxRzi8gwLteGUbIg29zulxIB3GSdg=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.13", "", { "os": "android", "cpu": "arm64" }, "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,6 @@
         "@cf-wasm/resvg": "^0.4.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
-        "@expo-google-fonts/inter": "^0.4.2",
         "@imput/libav.js-encode-cli": "6.8.7",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.15",
@@ -30,6 +29,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@expo-google-fonts/inter": "^0.4.2",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^24.12.2",

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
          here does not survive the Vite build, so the import lives in CSS instead. -->
     <link rel="preconnect" href="https://api.fontshare.com" />
     <link rel="preconnect" href="https://cdn.fontshare.com" crossorigin />
+    <!-- tagium:link-preview:start -->
     <title>tagium</title>
     <meta
       name="description"
@@ -38,6 +39,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://tagium.app/" />
+    <meta property="og:site_name" content="tagium" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="tagium" />
     <meta
@@ -45,6 +47,7 @@
       content="save your favorite music and edit mp3 tags all on the web."
     />
     <link rel="canonical" href="https://tagium.app/" />
+    <!-- tagium:link-preview:end -->
     <meta name="theme-color" content="#900f1a" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="alternate icon" href="/favicon.ico" sizes="16x16 32x32 48x48" />

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
     "shadcn": "shadcn"
   },
   "dependencies": {
+    "@cf-wasm/resvg": "^0.4.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
+    "@expo-google-fonts/inter": "^0.4.2",
     "@imput/libav.js-encode-cli": "6.8.7",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@cf-wasm/resvg": "^0.4.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
-    "@expo-google-fonts/inter": "^0.4.2",
     "@imput/libav.js-encode-cli": "6.8.7",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",
@@ -53,6 +52,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@expo-google-fonts/inter": "^0.4.2",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^24.12.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@cf-wasm/resvg": "^0.4.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
+    "@expo-google-fonts/inter": "^0.4.2",
     "@imput/libav.js-encode-cli": "6.8.7",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",
@@ -52,7 +53,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
-    "@expo-google-fonts/inter": "^0.4.2",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^24.12.2",

--- a/server/api/manifests/[slug]/preview-artwork.get.ts
+++ b/server/api/manifests/[slug]/preview-artwork.get.ts
@@ -1,0 +1,41 @@
+import { defineHandler } from "nitro";
+import { isShareArtworkBytes } from "../../../utils/share-manifest";
+import { admitShareRead, getShareStore, noStore } from "../../../utils/share-manifest-request";
+
+const fallback = (request: Request) =>
+  new Response(null, {
+    status: 302,
+    headers: {
+      ...noStore,
+      Location: new URL("/icon-512.png", request.url).href,
+    },
+  });
+
+/** Serves crawler artwork while guaranteeing a valid branded image on every failure path. */
+export default defineHandler(async (event) => {
+  const request = event.req;
+  if (!(await admitShareRead(request))) return fallback(request);
+
+  const store = getShareStore(request);
+  if (!store) return fallback(request);
+
+  try {
+    const result = await store.loadArtwork(event.context.params?.slug ?? "");
+    if (result.kind !== "available") return fallback(request);
+
+    const bytes = new Uint8Array(await new Response(result.artwork.body).arrayBuffer());
+    if (
+      (result.artwork.type !== "image/jpeg" && result.artwork.type !== "image/png") ||
+      !isShareArtworkBytes(bytes, result.artwork.type)
+    ) {
+      return fallback(request);
+    }
+    const headers = new Headers(noStore);
+    headers.set("Content-Type", result.artwork.type);
+    headers.set("Content-Length", String(bytes.byteLength));
+    if (result.artwork.sha256) headers.set("ETag", `"${result.artwork.sha256}"`);
+    return new Response(bytes, { headers });
+  } catch {
+    return fallback(request);
+  }
+});

--- a/server/api/manifests/[slug]/social-card.get.ts
+++ b/server/api/manifests/[slug]/social-card.get.ts
@@ -29,7 +29,7 @@ export const createShareSocialCardHandler = (renderSocialCard: RenderShareSocial
       if (manifestResult.kind !== "available") return unavailable();
 
       const artworkResult = manifestArtwork(manifestResult.manifest)
-        ? await store.loadArtwork(slug)
+        ? await store.loadArtwork(slug).catch(() => undefined)
         : undefined;
       let artwork: ShareSocialCardArtwork | undefined;
       if (

--- a/server/api/manifests/[slug]/social-card.get.ts
+++ b/server/api/manifests/[slug]/social-card.get.ts
@@ -1,0 +1,52 @@
+import { defineHandler } from "nitro";
+import { manifestArtwork } from "../../../../src/features/share/shareManifest";
+import {
+  admitShareRead,
+  getShareStore,
+  infrastructureFailure,
+  noStore,
+  unavailable,
+} from "../../../utils/share-manifest-request";
+import {
+  renderShareSocialCardPng,
+  type ShareSocialCardArtwork,
+} from "../../../utils/share-social-card";
+
+export default defineHandler(async (event) => {
+  const request = event.req;
+  if (!(await admitShareRead(request))) {
+    return new Response(null, { status: 429, headers: noStore });
+  }
+  const store = getShareStore(request);
+  if (!store) return infrastructureFailure();
+
+  try {
+    const slug = event.context.params?.slug ?? "";
+    const manifestResult = await store.load(slug);
+    if (manifestResult.kind !== "available") return unavailable();
+
+    const artworkResult = manifestArtwork(manifestResult.manifest)
+      ? await store.loadArtwork(slug)
+      : undefined;
+    let artwork: ShareSocialCardArtwork | undefined;
+    if (
+      artworkResult?.kind === "available" &&
+      (artworkResult.artwork.type === "image/jpeg" || artworkResult.artwork.type === "image/png")
+    ) {
+      artwork = {
+        bytes: new Uint8Array(await new Response(artworkResult.artwork.body).arrayBuffer()),
+        type: artworkResult.artwork.type,
+      };
+    }
+    const png = await renderShareSocialCardPng(manifestResult.manifest, artwork);
+    return new Response(Uint8Array.from(png).buffer, {
+      headers: {
+        ...noStore,
+        "Content-Type": "image/png",
+        "Content-Length": String(png.byteLength),
+      },
+    });
+  } catch {
+    return infrastructureFailure();
+  }
+});

--- a/server/api/manifests/[slug]/social-card.get.ts
+++ b/server/api/manifests/[slug]/social-card.get.ts
@@ -12,41 +12,46 @@ import {
   type ShareSocialCardArtwork,
 } from "../../../utils/share-social-card";
 
-export default defineHandler(async (event) => {
-  const request = event.req;
-  if (!(await admitShareRead(request))) {
-    return new Response(null, { status: 429, headers: noStore });
-  }
-  const store = getShareStore(request);
-  if (!store) return infrastructureFailure();
+type RenderShareSocialCard = typeof renderShareSocialCardPng;
 
-  try {
-    const slug = event.context.params?.slug ?? "";
-    const manifestResult = await store.load(slug);
-    if (manifestResult.kind !== "available") return unavailable();
-
-    const artworkResult = manifestArtwork(manifestResult.manifest)
-      ? await store.loadArtwork(slug)
-      : undefined;
-    let artwork: ShareSocialCardArtwork | undefined;
-    if (
-      artworkResult?.kind === "available" &&
-      (artworkResult.artwork.type === "image/jpeg" || artworkResult.artwork.type === "image/png")
-    ) {
-      artwork = {
-        bytes: new Uint8Array(await new Response(artworkResult.artwork.body).arrayBuffer()),
-        type: artworkResult.artwork.type,
-      };
+export const createShareSocialCardHandler = (renderSocialCard: RenderShareSocialCard) =>
+  defineHandler(async (event) => {
+    const request = event.req;
+    if (!(await admitShareRead(request))) {
+      return new Response(null, { status: 429, headers: noStore });
     }
-    const png = await renderShareSocialCardPng(manifestResult.manifest, artwork);
-    return new Response(Uint8Array.from(png).buffer, {
-      headers: {
-        ...noStore,
-        "Content-Type": "image/png",
-        "Content-Length": String(png.byteLength),
-      },
-    });
-  } catch {
-    return infrastructureFailure();
-  }
-});
+    const store = getShareStore(request);
+    if (!store) return infrastructureFailure();
+
+    try {
+      const slug = event.context.params?.slug ?? "";
+      const manifestResult = await store.load(slug);
+      if (manifestResult.kind !== "available") return unavailable();
+
+      const artworkResult = manifestArtwork(manifestResult.manifest)
+        ? await store.loadArtwork(slug)
+        : undefined;
+      let artwork: ShareSocialCardArtwork | undefined;
+      if (
+        artworkResult?.kind === "available" &&
+        (artworkResult.artwork.type === "image/jpeg" || artworkResult.artwork.type === "image/png")
+      ) {
+        artwork = {
+          bytes: new Uint8Array(await new Response(artworkResult.artwork.body).arrayBuffer()),
+          type: artworkResult.artwork.type,
+        };
+      }
+      const png = await renderSocialCard(manifestResult.manifest, artwork);
+      return new Response(Uint8Array.from(png).buffer, {
+        headers: {
+          ...noStore,
+          "Content-Type": "image/png",
+          "Content-Length": String(png.byteLength),
+        },
+      });
+    } catch {
+      return infrastructureFailure();
+    }
+  });
+
+export default createShareSocialCardHandler(renderShareSocialCardPng);

--- a/server/api/manifests/[slug]/social-card.get.ts
+++ b/server/api/manifests/[slug]/social-card.get.ts
@@ -28,18 +28,23 @@ export const createShareSocialCardHandler = (renderSocialCard: RenderShareSocial
       const manifestResult = await store.load(slug);
       if (manifestResult.kind !== "available") return unavailable();
 
-      const artworkResult = manifestArtwork(manifestResult.manifest)
-        ? await store.loadArtwork(slug).catch(() => undefined)
-        : undefined;
       let artwork: ShareSocialCardArtwork | undefined;
-      if (
-        artworkResult?.kind === "available" &&
-        (artworkResult.artwork.type === "image/jpeg" || artworkResult.artwork.type === "image/png")
-      ) {
-        artwork = {
-          bytes: new Uint8Array(await new Response(artworkResult.artwork.body).arrayBuffer()),
-          type: artworkResult.artwork.type,
-        };
+      if (manifestArtwork(manifestResult.manifest)) {
+        try {
+          const artworkResult = await store.loadArtwork(slug);
+          if (
+            artworkResult.kind === "available" &&
+            (artworkResult.artwork.type === "image/jpeg" ||
+              artworkResult.artwork.type === "image/png")
+          ) {
+            artwork = {
+              bytes: new Uint8Array(await new Response(artworkResult.artwork.body).arrayBuffer()),
+              type: artworkResult.artwork.type,
+            };
+          }
+        } catch {
+          // Artwork is optional for the social card; the renderer supplies the favicon fallback.
+        }
       }
       const png = await renderSocialCard(manifestResult.manifest, artwork);
       return new Response(Uint8Array.from(png).buffer, {

--- a/server/assets.d.ts
+++ b/server/assets.d.ts
@@ -1,0 +1,4 @@
+declare module "*.ttf?inline" {
+  const dataUrl: string;
+  export default dataUrl;
+}

--- a/server/assets.d.ts
+++ b/server/assets.d.ts
@@ -2,3 +2,8 @@ declare module "*.ttf?inline" {
   const dataUrl: string;
   export default dataUrl;
 }
+
+declare module "*.svg?raw" {
+  const source: string;
+  export default source;
+}

--- a/server/middleware/03-share-link-preview.ts
+++ b/server/middleware/03-share-link-preview.ts
@@ -1,0 +1,52 @@
+import { defineMiddleware } from "nitro";
+import { toResponse } from "nitro/h3";
+import { SHARE_SLUG_PATTERN } from "../../src/features/share/shareSlug";
+import { admitShareRead, getShareStore } from "../utils/share-manifest-request";
+import {
+  buildShareLinkPreviewMetadata,
+  injectShareLinkPreview,
+  type ShareLinkPreviewMetadata,
+} from "../utils/share-link-preview";
+
+type LoadShareLinkPreview = (
+  request: Request,
+  slug: string,
+) => Promise<ShareLinkPreviewMetadata | undefined>;
+
+const loadShareLinkPreview: LoadShareLinkPreview = async (request, slug) => {
+  if (!(await admitShareRead(request))) return undefined;
+  const store = getShareStore(request);
+  if (!store) return undefined;
+  const result = await store.load(slug);
+  return result.kind === "available"
+    ? buildShareLinkPreviewMetadata(result.manifest, slug, request.url)
+    : undefined;
+};
+
+export const createShareLinkPreviewMiddleware = (loadPreview: LoadShareLinkPreview) =>
+  defineMiddleware(async (event, next) => {
+    if (event.req.method !== "GET") return next();
+    const match = new URL(event.req.url).pathname.match(/^\/share\/([^/]+)\/?$/);
+    const slug = match?.[1] ?? "";
+    if (!SHARE_SLUG_PATTERN.test(slug)) return next();
+
+    const [response, metadata] = await Promise.all([
+      toResponse(next(), event),
+      loadPreview(event.req, slug).catch(() => undefined),
+    ]);
+    if (!metadata || !response.headers.get("content-type")?.startsWith("text/html")) {
+      return response;
+    }
+
+    const html = await response.text();
+    const headers = new Headers(response.headers);
+    headers.delete("content-length");
+    headers.set("cache-control", "no-store");
+    return new Response(injectShareLinkPreview(html, metadata), {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  });
+
+export default createShareLinkPreviewMiddleware(loadShareLinkPreview);

--- a/server/utils/share-link-preview.ts
+++ b/server/utils/share-link-preview.ts
@@ -1,0 +1,120 @@
+import {
+  manifestArtwork,
+  manifestTrackCount,
+  type Manifest,
+} from "../../src/features/share/shareManifest";
+
+export const SHARE_LINK_PREVIEW_START = "<!-- tagium:link-preview:start -->";
+export const SHARE_LINK_PREVIEW_END = "<!-- tagium:link-preview:end -->";
+
+export interface ShareLinkPreviewMetadata {
+  title: string;
+  description: string;
+  url: string;
+  image?: {
+    url: string;
+    type: "image/jpeg" | "image/png";
+    alt: string;
+  };
+}
+
+const contentForManifest = (manifest: Manifest) =>
+  manifest.kind === "album"
+    ? {
+        title: manifest.album.title.trim() || "untitled album",
+        artist: manifest.album.artist.trim() || "unknown artist",
+      }
+    : {
+        title: manifest.track.metadata.title.trim() || "untitled track",
+        artist: manifest.track.metadata.artist.trim() || "unknown artist",
+      };
+
+/** Project a public share into the small metadata surface understood by link crawlers. */
+export const buildShareLinkPreviewMetadata = (
+  manifest: Manifest,
+  slug: string,
+  requestUrl: string,
+): ShareLinkPreviewMetadata => {
+  const content = contentForManifest(manifest);
+  const canonicalUrl = new URL(`/share/${encodeURIComponent(slug)}`, requestUrl);
+  const artwork = manifestArtwork(manifest);
+  const trackCount = manifestTrackCount(manifest);
+  const description =
+    manifest.kind === "album"
+      ? `${content.artist} · ${trackCount} ${trackCount === 1 ? "track" : "tracks"} · shared on tagium`
+      : `${content.artist} · shared track on tagium`;
+  const image = artwork
+    ? {
+        url: new URL(`/api/manifests/${encodeURIComponent(slug)}/artwork`, canonicalUrl).href,
+        type: artwork.format,
+        alt: `${content.title} ${manifest.kind === "album" ? "cover" : "artwork"}`,
+      }
+    : {
+        url: new URL("/icon-512.png", canonicalUrl).href,
+        type: "image/png" as const,
+        alt: "tagium",
+      };
+
+  return {
+    title: content.title,
+    description,
+    url: canonicalUrl.href,
+    image,
+  };
+};
+
+const escapeHtml = (value: string) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+
+const meta = (attribute: "name" | "property", key: string, content: string) =>
+  `<meta ${attribute}="${key}" content="${escapeHtml(content)}" />`;
+
+export const renderShareLinkPreviewTags = (metadata: ShareLinkPreviewMetadata) => {
+  const tags = [
+    `<title>${escapeHtml(`${metadata.title} · tagium`)}</title>`,
+    meta("name", "description", metadata.description),
+    meta("property", "og:title", metadata.title),
+    meta("property", "og:description", metadata.description),
+    meta("property", "og:type", "website"),
+    meta("property", "og:url", metadata.url),
+    meta("property", "og:site_name", "tagium"),
+  ];
+
+  if (metadata.image) {
+    tags.push(
+      meta("property", "og:image", metadata.image.url),
+      meta("property", "og:image:type", metadata.image.type),
+      meta("property", "og:image:alt", metadata.image.alt),
+    );
+  }
+
+  tags.push(
+    meta("name", "twitter:card", "summary"),
+    meta("name", "twitter:title", metadata.title),
+    meta("name", "twitter:description", metadata.description),
+  );
+
+  if (metadata.image) {
+    tags.push(
+      meta("name", "twitter:image", metadata.image.url),
+      meta("name", "twitter:image:alt", metadata.image.alt),
+    );
+  }
+
+  tags.push(`<link rel="canonical" href="${escapeHtml(metadata.url)}" />`);
+  return `${SHARE_LINK_PREVIEW_START}\n    ${tags.join("\n    ")}\n    ${SHARE_LINK_PREVIEW_END}`;
+};
+
+/** Replace the one static metadata block while leaving Vite's transformed SPA shell intact. */
+export const injectShareLinkPreview = (html: string, metadata: ShareLinkPreviewMetadata) => {
+  const start = html.indexOf(SHARE_LINK_PREVIEW_START);
+  const end = html.indexOf(SHARE_LINK_PREVIEW_END, start);
+  if (start === -1 || end === -1) return html;
+  return `${html.slice(0, start)}${renderShareLinkPreviewTags(metadata)}${html.slice(
+    end + SHARE_LINK_PREVIEW_END.length,
+  )}`;
+};

--- a/server/utils/share-link-preview.ts
+++ b/server/utils/share-link-preview.ts
@@ -16,6 +16,10 @@ export interface ShareLinkPreviewMetadata {
     type: "image/jpeg" | "image/png";
     alt: string;
   };
+  twitterImage: {
+    url: string;
+    alt: string;
+  };
 }
 
 const contentForManifest = (manifest: Manifest) =>
@@ -60,6 +64,10 @@ export const buildShareLinkPreviewMetadata = (
     description,
     url: canonicalUrl.href,
     image,
+    twitterImage: {
+      url: new URL(`/api/manifests/${encodeURIComponent(slug)}/social-card`, canonicalUrl).href,
+      alt: `${content.title} by ${content.artist}`,
+    },
   };
 };
 
@@ -93,17 +101,12 @@ export const renderShareLinkPreviewTags = (metadata: ShareLinkPreviewMetadata) =
   }
 
   tags.push(
-    meta("name", "twitter:card", "summary"),
+    meta("name", "twitter:card", "summary_large_image"),
     meta("name", "twitter:title", metadata.title),
     meta("name", "twitter:description", metadata.description),
+    meta("name", "twitter:image", metadata.twitterImage.url),
+    meta("name", "twitter:image:alt", metadata.twitterImage.alt),
   );
-
-  if (metadata.image) {
-    tags.push(
-      meta("name", "twitter:image", metadata.image.url),
-      meta("name", "twitter:image:alt", metadata.image.alt),
-    );
-  }
 
   tags.push(`<link rel="canonical" href="${escapeHtml(metadata.url)}" />`);
   return `${SHARE_LINK_PREVIEW_START}\n    ${tags.join("\n    ")}\n    ${SHARE_LINK_PREVIEW_END}`;

--- a/server/utils/share-link-preview.ts
+++ b/server/utils/share-link-preview.ts
@@ -13,13 +13,13 @@ export interface ShareLinkPreviewMetadata {
   url: string;
   image?: {
     url: string;
-    type: "image/jpeg" | "image/png";
     alt: string;
   };
   twitterImage: {
     url: string;
     alt: string;
   };
+  twitterTitle: string;
 }
 
 const contentForManifest = (manifest: Manifest) =>
@@ -49,13 +49,12 @@ export const buildShareLinkPreviewMetadata = (
       : `${content.artist} · shared track on tagium`;
   const image = artwork
     ? {
-        url: new URL(`/api/manifests/${encodeURIComponent(slug)}/artwork`, canonicalUrl).href,
-        type: artwork.format,
+        url: new URL(`/api/manifests/${encodeURIComponent(slug)}/preview-artwork`, canonicalUrl)
+          .href,
         alt: `${content.title} ${manifest.kind === "album" ? "cover" : "artwork"}`,
       }
     : {
         url: new URL("/icon-512.png", canonicalUrl).href,
-        type: "image/png" as const,
         alt: "tagium",
       };
 
@@ -68,6 +67,7 @@ export const buildShareLinkPreviewMetadata = (
       url: new URL(`/api/manifests/${encodeURIComponent(slug)}/social-card`, canonicalUrl).href,
       alt: `${content.title} by ${content.artist}`,
     },
+    twitterTitle: `${content.title} - ${content.artist}`,
   };
 };
 
@@ -95,14 +95,13 @@ export const renderShareLinkPreviewTags = (metadata: ShareLinkPreviewMetadata) =
   if (metadata.image) {
     tags.push(
       meta("property", "og:image", metadata.image.url),
-      meta("property", "og:image:type", metadata.image.type),
       meta("property", "og:image:alt", metadata.image.alt),
     );
   }
 
   tags.push(
     meta("name", "twitter:card", "summary_large_image"),
-    meta("name", "twitter:title", metadata.title),
+    meta("name", "twitter:title", metadata.twitterTitle),
     meta("name", "twitter:description", metadata.description),
     meta("name", "twitter:image", metadata.twitterImage.url),
     meta("name", "twitter:image:alt", metadata.twitterImage.alt),

--- a/server/utils/share-link-preview.ts
+++ b/server/utils/share-link-preview.ts
@@ -19,7 +19,7 @@ export interface ShareLinkPreviewMetadata {
     url: string;
     alt: string;
   };
-  twitterTitle: string;
+  cardTitle: string;
 }
 
 const contentForManifest = (manifest: Manifest) =>
@@ -67,7 +67,7 @@ export const buildShareLinkPreviewMetadata = (
       url: new URL(`/api/manifests/${encodeURIComponent(slug)}/social-card`, canonicalUrl).href,
       alt: `${content.title} by ${content.artist}`,
     },
-    twitterTitle: `${content.title} - ${content.artist}`,
+    cardTitle: `${content.title} - ${content.artist}`,
   };
 };
 
@@ -85,7 +85,7 @@ export const renderShareLinkPreviewTags = (metadata: ShareLinkPreviewMetadata) =
   const tags = [
     `<title>${escapeHtml(`${metadata.title} · tagium`)}</title>`,
     meta("name", "description", metadata.description),
-    meta("property", "og:title", metadata.title),
+    meta("property", "og:title", metadata.cardTitle),
     meta("property", "og:description", metadata.description),
     meta("property", "og:type", "website"),
     meta("property", "og:url", metadata.url),
@@ -101,7 +101,7 @@ export const renderShareLinkPreviewTags = (metadata: ShareLinkPreviewMetadata) =
 
   tags.push(
     meta("name", "twitter:card", "summary_large_image"),
-    meta("name", "twitter:title", metadata.twitterTitle),
+    meta("name", "twitter:title", metadata.cardTitle),
     meta("name", "twitter:description", metadata.description),
     meta("name", "twitter:image", metadata.twitterImage.url),
     meta("name", "twitter:image:alt", metadata.twitterImage.alt),

--- a/server/utils/share-manifest.ts
+++ b/server/utils/share-manifest.ts
@@ -195,6 +195,10 @@ const detectImageType = (bytes: Uint8Array): ShareArtwork["type"] | undefined =>
   return undefined;
 };
 
+/** Revalidates stored artwork before it is exposed to link crawlers or image decoders. */
+export const isShareArtworkBytes = (bytes: Uint8Array, type: ShareArtwork["type"]) =>
+  detectImageType(bytes) === type;
+
 const validDimensions = (width: number, height: number) =>
   width > 0 &&
   height > 0 &&

--- a/server/utils/share-social-card.ts
+++ b/server/utils/share-social-card.ts
@@ -1,26 +1,42 @@
 import { Resvg } from "@cf-wasm/resvg";
-import interSemiBoldDataUrl from "@expo-google-fonts/inter/600SemiBold/Inter_600SemiBold.ttf?inline";
 import { manifestTrackCount, type Manifest } from "../../src/features/share/shareManifest";
 
 export const SHARE_SOCIAL_CARD_WIDTH = 1_200;
 export const SHARE_SOCIAL_CARD_HEIGHT = 630;
+export const SATOSHI_STYLESHEET_URL =
+  "https://api.fontshare.com/v2/css?f%5B%5D=satoshi%401&display=swap";
 
 export type ShareSocialCardArtwork = {
   bytes: Uint8Array;
   type: "image/jpeg" | "image/png";
 };
 
-const decodeDataUrl = (dataUrl: string) => {
-  const separator = dataUrl.indexOf(",");
-  if (separator === -1 || !dataUrl.slice(0, separator).endsWith(";base64")) {
-    throw new Error("invalid_inline_font");
-  }
-  return Uint8Array.from(atob(dataUrl.slice(separator + 1)), (character) =>
-    character.charCodeAt(0),
-  );
+type FetchFont = (input: string | URL) => Promise<Response>;
+
+/** Load Satoshi through Fontshare's API without redistributing its proprietary font file. */
+export const createSatoshiFontLoader = (fetchFont: FetchFont = fetch) => {
+  let fontPromise: Promise<Uint8Array> | undefined;
+  return () => {
+    fontPromise ??= (async () => {
+      const stylesheet = await fetchFont(SATOSHI_STYLESHEET_URL);
+      if (!stylesheet.ok) throw new Error("satoshi_stylesheet_unavailable");
+      const source = (await stylesheet.text()).match(
+        /url\(['"]?([^'")]+\.ttf)['"]?\)\s*format\(['"]truetype['"]\)/u,
+      )?.[1];
+      if (!source) throw new Error("satoshi_font_source_missing");
+
+      const font = await fetchFont(new URL(source, SATOSHI_STYLESHEET_URL));
+      if (!font.ok) throw new Error("satoshi_font_unavailable");
+      return new Uint8Array(await font.arrayBuffer());
+    })().catch((error: unknown) => {
+      fontPromise = undefined;
+      throw error;
+    });
+    return fontPromise;
+  };
 };
 
-const interSemiBold = decodeDataUrl(interSemiBoldDataUrl);
+const loadSatoshiFont = createSatoshiFontLoader();
 
 const cleanText = (value: string) =>
   Array.from(value, (character) => {
@@ -188,7 +204,7 @@ export const renderShareSocialCardSvg = (manifest: Manifest, artwork?: ShareSoci
   <rect width="1200" height="10" fill="#900f1a" />
   <rect x="72" y="72" width="486" height="486" rx="16" fill="#e8dddc" filter="url(#cover-shadow)" />
   ${artworkMarkup(artwork)}
-  <g font-family="Inter" font-weight="600">
+  <g font-family="Satoshi Variable" font-weight="600" font-feature-settings="'ss01' 1">
     <text x="630" y="92" font-size="30" fill="#900f1a">tagium</text>
     ${title.lines
       .map(
@@ -206,11 +222,13 @@ export const renderShareSocialCardSvg = (manifest: Manifest, artwork?: ShareSoci
 export const renderShareSocialCardPng = async (
   manifest: Manifest,
   artwork?: ShareSocialCardArtwork,
+  fontBytes?: Uint8Array,
 ) => {
+  const satoshi = fontBytes ?? (await loadSatoshiFont());
   const renderer = await Resvg.async(renderShareSocialCardSvg(manifest, artwork), {
     font: {
-      fontBuffers: [interSemiBold],
-      defaultFontFamily: "Inter",
+      fontBuffers: [satoshi],
+      defaultFontFamily: "Satoshi Variable",
       loadSystemFonts: false,
     },
     fitTo: { mode: "original" },

--- a/server/utils/share-social-card.ts
+++ b/server/utils/share-social-card.ts
@@ -1,0 +1,219 @@
+import { Resvg } from "@cf-wasm/resvg";
+import interSemiBoldDataUrl from "@expo-google-fonts/inter/600SemiBold/Inter_600SemiBold.ttf?inline";
+import { manifestTrackCount, type Manifest } from "../../src/features/share/shareManifest";
+
+export const SHARE_SOCIAL_CARD_WIDTH = 1_200;
+export const SHARE_SOCIAL_CARD_HEIGHT = 630;
+
+export type ShareSocialCardArtwork = {
+  bytes: Uint8Array;
+  type: "image/jpeg" | "image/png";
+};
+
+const decodeDataUrl = (dataUrl: string) => {
+  const separator = dataUrl.indexOf(",");
+  if (separator === -1 || !dataUrl.slice(0, separator).endsWith(";base64")) {
+    throw new Error("invalid_inline_font");
+  }
+  return Uint8Array.from(atob(dataUrl.slice(separator + 1)), (character) =>
+    character.charCodeAt(0),
+  );
+};
+
+const interSemiBold = decodeDataUrl(interSemiBoldDataUrl);
+
+const cleanText = (value: string) =>
+  Array.from(value, (character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const validXmlCharacter =
+      codePoint === 0x09 ||
+      codePoint === 0x0a ||
+      codePoint === 0x0d ||
+      (codePoint >= 0x20 && codePoint <= 0xd7ff) ||
+      (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
+      (codePoint >= 0x10000 && codePoint <= 0x10ffff);
+    return validXmlCharacter ? character : " ";
+  })
+    .join("")
+    .replaceAll(/\s+/g, " ")
+    .trim();
+
+const escapeXml = (value: string) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+
+const approximateTextWidth = (value: string, fontSize: number) => {
+  let units = 0;
+  for (const character of value) {
+    if (/\s/u.test(character)) units += 0.32;
+    else if (/[ilI1.,'`:;|!]/u.test(character)) units += 0.3;
+    else if (/[MW@#%&]/u.test(character)) units += 0.88;
+    else if (/\p{Lu}/u.test(character)) units += 0.69;
+    else if (/\p{Script=Han}|\p{Emoji_Presentation}/u.test(character)) units += 1;
+    else units += 0.56;
+  }
+  return units * fontSize;
+};
+
+const truncateLine = (value: string, maximumWidth: number, fontSize: number) => {
+  const characters = Array.from(value);
+  while (
+    characters.length > 0 &&
+    approximateTextWidth(`${characters.join("")}…`, fontSize) > maximumWidth
+  ) {
+    characters.pop();
+  }
+  return `${characters.join("").trimEnd()}…`;
+};
+
+const wrapText = (value: string, maximumWidth: number, fontSize: number, maximumLines: number) => {
+  const words = cleanText(value).split(" ").filter(Boolean);
+  const lines: string[] = [];
+  let line = "";
+
+  const pushLine = () => {
+    if (line) lines.push(line);
+    line = "";
+  };
+
+  for (const word of words) {
+    const candidate = line ? `${line} ${word}` : word;
+    if (approximateTextWidth(candidate, fontSize) <= maximumWidth) {
+      line = candidate;
+      continue;
+    }
+
+    pushLine();
+    if (lines.length === maximumLines) {
+      lines[maximumLines - 1] = truncateLine(
+        `${lines[maximumLines - 1]} ${word}`,
+        maximumWidth,
+        fontSize,
+      );
+      return { lines, truncated: true };
+    }
+
+    if (approximateTextWidth(word, fontSize) <= maximumWidth) {
+      line = word;
+      continue;
+    }
+
+    for (const character of word) {
+      const fragment = `${line}${character}`;
+      if (approximateTextWidth(fragment, fontSize) <= maximumWidth) {
+        line = fragment;
+        continue;
+      }
+      pushLine();
+      if (lines.length === maximumLines) {
+        lines[maximumLines - 1] = truncateLine(
+          `${lines[maximumLines - 1]}${character}`,
+          maximumWidth,
+          fontSize,
+        );
+        return { lines, truncated: true };
+      }
+      line = character;
+    }
+  }
+
+  pushLine();
+  return { lines: lines.length > 0 ? lines : ["untitled"], truncated: false };
+};
+
+const titleLayout = (title: string) => {
+  for (const fontSize of [64, 58, 52] as const) {
+    const wrapped = wrapText(title, 498, fontSize, 3);
+    if (!wrapped.truncated) return { ...wrapped, fontSize };
+  }
+  return { ...wrapText(title, 498, 46, 3), fontSize: 46 };
+};
+
+const bytesToBase64 = (bytes: Uint8Array) => {
+  let binary = "";
+  for (let offset = 0; offset < bytes.byteLength; offset += 32_768) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 32_768));
+  }
+  return btoa(binary);
+};
+
+const artworkMarkup = (artwork: ShareSocialCardArtwork | undefined) =>
+  artwork
+    ? `<image x="72" y="72" width="486" height="486" href="data:${artwork.type};base64,${bytesToBase64(
+        artwork.bytes,
+      )}" preserveAspectRatio="xMidYMid slice" clip-path="url(#cover)" />`
+    : `<rect x="72" y="72" width="486" height="486" rx="16" fill="#efe2e3" />
+       <g transform="translate(205 187) scale(12)" fill="none" stroke="#900f1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+         <circle cx="8" cy="18" r="4" />
+         <path d="M12 18V2l7 4" />
+       </g>`;
+
+/** Build the deterministic SVG that is rasterized for X's large-image card. */
+export const renderShareSocialCardSvg = (manifest: Manifest, artwork?: ShareSocialCardArtwork) => {
+  const content =
+    manifest.kind === "album"
+      ? {
+          title: cleanText(manifest.album.title) || "untitled album",
+          artist: cleanText(manifest.album.artist) || "unknown artist",
+          detail: `${manifestTrackCount(manifest)} ${
+            manifestTrackCount(manifest) === 1 ? "track" : "tracks"
+          } · shared on tagium`,
+        }
+      : {
+          title: cleanText(manifest.track.metadata.title) || "untitled track",
+          artist: cleanText(manifest.track.metadata.artist) || "unknown artist",
+          detail: "shared track on tagium",
+        };
+  const title = titleLayout(content.title);
+  const lineHeight = Math.round(title.fontSize * 1.08);
+  const titleHeight = title.lines.length * lineHeight;
+  const titleTop = Math.round(270 - titleHeight / 2);
+  const artist =
+    approximateTextWidth(content.artist, 31) <= 498
+      ? content.artist
+      : truncateLine(content.artist, 498, 31);
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${SHARE_SOCIAL_CARD_WIDTH}" height="${SHARE_SOCIAL_CARD_HEIGHT}" viewBox="0 0 ${SHARE_SOCIAL_CARD_WIDTH} ${SHARE_SOCIAL_CARD_HEIGHT}">
+  <defs>
+    <clipPath id="cover"><rect x="72" y="72" width="486" height="486" rx="16" /></clipPath>
+    <filter id="cover-shadow" x="36" y="44" width="558" height="558" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#2b171a" flood-opacity="0.2" />
+    </filter>
+  </defs>
+  <rect width="1200" height="630" fill="#fbf8f7" />
+  <circle cx="1130" cy="620" r="360" fill="#900f1a" opacity="0.055" />
+  <rect width="1200" height="10" fill="#900f1a" />
+  <rect x="72" y="72" width="486" height="486" rx="16" fill="#e8dddc" filter="url(#cover-shadow)" />
+  ${artworkMarkup(artwork)}
+  <g font-family="Inter" font-weight="600">
+    <text x="630" y="92" font-size="30" fill="#900f1a">tagium</text>
+    ${title.lines
+      .map(
+        (line, index) =>
+          `<text x="630" y="${titleTop + index * lineHeight}" dominant-baseline="hanging" font-size="${title.fontSize}" letter-spacing="-1.2" fill="#282124">${escapeXml(line)}</text>`,
+      )
+      .join("\n    ")}
+    <text x="630" y="405" font-size="31" fill="#75696c">${escapeXml(artist)}</text>
+    <text x="630" y="505" font-size="23" fill="#900f1a">${escapeXml(content.detail)}</text>
+  </g>
+</svg>`;
+};
+
+/** Rasterize a social card to the PNG format accepted by X's link crawler. */
+export const renderShareSocialCardPng = async (
+  manifest: Manifest,
+  artwork?: ShareSocialCardArtwork,
+) => {
+  const renderer = await Resvg.async(renderShareSocialCardSvg(manifest, artwork), {
+    font: {
+      fontBuffers: [interSemiBold],
+      defaultFontFamily: "Inter",
+      loadSystemFonts: false,
+    },
+    fitTo: { mode: "original" },
+  });
+  return renderer.render().asPng();
+};

--- a/server/utils/share-social-card.ts
+++ b/server/utils/share-social-card.ts
@@ -1,11 +1,16 @@
 import { Resvg } from "@cf-wasm/resvg";
+import interSemiBoldDataUrl from "@expo-google-fonts/inter/600SemiBold/Inter_600SemiBold.ttf?inline";
 import faviconSvg from "../../public/favicon.svg?raw";
 import { manifestTrackCount, type Manifest } from "../../src/features/share/shareManifest";
+import { isShareArtworkBytes } from "./share-manifest";
 
 export const SHARE_SOCIAL_CARD_WIDTH = 1_200;
 export const SHARE_SOCIAL_CARD_HEIGHT = 630;
 export const SATOSHI_STYLESHEET_URL =
   "https://api.fontshare.com/v2/css?f%5B%5D=satoshi%401&display=swap";
+export const SATOSHI_LOAD_TIMEOUT_MS = 3_000;
+export const SATOSHI_STYLESHEET_MAX_BYTES = 64 * 1024;
+export const SATOSHI_FONT_MAX_BYTES = 2 * 1024 * 1024;
 
 const ARTWORK_SIZE = 630;
 const CONTENT_LEFT = 690;
@@ -24,23 +29,94 @@ export type ShareSocialCardArtwork = {
   type: "image/jpeg" | "image/png";
 };
 
-type FetchFont = (input: string | URL) => Promise<Response>;
+type FetchFont = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+const readBoundedResponse = async (response: Response, maximumBytes: number) => {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > maximumBytes) {
+    throw new Error("font_response_too_large");
+  }
+  if (!response.body) {
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > maximumBytes) throw new Error("font_response_too_large");
+    return bytes;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  for (;;) {
+    const result = await reader.read();
+    if (result.done) break;
+    size += result.value.byteLength;
+    if (size > maximumBytes) {
+      await reader.cancel();
+      throw new Error("font_response_too_large");
+    }
+    chunks.push(result.value);
+  }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+};
+
+const fetchBounded = async (
+  fetchFont: FetchFont,
+  input: string | URL,
+  maximumBytes: number,
+  signal: AbortSignal,
+) => {
+  const response = await fetchFont(input, { signal });
+  if (!response.ok) throw new Error("font_response_unavailable");
+  return readBoundedResponse(response, maximumBytes);
+};
 
 /** Load Satoshi through Fontshare's API without redistributing its proprietary font file. */
-export const createSatoshiFontLoader = (fetchFont: FetchFont = fetch) => {
+export const createSatoshiFontLoader = (
+  fetchFont: FetchFont = fetch,
+  timeoutMs = SATOSHI_LOAD_TIMEOUT_MS,
+) => {
   let fontPromise: Promise<Uint8Array> | undefined;
   return () => {
     fontPromise ??= (async () => {
-      const stylesheet = await fetchFont(SATOSHI_STYLESHEET_URL);
-      if (!stylesheet.ok) throw new Error("satoshi_stylesheet_unavailable");
-      const source = (await stylesheet.text()).match(
-        /url\(['"]?([^'")]+\.ttf)['"]?\)\s*format\(['"]truetype['"]\)/u,
-      )?.[1];
-      if (!source) throw new Error("satoshi_font_source_missing");
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const source = new TextDecoder()
+          .decode(
+            await fetchBounded(
+              fetchFont,
+              SATOSHI_STYLESHEET_URL,
+              SATOSHI_STYLESHEET_MAX_BYTES,
+              controller.signal,
+            ),
+          )
+          .match(/url\(['"]?([^'")]+\.ttf)['"]?\)\s*format\(['"]truetype['"]\)/u)?.[1];
+        if (!source) throw new Error("satoshi_font_source_missing");
 
-      const font = await fetchFont(new URL(source, SATOSHI_STYLESHEET_URL));
-      if (!font.ok) throw new Error("satoshi_font_unavailable");
-      return new Uint8Array(await font.arrayBuffer());
+        const font = await fetchBounded(
+          fetchFont,
+          new URL(source, SATOSHI_STYLESHEET_URL),
+          SATOSHI_FONT_MAX_BYTES,
+          controller.signal,
+        );
+        if (
+          font.length < 4 ||
+          font[0] !== 0x00 ||
+          font[1] !== 0x01 ||
+          font[2] !== 0x00 ||
+          font[3] !== 0x00
+        ) {
+          throw new Error("satoshi_font_invalid");
+        }
+        return font;
+      } finally {
+        clearTimeout(timeout);
+      }
     })().catch((error: unknown) => {
       fontPromise = undefined;
       throw error;
@@ -50,6 +126,25 @@ export const createSatoshiFontLoader = (fetchFont: FetchFont = fetch) => {
 };
 
 const loadSatoshiFont = createSatoshiFontLoader();
+
+const decodeDataUrl = (dataUrl: string) => {
+  const separator = dataUrl.indexOf(",");
+  return Uint8Array.from(atob(dataUrl.slice(separator + 1)), (character) =>
+    character.charCodeAt(0),
+  );
+};
+
+// Inter is bundled under the SIL Open Font License as a deterministic fallback. It supplies Greek
+// and Cyrillic glyphs missing from Satoshi and keeps rendering available when Fontshare is down.
+// Unsupported scripts and emoji become a visible square instead of disappearing in a Worker.
+export const BUNDLED_FALLBACK_FONT = decodeDataUrl(interSemiBoldDataUrl);
+let defaultFontPromise: Promise<Uint8Array> | undefined;
+export const loadShareCardFont = (fetchFont?: FetchFont) => {
+  if (fetchFont) {
+    return createSatoshiFontLoader(fetchFont)().catch(() => BUNDLED_FALLBACK_FONT);
+  }
+  return (defaultFontPromise ??= loadSatoshiFont().catch(() => BUNDLED_FALLBACK_FONT));
+};
 
 const cleanText = (value: string) =>
   Array.from(value, (character) => {
@@ -61,7 +156,14 @@ const cleanText = (value: string) =>
       (codePoint >= 0x20 && codePoint <= 0xd7ff) ||
       (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
       (codePoint >= 0x10000 && codePoint <= 0x10ffff);
-    return validXmlCharacter ? character : " ";
+    if (!validXmlCharacter) return " ";
+    const supported =
+      codePoint <= 0x024f ||
+      (codePoint >= 0x0300 && codePoint <= 0x036f) ||
+      (codePoint >= 0x0370 && codePoint <= 0x052f) ||
+      (codePoint >= 0x1e00 && codePoint <= 0x1fff) ||
+      (codePoint >= 0x2000 && codePoint <= 0x218f);
+    return supported ? character : "□";
   })
     .join("")
     .replaceAll(/\s+/g, " ")
@@ -220,7 +322,7 @@ export const renderShareSocialCardSvg = (manifest: Manifest, artwork?: ShareSoci
   ${artworkMarkup(artwork)}
   <rect x="630" width="570" height="630" fill="${colors.background}" />
   <rect x="630" width="8" height="630" fill="${colors.primary}" />
-  <g font-family="Satoshi Variable" font-weight="600" font-feature-settings="'ss01' 1">
+  <g font-family="'Satoshi Variable', Inter" font-weight="600" font-feature-settings="'ss01' 1">
     <text x="${CONTENT_LEFT}" y="102" font-size="34" fill="${colors.primary}">tagium</text>
     ${title.lines
       .map(
@@ -241,11 +343,15 @@ export const renderShareSocialCardPng = async (
   artwork?: ShareSocialCardArtwork,
   fontBytes?: Uint8Array,
 ) => {
-  const satoshi = fontBytes ?? (await loadSatoshiFont());
+  const satoshi = fontBytes ?? (await loadShareCardFont());
   const rasterize = async (candidate: ShareSocialCardArtwork | undefined) => {
+    const fontBuffers =
+      satoshi === BUNDLED_FALLBACK_FONT
+        ? [BUNDLED_FALLBACK_FONT]
+        : [satoshi, BUNDLED_FALLBACK_FONT];
     const renderer = await Resvg.async(renderShareSocialCardSvg(manifest, candidate), {
       font: {
-        fontBuffers: [satoshi],
+        fontBuffers,
         defaultFontFamily: "Satoshi Variable",
         loadSystemFonts: false,
       },
@@ -255,9 +361,15 @@ export const renderShareSocialCardPng = async (
   };
 
   if (!artwork) return rasterize(undefined);
+  if (!isShareArtworkBytes(artwork.bytes, artwork.type)) return rasterize(undefined);
   try {
     return await rasterize(artwork);
-  } catch {
+  } catch (error) {
+    if (!isArtworkDecodeError(error)) throw error;
     return rasterize(undefined);
   }
 };
+
+const isArtworkDecodeError = (error: unknown) =>
+  error instanceof Error &&
+  /art|image|png|jpeg|decode|parse|invalid|unsupported/iu.test(error.message);

--- a/server/utils/share-social-card.ts
+++ b/server/utils/share-social-card.ts
@@ -1,10 +1,23 @@
 import { Resvg } from "@cf-wasm/resvg";
+import faviconSvg from "../../public/favicon.svg?raw";
 import { manifestTrackCount, type Manifest } from "../../src/features/share/shareManifest";
 
 export const SHARE_SOCIAL_CARD_WIDTH = 1_200;
 export const SHARE_SOCIAL_CARD_HEIGHT = 630;
 export const SATOSHI_STYLESHEET_URL =
   "https://api.fontshare.com/v2/css?f%5B%5D=satoshi%401&display=swap";
+
+const ARTWORK_SIZE = 630;
+const CONTENT_LEFT = 690;
+const CONTENT_WIDTH = 458;
+
+// Exact sRGB equivalents of the light theme tokens in src/index.css.
+const colors = {
+  background: "#fbf8f8",
+  foreground: "#1c1514",
+  mutedForeground: "#665b59",
+  primary: "#900f1a",
+} as const;
 
 export type ShareSocialCardArtwork = {
   bytes: Uint8Array;
@@ -141,11 +154,13 @@ const wrapText = (value: string, maximumWidth: number, fontSize: number, maximum
 };
 
 const titleLayout = (title: string) => {
-  for (const fontSize of [64, 58, 52] as const) {
-    const wrapped = wrapText(title, 498, fontSize, 3);
-    if (!wrapped.truncated) return { ...wrapped, fontSize };
+  for (const fontSize of [64, 58, 52, 48, 44] as const) {
+    const wrapped = wrapText(title, CONTENT_WIDTH, fontSize, 4);
+    if (!wrapped.truncated && (wrapped.lines.length <= 3 || fontSize === 44)) {
+      return { ...wrapped, fontSize };
+    }
   }
-  return { ...wrapText(title, 498, 46, 3), fontSize: 46 };
+  return { ...wrapText(title, CONTENT_WIDTH, 44, 4), fontSize: 44 };
 };
 
 const bytesToBase64 = (bytes: Uint8Array) => {
@@ -156,16 +171,17 @@ const bytesToBase64 = (bytes: Uint8Array) => {
   return btoa(binary);
 };
 
+const fallbackArtworkMarkup = faviconSvg.replace(
+  "<svg ",
+  `<svg x="0" y="0" width="${ARTWORK_SIZE}" height="${ARTWORK_SIZE}" `,
+);
+
 const artworkMarkup = (artwork: ShareSocialCardArtwork | undefined) =>
   artwork
-    ? `<image x="72" y="72" width="486" height="486" href="data:${artwork.type};base64,${bytesToBase64(
+    ? `<image x="0" y="0" width="${ARTWORK_SIZE}" height="${ARTWORK_SIZE}" href="data:${artwork.type};base64,${bytesToBase64(
         artwork.bytes,
-      )}" preserveAspectRatio="xMidYMid slice" clip-path="url(#cover)" />`
-    : `<rect x="72" y="72" width="486" height="486" rx="16" fill="#efe2e3" />
-       <g transform="translate(205 187) scale(12)" fill="none" stroke="#900f1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-         <circle cx="8" cy="18" r="4" />
-         <path d="M12 18V2l7 4" />
-       </g>`;
+      )}" preserveAspectRatio="xMidYMid slice" />`
+    : fallbackArtworkMarkup;
 
 /** Build the deterministic SVG that is rasterized for X's large-image card. */
 export const renderShareSocialCardSvg = (manifest: Manifest, artwork?: ShareSocialCardArtwork) => {
@@ -184,36 +200,37 @@ export const renderShareSocialCardSvg = (manifest: Manifest, artwork?: ShareSoci
           detail: "shared track on tagium",
         };
   const title = titleLayout(content.title);
-  const lineHeight = Math.round(title.fontSize * 1.08);
-  const titleHeight = title.lines.length * lineHeight;
-  const titleTop = Math.round(270 - titleHeight / 2);
+  const lineHeight = Math.round(title.fontSize * 1.1);
+  const artistFontSize = approximateTextWidth(content.artist, 36) <= CONTENT_WIDTH ? 36 : 34;
   const artist =
-    approximateTextWidth(content.artist, 31) <= 498
+    approximateTextWidth(content.artist, artistFontSize) <= CONTENT_WIDTH
       ? content.artist
-      : truncateLine(content.artist, 498, 31);
+      : truncateLine(content.artist, CONTENT_WIDTH, artistFontSize);
+  const detailFontSize =
+    ([30, 28] as const).find(
+      (fontSize) => approximateTextWidth(content.detail, fontSize) <= CONTENT_WIDTH,
+    ) ?? 27;
+  const detail =
+    approximateTextWidth(content.detail, detailFontSize) <= CONTENT_WIDTH
+      ? content.detail
+      : truncateLine(content.detail, CONTENT_WIDTH, detailFontSize);
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${SHARE_SOCIAL_CARD_WIDTH}" height="${SHARE_SOCIAL_CARD_HEIGHT}" viewBox="0 0 ${SHARE_SOCIAL_CARD_WIDTH} ${SHARE_SOCIAL_CARD_HEIGHT}">
-  <defs>
-    <clipPath id="cover"><rect x="72" y="72" width="486" height="486" rx="16" /></clipPath>
-    <filter id="cover-shadow" x="36" y="44" width="558" height="558" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#2b171a" flood-opacity="0.2" />
-    </filter>
-  </defs>
-  <rect width="1200" height="630" fill="#fbf8f7" />
-  <circle cx="1130" cy="620" r="360" fill="#900f1a" opacity="0.055" />
-  <rect width="1200" height="10" fill="#900f1a" />
-  <rect x="72" y="72" width="486" height="486" rx="16" fill="#e8dddc" filter="url(#cover-shadow)" />
+  <rect width="1200" height="630" fill="${colors.background}" />
   ${artworkMarkup(artwork)}
+  <rect x="630" width="570" height="630" fill="${colors.background}" />
+  <rect x="630" width="8" height="630" fill="${colors.primary}" />
   <g font-family="Satoshi Variable" font-weight="600" font-feature-settings="'ss01' 1">
-    <text x="630" y="92" font-size="30" fill="#900f1a">tagium</text>
+    <text x="${CONTENT_LEFT}" y="102" font-size="34" fill="${colors.primary}">tagium</text>
     ${title.lines
       .map(
         (line, index) =>
-          `<text x="630" y="${titleTop + index * lineHeight}" dominant-baseline="hanging" font-size="${title.fontSize}" letter-spacing="-1.2" fill="#282124">${escapeXml(line)}</text>`,
+          `<text x="${CONTENT_LEFT}" y="${144 + index * lineHeight}" dominant-baseline="hanging" font-size="${title.fontSize}" letter-spacing="-1.2" fill="${colors.foreground}">${escapeXml(line)}</text>`,
       )
       .join("\n    ")}
-    <text x="630" y="405" font-size="31" fill="#75696c">${escapeXml(artist)}</text>
-    <text x="630" y="505" font-size="23" fill="#900f1a">${escapeXml(content.detail)}</text>
+    <text x="${CONTENT_LEFT}" y="432" font-size="${artistFontSize}" fill="${colors.mutedForeground}">${escapeXml(artist)}</text>
+    <rect x="${CONTENT_LEFT}" y="468" width="64" height="4" rx="2" fill="${colors.primary}" />
+    <text x="${CONTENT_LEFT}" y="530" font-size="${detailFontSize}" fill="${colors.primary}">${escapeXml(detail)}</text>
   </g>
 </svg>`;
 };
@@ -225,13 +242,22 @@ export const renderShareSocialCardPng = async (
   fontBytes?: Uint8Array,
 ) => {
   const satoshi = fontBytes ?? (await loadSatoshiFont());
-  const renderer = await Resvg.async(renderShareSocialCardSvg(manifest, artwork), {
-    font: {
-      fontBuffers: [satoshi],
-      defaultFontFamily: "Satoshi Variable",
-      loadSystemFonts: false,
-    },
-    fitTo: { mode: "original" },
-  });
-  return renderer.render().asPng();
+  const rasterize = async (candidate: ShareSocialCardArtwork | undefined) => {
+    const renderer = await Resvg.async(renderShareSocialCardSvg(manifest, candidate), {
+      font: {
+        fontBuffers: [satoshi],
+        defaultFontFamily: "Satoshi Variable",
+        loadSystemFonts: false,
+      },
+      fitTo: { mode: "original" },
+    });
+    return renderer.render().asPng();
+  };
+
+  if (!artwork) return rasterize(undefined);
+  try {
+    return await rasterize(artwork);
+  } catch {
+    return rasterize(undefined);
+  }
 };

--- a/tests/server/manifests.test.ts
+++ b/tests/server/manifests.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import artworkHandler from "../../server/api/manifests/[slug]/artwork.get";
-import socialCardHandler from "../../server/api/manifests/[slug]/social-card.get";
+import { createShareSocialCardHandler } from "../../server/api/manifests/[slug]/social-card.get";
 import revokeHandler from "../../server/api/manifests/[slug].delete";
 import manifestHandler from "../../server/api/manifests/[slug].get";
 import publishHandler from "../../server/api/manifests/index.post";
@@ -50,6 +50,8 @@ const png = Uint8Array.from(
   ),
   (character) => character.charCodeAt(0),
 );
+
+const socialCardHandler = createShareSocialCardHandler(async () => png);
 
 const createRuntime = () => {
   const records = new Map<string, Record>();

--- a/tests/server/manifests.test.ts
+++ b/tests/server/manifests.test.ts
@@ -158,6 +158,7 @@ const createRuntime = () => {
   return {
     records,
     artwork,
+    bucket,
     env: { SHARE_MANIFESTS: database, SHARE_ARTWORK: bucket } as ShareRuntimeEnv,
   };
 };
@@ -272,6 +273,37 @@ describe("share manifest endpoints", () => {
     );
     expect(unavailable.status).toBe(404);
     expect(unavailable.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("renders the fallback social card when stored artwork cannot be loaded", async () => {
+    const runtime = createRuntime();
+    const form = new FormData();
+    form.set("manifest", JSON.stringify(manifest));
+    form.set("cover", new File([png], "cover.png", { type: "image/png" }));
+    const published = await publishHandler(
+      event(
+        request("https://tagium.test/api/manifests", { method: "POST", body: form }, runtime.env),
+      ),
+    );
+    const receipt = (await published.json()) as { slug: string };
+    runtime.bucket.get = async () => {
+      throw new Error("artwork unavailable");
+    };
+    let renderedWithArtwork: boolean | undefined;
+    const handler = createShareSocialCardHandler(async (_manifest, artwork) => {
+      renderedWithArtwork = Boolean(artwork);
+      return png;
+    });
+
+    const socialCard = await handler(
+      event(
+        request(`https://tagium.test/api/manifests/${receipt.slug}/social-card`, {}, runtime.env),
+        receipt.slug,
+      ),
+    );
+
+    expect(socialCard.status).toBe(200);
+    expect(renderedWithArtwork).toBe(false);
   });
 
   it("uses one unavailable response for missing manifests, artwork, and invalid revocation", async () => {

--- a/tests/server/manifests.test.ts
+++ b/tests/server/manifests.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import artworkHandler from "../../server/api/manifests/[slug]/artwork.get";
+import socialCardHandler from "../../server/api/manifests/[slug]/social-card.get";
 import revokeHandler from "../../server/api/manifests/[slug].delete";
 import manifestHandler from "../../server/api/manifests/[slug].get";
 import publishHandler from "../../server/api/manifests/index.post";
@@ -224,6 +225,18 @@ describe("share manifest endpoints", () => {
     expect(cover.headers.get("content-type")).toBe("image/png");
     expect(new Uint8Array(await cover.arrayBuffer())).toEqual(png);
 
+    const socialCard = await socialCardHandler(
+      event(
+        request(`https://tagium.test/api/manifests/${receipt.slug}/social-card`, {}, runtime.env),
+        receipt.slug,
+      ),
+    );
+    expect(socialCard.status).toBe(200);
+    expect(socialCard.headers.get("cache-control")).toBe("no-store");
+    expect(socialCard.headers.get("content-type")).toBe("image/png");
+    const socialCardBytes = new Uint8Array(await socialCard.arrayBuffer());
+    expect(Array.from(socialCardBytes.subarray(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
+
     const revoked = await revokeHandler(
       event(
         request(
@@ -268,6 +281,12 @@ describe("share manifest endpoints", () => {
       ),
       artworkHandler(
         event(request(`https://tagium.test/api/manifests/${slug}/artwork`, {}, runtime.env), slug),
+      ),
+      socialCardHandler(
+        event(
+          request(`https://tagium.test/api/manifests/${slug}/social-card`, {}, runtime.env),
+          slug,
+        ),
       ),
       revokeHandler(
         event(

--- a/tests/server/manifests.test.ts
+++ b/tests/server/manifests.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import artworkHandler from "../../server/api/manifests/[slug]/artwork.get";
+import previewArtworkHandler from "../../server/api/manifests/[slug]/preview-artwork.get";
 import { createShareSocialCardHandler } from "../../server/api/manifests/[slug]/social-card.get";
 import revokeHandler from "../../server/api/manifests/[slug].delete";
 import manifestHandler from "../../server/api/manifests/[slug].get";
@@ -228,6 +229,20 @@ describe("share manifest endpoints", () => {
     expect(cover.headers.get("content-type")).toBe("image/png");
     expect(new Uint8Array(await cover.arrayBuffer())).toEqual(png);
 
+    const previewArtwork = await previewArtworkHandler(
+      event(
+        request(
+          `https://tagium.test/api/manifests/${receipt.slug}/preview-artwork`,
+          {},
+          runtime.env,
+        ),
+        receipt.slug,
+      ),
+    );
+    expect(previewArtwork.status).toBe(200);
+    expect(previewArtwork.headers.get("content-type")).toBe("image/png");
+    expect(new Uint8Array(await previewArtwork.arrayBuffer())).toEqual(png);
+
     const socialCard = await socialCardHandler(
       event(
         request(`https://tagium.test/api/manifests/${receipt.slug}/social-card`, {}, runtime.env),
@@ -304,6 +319,129 @@ describe("share manifest endpoints", () => {
 
     expect(socialCard.status).toBe(200);
     expect(renderedWithArtwork).toBe(false);
+  });
+
+  it("renders the fallback social card when artwork streaming fails after lookup", async () => {
+    const runtime = createRuntime();
+    const form = new FormData();
+    form.set("manifest", JSON.stringify(manifest));
+    form.set("cover", new File([png], "cover.png", { type: "image/png" }));
+    const published = await publishHandler(
+      event(
+        request("https://tagium.test/api/manifests", { method: "POST", body: form }, runtime.env),
+      ),
+    );
+    const receipt = (await published.json()) as { slug: string };
+    runtime.bucket.get = async () => ({
+      body: new ReadableStream({
+        start(controller) {
+          controller.error(new Error("artwork stream failed"));
+        },
+      }),
+      httpMetadata: { contentType: "image/png" },
+      size: png.byteLength,
+      etag: "sha256",
+    });
+    let renderedWithArtwork: boolean | undefined;
+    const handler = createShareSocialCardHandler(async (_manifest, artwork) => {
+      renderedWithArtwork = Boolean(artwork);
+      return png;
+    });
+
+    const socialCard = await handler(
+      event(
+        request(`https://tagium.test/api/manifests/${receipt.slug}/social-card`, {}, runtime.env),
+        receipt.slug,
+      ),
+    );
+
+    expect(socialCard.status).toBe(200);
+    expect(renderedWithArtwork).toBe(false);
+  });
+
+  it("redirects preview artwork to the favicon when stored artwork is unavailable", async () => {
+    const runtime = createRuntime();
+    const response = await previewArtworkHandler(
+      event(
+        request("https://tagium.test/api/manifests/missing/preview-artwork", {}, runtime.env),
+        "missing",
+      ),
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://tagium.test/icon-512.png");
+  });
+
+  it("redirects preview artwork to the favicon when streaming fails", async () => {
+    const runtime = createRuntime();
+    const form = new FormData();
+    form.set("manifest", JSON.stringify(manifest));
+    form.set("cover", new File([png], "cover.png", { type: "image/png" }));
+    const published = await publishHandler(
+      event(
+        request("https://tagium.test/api/manifests", { method: "POST", body: form }, runtime.env),
+      ),
+    );
+    const receipt = (await published.json()) as { slug: string };
+    runtime.bucket.get = async () => ({
+      body: new ReadableStream({
+        start(controller) {
+          controller.error(new Error("artwork stream failed"));
+        },
+      }),
+      httpMetadata: { contentType: "image/png" },
+      size: png.byteLength,
+      etag: "sha256",
+    });
+
+    const response = await previewArtworkHandler(
+      event(
+        request(
+          `https://tagium.test/api/manifests/${receipt.slug}/preview-artwork`,
+          {},
+          runtime.env,
+        ),
+        receipt.slug,
+      ),
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://tagium.test/icon-512.png");
+  });
+
+  it("redirects preview artwork to the favicon when stored bytes are corrupt", async () => {
+    const runtime = createRuntime();
+    const form = new FormData();
+    form.set("manifest", JSON.stringify(manifest));
+    form.set("cover", new File([png], "cover.png", { type: "image/png" }));
+    const published = await publishHandler(
+      event(
+        request("https://tagium.test/api/manifests", { method: "POST", body: form }, runtime.env),
+      ),
+    );
+    const receipt = (await published.json()) as { slug: string };
+    const corruptPng = new Uint8Array(png.byteLength);
+    corruptPng.set([137, 80, 78, 71, 13, 10, 26, 10]);
+    runtime.bucket.get = async () => ({
+      body: new Blob([corruptPng]).stream(),
+      httpMetadata: { contentType: "image/png" },
+      size: corruptPng.byteLength,
+      etag: "sha256",
+    });
+
+    const response = await previewArtworkHandler(
+      event(
+        request(
+          `https://tagium.test/api/manifests/${receipt.slug}/preview-artwork`,
+          {},
+          runtime.env,
+        ),
+        receipt.slug,
+      ),
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://tagium.test/icon-512.png");
   });
 
   it("uses one unavailable response for missing manifests, artwork, and invalid revocation", async () => {

--- a/tests/server/utils/share-link-preview.test.ts
+++ b/tests/server/utils/share-link-preview.test.ts
@@ -65,7 +65,7 @@ describe("share link previews", () => {
         url: "https://tagium.app/api/manifests/abc234/social-card",
         alt: "Album & <Deluxe> by Artist",
       },
-      twitterTitle: "Album & <Deluxe> - Artist",
+      cardTitle: "Album & <Deluxe> - Artist",
     });
   });
 
@@ -93,7 +93,7 @@ describe("share link previews", () => {
         url: "http://localhost:5173/api/manifests/xyz789/social-card",
         alt: "untitled track by unknown artist",
       },
-      twitterTitle: "untitled track - unknown artist",
+      cardTitle: "untitled track - unknown artist",
     });
   });
 
@@ -117,6 +117,9 @@ describe("share link previews", () => {
     );
     expect(output).toContain(
       '<meta name="twitter:title" content="Album &amp; &lt;Deluxe&gt; - Artist" />',
+    );
+    expect(output).toContain(
+      '<meta property="og:title" content="Album &amp; &lt;Deluxe&gt; - Artist" />',
     );
     expect(output).not.toContain('<meta property="og:title" content="tagium" />');
     expect(output).toContain('<script src="/assets/app.js"></script>');
@@ -148,7 +151,7 @@ describe("share link previews", () => {
     expect(response.headers.get("content-length")).toBeNull();
     expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
     await expect(response.text()).resolves.toContain(
-      '<meta property="og:title" content="Album &amp; &lt;Deluxe&gt;" />',
+      '<meta property="og:title" content="Album &amp; &lt;Deluxe&gt; - Artist" />',
     );
   });
 

--- a/tests/server/utils/share-link-preview.test.ts
+++ b/tests/server/utils/share-link-preview.test.ts
@@ -62,6 +62,10 @@ describe("share link previews", () => {
         type: "image/png",
         alt: "Album & <Deluxe> cover",
       },
+      twitterImage: {
+        url: "https://tagium.app/api/manifests/abc234/social-card",
+        alt: "Album & <Deluxe> by Artist",
+      },
     });
   });
 
@@ -86,6 +90,10 @@ describe("share link previews", () => {
         type: "image/png",
         alt: "tagium",
       },
+      twitterImage: {
+        url: "http://localhost:5173/api/manifests/xyz789/social-card",
+        alt: "untitled track by unknown artist",
+      },
     });
   });
 
@@ -99,9 +107,12 @@ describe("share link previews", () => {
     expect(output).toContain(
       '<meta property="og:image" content="https://tagium.app/api/manifests/abc234/artwork" />',
     );
-    expect(output).toContain('<meta name="twitter:card" content="summary" />');
+    expect(output).toContain('<meta name="twitter:card" content="summary_large_image" />');
     expect(output).toContain(
-      '<meta name="twitter:image:alt" content="Album &amp; &lt;Deluxe&gt; cover" />',
+      '<meta name="twitter:image" content="https://tagium.app/api/manifests/abc234/social-card" />',
+    );
+    expect(output).toContain(
+      '<meta name="twitter:image:alt" content="Album &amp; &lt;Deluxe&gt; by Artist" />',
     );
     expect(output).not.toContain('<meta property="og:title" content="tagium" />');
     expect(output).toContain('<script src="/assets/app.js"></script>');

--- a/tests/server/utils/share-link-preview.test.ts
+++ b/tests/server/utils/share-link-preview.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { mockEvent } from "nitro/h3";
+import { createShareLinkPreviewMiddleware } from "../../../server/middleware/03-share-link-preview";
+import {
+  buildShareLinkPreviewMetadata,
+  injectShareLinkPreview,
+  SHARE_LINK_PREVIEW_END,
+  SHARE_LINK_PREVIEW_START,
+} from "../../../server/utils/share-link-preview";
+import type { Manifest } from "../../../src/features/share/shareManifest";
+
+const track = {
+  sourceUrl: "https://youtu.be/dQw4w9WgXcQ",
+  audioBitrate: "320" as const,
+  metadata: {
+    filename: "track",
+    title: "Track",
+    artist: "Artist",
+    album: "Album",
+    genre: "Genre",
+  },
+};
+
+const albumManifest = {
+  version: 1,
+  kind: "album",
+  album: {
+    title: "Album & <Deluxe>",
+    artist: "Artist",
+    genre: "Genre",
+    artwork: {
+      kind: "stored",
+      format: "image/png",
+      type: 3,
+      description: "album cover",
+    },
+  },
+  tracks: [track, track],
+} satisfies Manifest;
+
+const staticHtml = `<!doctype html><html><head>
+${SHARE_LINK_PREVIEW_START}
+<title>tagium</title>
+<meta property="og:title" content="tagium" />
+${SHARE_LINK_PREVIEW_END}
+</head><body><div id="root"></div><script src="/assets/app.js"></script></body></html>`;
+
+describe("share link previews", () => {
+  it("projects album content and stored artwork into absolute preview metadata", () => {
+    expect(
+      buildShareLinkPreviewMetadata(
+        albumManifest,
+        "abc234",
+        "https://tagium.app/share/abc234?utm_source=test",
+      ),
+    ).toEqual({
+      title: "Album & <Deluxe>",
+      description: "Artist · 2 tracks · shared on tagium",
+      url: "https://tagium.app/share/abc234",
+      image: {
+        url: "https://tagium.app/api/manifests/abc234/artwork",
+        type: "image/png",
+        alt: "Album & <Deluxe> cover",
+      },
+    });
+  });
+
+  it("uses track and artwork fallbacks without inventing shared content", () => {
+    const manifest = {
+      version: 1,
+      kind: "track",
+      track: {
+        ...track,
+        metadata: { ...track.metadata, title: "", artist: "" },
+      },
+    } satisfies Manifest;
+
+    expect(
+      buildShareLinkPreviewMetadata(manifest, "xyz789", "http://localhost:5173/share/xyz789"),
+    ).toEqual({
+      title: "untitled track",
+      description: "unknown artist · shared track on tagium",
+      url: "http://localhost:5173/share/xyz789",
+      image: {
+        url: "http://localhost:5173/icon-512.png",
+        type: "image/png",
+        alt: "tagium",
+      },
+    });
+  });
+
+  it("replaces only the marked static tags and escapes shared metadata", () => {
+    const output = injectShareLinkPreview(
+      staticHtml,
+      buildShareLinkPreviewMetadata(albumManifest, "abc234", "https://tagium.app/share/abc234"),
+    );
+
+    expect(output).toContain("<title>Album &amp; &lt;Deluxe&gt; · tagium</title>");
+    expect(output).toContain(
+      '<meta property="og:image" content="https://tagium.app/api/manifests/abc234/artwork" />',
+    );
+    expect(output).toContain('<meta name="twitter:card" content="summary" />');
+    expect(output).toContain(
+      '<meta name="twitter:image:alt" content="Album &amp; &lt;Deluxe&gt; cover" />',
+    );
+    expect(output).not.toContain('<meta property="og:title" content="tagium" />');
+    expect(output).toContain('<script src="/assets/app.js"></script>');
+  });
+
+  it("injects tags into the rendered SPA response and preserves response headers", async () => {
+    const metadata = buildShareLinkPreviewMetadata(
+      albumManifest,
+      "abc234",
+      "https://tagium.app/share/abc234",
+    );
+    const loadPreview = vi.fn(async () => metadata);
+    const middleware = createShareLinkPreviewMiddleware(loadPreview);
+    const rendered = new Response(staticHtml, {
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        "content-length": String(staticHtml.length),
+      },
+    });
+    const event = mockEvent("https://tagium.app/share/abc234");
+    event.res.headers.set("x-robots-tag", "noindex, nofollow");
+
+    const response = await middleware(event, async () => rendered);
+
+    expect(loadPreview).toHaveBeenCalledWith(expect.any(Request), "abc234");
+    expect(response).toBeInstanceOf(Response);
+    if (!(response instanceof Response)) throw new Error("expected a response");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+    await expect(response.text()).resolves.toContain(
+      '<meta property="og:title" content="Album &amp; &lt;Deluxe&gt;" />',
+    );
+  });
+
+  it("does not load metadata for malformed share paths", async () => {
+    const loadPreview = vi.fn(async () => undefined);
+    const middleware = createShareLinkPreviewMiddleware(loadPreview);
+    const rendered = new Response(staticHtml, {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+
+    const response = await middleware(
+      mockEvent("https://tagium.app/share/not-a-valid-slug"),
+      async () => rendered,
+    );
+
+    expect(response).toBe(rendered);
+    expect(loadPreview).not.toHaveBeenCalled();
+  });
+});

--- a/tests/server/utils/share-link-preview.test.ts
+++ b/tests/server/utils/share-link-preview.test.ts
@@ -58,14 +58,14 @@ describe("share link previews", () => {
       description: "Artist · 2 tracks · shared on tagium",
       url: "https://tagium.app/share/abc234",
       image: {
-        url: "https://tagium.app/api/manifests/abc234/artwork",
-        type: "image/png",
+        url: "https://tagium.app/api/manifests/abc234/preview-artwork",
         alt: "Album & <Deluxe> cover",
       },
       twitterImage: {
         url: "https://tagium.app/api/manifests/abc234/social-card",
         alt: "Album & <Deluxe> by Artist",
       },
+      twitterTitle: "Album & <Deluxe> - Artist",
     });
   });
 
@@ -87,13 +87,13 @@ describe("share link previews", () => {
       url: "http://localhost:5173/share/xyz789",
       image: {
         url: "http://localhost:5173/icon-512.png",
-        type: "image/png",
         alt: "tagium",
       },
       twitterImage: {
         url: "http://localhost:5173/api/manifests/xyz789/social-card",
         alt: "untitled track by unknown artist",
       },
+      twitterTitle: "untitled track - unknown artist",
     });
   });
 
@@ -105,14 +105,18 @@ describe("share link previews", () => {
 
     expect(output).toContain("<title>Album &amp; &lt;Deluxe&gt; · tagium</title>");
     expect(output).toContain(
-      '<meta property="og:image" content="https://tagium.app/api/manifests/abc234/artwork" />',
+      '<meta property="og:image" content="https://tagium.app/api/manifests/abc234/preview-artwork" />',
     );
+    expect(output).not.toContain('property="og:image:type"');
     expect(output).toContain('<meta name="twitter:card" content="summary_large_image" />');
     expect(output).toContain(
       '<meta name="twitter:image" content="https://tagium.app/api/manifests/abc234/social-card" />',
     );
     expect(output).toContain(
       '<meta name="twitter:image:alt" content="Album &amp; &lt;Deluxe&gt; by Artist" />',
+    );
+    expect(output).toContain(
+      '<meta name="twitter:title" content="Album &amp; &lt;Deluxe&gt; - Artist" />',
     );
     expect(output).not.toContain('<meta property="og:title" content="tagium" />');
     expect(output).toContain('<script src="/assets/app.js"></script>');

--- a/tests/server/utils/share-social-card.test.ts
+++ b/tests/server/utils/share-social-card.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  renderShareSocialCardPng,
+  renderShareSocialCardSvg,
+  SHARE_SOCIAL_CARD_HEIGHT,
+  SHARE_SOCIAL_CARD_WIDTH,
+} from "../../../server/utils/share-social-card";
+import type { Manifest } from "../../../src/features/share/shareManifest";
+
+const manifest = {
+  version: 1,
+  kind: "album",
+  album: {
+    title: "Album & <Deluxe>",
+    artist: "Artist",
+    genre: "Genre",
+  },
+  tracks: [
+    {
+      sourceUrl: "https://example.com/track",
+      audioBitrate: "320",
+      metadata: {
+        filename: "track",
+        title: "Track",
+        artist: "Artist",
+        album: "Album",
+        genre: "Genre",
+      },
+    },
+  ],
+} satisfies Manifest;
+
+describe("share social cards", () => {
+  it("lays out escaped share content in the wide card template", () => {
+    const svg = renderShareSocialCardSvg(manifest);
+
+    expect(svg).toContain(`width="${SHARE_SOCIAL_CARD_WIDTH}"`);
+    expect(svg).toContain(`height="${SHARE_SOCIAL_CARD_HEIGHT}"`);
+    expect(svg).toContain("Album &amp;");
+    expect(svg).toContain("&lt;Deluxe&gt;");
+    expect(svg).toContain("Artist");
+    expect(svg).toContain("1 track · shared on tagium");
+    expect(svg).not.toContain("Album & <Deluxe>");
+  });
+
+  it("rasterizes the template into a 1200 by 630 PNG", async () => {
+    const png = await renderShareSocialCardPng(manifest);
+
+    expect(Array.from(png.subarray(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
+    const view = new DataView(png.buffer, png.byteOffset, png.byteLength);
+    expect(view.getUint32(16)).toBe(SHARE_SOCIAL_CARD_WIDTH);
+    expect(view.getUint32(20)).toBe(SHARE_SOCIAL_CARD_HEIGHT);
+  });
+
+  it("truncates long unbroken titles without overflowing the text column", () => {
+    const longTitle = "a".repeat(500);
+    const svg = renderShareSocialCardSvg({
+      ...manifest,
+      album: { ...manifest.album, title: longTitle },
+    });
+
+    expect(svg).toContain("…");
+    expect(svg).not.toContain(longTitle);
+  });
+});

--- a/tests/server/utils/share-social-card.test.ts
+++ b/tests/server/utils/share-social-card.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
+import interSemiBoldDataUrl from "@expo-google-fonts/inter/600SemiBold/Inter_600SemiBold.ttf?inline";
 import {
+  createSatoshiFontLoader,
   renderShareSocialCardPng,
   renderShareSocialCardSvg,
+  SATOSHI_STYLESHEET_URL,
   SHARE_SOCIAL_CARD_HEIGHT,
   SHARE_SOCIAL_CARD_WIDTH,
 } from "../../../server/utils/share-social-card";
@@ -30,6 +33,15 @@ const manifest = {
   ],
 } satisfies Manifest;
 
+const decodeDataUrl = (dataUrl: string) => {
+  const separator = dataUrl.indexOf(",");
+  return Uint8Array.from(atob(dataUrl.slice(separator + 1)), (character) =>
+    character.charCodeAt(0),
+  );
+};
+
+const testFont = decodeDataUrl(interSemiBoldDataUrl);
+
 describe("share social cards", () => {
   it("lays out escaped share content in the wide card template", () => {
     const svg = renderShareSocialCardSvg(manifest);
@@ -44,12 +56,29 @@ describe("share social cards", () => {
   });
 
   it("rasterizes the template into a 1200 by 630 PNG", async () => {
-    const png = await renderShareSocialCardPng(manifest);
+    const png = await renderShareSocialCardPng(manifest, undefined, testFont);
 
     expect(Array.from(png.subarray(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
     const view = new DataView(png.buffer, png.byteOffset, png.byteLength);
     expect(view.getUint32(16)).toBe(SHARE_SOCIAL_CARD_WIDTH);
     expect(view.getUint32(20)).toBe(SHARE_SOCIAL_CARD_HEIGHT);
+  });
+
+  it("loads and reuses Satoshi from Fontshare's official stylesheet", async () => {
+    const requests: string[] = [];
+    const fontBytes = Uint8Array.of(1, 2, 3);
+    const loadSatoshi = createSatoshiFontLoader(async (input) => {
+      requests.push(String(input));
+      return requests.length === 1
+        ? new Response(
+            "@font-face { src: url('//cdn.fontshare.test/satoshi.ttf') format('truetype'); }",
+          )
+        : new Response(fontBytes.buffer);
+    });
+
+    await expect(loadSatoshi()).resolves.toEqual(fontBytes);
+    await expect(loadSatoshi()).resolves.toEqual(fontBytes);
+    expect(requests).toEqual([SATOSHI_STYLESHEET_URL, "https://cdn.fontshare.test/satoshi.ttf"]);
   });
 
   it("truncates long unbroken titles without overflowing the text column", () => {

--- a/tests/server/utils/share-social-card.test.ts
+++ b/tests/server/utils/share-social-card.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vite-plus/test";
 import interSemiBoldDataUrl from "@expo-google-fonts/inter/600SemiBold/Inter_600SemiBold.ttf?inline";
 import {
   createSatoshiFontLoader,
+  BUNDLED_FALLBACK_FONT,
+  loadShareCardFont,
   renderShareSocialCardPng,
   renderShareSocialCardSvg,
   SATOSHI_STYLESHEET_URL,
@@ -51,6 +53,7 @@ describe("share social cards", () => {
     expect(svg).toContain('<rect x="630" width="8" height="630" fill="#900f1a" />');
     expect(svg).toContain('<svg x="0" y="0" width="630" height="630"');
     expect(svg).toContain('<rect width="64" height="64" rx="4" fill="#900f1a" />');
+    expect(svg).toContain("font-family=\"'Satoshi Variable', Inter\"");
     expect(svg).toContain('font-size="34" fill="#900f1a">tagium</text>');
     expect(svg).toContain('font-size="36" fill="#665b59">Artist</text>');
     expect(svg).toContain('font-size="30" fill="#900f1a">1 track · shared on tagium</text>');
@@ -70,19 +73,22 @@ describe("share social cards", () => {
     expect(view.getUint32(20)).toBe(SHARE_SOCIAL_CARD_HEIGHT);
   });
 
-  it("still renders a PNG when supplied artwork cannot be decoded", async () => {
+  it("uses the favicon when corrupt artwork has a valid image signature", async () => {
+    const corruptPng = new Uint8Array(24);
+    corruptPng.set([137, 80, 78, 71, 13, 10, 26, 10]);
+    const fallback = await renderShareSocialCardPng(manifest, undefined, testFont);
     const png = await renderShareSocialCardPng(
       manifest,
-      { bytes: Uint8Array.of(1, 2, 3), type: "image/png" },
+      { bytes: corruptPng, type: "image/png" },
       testFont,
     );
 
-    expect(Array.from(png.subarray(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
+    expect(png).toEqual(fallback);
   });
 
   it("loads and reuses Satoshi from Fontshare's official stylesheet", async () => {
     const requests: string[] = [];
-    const fontBytes = Uint8Array.of(1, 2, 3);
+    const fontBytes = Uint8Array.of(0, 1, 0, 0, 1);
     const loadSatoshi = createSatoshiFontLoader(async (input) => {
       requests.push(String(input));
       return requests.length === 1
@@ -95,6 +101,70 @@ describe("share social cards", () => {
     await expect(loadSatoshi()).resolves.toEqual(fontBytes);
     await expect(loadSatoshi()).resolves.toEqual(fontBytes);
     expect(requests).toEqual([SATOSHI_STYLESHEET_URL, "https://cdn.fontshare.test/satoshi.ttf"]);
+  });
+
+  it("rejects malformed Fontshare font payloads", async () => {
+    let request = 0;
+    const loadSatoshi = createSatoshiFontLoader(async () => {
+      request++;
+      return request === 1
+        ? new Response(
+            "@font-face { src: url('//cdn.fontshare.test/satoshi.ttf') format('truetype'); }",
+          )
+        : new Response(Uint8Array.of(1, 2, 3));
+    });
+
+    await expect(loadSatoshi()).rejects.toThrow("satoshi_font_invalid");
+  });
+
+  it("bounds Fontshare responses and falls back to the bundled font", async () => {
+    const oversized = new Response("x", { headers: { "content-length": "70000" } });
+    const loader = createSatoshiFontLoader(async () => oversized, 10);
+    await expect(loader()).rejects.toThrow("font_response_too_large");
+
+    const chunkedLoader = createSatoshiFontLoader(
+      async () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array(70_000));
+              controller.close();
+            },
+          }),
+        ),
+      10,
+    );
+    await expect(chunkedLoader()).rejects.toThrow("font_response_too_large");
+
+    const hangingLoader = createSatoshiFontLoader(
+      (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+      5,
+    );
+    await expect(hangingLoader()).rejects.toThrow("aborted");
+
+    const fallback = await loadShareCardFont(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      throw new Error("fontshare_down");
+    });
+    expect(fallback).toEqual(BUNDLED_FALLBACK_FONT);
+  });
+
+  it("makes unsupported scripts and emoji visible instead of silently dropping glyphs", () => {
+    const svg = renderShareSocialCardSvg({
+      ...manifest,
+      album: { ...manifest.album, title: "東京 عربي 🎵 · café Ạ ᾈ € ™ Ж" },
+    });
+
+    expect(svg).toContain("□");
+    expect(svg).toContain("café Ạ ᾈ € ™ Ж");
+    expect(svg).toContain("Artist");
   });
 
   it("truncates long unbroken titles without overflowing the text column", () => {

--- a/tests/server/utils/share-social-card.test.ts
+++ b/tests/server/utils/share-social-card.test.ts
@@ -43,11 +43,17 @@ const decodeDataUrl = (dataUrl: string) => {
 const testFont = decodeDataUrl(interSemiBoldDataUrl);
 
 describe("share social cards", () => {
-  it("lays out escaped share content in the wide card template", () => {
+  it("lays out escaped share content in the artwork-first card template", () => {
     const svg = renderShareSocialCardSvg(manifest);
 
     expect(svg).toContain(`width="${SHARE_SOCIAL_CARD_WIDTH}"`);
     expect(svg).toContain(`height="${SHARE_SOCIAL_CARD_HEIGHT}"`);
+    expect(svg).toContain('<rect x="630" width="8" height="630" fill="#900f1a" />');
+    expect(svg).toContain('<svg x="0" y="0" width="630" height="630"');
+    expect(svg).toContain('<rect width="64" height="64" rx="4" fill="#900f1a" />');
+    expect(svg).toContain('font-size="34" fill="#900f1a">tagium</text>');
+    expect(svg).toContain('font-size="36" fill="#665b59">Artist</text>');
+    expect(svg).toContain('font-size="30" fill="#900f1a">1 track · shared on tagium</text>');
     expect(svg).toContain("Album &amp;");
     expect(svg).toContain("&lt;Deluxe&gt;");
     expect(svg).toContain("Artist");
@@ -62,6 +68,16 @@ describe("share social cards", () => {
     const view = new DataView(png.buffer, png.byteOffset, png.byteLength);
     expect(view.getUint32(16)).toBe(SHARE_SOCIAL_CARD_WIDTH);
     expect(view.getUint32(20)).toBe(SHARE_SOCIAL_CARD_HEIGHT);
+  });
+
+  it("still renders a PNG when supplied artwork cannot be decoded", async () => {
+    const png = await renderShareSocialCardPng(
+      manifest,
+      { bytes: Uint8Array.of(1, 2, 3), type: "image/png" },
+      testFont,
+    );
+
+    expect(Array.from(png.subarray(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
   });
 
   it("loads and reuses Satoshi from Fontshare's official stylesheet", async () => {


### PR DESCRIPTION
## review

- open the preview deployment and publish an album or individual track with artwork. open `/api/manifests/<slug>/social-card` on the same preview origin; expect a 1200×630 image with square artwork on the left, a warm near-white metadata panel on the right, the existing crimson palette, and Satoshi-led typography.
- paste a newly created share URL into x. expect the artwork-first large-image card and a bottom-left label formatted as `title - artist`. x caches cards, so use a fresh share or append a new query parameter when retesting an older URL.
- paste the same share URL into messages. expect the native square-art preview with its title formatted as `title - artist`.
- publish without artwork and check both x and messages. expect the tagium favicon instead of a broken or empty image. missing, unreadable, or corrupt stored artwork follows the same fallback path.
- try a long title and Latin, Greek, or Cyrillic metadata. expect the title to step down or truncate cleanly and supported glyphs to remain visible. unsupported scripts and emoji currently render as visible squares; please consider whether that tradeoff is acceptable for this release.
- the wide card is generated on demand rather than uploaded per share. Satoshi is fetched from Fontshare within one three-second total deadline; bundled Inter supplies missing glyphs and becomes the stable fallback for the worker if Fontshare is unavailable.
- external clients may cache an earlier preview after a share changes or is revoked.
- automated verification: 769 tests, typecheck, lint, formatting, and the cloudflare production build pass. real x and messages rendering still needs manual verification against the updated preview deployment.

prepared by codex (gpt-5.6-sol) in t3 code.