### PR TITLE
fix: reset title after adding shared content

### DIFF
--- a/src/features/share/useShareWorkflow.ts
+++ b/src/features/share/useShareWorkflow.ts
@@ -723,6 +723,7 @@ export const useShareWorkflow = ({
           trackCount: manifestTrackCount(fresh.manifest),
         });
         history.replaceState({}, "", "/");
+        document.title = "tagium";
         setPage(null);
         toast.success(`${fresh.manifest.kind} added to your library`, {
           description: sharedContentAddedDescription(fresh.manifest),

--- a/tests/unit/features/share/useShareWorkflow.test.tsx
+++ b/tests/unit/features/share/useShareWorkflow.test.tsx
@@ -199,6 +199,7 @@ beforeEach(() => {
   vi.stubGlobal("location", location);
   vi.stubGlobal("history", fakeHistory);
   vi.stubGlobal("window", new EventTarget());
+  vi.stubGlobal("document", { title: "tagium" });
 });
 
 afterEach(() => {
@@ -314,6 +315,23 @@ describe("share workflow pasted links", () => {
       shareKind: "album",
       trackCount: 1,
     });
+    hook.unmount();
+  });
+
+  it("restores the app title after adding from a share preview", async () => {
+    history.replaceState({}, "", `/share/${slug}`);
+    document.title = "Track · tagium";
+    mocks.fetchSharedContent.mockResolvedValue({
+      manifest: sharedManifest,
+      expiresAt: "2026-10-20T12:00:00.000Z",
+      analyticsId,
+    });
+    const { hook } = workflow();
+
+    await vi.waitFor(() => expect(hook.result.page).toMatchObject({ status: "ready", slug }));
+    await act(async () => hook.result.addSharedContent());
+
+    expect(document.title).toBe("tagium");
     hook.unmount();
   });
 


### PR DESCRIPTION
## Problem

Share pages receive a content-specific document title from the server. Adding that content returns the single-page app to the library with `history.replaceState`, which changes the URL but leaves the share title in the browser tab.

## Solution

Reset the document title to `tagium` after a shared track or album is imported successfully. A regression test covers the share-preview-to-library transition.

## Human review

- Open a valid track or album share link.
- Click **add to library**.
- Confirm the content appears in the library, the URL returns to `/`, and the browser tab reads `tagium`.
- If adding fails, confirm the share page and its content-specific title remain visible.
- Reviewer decision: the reset intentionally happens only after a successful import.

## Verification

- `bun run test tests/unit/features/share/useShareWorkflow.test.tsx` — 16 tests passed
- `bun run typecheck`
- `bunx vp lint src/features/share/useShareWorkflow.ts tests/unit/features/share/useShareWorkflow.test.tsx` — no warnings or errors

Changes prepared by GPT-5.6-Sol using the Codex harness in T3 Code.