### PR TITLE
fix: keep title editing responsive

### DIFF
--- a/src/features/editor/useTrackEditorSession.ts
+++ b/src/features/editor/useTrackEditorSession.ts
@@ -29,6 +29,15 @@ import { EDITABLE_METADATA_FIELDS } from "@/features/audio/metadataFields";
 
 type PreviewField = "filename" | "title" | "artist";
 
+// Keep keystrokes local to the form while coalescing the more expensive library/sidebar preview.
+const PREVIEW_COMMIT_DELAY_MS = 150;
+
+interface PendingPreview {
+  fileId: string;
+  field: PreviewField;
+  value: string;
+}
+
 const hasOwn = <Key extends PropertyKey>(object: object, key: Key) =>
   Object.prototype.hasOwnProperty.call(object, key);
 
@@ -151,6 +160,8 @@ export const useTrackEditorSession = ({
   const lastResetFileIdRef = useRef<string | null>(null);
   const lastResetMetadataRef = useRef<AudioMetadata | null>(null);
   const formDirtyRef = useRef(false);
+  const pendingPreviewRef = useRef<PendingPreview | null>(null);
+  const previewTimerRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
   const latestMetadataWritesRef = useRef(new Map<string, symbol>());
   const [isCoverProcessing, setCoverProcessing] = useState(false);
   const {
@@ -275,8 +286,57 @@ export const useTrackEditorSession = ({
     [applyCurrentFormMetadataToFiles, library],
   );
 
+  const cancelPendingPreview = useCallback(() => {
+    if (previewTimerRef.current !== null) {
+      globalThis.clearTimeout(previewTimerRef.current);
+      previewTimerRef.current = null;
+    }
+    pendingPreviewRef.current = null;
+  }, []);
+
+  const commitPendingPreview = useCallback(() => {
+    if (previewTimerRef.current !== null) {
+      globalThis.clearTimeout(previewTimerRef.current);
+      previewTimerRef.current = null;
+    }
+    const pendingPreview = pendingPreviewRef.current;
+    pendingPreviewRef.current = null;
+    if (!pendingPreview || selectedFileIdRef.current !== pendingPreview.fileId) return;
+
+    const snapshot = library.getSnapshot();
+    const currentFile = snapshot.files.find((file) => file.id === pendingPreview.fileId);
+    if (!currentFile) return;
+    const formValues = { ...getValues(), [pendingPreview.field]: pendingPreview.value };
+    const submittedData = getProjectableAudioMetadata(
+      getSubmittedMetadata(formValues),
+      currentFile.metadata,
+      formValues,
+    );
+    const metadataPatch = createCurrentMetadataPatch(submittedData, dirtyFieldsRef.current, [
+      pendingPreview.field,
+    ]);
+    if (!metadataPatch) return;
+    const nextFiles = snapshot.files.map((file) =>
+      file.id === pendingPreview.fileId
+        ? withMergedPendingMetadataPatch(
+            {
+              ...file,
+              filename: getFilenameFromPatch(file, metadataPatch),
+              metadata: file.metadata
+                ? applyMetadataPatch(file.metadata, metadataPatch)
+                : submittedData,
+              status: file.status === "saved" ? "pending" : file.status,
+            },
+            metadataPatch,
+          )
+        : file,
+    );
+    library.dispatch({ type: "content-replaced", files: nextFiles });
+  }, [createCurrentMetadataPatch, getSubmittedMetadata, getValues, library]);
+
   const flush = useCallback(
     (trackIds?: string[]) => {
+      cancelPendingPreview();
       const currentFiles = library.getSnapshot().files;
       const nextFiles = projectFiles(trackIds);
       if (nextFiles !== currentFiles) {
@@ -284,7 +344,7 @@ export const useTrackEditorSession = ({
       }
       return nextFiles;
     },
-    [library, projectFiles],
+    [cancelPendingPreview, library, projectFiles],
   );
 
   const preview = useCallback(
@@ -293,38 +353,20 @@ export const useTrackEditorSession = ({
       if (!selectedId) return;
 
       formDirtyRef.current = true;
-      const currentFiles = library.getSnapshot().files;
-      const currentFile = currentFiles.find((file) => file.id === selectedId);
-      if (!currentFile) return;
-      const formValues = { ...getValues(), [field]: value };
-      const submittedData = getProjectableAudioMetadata(
-        getSubmittedMetadata(formValues),
-        currentFile.metadata,
-        formValues,
+      dirtyFieldsRef.current = { ...dirtyFieldsRef.current, [field]: true };
+      pendingPreviewRef.current = { fileId: selectedId, field, value };
+      if (previewTimerRef.current !== null) {
+        globalThis.clearTimeout(previewTimerRef.current);
+      }
+      previewTimerRef.current = globalThis.setTimeout(
+        commitPendingPreview,
+        PREVIEW_COMMIT_DELAY_MS,
       );
-      const metadataPatch = createCurrentMetadataPatch(submittedData, dirtyFieldsRef.current, [
-        field,
-      ]);
-      if (!metadataPatch) return;
-      const nextFiles = currentFiles.map((file) =>
-        file.id === selectedId
-          ? withMergedPendingMetadataPatch(
-              {
-                ...file,
-                filename: getFilenameFromPatch(file, metadataPatch),
-                metadata: file.metadata
-                  ? applyMetadataPatch(file.metadata, metadataPatch)
-                  : submittedData,
-                status: file.status === "saved" ? "pending" : file.status,
-              },
-              metadataPatch,
-            )
-          : file,
-      );
-      library.dispatch({ type: "content-replaced", files: nextFiles });
     },
-    [createCurrentMetadataPatch, getSubmittedMetadata, getValues, library],
+    [commitPendingPreview],
   );
+
+  useLayoutEffect(() => cancelPendingPreview, [cancelPendingPreview]);
 
   const updateTags = useCallback(
     async (fileToUpdate: TagiumFile, newTags: AudioMetadata) => {

--- a/tests/e2e/title-editing-performance.spec.ts
+++ b/tests/e2e/title-editing-performance.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { Buffer } from "node:buffer";
+import { materializeFixture } from "./support/audioFixtures";
+
+const sampleText = "abcdefghijklmnopqrstuvwx";
+
+const enableAdvancedMetadata = async (page: Page) => {
+  await page.getByRole("button", { name: "settings" }).click();
+  await page.getByRole("checkbox", { name: "enable advanced metadata" }).click();
+  await page.getByRole("button", { name: "back to workspace" }).click();
+};
+
+const uploadAlbum = async (page: Page) => {
+  const fixture = await materializeFixture("mp3");
+  await page.locator('input[type="file"][multiple]').setInputFiles(
+    Array.from({ length: 40 }, (_, index) => ({
+      name: `performance-track-${index + 1}.mp3`,
+      mimeType: "audio/mpeg",
+      buffer: Buffer.from(fixture),
+    })),
+  );
+  await expect(page.locator("#track-title")).toBeVisible();
+};
+
+const typeMeasuredText = async (page: Page, input: Locator) => {
+  await input.fill("");
+  await input.focus();
+  const inputId = await input.getAttribute("id");
+  await page.evaluate((id) => {
+    const entries = Reflect.get(window, "__tagiumInputProcessing") as {
+      id: string;
+      processingMs: number;
+    }[];
+    for (let index = entries.length - 1; index >= 0; index--) {
+      if (entries[index]?.id === id) entries.splice(index, 1);
+    }
+  }, inputId);
+  for (const character of sampleText) {
+    await page.keyboard.type(character);
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+        ),
+    );
+  }
+  await page.waitForTimeout(100);
+};
+
+const readP95ProcessingTime = async (page: Page, targetId: string) =>
+  page.evaluate(
+    ({ id, sampleCount }) => {
+      const entries = Reflect.get(window, "__tagiumInputProcessing") as
+        | { id: string; processingMs: number }[]
+        | undefined;
+      if (!entries) throw new Error("input processing measurement was not installed");
+
+      const samples = entries.filter((entry) => entry.id === id).map((entry) => entry.processingMs);
+      if (samples.length !== sampleCount) {
+        throw new Error(`expected ${sampleCount} ${id} samples, received ${samples.length}`);
+      }
+      samples.sort((left, right) => left - right);
+      return samples[Math.ceil(samples.length * 0.95) - 1] ?? Number.POSITIVE_INFINITY;
+    },
+    { id: targetId, sampleCount: sampleText.length },
+  );
+
+test("keeps track title editing responsive in a large album", async ({ page, browserName }) => {
+  test.skip(browserName !== "chromium", "Event Timing is covered in Chromium");
+  await page.goto("/");
+  await enableAdvancedMetadata(page);
+  await uploadAlbum(page);
+  await page.evaluate(() => {
+    const startedAt = new WeakMap<Event, number>();
+    const entries: { id: string; processingMs: number }[] = [];
+    Reflect.set(window, "__tagiumInputProcessing", entries);
+    document.addEventListener(
+      "input",
+      (event) => {
+        startedAt.set(event, performance.now());
+      },
+      true,
+    );
+    document.addEventListener("input", (event) => {
+      const start = startedAt.get(event);
+      if (start === undefined) return;
+      entries.push({
+        id: event.target instanceof HTMLElement ? event.target.id : "",
+        processingMs: performance.now() - start,
+      });
+    });
+  });
+
+  await typeMeasuredText(page, page.locator("#track-title"));
+  await page.getByRole("button", { name: "advanced" }).click();
+  await typeMeasuredText(page, page.locator("#track-comment"));
+
+  const titleP95 = await readP95ProcessingTime(page, "track-title");
+  const commentP95 = await readP95ProcessingTime(page, "track-comment");
+  expect(
+    titleP95,
+    `title p95 ${titleP95.toFixed(1)} ms; comment p95 ${commentP95.toFixed(1)} ms`,
+  ).toBeLessThanOrEqual(commentP95 + 8);
+  await expect(
+    page.getByRole("button", { name: new RegExp(`${sampleText}\\.mp3`, "u") }).first(),
+  ).toBeVisible();
+});

--- a/tests/unit/features/editor/useTrackEditorSession.test.ts
+++ b/tests/unit/features/editor/useTrackEditorSession.test.ts
@@ -68,6 +68,10 @@ describe("track editor session", () => {
       void title.onChange({ target: { name: "title", value: "Edited First" }, type: "change" });
     });
     act(() => hook.result.editor.commands.preview("title", "Edited First"));
+    expect(hook.result.library.getSnapshot().files[0]?.metadata?.title).toBe("First");
+    act(() => {
+      hook.result.editor.commands.flush();
+    });
     expect(hook.result.library.getSnapshot().files[0]).toMatchObject({
       status: "pending",
       hasBufferedChanges: true,
@@ -91,6 +95,46 @@ describe("track editor session", () => {
     expect(hook.result.editor.selectedFile?.id).toBe(second.id);
     expect(hook.result.library.getSnapshot().files[1].metadata?.title).toBe("Second");
     hook.unmount();
+  });
+
+  it("coalesces sidebar previews until typing pauses", () => {
+    vi.useFakeTimers();
+    const hook = renderHook(() => {
+      const library = useLibraryStore();
+      return { library, editor: useTrackEditorSession({ library, settings }) };
+    }, undefined);
+    const file = readyFile("track", "Original");
+    act(() => {
+      hook.result.library.dispatch({
+        type: "content-replaced",
+        files: [file],
+        looseTrackIds: [file.id],
+        selection: { selectedAlbumId: null, selectedFileId: file.id },
+      });
+    });
+
+    const title = hook.result.editor.form.register("title");
+    for (const value of ["E", "Ed", "Edited"] as const) {
+      act(() => {
+        void title.onChange({ target: { name: "title", value }, type: "change" });
+        hook.result.editor.commands.preview("title", value);
+      });
+    }
+
+    act(() => {
+      vi.advanceTimersByTime(149);
+    });
+    expect(hook.result.library.getSnapshot().files[0]?.metadata?.title).toBe("Original");
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(hook.result.library.getSnapshot().files[0]).toMatchObject({
+      status: "pending",
+      metadata: { title: "Edited" },
+      pendingMetadataPatch: { title: "Edited" },
+    });
+    hook.unmount();
+    vi.useRealTimers();
   });
 
   it("preserves pending edits while hydrating a downloaded file", async () => {


### PR DESCRIPTION
## problem

editing a title synchronously rebuilt and published the whole library on every keystroke. that path was already expensive, and the per-track action menus added in #153 pushed a 40-track album to about 23 ms of input processing per key.

## solution

coalesce library/sidebar previews until typing pauses for 150 ms, while keeping the form itself immediate. existing flush boundaries still commit the latest form state synchronously before selection, navigation, sharing, or export.

the regression test measures every native input event in a 40-track album and compares title processing with an adjacent metadata field.

## human review

1. import an album with several tracks and type continuously in the selected track's title field.
   - expected: characters appear without visible input lag.
   - expected: the sidebar filename catches up shortly after typing pauses.
2. type a title and immediately select another track or leave the editor.
   - expected: the final title is retained; no last character is lost.
3. check title editing with filename syncing both enabled and disabled.
   - expected: the correct sidebar filename is projected in either mode.
4. if practical, repeat with a large album (around 40 tracks), where the old delay was easiest to feel.

edge cases worth checking: a background download finishing while the title is dirty, immediate export after typing, and quickly switching between tracks.

reviewer decision: the sidebar preview intentionally trails typing by up to 150 ms so the input stays responsive. operations that consume metadata do not wait for this delay; they flush immediately.

## verification

- `bun run test` — 113 files, 770 tests passed
- `bun run typecheck`
- `bun run lint` — 0 warnings and 0 errors
- `bun run build`
- `bun run test:e2e tests/e2e/title-editing-performance.spec.ts --project=chromium --repeat-each=5` — 5/5 passed
- forced synchronous-preview probe — regression test failed 3/3 at 23.0–23.1 ms title p95
- full existing metadata-format e2e was attempted, but current `main` still waits for the album edit control removed by #160; updating that locator then exposes a separate pre-existing cover-art assertion failure, so neither unrelated test issue is included here
- manual browser verification still recommended for perceived typing feel

## agent

implemented by codex using the gpt-5.6-sol model in the t3 code harness.