### PR TITLE
fix: detect all shared metadata edits

### DIFF
--- a/src/features/editor/useTrackEditorSession.ts
+++ b/src/features/editor/useTrackEditorSession.ts
@@ -129,7 +129,14 @@ export interface TrackEditorSession {
   isCoverProcessing: boolean;
   form: Pick<
     ReturnType<typeof useForm<AudioMetadata>>,
-    "register" | "control" | "getValues" | "setError" | "clearErrors" | "setFocus" | "reset"
+    | "register"
+    | "control"
+    | "getValues"
+    | "setError"
+    | "clearErrors"
+    | "setFocus"
+    | "reset"
+    | "subscribe"
   >;
   commands: {
     projectFiles: (trackIds?: string[]) => TagiumFile[];
@@ -173,6 +180,7 @@ export const useTrackEditorSession = ({
     setError,
     clearErrors,
     setFocus,
+    subscribe,
     formState: { dirtyFields },
   } = useForm<AudioMetadata>();
   const formIsDirty = Object.keys(dirtyFields).length > 0;
@@ -684,7 +692,7 @@ export const useTrackEditorSession = ({
     selectedFile,
     selectedFileAlbum,
     isCoverProcessing,
-    form: { register, control, getValues, setError, clearErrors, setFocus, reset },
+    form: { register, control, getValues, setError, clearErrors, setFocus, reset, subscribe },
     commands: {
       projectFiles,
       flush,

--- a/src/features/share/useShareWorkflow.ts
+++ b/src/features/share/useShareWorkflow.ts
@@ -3,7 +3,7 @@ import { toast } from "sonner";
 import { analytics } from "@/analytics";
 import { coverArtFileToPicture } from "@/features/editor/coverArtProcessing";
 import type { TrackEditorSession } from "@/features/editor/useTrackEditorSession";
-import type { AlbumGroup, SharePublication, TagiumFile } from "@/features/library/types";
+import type { AlbumGroup, SharePublication } from "@/features/library/types";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
 import type { AudioImportSession } from "@/features/workspace/useAudioImportSession";
 import {
@@ -117,7 +117,6 @@ export const useShareWorkflow = ({
   );
   const [adding, setAdding] = useState(false);
   const [anotherTabOpen, setAnotherTabOpen] = useState(false);
-  const [editorProjectionVersion, setEditorProjectionVersion] = useState(0);
   const [, setExpiryTick] = useState(0);
   const loadingSlugRef = useRef<string | null>(null);
   const pageLoadIdRef = useRef(0);
@@ -126,10 +125,21 @@ export const useShareWorkflow = ({
     new Map<string, { slug: string; expiresAt: string; token: string }>(),
   );
   const publicationActionInFlightRef = useRef(false);
+  const projectFilesRef = useRef(editor.commands.projectFiles);
+  const [projectedFiles, setProjectedFiles] = useState(() => library.state.files);
   const getPublicationCapability = useCallback(
     (slug: string) => publicationReceiptsRef.current.get(slug) ?? safelyGetRevocationReceipt(slug),
     [],
   );
+
+  // Keep form projection work outside render while always calling the latest editor command.
+  useEffect(() => {
+    projectFilesRef.current = editor.commands.projectFiles;
+  });
+
+  useEffect(() => {
+    setProjectedFiles(projectFilesRef.current());
+  }, [library.state.files]);
 
   const subscribeToEditorForm = editor.form.subscribe;
   useEffect(() => {
@@ -141,7 +151,7 @@ export const useShareWorkflow = ({
       callback: () => {
         if (timer !== undefined) globalThis.clearTimeout(timer);
         timer = globalThis.setTimeout(
-          () => setEditorProjectionVersion((version) => version + 1),
+          () => setProjectedFiles(projectFilesRef.current()),
           SHARE_FINGERPRINT_DELAY_MS,
         );
       },
@@ -151,30 +161,6 @@ export const useShareWorkflow = ({
       unsubscribe();
     };
   }, [enabled, subscribeToEditorForm]);
-
-  // Form edits are projected without mutating library state; cache that projection by its real inputs.
-  const projectFilesRef = useRef(editor.commands.projectFiles);
-  projectFilesRef.current = editor.commands.projectFiles;
-  const projectedFilesCacheRef = useRef<
-    | {
-        sourceFiles: readonly TagiumFile[];
-        version: number;
-        projectedFiles: TagiumFile[];
-      }
-    | undefined
-  >(undefined);
-  if (
-    !projectedFilesCacheRef.current ||
-    projectedFilesCacheRef.current.sourceFiles !== library.state.files ||
-    projectedFilesCacheRef.current.version !== editorProjectionVersion
-  ) {
-    projectedFilesCacheRef.current = {
-      sourceFiles: library.state.files,
-      version: editorProjectionVersion,
-      projectedFiles: projectFilesRef.current(),
-    };
-  }
-  const projectedFiles = projectedFilesCacheRef.current.projectedFiles;
 
   useEffect(() => {
     const expiries: number[] = [];

--- a/src/features/share/useShareWorkflow.ts
+++ b/src/features/share/useShareWorkflow.ts
@@ -3,7 +3,7 @@ import { toast } from "sonner";
 import { analytics } from "@/analytics";
 import { coverArtFileToPicture } from "@/features/editor/coverArtProcessing";
 import type { TrackEditorSession } from "@/features/editor/useTrackEditorSession";
-import type { AlbumGroup, SharePublication } from "@/features/library/types";
+import type { AlbumGroup, SharePublication, TagiumFile } from "@/features/library/types";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
 import type { AudioImportSession } from "@/features/workspace/useAudioImportSession";
 import {
@@ -39,6 +39,18 @@ import {
 import type { SharedContentPageState } from "@/features/share/SharedAlbumPage";
 
 type ShareTarget = { kind: "album"; id: string } | { kind: "track"; id: string };
+
+const SHAREABLE_TRACK_METADATA_FIELDS = [
+  "filename",
+  "title",
+  "artist",
+  "album",
+  "genre",
+  "year",
+  "trackNumber",
+  "picture",
+] as const;
+const SHARE_FINGERPRINT_DELAY_MS = 150;
 
 const safelyGetRevocationReceipt = (slug: string) => {
   try {
@@ -81,7 +93,9 @@ export const useShareWorkflow = ({
   enabled,
 }: {
   library: LibraryStore;
-  editor: Pick<TrackEditorSession, "commands">;
+  editor: Pick<TrackEditorSession, "commands"> & {
+    form: Pick<TrackEditorSession["form"], "subscribe">;
+  };
   importing: Pick<AudioImportSession, "commands">;
   enabled: boolean;
 }) => {
@@ -103,6 +117,7 @@ export const useShareWorkflow = ({
   );
   const [adding, setAdding] = useState(false);
   const [anotherTabOpen, setAnotherTabOpen] = useState(false);
+  const [editorProjectionVersion, setEditorProjectionVersion] = useState(0);
   const [, setExpiryTick] = useState(0);
   const loadingSlugRef = useRef<string | null>(null);
   const pageLoadIdRef = useRef(0);
@@ -115,6 +130,51 @@ export const useShareWorkflow = ({
     (slug: string) => publicationReceiptsRef.current.get(slug) ?? safelyGetRevocationReceipt(slug),
     [],
   );
+
+  const subscribeToEditorForm = editor.form.subscribe;
+  useEffect(() => {
+    if (!enabled) return;
+    let timer: ReturnType<typeof globalThis.setTimeout> | undefined;
+    const unsubscribe = subscribeToEditorForm({
+      name: SHAREABLE_TRACK_METADATA_FIELDS,
+      formState: { values: true },
+      callback: () => {
+        if (timer !== undefined) globalThis.clearTimeout(timer);
+        timer = globalThis.setTimeout(
+          () => setEditorProjectionVersion((version) => version + 1),
+          SHARE_FINGERPRINT_DELAY_MS,
+        );
+      },
+    });
+    return () => {
+      if (timer !== undefined) globalThis.clearTimeout(timer);
+      unsubscribe();
+    };
+  }, [enabled, subscribeToEditorForm]);
+
+  // Form edits are projected without mutating library state; cache that projection by its real inputs.
+  const projectFilesRef = useRef(editor.commands.projectFiles);
+  projectFilesRef.current = editor.commands.projectFiles;
+  const projectedFilesCacheRef = useRef<
+    | {
+        sourceFiles: readonly TagiumFile[];
+        version: number;
+        projectedFiles: TagiumFile[];
+      }
+    | undefined
+  >(undefined);
+  if (
+    !projectedFilesCacheRef.current ||
+    projectedFilesCacheRef.current.sourceFiles !== library.state.files ||
+    projectedFilesCacheRef.current.version !== editorProjectionVersion
+  ) {
+    projectedFilesCacheRef.current = {
+      sourceFiles: library.state.files,
+      version: editorProjectionVersion,
+      projectedFiles: projectFilesRef.current(),
+    };
+  }
+  const projectedFiles = projectedFilesCacheRef.current.projectedFiles;
 
   useEffect(() => {
     const expiries: number[] = [];
@@ -153,7 +213,7 @@ export const useShareWorkflow = ({
     void Promise.all(
       publishedAlbums.map(async (album) => {
         const files = album.trackIds.map((trackId) =>
-          library.state.files.find((file) => file.id === trackId),
+          projectedFiles.find((file) => file.id === trackId),
         );
         if (files.some((file) => !file)) return [album.id, undefined] as const;
         try {
@@ -172,11 +232,11 @@ export const useShareWorkflow = ({
     return () => {
       canceled = true;
     };
-  }, [library.state.albums, library.state.files]);
+  }, [library.state.albums, projectedFiles]);
 
   useEffect(() => {
     let canceled = false;
-    const publishedTracks = library.state.files.filter(
+    const publishedTracks = projectedFiles.filter(
       (file) => file.sharePublication?.status === "active",
     );
     if (!publishedTracks.length) {
@@ -203,7 +263,7 @@ export const useShareWorkflow = ({
     return () => {
       canceled = true;
     };
-  }, [library.state.files]);
+  }, [projectedFiles]);
 
   const currentLibrary = library.getSnapshot();
   const shareActions = Object.fromEntries(

--- a/tests/unit/features/share/shareWorkflowPreview.test.tsx
+++ b/tests/unit/features/share/shareWorkflowPreview.test.tsx
@@ -74,7 +74,10 @@ describe("share creator preview state", () => {
       () =>
         useShareWorkflow({
           library,
-          editor: { commands: { flush: vi.fn() } } as never,
+          editor: {
+            commands: { flush: vi.fn(), projectFiles: () => files },
+            form: { subscribe: () => () => undefined },
+          } as never,
           importing: { commands: { importSharedContent: vi.fn() } } as never,
           enabled: true,
         }),
@@ -148,7 +151,10 @@ describe("share creator preview state", () => {
       () =>
         useShareWorkflow({
           library,
-          editor: { commands: { flush: vi.fn() } } as never,
+          editor: {
+            commands: { flush: vi.fn(), projectFiles: () => files },
+            form: { subscribe: () => () => undefined },
+          } as never,
           importing: { commands: { importSharedContent: vi.fn() } } as never,
           enabled: true,
         }),
@@ -219,7 +225,10 @@ describe("share creator preview state", () => {
       () =>
         useShareWorkflow({
           library,
-          editor: { commands: { flush: vi.fn() } } as never,
+          editor: {
+            commands: { flush: vi.fn(), projectFiles: () => files },
+            form: { subscribe: () => () => undefined },
+          } as never,
           importing: { commands: { importSharedContent: vi.fn() } } as never,
           enabled: true,
         }),

--- a/tests/unit/features/share/useShareWorkflow.test.tsx
+++ b/tests/unit/features/share/useShareWorkflow.test.tsx
@@ -2,6 +2,9 @@ import { act } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { AlbumGroup, TagiumFile } from "@/features/library/types";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
+import { useTrackEditorSession } from "@/features/editor/useTrackEditorSession";
+import { useLibraryStore } from "@/features/library/useLibraryStore";
+import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 
 const mocks = vi.hoisted(() => ({
   fetchSharedContent: vi.fn(),
@@ -80,7 +83,10 @@ const workflow = (albums: Array<{ id: string; sourceManifestSlug?: string }> = [
     getSnapshot: () => ({ albums, files: [] }),
     dispatch: vi.fn(() => events.push("select")),
   } as unknown as LibraryStore;
-  const editor = { commands: { flush: vi.fn(() => events.push("flush")) } };
+  const editor = {
+    commands: { flush: vi.fn(() => events.push("flush")), projectFiles: () => [] },
+    form: { subscribe: () => () => undefined },
+  };
   const importing = { commands: { importSharedContent: mocks.importSharedContent } };
   const hook = renderHook(
     () =>
@@ -111,7 +117,10 @@ const creatorWorkflow = (album: AlbumGroup, file: TagiumFile) => {
     () =>
       useShareWorkflow({
         library,
-        editor: { commands: { flush: vi.fn() } } as never,
+        editor: {
+          commands: { flush: vi.fn(), projectFiles: () => files },
+          form: { subscribe: () => () => undefined },
+        } as never,
         importing: { commands: { importSharedContent: vi.fn() } } as never,
         enabled: true,
       }),
@@ -135,7 +144,10 @@ const trackCreatorWorkflow = (file: TagiumFile, albums: AlbumGroup[] = [], flush
     () =>
       useShareWorkflow({
         library,
-        editor: { commands: { flush } } as never,
+        editor: {
+          commands: { flush, projectFiles: () => files },
+          form: { subscribe: () => () => undefined },
+        } as never,
         importing: { commands: { importSharedContent: vi.fn() } } as never,
         enabled: true,
       }),
@@ -381,7 +393,10 @@ describe("share workflow pasted links", () => {
       () =>
         useShareWorkflow({
           library,
-          editor: { commands: { flush: vi.fn() } } as never,
+          editor: {
+            commands: { flush: vi.fn(), projectFiles: () => [] },
+            form: { subscribe: () => () => undefined },
+          } as never,
           importing: { commands: { importSharedContent: vi.fn() } } as never,
           enabled: false,
         }),
@@ -565,6 +580,79 @@ describe("share workflow publication lifecycle", () => {
       preview: { kind: "track" },
     });
     expect(file.pendingMetadataPatch).toEqual({ genre: "Ambient" });
+    hook.unmount();
+  });
+
+  it.each([
+    ["year", "2026"],
+    ["genre", "Ambient"],
+    ["trackNumber", "2"],
+  ] as const)("offers an update after a %s-only form edit", async (field, value) => {
+    const file: TagiumFile = structuredClone(creatorFile);
+    const published = await projectTrackShareSnapshot(file);
+    file.sharePublication = {
+      slug: oldPublication.slug,
+      url: oldPublication.url,
+      expiresAt: oldPublication.expiresAt,
+      publishedFingerprint: published.fingerprint,
+      status: "active",
+    };
+    mocks.getRevocationReceipt.mockReturnValue(capability);
+    const hook = renderHook(() => {
+      const library = useLibraryStore();
+      const editor = useTrackEditorSession({
+        library,
+        settings: {
+          ...DEFAULT_APP_SETTINGS,
+          syncFilenames: false,
+          syncTrackNumbers: false,
+          metadataLinks: { ...DEFAULT_APP_SETTINGS.metadataLinks, singleAlbum: false },
+        },
+      });
+      const sharing = useShareWorkflow({
+        library,
+        editor,
+        importing: { commands: { importSharedContent: vi.fn() } } as never,
+        enabled: true,
+      });
+      return { editor, library, sharing };
+    }, undefined);
+    act(() => {
+      hook.result.library.dispatch({
+        type: "content-replaced",
+        files: [file],
+        looseTrackIds: [file.id],
+        selection: { selectedAlbumId: null, selectedFileId: file.id },
+      });
+    });
+    await vi.waitFor(() =>
+      expect(hook.result.sharing.shareTrackActions[file.id]?.label).toBe("view share link"),
+    );
+
+    const registration = hook.result.editor.form.register(
+      field,
+      field === "genre" ? {} : { valueAsNumber: true },
+    );
+    const target = {
+      name: field,
+      value,
+      ...(field === "genre" ? {} : { type: "number", valueAsNumber: Number(value) }),
+    };
+    act(() => {
+      if (field !== "genre") {
+        registration.ref(target as HTMLInputElement);
+        target.value = value;
+        target.valueAsNumber = Number(value);
+      }
+      void registration.onChange({ target, type: "change" });
+    });
+    expect(hook.result.editor.form.getValues(field)).toBe(
+      field === "genre" ? value : Number(value),
+    );
+
+    await vi.waitFor(() =>
+      expect(hook.result.sharing.shareTrackActions[file.id]?.label).toBe("update shared track"),
+    );
     hook.unmount();
   });
 


### PR DESCRIPTION
## problem

share actions only reacted immediately to fields already previewed into library state. changing year, genre, or track number left an active publication labeled as view share link even though opening it correctly discovered the pending update.

## solution

subscribe to shareable editor fields, debounce the work, and fingerprint projected files that include form-local edits without mutating library state. regression coverage now exercises year-, genre-, and track-number-only edits through the real editor and share workflow boundary.

## review

- create a share link for a downloaded track, then change only its year, genre, or track number. expect the action to become update shared track after the short debounce.
- repeat with a track inside a shared album. expect the album action to become update shared album.
- revert the edited value to the published value. expect the action to return to view share link.
- confirm title and artist edits still update the action as before.
- edge cases: a browser without the publication capability must still be unable to update, and content imported from another share must remain view-only.

The implementation deliberately projects form state for comparison instead of committing every keystroke to library state. Fingerprinting is debounced by 150 ms to avoid expensive work while typing.

## verification

- bun run test — 779 tests passed
- bun run build
- bun run lint
- manual UI verification remains for the reviewer flows above

Changes prepared by GPT-5.6 Sol in T3 Code using the Codex harness.