### PR TITLE
fix: preserve fetched metadata during edits

### DIFF
--- a/src/features/editor/useTrackEditorSession.ts
+++ b/src/features/editor/useTrackEditorSession.ts
@@ -597,9 +597,10 @@ export const useTrackEditorSession = ({
               const latestFormPatch = latestFormMetadata
                 ? createCurrentMetadataPatch(latestFormMetadata, dirtyFieldsRef.current)
                 : undefined;
+              // Downloaded metadata is authoritative for untouched fields; only replay user edits.
               const latestMetadataForResolve =
-                latestFormPatch && latestFile.metadata
-                  ? applyMetadataPatch(latestFile.metadata, latestFormPatch)
+                latestFormPatch && hydratedFile.metadata
+                  ? applyMetadataPatch(hydratedFile.metadata, latestFormPatch)
                   : latestFormMetadata;
               const latestFileForResolve = latestFormPatch
                 ? withMergedPendingMetadataPatch(

--- a/tests/unit/features/editor/useTrackEditorSession.test.ts
+++ b/tests/unit/features/editor/useTrackEditorSession.test.ts
@@ -200,7 +200,7 @@ describe("track editor session", () => {
   it.each([
     { field: "title", value: "Edited Title" },
     { field: "album", value: "Edited Album" },
-  ] as const)("shows downloaded cover art while $field is dirty", async ({ field, value }) => {
+  ] as const)("shows downloaded metadata while $field is dirty", async ({ field, value }) => {
     const hook = renderHook(() => {
       const library = useLibraryStore();
       return { library, editor: useTrackEditorSession({ library, settings }) };
@@ -239,7 +239,7 @@ describe("track editor session", () => {
       file: downloaded,
       originalFile: downloaded,
       filename: downloaded.name,
-      metadata: { ...metadata("Parsed"), picture: downloadedCover },
+      metadata: { ...metadata("Parsed"), year: 2025, picture: downloadedCover },
     };
     const backend = AudioBackend.of({
       downloadFromCobalt: () => Effect.fail(new Error("unused")),
@@ -257,6 +257,7 @@ describe("track editor session", () => {
     });
 
     expect(hook.result.library.getSnapshot().files[0]?.metadata?.picture).toEqual(downloadedCover);
+    expect(hook.result.library.getSnapshot().files[0]?.metadata?.year).toBe(2025);
     expect(hook.result.editor.form.getValues(field)).toBe(value);
     expect(hook.result.editor.form.getValues("picture")).toEqual(downloadedCover);
     hook.unmount();


### PR DESCRIPTION
## problem

Editing track metadata while a SoundCloud or YouTube download is still hydrating can replace later-fetched fields, such as year, with stale placeholder values after the metadata write succeeds.

## solution

Use hydrated download metadata as the authoritative base and replay only the sparse dirty form patch. The existing hydration regression test now verifies that fetched year and artwork survive while title or album is edited.

## review

1. Import a SoundCloud or YouTube track that has a known year in its downloaded metadata.
2. Before the download finishes, edit the title or album.
3. Confirm the edit is retained and the fetched year and artwork appear after hydration.
4. As an edge case, edit the year itself and confirm that explicit user edit still wins over the fetched value.

The business-logic decision is that downloaded metadata owns untouched fields, while the sparse pending patch owns fields the user actually changed. No provider-specific behavior was added.

Automated verification:
- `vp test run` — 113 files, 770 tests passed
- `bun run typecheck`
- `vp lint src/features/editor/useTrackEditorSession.ts tests/unit/features/editor/useTrackEditorSession.test.ts`

Manual browser verification remains for review.

Built by GPT-5.6-sol through the Codex harness in T3 Code.