### PR TITLE
fix: move mobile menu into track header

### DIFF
--- a/src/features/editor/TrackMetadataEditor.tsx
+++ b/src/features/editor/TrackMetadataEditor.tsx
@@ -44,6 +44,7 @@ type LoadedTrack = TagiumFile & { metadata: AudioMetadata };
 
 interface TrackMetadataEditorProps {
   viewActive?: boolean;
+  headerLeadingAction?: ReactNode;
   selectedFile: TagiumFile | null;
   selectedFileId: string | null;
   register: UseFormRegister<AudioMetadata>;
@@ -79,7 +80,7 @@ interface LoadedTrackMetadataEditorProps extends Omit<TrackMetadataEditorProps, 
 
 interface PendingTrackMetadataEditorProps extends Pick<
   TrackMetadataEditorProps,
-  "selectedFile" | "advancedMetadata"
+  "selectedFile" | "advancedMetadata" | "headerLeadingAction"
 > {
   editorMode: MetadataEditorMode;
   onEditorModeChange: (mode: MetadataEditorMode) => void;
@@ -120,6 +121,7 @@ interface TrackFailure {
 }
 
 function TrackFilenameHeader({
+  headerLeadingAction,
   syncFilenames,
   watchedFilename,
   sanitizedFilename,
@@ -130,6 +132,7 @@ function TrackFilenameHeader({
   extension,
   actions,
 }: {
+  headerLeadingAction?: ReactNode;
   syncFilenames: boolean;
   watchedFilename: string;
   sanitizedFilename: string;
@@ -141,42 +144,54 @@ function TrackFilenameHeader({
   actions?: ReactNode;
 }) {
   return (
-    <div className="relative h-16 border-b flex-shrink-0 px-4 max-lg:[@media(max-height:700px)]:h-14 max-lg:[@media(max-height:700px)]:px-3 lg:h-[104px] lg:px-6">
-      <div className="flex h-full min-w-0 items-center justify-between gap-3">
-        {syncFilenames ? (
-          <h2 className="inline-flex min-w-0 items-center text-base font-semibold text-muted-foreground max-lg:[@media(max-height:700px)]:text-sm lg:text-lg">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="min-w-0 cursor-not-allowed truncate">
-                  {sanitizedFilename || filenamePlaceholder}
+    <div
+      data-track-filename-header
+      className="relative h-16 border-b flex-shrink-0 px-4 max-lg:[@media(max-height:700px)]:h-14 max-lg:[@media(max-height:700px)]:px-3 lg:h-[104px] lg:px-6"
+    >
+      <div className="flex h-full min-w-0 items-center gap-3">
+        {headerLeadingAction}
+        <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
+          {syncFilenames ? (
+            <h2 className="inline-flex min-w-0 items-center text-base font-semibold text-muted-foreground max-lg:[@media(max-height:700px)]:text-sm lg:text-lg">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="min-w-0 cursor-not-allowed truncate">
+                    {sanitizedFilename || filenamePlaceholder}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>filename follows the title</TooltipContent>
+              </Tooltip>
+              <span className="shrink-0 select-none text-muted-foreground/70">.{extension}</span>
+            </h2>
+          ) : (
+            <label className="inline-flex min-w-0 items-center text-base font-semibold max-lg:[@media(max-height:700px)]:text-sm lg:text-lg">
+              <span className="grid w-fit max-w-[calc(100%-2.25rem)] overflow-hidden">
+                <span className="invisible col-start-1 row-start-1 whitespace-pre" aria-hidden>
+                  {watchedFilename || filenamePlaceholder}
                 </span>
-              </TooltipTrigger>
-              <TooltipContent>filename follows the title</TooltipContent>
-            </Tooltip>
-            <span className="shrink-0 select-none text-muted-foreground/70">.{extension}</span>
-          </h2>
-        ) : (
-          <label className="inline-flex min-w-0 items-center text-base font-semibold max-lg:[@media(max-height:700px)]:text-sm lg:text-lg">
-            <span className="grid w-fit max-w-[calc(100%-2.25rem)] overflow-hidden">
-              <span className="invisible col-start-1 row-start-1 whitespace-pre" aria-hidden>
-                {watchedFilename || filenamePlaceholder}
+                <input
+                  {...filenameRegistration}
+                  aria-label="filename"
+                  aria-invalid={filenameInvalid}
+                  aria-describedby={filenameInvalid ? "track-filename-error" : undefined}
+                  size={1}
+                  className="col-start-1 row-start-1 min-w-0 truncate bg-transparent outline-none placeholder:text-muted-foreground/45"
+                  placeholder={filenamePlaceholder}
+                />
               </span>
-              <input
-                {...filenameRegistration}
-                aria-label="filename"
-                aria-invalid={filenameInvalid}
-                aria-describedby={filenameInvalid ? "track-filename-error" : undefined}
-                size={1}
-                className="col-start-1 row-start-1 min-w-0 truncate bg-transparent outline-none placeholder:text-muted-foreground/45"
-                placeholder={filenamePlaceholder}
-              />
-            </span>
-            <span className="shrink-0 select-none text-muted-foreground/70">.{extension}</span>
-          </label>
-        )}
-        {actions}
+              <span className="shrink-0 select-none text-muted-foreground/70">.{extension}</span>
+            </label>
+          )}
+          {actions}
+        </div>
       </div>
-      <div className="absolute inset-x-4 bottom-1 h-4 min-w-0 overflow-hidden text-xs leading-4 text-destructive max-lg:[@media(max-height:700px)]:inset-x-3 max-lg:[@media(max-height:700px)]:bottom-0 lg:inset-x-6 lg:h-8">
+      <div
+        className={`absolute bottom-1 h-4 min-w-0 overflow-hidden text-xs leading-4 text-destructive max-lg:[@media(max-height:700px)]:bottom-0 lg:inset-x-6 lg:h-8 ${
+          headerLeadingAction
+            ? "left-[4.5rem] right-4 max-lg:[@media(max-height:700px)]:left-[4.25rem] max-lg:[@media(max-height:700px)]:right-3"
+            : "inset-x-4 max-lg:[@media(max-height:700px)]:inset-x-3"
+        }`}
+      >
         {filenameInvalid ? (
           <div className="flex min-w-0 items-center gap-2">
             <p
@@ -640,6 +655,7 @@ export function MetadataEditorModeToggle({
 function PendingTrackMetadataEditor({
   selectedFile,
   advancedMetadata,
+  headerLeadingAction,
   editorMode,
   onEditorModeChange,
 }: PendingTrackMetadataEditorProps) {
@@ -656,8 +672,12 @@ function PendingTrackMetadataEditor({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      <div className="flex h-16 shrink-0 items-center justify-between gap-3 border-b px-4 max-lg:[@media(max-height:700px)]:h-14 max-lg:[@media(max-height:700px)]:px-3 lg:h-[104px] lg:px-6">
-        <div className="min-w-0">
+      <div
+        data-track-filename-header
+        className="flex h-16 shrink-0 items-center gap-3 border-b px-4 max-lg:[@media(max-height:700px)]:h-14 max-lg:[@media(max-height:700px)]:px-3 lg:h-[104px] lg:px-6"
+      >
+        {headerLeadingAction}
+        <div className="min-w-0 flex-1">
           <h2 className="truncate text-base font-semibold text-muted-foreground max-lg:[@media(max-height:700px)]:text-sm lg:text-lg">
             {selectedFile.filename}
           </h2>
@@ -677,6 +697,7 @@ function PendingTrackMetadataEditor({
 }
 
 function LoadedTrackMetadataEditor({
+  headerLeadingAction,
   selectedFile,
   selectedFileId,
   focusedTitleFileIdRef,
@@ -779,6 +800,7 @@ function LoadedTrackMetadataEditor({
         className="flex min-h-0 flex-col h-full"
       >
         <TrackFilenameHeader
+          headerLeadingAction={headerLeadingAction}
           syncFilenames={syncFilenames}
           watchedFilename={watchedFilename}
           sanitizedFilename={sanitizeFilenameBase(filenameValue)}
@@ -964,6 +986,7 @@ export default function TrackMetadataEditor(props: TrackMetadataEditorProps) {
             <PendingTrackMetadataEditor
               selectedFile={displayedSelection.selectedFile}
               advancedMetadata={props.advancedMetadata}
+              headerLeadingAction={props.headerLeadingAction}
               editorMode={editorMode}
               onEditorModeChange={setEditorMode}
             />

--- a/src/features/workspace/audioTagger.tsx
+++ b/src/features/workspace/audioTagger.tsx
@@ -100,6 +100,23 @@ export default function AudioTagger() {
     activeView === "settings",
     Boolean(editor.selectedFile),
   );
+  const menuInTrackHeader =
+    mobileNavigation.isMobile && activeView === "editor" && Boolean(editor.selectedFile);
+  const mobileMenuButton = mobileNavigation.isMobile ? (
+    <Button
+      ref={menuButtonRef}
+      type="button"
+      size="icon"
+      variant="outline"
+      className={`size-11 bg-background/95 shadow-sm md:hidden ${mobileNavigation.drawerOpen ? "pointer-events-none opacity-0" : ""}`}
+      tabIndex={mobileNavigation.drawerOpen ? -1 : 0}
+      aria-label="open library"
+      data-export-focus-fallback
+      onClick={(event) => mobileNavigation.openDrawer(event.currentTarget)}
+    >
+      <Menu />
+    </Button>
+  ) : null;
 
   if (shareLinksEnabled && sharing.page) {
     return (
@@ -142,20 +159,8 @@ export default function AudioTagger() {
         onConfirm={() => void exporting.confirmDownload()}
         onRestoreFocus={exporting.restoreConfirmationFocus}
       />
-      {mobileNavigation.isMobile && (
-        <Button
-          ref={menuButtonRef}
-          type="button"
-          size="icon"
-          variant="outline"
-          className={`fixed left-3 top-3 z-30 size-11 bg-background/95 shadow-sm md:hidden ${mobileNavigation.drawerOpen ? "pointer-events-none opacity-0" : ""}`}
-          tabIndex={mobileNavigation.drawerOpen ? -1 : 0}
-          aria-label="open library"
-          data-export-focus-fallback
-          onClick={(event) => mobileNavigation.openDrawer(event.currentTarget)}
-        >
-          <Menu />
-        </Button>
+      {mobileMenuButton && !menuInTrackHeader && (
+        <div className="fixed left-3 top-3 z-30 md:hidden">{mobileMenuButton}</div>
       )}
       <div className="min-h-svh touch-pan-y flex flex-col overflow-x-hidden bg-background md:h-svh md:touch-auto md:flex-row md:overflow-hidden">
         <TagSidebarPanel
@@ -235,6 +240,7 @@ export default function AudioTagger() {
                 >
                   <TrackMetadataEditor
                     viewActive={activeView === "editor"}
+                    headerLeadingAction={menuInTrackHeader ? mobileMenuButton : undefined}
                     selectedFile={editor.selectedFile}
                     selectedFileId={selectedFileId}
                     register={editor.form.register}

--- a/tests/e2e/metadata-editor-layout.spec.ts
+++ b/tests/e2e/metadata-editor-layout.spec.ts
@@ -52,6 +52,37 @@ const readEditorLayout = async (page: Page) =>
     };
   });
 
+test("keeps the mobile library button beside the filename", async ({ page, browserName }) => {
+  test.skip(browserName !== "chromium", "layout geometry is covered in Chromium");
+  await page.setViewportSize({ width: 320, height: 568 });
+  await uploadTrack(page);
+  await enableAdvancedMetadata(page);
+  await page
+    .locator("#track-title")
+    .fill("a very long filename that needs all of the available header width");
+
+  const header = page.locator("[data-track-filename-header]");
+  const menu = header.getByRole("button", { name: "open library" });
+  const filename = header.getByRole("heading", { level: 2 });
+  const modeToggle = header.getByRole("group", { name: "metadata fields" });
+  const [headerBox, menuBox, filenameBox, modeToggleBox] = await Promise.all([
+    header.boundingBox(),
+    menu.boundingBox(),
+    filename.boundingBox(),
+    modeToggle.boundingBox(),
+  ]);
+
+  expect(headerBox).not.toBeNull();
+  expect(menuBox).not.toBeNull();
+  expect(filenameBox).not.toBeNull();
+  expect(modeToggleBox).not.toBeNull();
+  expect(menuBox!.x + menuBox!.width + 8).toBeLessThanOrEqual(filenameBox!.x);
+  expect(filenameBox!.x + filenameBox!.width + 8).toBeLessThanOrEqual(modeToggleBox!.x);
+  expect(modeToggleBox!.x + modeToggleBox!.width).toBeLessThanOrEqual(
+    headerBox!.x + headerBox!.width - 12,
+  );
+});
+
 for (const viewport of [
   { name: "desktop", width: 1280, height: 900 },
   { name: "compact", width: 390, height: 700 },

--- a/tests/unit/features/editor/errorPresentation.test.ts
+++ b/tests/unit/features/editor/errorPresentation.test.ts
@@ -34,15 +34,6 @@ describe("local error presentation", () => {
     );
   });
 
-  it("centers the filename independently from the fixed error margin", () => {
-    expect(trackMetadataEditorSource).toContain(
-      'className="flex h-full min-w-0 items-center justify-between gap-3"',
-    );
-    expect(trackMetadataEditorSource).toContain(
-      'className="absolute inset-x-4 bottom-1 h-4 min-w-0 overflow-hidden',
-    );
-  });
-
   it("keeps cover validation state separate from tooltip visibility", () => {
     expect(coverArtSource).toContain(
       'onOpenChange={(open) => dispatch({ type: "errorOpenChanged", open })}',

--- a/tests/unit/features/editor/trackMetadataEditor.test.tsx
+++ b/tests/unit/features/editor/trackMetadataEditor.test.tsx
@@ -1,4 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
+import type { ReactNode } from "react";
 import { useForm } from "react-hook-form";
 import { describe, expect, it, vi } from "vite-plus/test";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -48,10 +49,12 @@ function EditorHarness({
     albumArtist: true,
     trackNumber: true,
   },
+  headerLeadingAction,
 }: {
   selectedFile?: TagiumFile | null;
   syncFilenames?: boolean;
   metadataLinks?: MetadataLinkState;
+  headerLeadingAction?: ReactNode;
 }) {
   const { register, control, getValues, setError, clearErrors, setFocus } = useForm<AudioMetadata>({
     defaultValues: selectedFile?.metadata ?? metadata,
@@ -60,6 +63,7 @@ function EditorHarness({
   return (
     <TooltipProvider>
       <TrackMetadataEditor
+        headerLeadingAction={headerLeadingAction}
         selectedFile={selectedFile}
         selectedFileId={selectedFile?.id ?? null}
         register={register}
@@ -105,6 +109,27 @@ describe("track metadata editor form seam", () => {
     expect(markup).toContain("loading metadata");
     expect(markup.match(/aria-label="metadata fields"/g)).toHaveLength(1);
     expect(markup).not.toContain('id="track-title"');
+  });
+
+  it("keeps a leading action inside loaded and pending track headers", () => {
+    const leadingAction = <button aria-label="open library">menu</button>;
+    const loadedMarkup = renderToStaticMarkup(
+      <EditorHarness syncFilenames={false} headerLeadingAction={leadingAction} />,
+    );
+    const pendingMarkup = renderToStaticMarkup(
+      <EditorHarness
+        selectedFile={{
+          id: "pending-track",
+          filename: "pending-track.flac",
+          status: "pending",
+          downloadStatus: "downloading",
+        }}
+        headerLeadingAction={leadingAction}
+      />,
+    );
+
+    expect(loadedMarkup).toMatch(/aria-label="open library".*aria-label="filename"/);
+    expect(pendingMarkup).toMatch(/aria-label="open library".*pending-track\.flac/);
   });
 
   it("associates every metadata label with its input", () => {


### PR DESCRIPTION
## problem

on mobile, the fixed library menu button overlaid the track filename in the editor header.

## solution

render the library button as the leading action inside loaded and loading track headers. the filename now uses the remaining header width, truncates before the metadata mode control, and keeps validation errors aligned beneath it. headerless screens still use the existing floating button.

## review

1. open tagium at a 320–390 px viewport and import an mp3, flac, or m4a/mp4 track.
2. confirm the library button sits inside the filename bar and the filename begins to its right.
3. use a long title with filename syncing enabled; expect the filename to truncate without touching the menu or normal/advanced control.
4. open and close the library drawer; expect the button to work normally and regain focus after close.
5. briefly check a pending URL import and an empty workspace; expect the pending header to keep the button inline, while the headerless importer keeps the floating button.

important edge cases: long filenames, the required-filename error, the advanced metadata toggle, and tracks whose metadata is still loading.

decision: the filename remains left-aligned after the menu instead of being visually centered. centering would compete with the optional mode control and reduce usable filename width on the smallest supported screens. desktop layout is unchanged.

## verification

- `bun run typecheck`
- `bun run lint -- src/features/editor/TrackMetadataEditor.tsx src/features/workspace/audioTagger.tsx tests/unit/features/editor/trackMetadataEditor.test.tsx tests/e2e/metadata-editor-layout.spec.ts`
- `bun run test tests/unit/features/editor/trackMetadataEditor.test.tsx`
- `bun run test:e2e tests/e2e/metadata-editor-layout.spec.ts --project=chromium`
- automated 320 px geometry coverage verifies spacing between the menu, a long filename, and the mode control
- manual verification is still recommended on a real touch device

created by gpt-5.6-sol in t3 code through the codex harness.