### PR TITLE
feat: link single album titles to track titles

### DIFF
--- a/src/features/editor/TrackMetadataEditor.tsx
+++ b/src/features/editor/TrackMetadataEditor.tsx
@@ -221,6 +221,7 @@ function TrackDetailsFields({
   register,
   placeholder,
   inAlbum,
+  linkedAlbumValue,
   syncFilenames,
   metadataLinks,
   filenameInvalid,
@@ -232,6 +233,7 @@ function TrackDetailsFields({
   register: UseFormRegister<AudioMetadata>;
   placeholder: SampleTrackMetadata;
   inAlbum: boolean;
+  linkedAlbumValue: string;
   syncFilenames: boolean;
   metadataLinks: MetadataLinkState;
   filenameInvalid: boolean;
@@ -244,6 +246,7 @@ function TrackDetailsFields({
   const artistRegistration = register("artist", {
     onChange: (event) => onPreviewMetadataChange("artist", event),
   });
+  const albumRegistration = register("album");
   const { ref: titleRegistrationRef, ...titleInputRegistration } = titleRegistration;
   const titleInputRef = useCallback(
     (node: HTMLInputElement | null) => {
@@ -256,7 +259,12 @@ function TrackDetailsFields({
     },
     [active, focusedTitleFileIdRef, selectedFileId, titleRegistrationRef],
   );
-  const albumFieldReason = "album title is synced with the album.";
+  const singleAlbumLinked = !inAlbum && metadataLinks.singleAlbum;
+  const albumLinked = inAlbum || singleAlbumLinked;
+  const albumFieldReason = singleAlbumLinked
+    ? getMetadataLinkDescriptor("singleAlbum").disabledReason
+    : "album title is synced with the album.";
+  const albumFieldReasonId = "track-album-sync-reason";
 
   return (
     <>
@@ -295,15 +303,24 @@ function TrackDetailsFields({
         <label htmlFor="track-album" className={fieldLabelClassName}>
           album:
         </label>
-        <DisabledReason disabled={inAlbum} reason={albumFieldReason}>
+        <DisabledReason disabled={albumLinked} reason={albumFieldReason}>
           <Input
-            {...register("album")}
+            key={singleAlbumLinked ? "linked" : "unlinked"}
+            {...(singleAlbumLinked ? { name: albumRegistration.name } : albumRegistration)}
             id="track-album"
+            aria-describedby={albumLinked ? albumFieldReasonId : undefined}
             placeholder={placeholder.album}
-            disabled={inAlbum}
+            disabled={albumLinked}
+            readOnly={albumLinked}
+            value={singleAlbumLinked ? linkedAlbumValue : undefined}
             className={`${placeholderClassName} ${syncedInputClassName}`}
           />
         </DisabledReason>
+        {albumLinked && (
+          <p id={albumFieldReasonId} className="sr-only">
+            {albumFieldReason}
+          </p>
+        )}
       </div>
       <div className="grid grid-cols-[minmax(4.5rem,0.8fr)_minmax(0,1.4fr)_minmax(4.5rem,0.8fr)] gap-2">
         <div>
@@ -681,7 +698,11 @@ function LoadedTrackMetadataEditor({
   editorMode,
   onEditorModeChange,
 }: LoadedTrackMetadataEditorProps) {
-  const watchedTitle = useWatch({ control, name: "title", defaultValue: "" });
+  const watchedTitle = useWatch({
+    control,
+    name: "title",
+    defaultValue: selectedFile.metadata.title,
+  });
   const watchedFilename = useWatch({ control, name: "filename", defaultValue: "" });
   const linkedAlbumArtistDisplay = useWatch({
     control,
@@ -817,6 +838,7 @@ function LoadedTrackMetadataEditor({
                       trackNumber: placeholder.trackNumber.toLowerCase(),
                     }}
                     inAlbum={Boolean(selectedFileAlbum)}
+                    linkedAlbumValue={watchedTitle}
                     syncFilenames={syncFilenames}
                     metadataLinks={metadataLinks}
                     filenameInvalid={filenameInvalid}

--- a/src/features/editor/audioTaggerUtils.ts
+++ b/src/features/editor/audioTaggerUtils.ts
@@ -75,9 +75,11 @@ export const getSubmittedAudioMetadata = (
   data: AudioMetadata,
   syncFilenames: boolean,
   albumArtistLinked = false,
+  singleAlbumLinked = false,
 ): AudioMetadata => ({
   ...data,
   filename: sanitizeFilenameBase(syncFilenames ? data.title : data.filename),
+  album: singleAlbumLinked ? data.title : data.album,
   year: getNullableNumericMetadataValue(data.year),
   trackNumber: getNullableNumericMetadataValue(data.trackNumber),
   albumArtist: albumArtistLinked ? data.artist : data.albumArtist,

--- a/src/features/editor/useTrackEditorSession.ts
+++ b/src/features/editor/useTrackEditorSession.ts
@@ -211,20 +211,30 @@ export const useTrackEditorSession = ({
     formDirtyRef.current = nextFormIsDirty;
   }, [formIsDirty, library.state.selectedFileId, reset, selectedFile]);
 
+  const isSingleAlbumLinkedForFile = useCallback(
+    (fileId: string | null) => {
+      if (!fileId || !settingsRef.current.metadataLinks.singleAlbum) return false;
+      return !library.getSnapshot().albums.some((album) => album.trackIds.includes(fileId));
+    },
+    [library],
+  );
+
   const getSubmittedMetadata = useCallback(
-    (data: AudioMetadata) =>
+    (data: AudioMetadata, fileId: string | null) =>
       getSubmittedAudioMetadata(
         data,
         settingsRef.current.syncFilenames,
         settingsRef.current.metadataLinks.albumArtist,
+        isSingleAlbumLinkedForFile(fileId),
       ),
-    [],
+    [isSingleAlbumLinkedForFile],
   );
 
   const createCurrentMetadataPatch = useCallback(
     (
       metadata: AudioMetadata,
       dirtyFields: Partial<Record<keyof AudioMetadata, unknown>>,
+      fileId: string | null,
       extraFields: Iterable<keyof MetadataPatch> = [],
     ) => {
       const fields = new Set(extraFields);
@@ -234,6 +244,9 @@ export const useTrackEditorSession = ({
       ) {
         fields.add("albumArtist");
       }
+      if (isSingleAlbumLinkedForFile(fileId) && (dirtyFields.title || fields.has("title"))) {
+        fields.add("album");
+      }
       return createDirtyMetadataPatch(
         metadata,
         dirtyFields,
@@ -241,7 +254,7 @@ export const useTrackEditorSession = ({
         fields,
       );
     },
-    [],
+    [isSingleAlbumLinkedForFile],
   );
 
   const applyCurrentFormMetadataToFiles = useCallback(
@@ -253,11 +266,15 @@ export const useTrackEditorSession = ({
       const currentFile = files.find((file) => file.id === selectedId);
       if (!currentFile) return files;
       const submittedData = getProjectableAudioMetadata(
-        getSubmittedMetadata(getValues()),
+        getSubmittedMetadata(getValues(), selectedId),
         currentFile.metadata,
         getValues(),
       );
-      const metadataPatch = createCurrentMetadataPatch(submittedData, dirtyFieldsRef.current);
+      const metadataPatch = createCurrentMetadataPatch(
+        submittedData,
+        dirtyFieldsRef.current,
+        selectedId,
+      );
       if (!metadataPatch) return files;
       return files.map((file) =>
         file.id === selectedId
@@ -308,13 +325,16 @@ export const useTrackEditorSession = ({
     if (!currentFile) return;
     const formValues = { ...getValues(), [pendingPreview.field]: pendingPreview.value };
     const submittedData = getProjectableAudioMetadata(
-      getSubmittedMetadata(formValues),
+      getSubmittedMetadata(formValues, pendingPreview.fileId),
       currentFile.metadata,
       formValues,
     );
-    const metadataPatch = createCurrentMetadataPatch(submittedData, dirtyFieldsRef.current, [
-      pendingPreview.field,
-    ]);
+    const metadataPatch = createCurrentMetadataPatch(
+      submittedData,
+      dirtyFieldsRef.current,
+      pendingPreview.fileId,
+      [pendingPreview.field],
+    );
     if (!metadataPatch) return;
     const nextFiles = snapshot.files.map((file) =>
       file.id === pendingPreview.fileId
@@ -381,7 +401,7 @@ export const useTrackEditorSession = ({
       const latestFileToUpdate =
         snapshot.files.find((file) => file.id === fileToUpdate.id) ?? fileToUpdate;
       const submittedMetadata = getProjectableAudioMetadata(
-        getSubmittedMetadata(newTags),
+        getSubmittedMetadata(newTags, fileToUpdate.id),
         latestFileToUpdate.metadata,
         newTags,
       );
@@ -427,13 +447,13 @@ export const useTrackEditorSession = ({
         const latestFormMetadata =
           latestFile?.metadata && latestFormValues
             ? getProjectableAudioMetadata(
-                getSubmittedMetadata(latestFormValues),
+                getSubmittedMetadata(latestFormValues, fileToUpdate.id),
                 latestFile.metadata,
                 latestFormValues,
               )
             : undefined;
         const latestFormPatch = latestFormMetadata
-          ? createCurrentMetadataPatch(latestFormMetadata, dirtyFieldsRef.current)
+          ? createCurrentMetadataPatch(latestFormMetadata, dirtyFieldsRef.current, fileToUpdate.id)
           : undefined;
         const latestPendingPatch = sanitizePendingMetadataPatch({
           ...latestFile?.pendingMetadataPatch,
@@ -548,13 +568,13 @@ export const useTrackEditorSession = ({
             const formMetadata =
               selectedFileIdRef.current === fileId && formDirtyRef.current && currentFile.metadata
                 ? getProjectableAudioMetadata(
-                    getSubmittedMetadata(getValues()),
+                    getSubmittedMetadata(getValues(), fileId),
                     currentFile.metadata,
                     getValues(),
                   )
                 : undefined;
             const currentFormPatch = formMetadata
-              ? createCurrentMetadataPatch(formMetadata, dirtyFieldsRef.current)
+              ? createCurrentMetadataPatch(formMetadata, dirtyFieldsRef.current, fileId)
               : undefined;
             const currentPendingPatch = currentFormPatch
               ? sanitizePendingMetadataPatch({
@@ -589,13 +609,13 @@ export const useTrackEditorSession = ({
               const latestFormMetadata =
                 selectedFileIdRef.current === fileId && formDirtyRef.current
                   ? getProjectableAudioMetadata(
-                      getSubmittedMetadata(getValues()),
+                      getSubmittedMetadata(getValues(), fileId),
                       latestFile.metadata,
                       getValues(),
                     )
                   : undefined;
               const latestFormPatch = latestFormMetadata
-                ? createCurrentMetadataPatch(latestFormMetadata, dirtyFieldsRef.current)
+                ? createCurrentMetadataPatch(latestFormMetadata, dirtyFieldsRef.current, fileId)
                 : undefined;
               // Downloaded metadata is authoritative for untouched fields; only replay user edits.
               const latestMetadataForResolve =

--- a/src/features/export/useExportSession.ts
+++ b/src/features/export/useExportSession.ts
@@ -12,6 +12,7 @@ import {
 } from "@/features/export/downloadLibrary";
 import {
   applyAlbumSharedTagsToFiles,
+  applySingleAlbumTitlesToFiles,
   applySyncedFilenamesToFiles,
   applyTrackOrderNumbersToFiles,
 } from "@/features/library/fileMetadataOps";
@@ -91,17 +92,29 @@ export const useExportSession = ({
         album,
         albums,
         trackIds: album?.trackIds,
+        singleTrackIds: album ? [] : snapshot.looseTrackIds,
       };
     },
     [library],
   );
 
   const applyExportProjection = useCallback(
-    (files: TagiumFile[], albums: AlbumGroup[], allAlbums: AlbumGroup[], trackIds?: string[]) => {
+    (
+      files: TagiumFile[],
+      albums: AlbumGroup[],
+      allAlbums: AlbumGroup[],
+      singleTrackIds: string[],
+      trackIds?: string[],
+    ) => {
       let projectedFiles = files;
       for (const album of albums) {
         projectedFiles = applyAlbumSharedTagsToFiles(projectedFiles, album, settingsRef.current);
       }
+      projectedFiles = applySingleAlbumTitlesToFiles(
+        projectedFiles,
+        singleTrackIds,
+        settingsRef.current,
+      );
       if (settingsRef.current.syncTrackNumbers) {
         projectedFiles = applyTrackOrderNumbersToFiles(
           projectedFiles,
@@ -128,6 +141,7 @@ export const useExportSession = ({
           editor.projectFiles(context.trackIds),
           context.albums,
           context.snapshot.albums,
+          context.singleTrackIds,
           context.trackIds,
         ),
       };
@@ -143,6 +157,7 @@ export const useExportSession = ({
         editor.flush(context.trackIds),
         context.albums,
         context.snapshot.albums,
+        context.singleTrackIds,
         context.trackIds,
       );
       library.dispatch({ type: "content-replaced", files });

--- a/src/features/import/audioUploadSession.ts
+++ b/src/features/import/audioUploadSession.ts
@@ -10,6 +10,7 @@ import {
 } from "@/features/editor/audioTaggerUtils";
 import {
   applyAlbumSharedTagsToFiles,
+  applySingleAlbumTitlesToFiles,
   applySyncedFilenamesToFiles,
   applyTrackOrderNumbersToFiles,
 } from "@/features/library/fileMetadataOps";
@@ -224,7 +225,11 @@ export const createAudioUploadSession = ({
             !forceSingleAlbum && merged.unassignedTrackIds.length > 0
               ? asUniqueTrackIds([...latest.looseTrackIds, ...merged.unassignedTrackIds])
               : latest.looseTrackIds;
-          let finalFiles = latest.files;
+          let finalFiles = applySingleAlbumTitlesToFiles(
+            latest.files,
+            merged.unassignedTrackIds,
+            settings,
+          );
           const uploadedTrackIds = orderedUploads.map((entry) => entry.file.id);
           if (settings.syncFilenames) {
             finalFiles = applySyncedFilenamesToFiles(finalFiles, uploadedTrackIds);

--- a/src/features/import/audioUrlImportSession.ts
+++ b/src/features/import/audioUrlImportSession.ts
@@ -4,7 +4,10 @@ import type {
   CobaltAudioDownloadRequest,
 } from "@/features/import/cobaltAudio";
 import { downloadFromCobalt, provideAudioBackend } from "@/features/audio/audioBackend";
-import { applyPlaylistImportedCover } from "@/features/library/fileMetadataOps";
+import {
+  applyPlaylistImportedCover,
+  applySingleAlbumTitlesToFiles,
+} from "@/features/library/fileMetadataOps";
 import {
   createPlaylistDownloadPlan,
   createSingleUrlDownloadPlan,
@@ -285,9 +288,14 @@ export const createAudioUrlImportSession = ({
       importId: importOperationId,
       metadata,
     });
+    const pendingFiles = applySingleAlbumTitlesToFiles(
+      plan.pendingFiles,
+      plan.looseTrackIds,
+      getSettings(),
+    );
     library.dispatch({
       type: "content-replaced",
-      files: [...snapshot.files, ...plan.pendingFiles],
+      files: [...snapshot.files, ...pendingFiles],
       looseTrackIds: asUniqueTrackIds([...snapshot.looseTrackIds, ...plan.looseTrackIds]),
       selection: {
         selectedAlbumId: plan.selection.selectedAlbumId,

--- a/src/features/library/fileMetadataOps.ts
+++ b/src/features/library/fileMetadataOps.ts
@@ -281,6 +281,7 @@ export type MetadataPolicySettings = Pick<AppSettings, "metadataLinks" | "syncTr
 const defaultMetadataPolicySettings: MetadataPolicySettings = {
   syncTrackNumbers: true,
   metadataLinks: {
+    singleAlbum: true,
     artist: true,
     year: true,
     genre: true,
@@ -288,6 +289,32 @@ const defaultMetadataPolicySettings: MetadataPolicySettings = {
     albumArtist: true,
   },
 };
+
+/** Applies the loose-track policy that treats a single's album title as its track title. */
+export function applySingleAlbumTitlesToFiles(
+  files: TagiumFile[],
+  trackIds: readonly string[],
+  settings: MetadataPolicySettings = defaultMetadataPolicySettings,
+) {
+  if (!settings.metadataLinks.singleAlbum || trackIds.length === 0) return files;
+
+  const trackIdSet = new Set(trackIds);
+  return files.map((file) => {
+    if (!trackIdSet.has(file.id) || !file.metadata || file.metadata.album === file.metadata.title) {
+      return file;
+    }
+
+    const patch: MetadataPatch = { album: file.metadata.title };
+    return markPendingMetadataPatch(
+      {
+        ...file,
+        status: file.status === "saved" ? "pending" : file.status,
+        metadata: { ...file.metadata, ...patch },
+      },
+      patch,
+    );
+  });
+}
 
 export interface AlbumMetadataPolicyOptions {
   shared?: boolean;

--- a/src/features/library/metadataLinks.ts
+++ b/src/features/library/metadataLinks.ts
@@ -12,6 +12,7 @@ export interface MetadataLinkDescriptor {
     | "link_year"
     | "link_genre"
     | "link_artwork"
+    | "link_single_album"
     | "sync_track_numbers"
     | "link_album_artist";
   setting: { kind: "metadataLink"; key: keyof MetadataLinks } | { kind: "trackNumbers" };
@@ -19,6 +20,13 @@ export interface MetadataLinkDescriptor {
 }
 
 const descriptorById = {
+  singleAlbum: {
+    id: "singleAlbum",
+    label: "link single album title to track title",
+    disabledReason: "album title is synced with the track title.",
+    analyticsProperty: "link_single_album",
+    setting: { kind: "metadataLink", key: "singleAlbum" },
+  },
   artist: {
     id: "artist",
     label: "link artist to album",

--- a/src/features/library/types.ts
+++ b/src/features/library/types.ts
@@ -57,6 +57,7 @@ export interface AlbumGroup {
 }
 
 export interface MetadataLinks {
+  singleAlbum: boolean;
   artist: boolean;
   year: boolean;
   genre: boolean;

--- a/src/features/settings/SettingsPageSections.tsx
+++ b/src/features/settings/SettingsPageSections.tsx
@@ -79,7 +79,7 @@ export function MetadataSettingsSection({ settings, onChange }: SettingsSectionP
       <div className="space-y-1">
         <h3 className="text-base font-semibold">metadata</h3>
         <p className="text-sm leading-5 text-muted-foreground">
-          control which tags appear in the editor and follow their album.
+          control which tags appear in the editor and how metadata stays in sync.
         </p>
       </div>
       <label className={checkboxRowClassName}>

--- a/src/features/settings/settings.ts
+++ b/src/features/settings/settings.ts
@@ -17,6 +17,7 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   applySoundCloudAlbumCoverToTracks: true,
   advancedMetadata: false,
   metadataLinks: {
+    singleAlbum: true,
     artist: true,
     year: true,
     genre: true,
@@ -45,6 +46,7 @@ const storedAppSettingsSchema = Schema.Struct({
   ),
   advancedMetadata: booleanWithDefault(DEFAULT_APP_SETTINGS.advancedMetadata),
   metadataLinks: Schema.Struct({
+    singleAlbum: booleanWithDefault(DEFAULT_APP_SETTINGS.metadataLinks.singleAlbum),
     artist: booleanWithDefault(DEFAULT_APP_SETTINGS.metadataLinks.artist),
     year: booleanWithDefault(DEFAULT_APP_SETTINGS.metadataLinks.year),
     genre: booleanWithDefault(DEFAULT_APP_SETTINGS.metadataLinks.genre),

--- a/src/features/workspace/useWorkspaceSelection.ts
+++ b/src/features/workspace/useWorkspaceSelection.ts
@@ -12,7 +12,11 @@ import {
   subscribeToEditorKeyboardShortcuts,
   type EditorKeyboardShortcutActions,
 } from "@/features/editor/editorKeyboardShortcuts";
-import { applyTrackOrderNumbersToFiles } from "@/features/library/fileMetadataOps";
+import {
+  applyAlbumSharedTagsToFiles,
+  applySingleAlbumTitlesToFiles,
+  applyTrackOrderNumbersToFiles,
+} from "@/features/library/fileMetadataOps";
 import type { TagSidebarPanelProps } from "@/features/library/TagSidebarPanel";
 import type { TrackEditorSession } from "@/features/editor/useTrackEditorSession";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
@@ -189,6 +193,18 @@ export const useWorkspaceSelection = ({
           moved.albumsToSync,
           settingsRef.current,
         );
+      }
+      if (destination.type === "loose") {
+        finalFiles = applySingleAlbumTitlesToFiles(finalFiles, [trackId], settingsRef.current);
+      } else {
+        const destinationAlbum = moved.albums.find((album) => album.id === destination.albumId);
+        if (destinationAlbum) {
+          finalFiles = applyAlbumSharedTagsToFiles(
+            finalFiles,
+            { ...destinationAlbum, trackIds: [trackId] },
+            settingsRef.current,
+          );
+        }
       }
       library.dispatch({
         type: "content-replaced",

--- a/tests/e2e/metadata-editor-layout.spec.ts
+++ b/tests/e2e/metadata-editor-layout.spec.ts
@@ -16,9 +16,21 @@ const uploadTrack = async (page: Page) => {
 };
 
 const enableAdvancedMetadata = async (page: Page) => {
-  await page.getByRole("button", { name: "settings" }).click();
+  const openLibrary = page.getByRole("button", { name: "open library" });
+  const openedFromMobileLibrary = await openLibrary.isVisible();
+  if (openedFromMobileLibrary) {
+    await openLibrary.click();
+    const library = page.getByRole("dialog", { name: "library" });
+    await library.getByRole("button", { name: "settings" }).click();
+  } else {
+    await page.getByRole("button", { name: "settings" }).click();
+  }
   await page.getByRole("checkbox", { name: "enable advanced metadata" }).click();
-  await page.getByRole("button", { name: "back to workspace" }).click();
+  if (openedFromMobileLibrary) {
+    await page.goBack();
+  } else {
+    await page.getByRole("button", { name: "back to workspace" }).click();
+  }
   await expect(page.getByRole("button", { name: "advanced" })).toBeVisible();
 };
 

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -683,6 +683,7 @@ describe("analytics", () => {
       applySoundCloudCover: true,
       advancedMetadata: true,
       metadataLinks: {
+        singleAlbum: false,
         artist: true,
         year: false,
         genre: true,
@@ -727,6 +728,7 @@ describe("analytics", () => {
           audio_bitrate: "256",
           apply_soundcloud_cover: true,
           advanced_metadata: true,
+          link_single_album: false,
           link_artist: true,
           link_year: false,
           link_genre: true,

--- a/tests/unit/features/editor/audioTagger.test.ts
+++ b/tests/unit/features/editor/audioTagger.test.ts
@@ -128,6 +128,17 @@ describe("audioTagger metadata patches", () => {
     expect(patch).toEqual({ filename: "New Title", title: "New Title" });
   });
 
+  it("derives a linked single album title from the submitted track title", () => {
+    const submittedMetadata = getSubmittedAudioMetadata(
+      metadata({ title: "Single Title", album: "Old Album" }),
+      false,
+      false,
+      true,
+    );
+
+    expect(submittedMetadata.album).toBe("Single Title");
+  });
+
   it("quietly sanitizes manual filenames before metadata is committed", () => {
     const submittedMetadata = getSubmittedAudioMetadata(
       metadata({ filename: " ../mix/name?.mp3 " }),

--- a/tests/unit/features/editor/trackMetadataEditor.test.tsx
+++ b/tests/unit/features/editor/trackMetadataEditor.test.tsx
@@ -6,6 +6,7 @@ import TrackMetadataEditor, {
   MetadataEditorModeToggle,
 } from "@/features/editor/TrackMetadataEditor";
 import { getMetadataLinkDescriptor } from "@/features/library/metadataLinks";
+import type { MetadataLinkState } from "@/features/library/metadataLinks";
 import type { AudioMetadata, TagiumFile } from "@/features/library/types";
 
 const metadata: AudioMetadata = {
@@ -38,12 +39,22 @@ const loadedTrack: TagiumFile = {
 function EditorHarness({
   selectedFile = loadedTrack,
   syncFilenames = true,
+  metadataLinks = {
+    singleAlbum: true,
+    artist: true,
+    year: true,
+    genre: true,
+    artwork: true,
+    albumArtist: true,
+    trackNumber: true,
+  },
 }: {
   selectedFile?: TagiumFile | null;
   syncFilenames?: boolean;
+  metadataLinks?: MetadataLinkState;
 }) {
   const { register, control, getValues, setError, clearErrors, setFocus } = useForm<AudioMetadata>({
-    defaultValues: metadata,
+    defaultValues: selectedFile?.metadata ?? metadata,
   });
 
   return (
@@ -64,14 +75,7 @@ function EditorHarness({
         selectedFileAlbum={undefined}
         syncFilenames={syncFilenames}
         advancedMetadata
-        metadataLinks={{
-          artist: true,
-          year: true,
-          genre: true,
-          artwork: true,
-          albumArtist: true,
-          trackNumber: true,
-        }}
+        metadataLinks={metadataLinks}
         onPreviewMetadataChange={vi.fn()}
         onAudioUpload={vi.fn()}
       />
@@ -158,6 +162,37 @@ describe("track metadata editor form seam", () => {
     expect(markup).toContain('id="track-album-artist-sync-reason"');
     expect(markup).toMatch(/id="track-album-artist-sync-reason" class="sr-only"/);
     expect(markup).toContain(getMetadataLinkDescriptor("albumArtist").disabledReason);
+  });
+
+  it("shows a single's album title as a disabled link to its track title by default", () => {
+    const selectedFile = {
+      ...loadedTrack,
+      metadata: { ...metadata, title: "Single Title", album: "Old Album" },
+    };
+    const linkedMarkup = renderToStaticMarkup(<EditorHarness selectedFile={selectedFile} />);
+    const unlinkedMarkup = renderToStaticMarkup(
+      <EditorHarness
+        selectedFile={selectedFile}
+        metadataLinks={{
+          singleAlbum: false,
+          artist: true,
+          year: true,
+          genre: true,
+          artwork: true,
+          albumArtist: true,
+          trackNumber: true,
+        }}
+      />,
+    );
+    const linkedInput = linkedMarkup.match(/<input[^>]*id="track-album"[^>]*>/)?.[0];
+    const unlinkedInput = unlinkedMarkup.match(/<input[^>]*id="track-album"[^>]*>/)?.[0];
+
+    expect(linkedInput).toContain('value="Single Title"');
+    expect(linkedInput).toContain(' disabled=""');
+    expect(linkedInput).toContain('aria-describedby="track-album-sync-reason"');
+    expect(linkedMarkup).toContain(getMetadataLinkDescriptor("singleAlbum").disabledReason);
+    expect(unlinkedInput).not.toContain(' disabled=""');
+    expect(unlinkedInput).not.toContain("aria-describedby");
   });
 
   it("lowercases metadata placeholders", () => {

--- a/tests/unit/features/editor/useTrackEditorSession.test.ts
+++ b/tests/unit/features/editor/useTrackEditorSession.test.ts
@@ -14,6 +14,7 @@ const settings: AppSettings = {
   syncFilenames: false,
   audioBitrate: "320",
   applySoundCloudAlbumCoverToTracks: false,
+  metadataLinks: { ...DEFAULT_APP_SETTINGS.metadataLinks, singleAlbum: false },
 };
 const metadata = (title: string): AudioMetadata => ({
   filename: title.toLowerCase().replaceAll(" ", "-"),
@@ -47,6 +48,39 @@ const readyFile = (id: string, title: string): TagiumFile => {
 };
 
 describe("track editor session", () => {
+  it("buffers the linked album title when a single's title changes", () => {
+    const linkedSettings: AppSettings = {
+      ...settings,
+      metadataLinks: { ...settings.metadataLinks, singleAlbum: true },
+    };
+    const hook = renderHook(() => {
+      const library = useLibraryStore();
+      return { library, editor: useTrackEditorSession({ library, settings: linkedSettings }) };
+    }, undefined);
+    const file = readyFile("single", "Original");
+    act(() => {
+      hook.result.library.dispatch({
+        type: "content-replaced",
+        files: [file],
+        looseTrackIds: [file.id],
+        selection: { selectedAlbumId: null, selectedFileId: file.id },
+      });
+    });
+
+    const title = hook.result.editor.form.register("title");
+    act(() => {
+      void title.onChange({ target: { name: "title", value: "Edited Single" }, type: "change" });
+      hook.result.editor.commands.preview("title", "Edited Single");
+      hook.result.editor.commands.flush();
+    });
+
+    expect(hook.result.library.getSnapshot().files[0]).toMatchObject({
+      metadata: { title: "Edited Single", album: "Edited Single" },
+      pendingMetadataPatch: { title: "Edited Single", album: "Edited Single" },
+    });
+    hook.unmount();
+  });
+
   it("flushes dirty metadata before selection and resets the next form", () => {
     const hook = renderHook(() => {
       const library = useLibraryStore();

--- a/tests/unit/features/import/audioUrlImportSession.test.ts
+++ b/tests/unit/features/import/audioUrlImportSession.test.ts
@@ -121,7 +121,7 @@ describe("audio URL import session", () => {
   });
 
   it("records accepted and rejected URL processing after resolution", async () => {
-    mocks.resolveTrackMetadata.mockResolvedValue(undefined);
+    mocks.resolveTrackMetadata.mockResolvedValue({ title: "Linked Single", artist: "Artist" });
     const hook = renderHook(() => {
       const library = useLibraryStore();
       const editor = useTrackEditorSession({ library, settings: settings("320") });
@@ -136,6 +136,10 @@ describe("audio URL import session", () => {
 
     await act(async () => {
       await hook.result.importing.commands.importUrl("https://www.youtube.com/watch?v=abcdefghijk");
+    });
+    expect(hook.result.library.getSnapshot().files[0]).toMatchObject({
+      metadata: { title: "Linked Single", album: "Linked Single" },
+      pendingMetadataPatch: { album: "Linked Single" },
     });
     expect(mocks.capture).toHaveBeenCalledWith({
       type: "media_link_processed",

--- a/tests/unit/features/library/fileMetadataOps.test.ts
+++ b/tests/unit/features/library/fileMetadataOps.test.ts
@@ -3,6 +3,7 @@ import {
   applyAlbumCoverToFiles,
   applyAlbumCoverToFilesWithSelectedMetadata,
   applyAlbumSharedTagsToFiles,
+  applySingleAlbumTitlesToFiles,
   applySyncedFilenamesToFiles,
   applyTrackOrderNumbersToFiles,
   areAlbumTrackCoversSynced,
@@ -47,6 +48,26 @@ const readyFile = (overrides: Partial<TagiumFile> = {}): TagiumFile => ({
 });
 
 describe("fileMetadataOps", () => {
+  it("links a single's album title to its track title when enabled", () => {
+    const file = readyFile({
+      status: "saved",
+      metadata: metadata({ title: "Single Title", album: "Old Album" }),
+    });
+
+    const [linked] = applySingleAlbumTitlesToFiles([file], [file.id], DEFAULT_APP_SETTINGS);
+    const [unlinked] = applySingleAlbumTitlesToFiles([file], [file.id], {
+      ...DEFAULT_APP_SETTINGS,
+      metadataLinks: { ...DEFAULT_APP_SETTINGS.metadataLinks, singleAlbum: false },
+    });
+
+    expect(linked).toMatchObject({
+      status: "pending",
+      metadata: { album: "Single Title" },
+      pendingMetadataPatch: { album: "Single Title" },
+    });
+    expect(unlinked).toBe(file);
+  });
+
   it("sanitizes sparse numeric metadata patches without losing explicit clears", () => {
     expect(
       sanitizePendingMetadataPatch({
@@ -213,6 +234,7 @@ describe("fileMetadataOps", () => {
       ...DEFAULT_APP_SETTINGS,
       advancedMetadata: true,
       metadataLinks: {
+        ...DEFAULT_APP_SETTINGS.metadataLinks,
         artist: false,
         year: true,
         genre: false,

--- a/tests/unit/features/library/metadataLinks.test.ts
+++ b/tests/unit/features/library/metadataLinks.test.ts
@@ -10,6 +10,11 @@ import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 
 describe("metadata link descriptors", () => {
   it("keeps stable labels, disabled reasons, and analytics-facing ids", () => {
+    expect(getMetadataLinkDescriptor("singleAlbum")).toMatchObject({
+      label: "link single album title to track title",
+      disabledReason: "album title is synced with the track title.",
+      analyticsProperty: "link_single_album",
+    });
     expect(getMetadataLinkDescriptor("albumArtist")).toMatchObject({
       label: "link album artist to track artist",
       disabledReason: "album artist is synced with the album.",
@@ -31,6 +36,7 @@ describe("metadata link descriptors", () => {
 
     expect(state.artist).toBe(false);
     expect(serializeMetadataLinkAnalytics(state)).toMatchObject({
+      link_single_album: true,
       link_artist: false,
       link_album_artist: true,
       sync_track_numbers: true,

--- a/tests/unit/features/settings/SettingsPage.test.tsx
+++ b/tests/unit/features/settings/SettingsPage.test.tsx
@@ -25,7 +25,7 @@ describe("settings page advanced metadata controls", () => {
     expect(normalMarkup).not.toContain(getMetadataLinkDescriptor("albumArtist").label);
     expect(advancedMarkup).toContain(getMetadataLinkDescriptor("albumArtist").label);
 
-    for (const id of ["artist", "year", "genre", "artwork"] as const) {
+    for (const id of ["singleAlbum", "artist", "year", "genre", "artwork"] as const) {
       expect(normalMarkup).toContain(getMetadataLinkDescriptor(id).label);
     }
     for (const removedSubtitle of [

--- a/tests/unit/features/workspace/useAudioImportSession.test.ts
+++ b/tests/unit/features/workspace/useAudioImportSession.test.ts
@@ -85,7 +85,32 @@ describe("audio upload session", () => {
 
     expect(backendMocks.parseUploads).toHaveBeenCalledTimes(1);
     expect(library.getSnapshot().files).toHaveLength(1);
+    expect(library.getSnapshot().files[0]).toMatchObject({
+      metadata: { title: "Track", album: "Track" },
+      pendingMetadataPatch: { album: "Track" },
+    });
     expect(bufferEditor).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves a single's album title when its metadata link is disabled", async () => {
+    const source = new File(["audio"], "track.mp3", { lastModified: 42 });
+    backendMocks.parseUploads.mockResolvedValue([parsedUpload(source)]);
+    const library = createLibrary();
+    const session = createAudioUploadSession({
+      library,
+      getSettings: () => ({
+        ...defaultSettings,
+        metadataLinks: { ...defaultSettings.metadataLinks, singleAlbum: false },
+      }),
+      bufferEditor: vi.fn(),
+      activateEditor: vi.fn(),
+      setUploading: vi.fn(),
+    });
+
+    await session.upload([source]);
+
+    expect(library.getSnapshot().files[0].metadata?.album).toBe("");
+    expect(library.getSnapshot().files[0].pendingMetadataPatch).toBeUndefined();
   });
 
   it("reads current settings after an asynchronous parse before committing", async () => {

--- a/tests/unit/features/workspace/useAudioWorkspace.test.tsx
+++ b/tests/unit/features/workspace/useAudioWorkspace.test.tsx
@@ -75,6 +75,54 @@ afterEach(() => {
 });
 
 describe("audio workspace", () => {
+  it("replaces a single's album title when the track moves into an album", () => {
+    const hook = renderHook(() => {
+      const library = useLibraryStore();
+      const [settings, setSettings] = useState(initialSettings);
+      const editor = useTrackEditorSession({ library, settings });
+      const navigation = useWorkspaceNavigation({ library, editor });
+      const workspace = useAudioWorkspace({
+        library,
+        editor,
+        settings,
+        setSettings,
+        navigation,
+        removeDownloads: vi.fn(),
+        busy: false,
+      });
+      return { library, workspace };
+    }, undefined);
+    const single = readyFile("single", "Single Title");
+    single.status = "pending";
+    single.metadata = { ...single.metadata!, album: "Single Title" };
+    single.pendingMetadataPatch = { album: "Single Title" };
+
+    act(() => {
+      hook.result.library.dispatch({
+        type: "content-replaced",
+        files: [single],
+        albums: [
+          {
+            id: "album",
+            title: "Album Title",
+            artist: "Album Artist",
+            genre: "Album Genre",
+            trackIds: [],
+          },
+        ],
+        looseTrackIds: [single.id],
+      });
+    });
+    act(() => hook.result.workspace.sidebarProps.onMoveTrackToAlbum(single.id, "album", "append"));
+
+    expect(hook.result.library.getSnapshot().files[0]).toMatchObject({
+      status: "pending",
+      metadata: { album: "Album Title" },
+      pendingMetadataPatch: { album: "Album Title" },
+    });
+    hook.unmount();
+  });
+
   it("confirms album deletion from the sidebar action before removing its tracks", () => {
     const removeDownloads = vi.fn();
     const hook = renderHook(() => {


### PR DESCRIPTION
## problem

loose tracks are presented as singles, but their album title can drift from the track title. this produces inconsistent single metadata and leaves a field editable even when tagium is managing it.

## solution

- add a default-on metadata link that keeps a single's album title equal to its track title
- show the linked album field as disabled with an accessible sync explanation
- apply the loose-track policy when singles are imported, moved out of albums, edited, and exported
- apply the destination album policy to a single when it moves into an album, replacing the pending single album title
- add a metadata setting that makes the album field editable again when the link is disabled
- default existing stored settings to the new enabled behavior

## reviewer fast path

1. start with default settings and upload a loose track. edit its title and confirm the album field follows the title, is disabled, and the downloaded file contains the same title and album title.
2. open settings, expand metadata linking, and disable **link single album title to track title**. return to the track and confirm the album field is editable.
3. move that single into an album with a different title. confirm its disabled album field switches to the containing album's title and the downloaded tag uses that value, regardless of the new single setting.
4. move an album track back to singles and confirm its album title follows its track title when the setting is enabled.

### decisions and edge cases

- a single means a loose track in the singles collection, not an album that happens to contain one track.
- moving a single into an album synchronizes only the moved track; existing album members are not rewritten by the move.
- disabling the setting does not rewrite existing metadata; it changes future edits, imports, moves, and exports.
- shared-track imports retain the shared metadata on receipt; the local single policy applies when the track is subsequently edited or exported.
- existing stored settings without this key decode to enabled.

## verification

- `bun run test` — 113 files and 776 tests passed
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run test:e2e -- tests/e2e/settings-transition.spec.ts tests/e2e/metadata-editor-layout.spec.ts --project=chromium` — 19 passed
- manually verified the enabled and disabled flows at 1280×800 and 390×844, including disabled-field accessibility and horizontal overflow

the full local cross-browser e2e command could not be completed because Firefox and WebKit are not installed in this workspace; several unrelated Chromium specs also timed out only under the full 90-test parallel load. the feature-relevant Chromium suite passes reliably in isolation.

---

built with gpt-5.6-sol in T3 Code through the Codex harness.
