### PR TITLE
feat: add floating labels to metadata forms

### DIFF
--- a/src/components/ui/floating-label-field.tsx
+++ b/src/components/ui/floating-label-field.tsx
@@ -14,7 +14,7 @@ function FloatingFieldLabel({ htmlFor, label, required }: FloatingFieldLabelProp
   return (
     <label
       htmlFor={htmlFor}
-      className="absolute left-2.5 top-0 z-10 flex max-w-[calc(100%-1.25rem)] -translate-y-1/2 items-center gap-0.5 bg-background px-1 text-xs leading-none font-medium text-muted-foreground transition-colors peer-focus-visible:text-ring peer-aria-invalid:text-destructive"
+      className="absolute left-2 top-0 z-20 flex max-w-[calc(100%-1rem)] -translate-y-1/2 items-center gap-0.5 px-1 text-xs leading-none font-medium text-muted-foreground transition-colors peer-focus-visible:text-ring peer-aria-invalid:text-destructive"
     >
       <span className="truncate">{label}</span>
       {required && (
@@ -26,6 +26,22 @@ function FloatingFieldLabel({ htmlFor, label, required }: FloatingFieldLabelProp
         </>
       )}
     </label>
+  );
+}
+
+function FloatingFieldOutline({ label, required }: Omit<FloatingFieldLabelProps, "htmlFor">) {
+  return (
+    <fieldset
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 z-10 m-0 min-w-0 rounded-md border border-input px-2 py-0 shadow-xs transition-[border-color,box-shadow] peer-focus-visible:border-ring peer-focus-visible:ring-[3px] peer-focus-visible:ring-ring/50 peer-aria-invalid:border-destructive peer-aria-invalid:ring-destructive/20 peer-disabled:border-dashed dark:peer-aria-invalid:ring-destructive/40"
+    >
+      <legend className="float-none w-auto max-w-[calc(100%-1rem)] overflow-hidden whitespace-nowrap p-0 text-xs leading-none">
+        <span className="invisible inline-flex max-w-full items-center gap-0.5 px-1">
+          <span className="truncate">{label}</span>
+          {required && <span className="shrink-0">*</span>}
+        </span>
+      </legend>
+    </fieldset>
   );
 }
 
@@ -44,14 +60,20 @@ function FloatingLabelInput({
   ...props
 }: FloatingLabelInputProps) {
   return (
-    <div data-slot="floating-label-field" className={cn("relative", containerClassName)}>
+    <div data-slot="floating-label-field" className={cn("relative isolate", containerClassName)}>
       <Input
         id={id}
         required={required}
-        className={cn("peer h-14 px-3 pb-1.5 pt-4 placeholder:text-muted-foreground", className)}
+        className={cn(
+          "peer relative z-0 h-14 border-transparent px-3 pb-1.5 pt-4 shadow-none placeholder:text-muted-foreground",
+          "focus-visible:border-transparent focus-visible:ring-0",
+          "aria-invalid:border-transparent aria-invalid:ring-0",
+          className,
+        )}
         {...props}
       />
       <FloatingFieldLabel htmlFor={id} label={label} required={required} />
+      <FloatingFieldOutline label={label} required={required} />
     </div>
   );
 }
@@ -71,19 +93,20 @@ function FloatingLabelTextarea({
   ...props
 }: FloatingLabelTextareaProps) {
   return (
-    <div data-slot="floating-label-field" className={cn("relative", containerClassName)}>
+    <div data-slot="floating-label-field" className={cn("relative isolate", containerClassName)}>
       <textarea
         id={id}
         required={required}
         className={cn(
-          "peer border-input placeholder:text-muted-foreground selection:bg-brand selection:text-background dark:bg-input/30 flex min-h-20 w-full resize-y rounded-md border bg-transparent px-3 pb-2 pt-4 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-          "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-          "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+          "peer relative z-0 flex min-h-20 w-full resize-y rounded-md border border-transparent bg-transparent px-3 pb-2 pt-4 text-base shadow-none outline-none placeholder:text-muted-foreground selection:bg-brand selection:text-background disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+          "focus-visible:border-transparent focus-visible:ring-0",
+          "aria-invalid:border-transparent aria-invalid:ring-0",
           className,
         )}
         {...props}
       />
       <FloatingFieldLabel htmlFor={id} label={label} required={required} />
+      <FloatingFieldOutline label={label} required={required} />
     </div>
   );
 }

--- a/src/components/ui/floating-label-field.tsx
+++ b/src/components/ui/floating-label-field.tsx
@@ -4,18 +4,30 @@ import * as React from "react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
-interface FloatingFieldLabelProps {
+/**
+ * Metadata fields are one uninterrupted outlined box with the label seated inside its top
+ * edge, so the outline never has to be notched or painted over. The label borrows the small
+ * wide-tracked caption idiom used elsewhere in the app (see SettingsLinkMap), and the control
+ * keeps every one of its own states — border, focus ring, invalid, disabled.
+ */
+const insetLabelClassName = cn(
+  "pointer-events-none absolute top-2.5 left-3 flex max-w-[calc(100%-1.5rem)] items-center gap-0.5",
+  "text-[0.6875rem] leading-none tracking-widest text-muted-foreground transition-colors select-none",
+  "peer-focus-visible:text-ring peer-aria-invalid:text-destructive",
+);
+
+/** Reserves room for the inset label above the value and gives disabled fields a dashed outline. */
+const insetFieldClassName = "peer px-3 pt-7 disabled:border-dashed";
+
+interface InsetFieldLabelProps {
   htmlFor: string;
   label: string;
   required?: boolean;
 }
 
-function FloatingFieldLabel({ htmlFor, label, required }: FloatingFieldLabelProps) {
+function InsetFieldLabel({ htmlFor, label, required }: InsetFieldLabelProps) {
   return (
-    <label
-      htmlFor={htmlFor}
-      className="absolute left-2 top-0 z-20 flex max-w-[calc(100%-1rem)] -translate-y-1/2 items-center gap-0.5 px-1 text-xs leading-none font-medium text-muted-foreground transition-colors peer-focus-visible:text-ring peer-aria-invalid:text-destructive"
-    >
+    <label htmlFor={htmlFor} className={insetLabelClassName}>
       <span className="truncate">{label}</span>
       {required && (
         <>
@@ -26,22 +38,6 @@ function FloatingFieldLabel({ htmlFor, label, required }: FloatingFieldLabelProp
         </>
       )}
     </label>
-  );
-}
-
-function FloatingFieldOutline({ label, required }: Omit<FloatingFieldLabelProps, "htmlFor">) {
-  return (
-    <fieldset
-      aria-hidden="true"
-      className="pointer-events-none absolute inset-0 z-10 m-0 min-w-0 rounded-md border border-input px-2 py-0 shadow-xs transition-[border-color,box-shadow] peer-focus-visible:border-ring peer-focus-visible:ring-[3px] peer-focus-visible:ring-ring/50 peer-aria-invalid:border-destructive peer-aria-invalid:ring-destructive/20 peer-disabled:border-dashed dark:peer-aria-invalid:ring-destructive/40"
-    >
-      <legend className="float-none w-auto max-w-[calc(100%-1rem)] overflow-hidden whitespace-nowrap p-0 text-xs leading-none">
-        <span className="invisible inline-flex max-w-full items-center gap-0.5 px-1">
-          <span className="truncate">{label}</span>
-          {required && <span className="shrink-0">*</span>}
-        </span>
-      </legend>
-    </fieldset>
   );
 }
 
@@ -60,20 +56,14 @@ function FloatingLabelInput({
   ...props
 }: FloatingLabelInputProps) {
   return (
-    <div data-slot="floating-label-field" className={cn("relative isolate", containerClassName)}>
+    <div data-slot="floating-label-field" className={cn("relative", containerClassName)}>
       <Input
         id={id}
         required={required}
-        className={cn(
-          "peer relative z-0 h-14 border-transparent px-3 pb-1.5 pt-4 shadow-none placeholder:text-muted-foreground",
-          "focus-visible:border-transparent focus-visible:ring-0",
-          "aria-invalid:border-transparent aria-invalid:ring-0",
-          className,
-        )}
+        className={cn(insetFieldClassName, "h-14 pb-1.5", className)}
         {...props}
       />
-      <FloatingFieldLabel htmlFor={id} label={label} required={required} />
-      <FloatingFieldOutline label={label} required={required} />
+      <InsetFieldLabel htmlFor={id} label={label} required={required} />
     </div>
   );
 }
@@ -84,6 +74,15 @@ type FloatingLabelTextareaProps = Omit<React.ComponentProps<"textarea">, "id"> &
   containerClassName?: string;
 };
 
+/* There is no textarea primitive in the app, so the surface below mirrors `Input`. */
+const textareaSurfaceClassName = cn(
+  "border-input flex w-full min-w-0 resize-y rounded-md border bg-transparent text-base shadow-xs",
+  "transition-[color,box-shadow] outline-none placeholder:text-muted-foreground selection:bg-brand selection:text-background",
+  "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+  "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+  "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+);
+
 function FloatingLabelTextarea({
   id,
   label,
@@ -93,20 +92,14 @@ function FloatingLabelTextarea({
   ...props
 }: FloatingLabelTextareaProps) {
   return (
-    <div data-slot="floating-label-field" className={cn("relative isolate", containerClassName)}>
+    <div data-slot="floating-label-field" className={cn("relative", containerClassName)}>
       <textarea
         id={id}
         required={required}
-        className={cn(
-          "peer relative z-0 flex min-h-20 w-full resize-y rounded-md border border-transparent bg-transparent px-3 pb-2 pt-4 text-base shadow-none outline-none placeholder:text-muted-foreground selection:bg-brand selection:text-background disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
-          "focus-visible:border-transparent focus-visible:ring-0",
-          "aria-invalid:border-transparent aria-invalid:ring-0",
-          className,
-        )}
+        className={cn(textareaSurfaceClassName, insetFieldClassName, "min-h-20 pb-2", className)}
         {...props}
       />
-      <FloatingFieldLabel htmlFor={id} label={label} required={required} />
-      <FloatingFieldOutline label={label} required={required} />
+      <InsetFieldLabel htmlFor={id} label={label} required={required} />
     </div>
   );
 }

--- a/src/components/ui/floating-label-field.tsx
+++ b/src/components/ui/floating-label-field.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import * as React from "react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface FloatingFieldLabelProps {
+  htmlFor: string;
+  label: string;
+  required?: boolean;
+}
+
+function FloatingFieldLabel({ htmlFor, label, required }: FloatingFieldLabelProps) {
+  return (
+    <label
+      htmlFor={htmlFor}
+      className="absolute left-2.5 top-0 z-10 flex max-w-[calc(100%-1.25rem)] -translate-y-1/2 items-center gap-0.5 bg-background px-1 text-xs leading-none font-medium text-muted-foreground transition-colors peer-focus-visible:text-ring peer-aria-invalid:text-destructive"
+    >
+      <span className="truncate">{label}</span>
+      {required && (
+        <>
+          <span className="shrink-0 text-destructive" aria-hidden="true">
+            *
+          </span>
+          <span className="sr-only"> required</span>
+        </>
+      )}
+    </label>
+  );
+}
+
+type FloatingLabelInputProps = Omit<React.ComponentProps<typeof Input>, "id"> & {
+  id: string;
+  label: string;
+  containerClassName?: string;
+};
+
+function FloatingLabelInput({
+  id,
+  label,
+  required,
+  className,
+  containerClassName,
+  ...props
+}: FloatingLabelInputProps) {
+  return (
+    <div data-slot="floating-label-field" className={cn("relative", containerClassName)}>
+      <Input
+        id={id}
+        required={required}
+        className={cn("peer h-14 px-3 pb-1.5 pt-4 placeholder:text-muted-foreground", className)}
+        {...props}
+      />
+      <FloatingFieldLabel htmlFor={id} label={label} required={required} />
+    </div>
+  );
+}
+
+type FloatingLabelTextareaProps = Omit<React.ComponentProps<"textarea">, "id"> & {
+  id: string;
+  label: string;
+  containerClassName?: string;
+};
+
+function FloatingLabelTextarea({
+  id,
+  label,
+  required,
+  className,
+  containerClassName,
+  ...props
+}: FloatingLabelTextareaProps) {
+  return (
+    <div data-slot="floating-label-field" className={cn("relative", containerClassName)}>
+      <textarea
+        id={id}
+        required={required}
+        className={cn(
+          "peer border-input placeholder:text-muted-foreground selection:bg-brand selection:text-background dark:bg-input/30 flex min-h-20 w-full resize-y rounded-md border bg-transparent px-3 pb-2 pt-4 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+          "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+          className,
+        )}
+        {...props}
+      />
+      <FloatingFieldLabel htmlFor={id} label={label} required={required} />
+    </div>
+  );
+}
+
+export { FloatingLabelInput, FloatingLabelTextarea };

--- a/src/components/ui/floating-label-field.tsx
+++ b/src/components/ui/floating-label-field.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
  */
 const insetLabelClassName = cn(
   "pointer-events-none absolute top-2.5 left-3 flex max-w-[calc(100%-1.5rem)] items-center gap-0.5",
-  "text-[0.6875rem] leading-none tracking-widest text-muted-foreground transition-colors select-none",
+  "text-[0.6875rem] leading-tight tracking-widest text-muted-foreground transition-colors select-none",
   "peer-focus-visible:text-ring peer-aria-invalid:text-destructive",
 );
 

--- a/src/features/editor/AlbumMetadataDialog.tsx
+++ b/src/features/editor/AlbumMetadataDialog.tsx
@@ -13,7 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
+import { FloatingLabelInput } from "@/components/ui/floating-label-field";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import CoverArt from "@/features/editor/coverArt";
 import { useAlbumCoverSync } from "@/features/editor/useAlbumCoverSync";
@@ -58,7 +58,6 @@ export default function AlbumMetadataDialog({
   });
   const canSyncCoverToTracks =
     mode === "edit" && draft.cover && draft.cover.length > 0 && onSyncCoverToTracks;
-  const placeholderClassName = "placeholder:text-muted-foreground/45";
   const titleInvalid = !draft.title.trim();
   const artistInvalid = !draft.artist.trim();
   const formInvalid = titleInvalid || artistInvalid;
@@ -107,15 +106,9 @@ export default function AlbumMetadataDialog({
               <div className="order-2 min-w-0 h-full flex flex-col justify-between gap-3 md:order-2">
                 <div className="flex flex-col gap-0">
                   <div>
-                    <label htmlFor="album-title" className="block text-sm font-medium mb-1">
-                      album title:{" "}
-                      <span className="text-destructive" aria-hidden="true">
-                        *
-                      </span>
-                      <span className="sr-only"> required</span>
-                    </label>
-                    <Input
+                    <FloatingLabelInput
                       id="album-title"
+                      label="album title"
                       required
                       aria-required="true"
                       value={draft.title}
@@ -126,12 +119,11 @@ export default function AlbumMetadataDialog({
                         })
                       }
                       onBlur={() => setTouchedFields((current) => ({ ...current, title: true }))}
-                      placeholder={placeholder.title.toLowerCase()}
+                      placeholder={placeholder.title}
                       aria-invalid={touchedFields.title && titleInvalid}
                       aria-describedby={
                         touchedFields.title && titleInvalid ? "album-title-error" : undefined
                       }
-                      className={placeholderClassName}
                     />
                     <p
                       id="album-title-error"
@@ -142,15 +134,9 @@ export default function AlbumMetadataDialog({
                     </p>
                   </div>
                   <div>
-                    <label htmlFor="album-artist" className="block text-sm font-medium mb-1">
-                      artist:{" "}
-                      <span className="text-destructive" aria-hidden="true">
-                        *
-                      </span>
-                      <span className="sr-only"> required</span>
-                    </label>
-                    <Input
+                    <FloatingLabelInput
                       id="album-artist"
+                      label="artist"
                       required
                       aria-required="true"
                       value={draft.artist}
@@ -161,12 +147,11 @@ export default function AlbumMetadataDialog({
                         })
                       }
                       onBlur={() => setTouchedFields((current) => ({ ...current, artist: true }))}
-                      placeholder={placeholder.artist.toLowerCase()}
+                      placeholder={placeholder.artist}
                       aria-invalid={touchedFields.artist && artistInvalid}
                       aria-describedby={
                         touchedFields.artist && artistInvalid ? "album-artist-error" : undefined
                       }
-                      className={placeholderClassName}
                     />
                     <p
                       id="album-artist-error"
@@ -177,11 +162,9 @@ export default function AlbumMetadataDialog({
                     </p>
                   </div>
                   <div className="mb-3">
-                    <label htmlFor="album-genre" className="block text-sm font-medium mb-1">
-                      genre:
-                    </label>
-                    <Input
+                    <FloatingLabelInput
                       id="album-genre"
+                      label="genre"
                       value={draft.genre}
                       onChange={(event) =>
                         onChange({
@@ -189,31 +172,26 @@ export default function AlbumMetadataDialog({
                           genre: event.target.value,
                         })
                       }
-                      placeholder={placeholder.genre.toLowerCase()}
-                      className={placeholderClassName}
+                      placeholder={placeholder.genre}
                     />
                   </div>
-                  <div>
-                    <label htmlFor="album-year" className="block text-sm font-medium mb-1">
-                      year:
-                    </label>
-                    <Input
-                      id="album-year"
-                      type="number"
-                      min={0}
-                      max={9999}
-                      step={1}
-                      value={draft.year ?? ""}
-                      onChange={(event) =>
-                        onChange({
-                          ...draft,
-                          year: event.target.value ? Number(event.target.value) : undefined,
-                        })
-                      }
-                      placeholder={placeholder.year.toLowerCase()}
-                      className={`${placeholderClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
-                    />
-                  </div>
+                  <FloatingLabelInput
+                    id="album-year"
+                    label="year"
+                    type="number"
+                    min={0}
+                    max={9999}
+                    step={1}
+                    value={draft.year ?? ""}
+                    onChange={(event) =>
+                      onChange({
+                        ...draft,
+                        year: event.target.value ? Number(event.target.value) : undefined,
+                      })
+                    }
+                    placeholder={placeholder.year}
+                    className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  />
                 </div>
               </div>
               <CoverArt

--- a/src/features/editor/TrackMetadataEditor.tsx
+++ b/src/features/editor/TrackMetadataEditor.tsx
@@ -17,7 +17,7 @@ import {
   type UseFormSetFocus,
 } from "react-hook-form";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { FloatingLabelInput, FloatingLabelTextarea } from "@/components/ui/floating-label-field";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import CoverArt from "@/features/editor/coverArt";
 import AudioImportDropzone from "@/features/import/AudioImportDropzone";
@@ -89,8 +89,6 @@ interface PendingTrackMetadataEditorProps extends Pick<
 const hasMetadata = (selectedFile: TagiumFile | null): selectedFile is LoadedTrack =>
   Boolean(selectedFile?.metadata);
 
-const fieldLabelClassName = "mb-1 block text-xs font-medium md:text-sm";
-const placeholderClassName = "placeholder:text-muted-foreground/45";
 const syncedInputClassName =
   "disabled:pointer-events-auto disabled:cursor-not-allowed disabled:border-dashed disabled:bg-muted/10 disabled:text-muted-foreground disabled:opacity-100 dark:disabled:bg-muted/10";
 
@@ -283,52 +281,41 @@ function TrackDetailsFields({
 
   return (
     <>
-      <div>
-        <label htmlFor="track-title" className={fieldLabelClassName}>
-          title:
-        </label>
-        <Input
-          {...titleInputRegistration}
-          id="track-title"
-          ref={titleInputRef}
-          aria-invalid={syncFilenames && filenameInvalid}
-          aria-describedby={syncFilenames && filenameInvalid ? "track-filename-error" : undefined}
-          placeholder={placeholder.title}
-          className={placeholderClassName}
-        />
-      </div>
-      <div>
-        <label htmlFor="track-artist" className={fieldLabelClassName}>
-          artist:
-        </label>
-        <DisabledReason
+      <FloatingLabelInput
+        {...titleInputRegistration}
+        id="track-title"
+        label="title"
+        ref={titleInputRef}
+        aria-invalid={syncFilenames && filenameInvalid}
+        aria-describedby={syncFilenames && filenameInvalid ? "track-filename-error" : undefined}
+        placeholder={placeholder.title}
+      />
+      <DisabledReason
+        disabled={inAlbum && metadataLinks.artist}
+        reason={getMetadataLinkDescriptor("artist").disabledReason}
+      >
+        <FloatingLabelInput
+          {...artistRegistration}
+          id="track-artist"
+          label="artist"
+          placeholder={placeholder.artist}
           disabled={inAlbum && metadataLinks.artist}
-          reason={getMetadataLinkDescriptor("artist").disabledReason}
-        >
-          <Input
-            {...artistRegistration}
-            id="track-artist"
-            placeholder={placeholder.artist}
-            disabled={inAlbum && metadataLinks.artist}
-            className={`${placeholderClassName} ${syncedInputClassName}`}
-          />
-        </DisabledReason>
-      </div>
+          className={syncedInputClassName}
+        />
+      </DisabledReason>
       <div>
-        <label htmlFor="track-album" className={fieldLabelClassName}>
-          album:
-        </label>
         <DisabledReason disabled={albumLinked} reason={albumFieldReason}>
-          <Input
+          <FloatingLabelInput
             key={singleAlbumLinked ? "linked" : "unlinked"}
             {...(singleAlbumLinked ? { name: albumRegistration.name } : albumRegistration)}
             id="track-album"
+            label="album"
             aria-describedby={albumLinked ? albumFieldReasonId : undefined}
             placeholder={placeholder.album}
             disabled={albumLinked}
             readOnly={albumLinked}
             value={singleAlbumLinked ? linkedAlbumValue : undefined}
-            className={`${placeholderClassName} ${syncedInputClassName}`}
+            className={syncedInputClassName}
           />
         </DisabledReason>
         {albumLinked && (
@@ -338,65 +325,53 @@ function TrackDetailsFields({
         )}
       </div>
       <div className="grid grid-cols-[minmax(4.5rem,0.8fr)_minmax(0,1.4fr)_minmax(4.5rem,0.8fr)] gap-2">
-        <div>
-          <label htmlFor="track-year" className={fieldLabelClassName}>
-            year:
-          </label>
-          <DisabledReason
+        <DisabledReason
+          disabled={inAlbum && metadataLinks.year}
+          reason={getMetadataLinkDescriptor("year").disabledReason}
+        >
+          <FloatingLabelInput
+            type="number"
+            min={0}
+            max={9999}
+            step={1}
+            {...register("year", { valueAsNumber: true })}
+            id="track-year"
+            label="year"
+            placeholder={placeholder.year}
             disabled={inAlbum && metadataLinks.year}
-            reason={getMetadataLinkDescriptor("year").disabledReason}
-          >
-            <Input
-              type="number"
-              min={0}
-              max={9999}
-              step={1}
-              {...register("year", { valueAsNumber: true })}
-              id="track-year"
-              placeholder={placeholder.year}
-              disabled={inAlbum && metadataLinks.year}
-              className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
-            />
-          </DisabledReason>
-        </div>
-        <div>
-          <label htmlFor="track-genre" className={fieldLabelClassName}>
-            genre:
-          </label>
-          <DisabledReason
+            className={`${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
+          />
+        </DisabledReason>
+        <DisabledReason
+          disabled={inAlbum && metadataLinks.genre}
+          reason={getMetadataLinkDescriptor("genre").disabledReason}
+        >
+          <FloatingLabelInput
+            {...register("genre")}
+            id="track-genre"
+            label="genre"
+            placeholder={placeholder.genre}
             disabled={inAlbum && metadataLinks.genre}
-            reason={getMetadataLinkDescriptor("genre").disabledReason}
-          >
-            <Input
-              {...register("genre")}
-              id="track-genre"
-              placeholder={placeholder.genre}
-              disabled={inAlbum && metadataLinks.genre}
-              className={`${placeholderClassName} ${syncedInputClassName}`}
-            />
-          </DisabledReason>
-        </div>
-        <div>
-          <label htmlFor="track-number" className={fieldLabelClassName}>
-            track:
-          </label>
-          <DisabledReason
+            className={syncedInputClassName}
+          />
+        </DisabledReason>
+        <DisabledReason
+          disabled={inAlbum && metadataLinks.trackNumber}
+          reason={getMetadataLinkDescriptor("trackNumber").disabledReason}
+        >
+          <FloatingLabelInput
+            type="number"
+            min={1}
+            max={65535}
+            step={1}
+            {...register("trackNumber", { valueAsNumber: true })}
+            id="track-number"
+            label="track"
+            placeholder={placeholder.trackNumber}
             disabled={inAlbum && metadataLinks.trackNumber}
-            reason={getMetadataLinkDescriptor("trackNumber").disabledReason}
-          >
-            <Input
-              type="number"
-              min={1}
-              max={65535}
-              step={1}
-              {...register("trackNumber", { valueAsNumber: true })}
-              id="track-number"
-              placeholder={placeholder.trackNumber}
-              disabled={inAlbum && metadataLinks.trackNumber}
-              className={`${placeholderClassName} ${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
-            />
-          </DisabledReason>
-        </div>
+            className={`${syncedInputClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
+          />
+        </DisabledReason>
       </div>
     </>
   );
@@ -433,22 +408,20 @@ function AdvancedTrackDetailsFields({
   return (
     <>
       <div>
-        <label htmlFor="track-album-artist" className={fieldLabelClassName}>
-          album artist:
-        </label>
         <DisabledReason disabled={albumArtistLinked} reason={albumArtistReason}>
-          <Input
+          <FloatingLabelInput
             key={albumArtistLinked ? "linked" : "unlinked"}
             {...(albumArtistLinked
               ? { name: registrations.albumArtist.name }
               : registrations.albumArtist)}
             id="track-album-artist"
+            label="album artist"
             aria-describedby={albumArtistLinked ? albumArtistReasonId : undefined}
             disabled={albumArtistLinked}
             readOnly={albumArtistLinked}
             value={albumArtistLinked ? linkedArtistValue : undefined}
             placeholder="album artist"
-            className={`${placeholderClassName} ${syncedInputClassName}`}
+            className={syncedInputClassName}
           />
         </DisabledReason>
         {albumArtistLinked && (
@@ -459,10 +432,7 @@ function AdvancedTrackDetailsFields({
       </div>
       <div ref={onFieldsMount} className="grid grid-cols-2 gap-2">
         <div>
-          <label htmlFor="track-disc-number" className={fieldLabelClassName}>
-            disc number:
-          </label>
-          <Input
+          <FloatingLabelInput
             type="number"
             inputMode="numeric"
             min={1}
@@ -470,10 +440,11 @@ function AdvancedTrackDetailsFields({
             step={1}
             {...registrations.discNumber}
             id="track-disc-number"
+            label="disc number"
             aria-invalid={Boolean(errors.discNumber)}
             aria-describedby={errors.discNumber ? "track-disc-number-error" : undefined}
             placeholder="1"
-            className={`${placeholderClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
+            className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
           />
           {errors.discNumber && (
             <p
@@ -486,10 +457,7 @@ function AdvancedTrackDetailsFields({
           )}
         </div>
         <div>
-          <label htmlFor="track-bpm" className={fieldLabelClassName}>
-            bpm:
-          </label>
-          <Input
+          <FloatingLabelInput
             type="number"
             inputMode="numeric"
             min={1}
@@ -497,10 +465,11 @@ function AdvancedTrackDetailsFields({
             step={1}
             {...registrations.bpm}
             id="track-bpm"
+            label="bpm"
             aria-invalid={Boolean(errors.bpm)}
             aria-describedby={errors.bpm ? "track-bpm-error" : undefined}
             placeholder="120"
-            className={`${placeholderClassName} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
+            className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
           />
           {errors.bpm && (
             <p
@@ -513,29 +482,19 @@ function AdvancedTrackDetailsFields({
           )}
         </div>
       </div>
-      <div>
-        <label htmlFor="track-composer" className={fieldLabelClassName}>
-          composer:
-        </label>
-        <Input
-          {...registrations.composer}
-          id="track-composer"
-          placeholder="composer"
-          className={placeholderClassName}
-        />
-      </div>
-      <div>
-        <label htmlFor="track-comment" className={fieldLabelClassName}>
-          comment:
-        </label>
-        <textarea
-          {...registrations.comment}
-          id="track-comment"
-          rows={2}
-          placeholder="add a comment"
-          className="border-input placeholder:text-muted-foreground/45 selection:bg-brand selection:text-background focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex min-h-16 w-full resize-y rounded-md border bg-transparent px-3 py-2 text-base shadow-xs outline-none focus-visible:ring-[3px] md:text-sm"
-        />
-      </div>
+      <FloatingLabelInput
+        {...registrations.composer}
+        id="track-composer"
+        label="composer"
+        placeholder="composer"
+      />
+      <FloatingLabelTextarea
+        {...registrations.comment}
+        id="track-comment"
+        label="comment"
+        rows={2}
+        placeholder="add a comment"
+      />
     </>
   );
 }
@@ -804,7 +763,7 @@ function LoadedTrackMetadataEditor({
           syncFilenames={syncFilenames}
           watchedFilename={watchedFilename}
           sanitizedFilename={sanitizeFilenameBase(filenameValue)}
-          filenamePlaceholder={placeholder.filename.toLowerCase()}
+          filenamePlaceholder={placeholder.filename}
           filenameInvalid={filenameInvalid}
           filenameRegistration={filenameRegistration}
           failure={failure}
@@ -851,13 +810,13 @@ function LoadedTrackMetadataEditor({
                     focusedTitleFileIdRef={focusedTitleFileIdRef}
                     register={register}
                     placeholder={{
-                      filename: placeholder.filename.toLowerCase(),
-                      title: placeholder.title.toLowerCase(),
-                      artist: placeholder.artist.toLowerCase(),
-                      album: placeholder.album.toLowerCase(),
-                      year: placeholder.year.toLowerCase(),
-                      genre: placeholder.genre.toLowerCase(),
-                      trackNumber: placeholder.trackNumber.toLowerCase(),
+                      filename: placeholder.filename,
+                      title: placeholder.title,
+                      artist: placeholder.artist,
+                      album: placeholder.album,
+                      year: placeholder.year,
+                      genre: placeholder.genre,
+                      trackNumber: placeholder.trackNumber,
                     }}
                     inAlbum={Boolean(selectedFileAlbum)}
                     linkedAlbumValue={watchedTitle}

--- a/src/features/editor/TrackMetadataEditor.tsx
+++ b/src/features/editor/TrackMetadataEditor.tsx
@@ -90,7 +90,7 @@ const hasMetadata = (selectedFile: TagiumFile | null): selectedFile is LoadedTra
   Boolean(selectedFile?.metadata);
 
 const syncedInputClassName =
-  "disabled:pointer-events-auto disabled:cursor-not-allowed disabled:border-dashed disabled:bg-muted/10 disabled:text-muted-foreground disabled:opacity-100 dark:disabled:bg-muted/10";
+  "disabled:pointer-events-auto disabled:cursor-not-allowed disabled:bg-muted/10 disabled:text-muted-foreground disabled:opacity-100 dark:disabled:bg-muted/10";
 
 function DisabledReason({
   disabled,

--- a/tests/unit/components/ui/floatingLabelField.test.tsx
+++ b/tests/unit/components/ui/floatingLabelField.test.tsx
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+import { FloatingLabelInput, FloatingLabelTextarea } from "@/components/ui/floating-label-field";
+
+describe("floating label fields", () => {
+  it("keeps a persistent label associated with a larger input", () => {
+    const markup = renderToStaticMarkup(
+      <FloatingLabelInput
+        id="track-title"
+        label="title"
+        placeholder="Died But Came Back"
+        required
+      />,
+    );
+
+    expect(markup).toContain('data-slot="floating-label-field"');
+    expect(markup).toContain('id="track-title"');
+    expect(markup).toContain('placeholder="Died But Came Back"');
+    expect(markup).toContain("h-14");
+    expect(markup).toContain('<label for="track-title"');
+    expect(markup).toContain("title</span>");
+    expect(markup).toContain('<span class="sr-only"> required</span>');
+    expect(markup.indexOf('id="track-title"')).toBeLessThan(markup.indexOf("<label"));
+  });
+
+  it("uses the same label treatment for multiline metadata", () => {
+    const markup = renderToStaticMarkup(
+      <FloatingLabelTextarea id="track-comment" label="comment" placeholder="add a comment" />,
+    );
+
+    expect(markup).toContain('<textarea id="track-comment"');
+    expect(markup).toContain('placeholder="add a comment"');
+    expect(markup).toContain('<label for="track-comment"');
+  });
+});

--- a/tests/unit/components/ui/floatingLabelField.test.tsx
+++ b/tests/unit/components/ui/floatingLabelField.test.tsx
@@ -27,6 +27,8 @@ describe("floating label fields", () => {
     expect(markup).toContain("border-input");
     expect(markup).toContain("pointer-events-none");
     expect(markup).toContain("absolute");
+    expect(markup).toContain("leading-tight");
+    expect(markup).not.toContain("leading-none");
     expect(markup).not.toContain("bg-background");
 
     // The label follows the control so its focus and invalid colors can key off `peer`.

--- a/tests/unit/components/ui/floatingLabelField.test.tsx
+++ b/tests/unit/components/ui/floatingLabelField.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { FloatingLabelInput, FloatingLabelTextarea } from "@/components/ui/floating-label-field";
 
 describe("floating label fields", () => {
-  it("keeps a persistent label associated with a larger input", () => {
+  it("seats a persistent label inside one uninterrupted control", () => {
     const markup = renderToStaticMarkup(
       <FloatingLabelInput
         id="track-title"
@@ -20,10 +20,16 @@ describe("floating label fields", () => {
     expect(markup).toContain('<label for="track-title"');
     expect(markup).toContain("title</span>");
     expect(markup).toContain('<span class="sr-only"> required</span>');
-    expect(markup).toContain('<fieldset aria-hidden="true"');
-    expect(markup).toContain("<legend");
-    expect(markup).toContain("invisible inline-flex");
+
+    // The control owns the outline and the label overlays the space reserved above the value,
+    // so the border is never notched or covered by a painted chip.
+    expect(markup.match(/<(input|textarea|fieldset)/g)).toEqual(["<input"]);
+    expect(markup).toContain("border-input");
+    expect(markup).toContain("pointer-events-none");
+    expect(markup).toContain("absolute");
     expect(markup).not.toContain("bg-background");
+
+    // The label follows the control so its focus and invalid colors can key off `peer`.
     expect(markup.indexOf('id="track-title"')).toBeLessThan(markup.indexOf("<label"));
   });
 
@@ -35,6 +41,8 @@ describe("floating label fields", () => {
     expect(markup).toContain('<textarea id="track-comment"');
     expect(markup).toContain('placeholder="add a comment"');
     expect(markup).toContain('<label for="track-comment"');
-    expect(markup).toContain('<fieldset aria-hidden="true"');
+    expect(markup.match(/<(input|textarea|fieldset)/g)).toEqual(["<textarea"]);
+    expect(markup).toContain("border-input");
+    expect(markup).toContain("min-h-20");
   });
 });

--- a/tests/unit/components/ui/floatingLabelField.test.tsx
+++ b/tests/unit/components/ui/floatingLabelField.test.tsx
@@ -20,6 +20,10 @@ describe("floating label fields", () => {
     expect(markup).toContain('<label for="track-title"');
     expect(markup).toContain("title</span>");
     expect(markup).toContain('<span class="sr-only"> required</span>');
+    expect(markup).toContain('<fieldset aria-hidden="true"');
+    expect(markup).toContain("<legend");
+    expect(markup).toContain("invisible inline-flex");
+    expect(markup).not.toContain("bg-background");
     expect(markup.indexOf('id="track-title"')).toBeLessThan(markup.indexOf("<label"));
   });
 
@@ -31,5 +35,6 @@ describe("floating label fields", () => {
     expect(markup).toContain('<textarea id="track-comment"');
     expect(markup).toContain('placeholder="add a comment"');
     expect(markup).toContain('<label for="track-comment"');
+    expect(markup).toContain('<fieldset aria-hidden="true"');
   });
 });

--- a/tests/unit/features/editor/albumMetadataDialog.test.tsx
+++ b/tests/unit/features/editor/albumMetadataDialog.test.tsx
@@ -147,8 +147,8 @@ describe("album metadata validation layout", () => {
     );
 
     for (const id of ["album-title", "album-artist", "album-genre", "album-year"]) {
-      findElement(tree, (element) => element.type === "label" && element.props.htmlFor === id);
-      findElement(tree, (element) => element.props.id === id);
+      const field = findElement(tree, (element) => element.props.id === id);
+      expect(field.props.label).toEqual(expect.any(String));
     }
 
     const titleInput = findElement(tree, (element) => element.props.id === "album-title");
@@ -158,14 +158,7 @@ describe("album metadata validation layout", () => {
     expect(titleInput.props["aria-required"]).toBe("true");
     expect(artistInput.props.required).toBe(true);
     expect(artistInput.props["aria-required"]).toBe("true");
-    expect(
-      textContent(
-        findElement(
-          tree,
-          (element) => element.type === "label" && element.props.htmlFor === "album-title",
-        ),
-      ),
-    ).toContain("required");
+    expect(titleInput.props.label).toBe("album title");
   });
 
   it.each([
@@ -275,10 +268,10 @@ describe("album metadata validation layout", () => {
 
     expect(
       findElement(tree, (element) => element.props.id === "album-title").props.placeholder,
-    ).toBe("placeholder album");
+    ).toBe("Placeholder Album");
     expect(
       findElement(tree, (element) => element.props.id === "album-artist").props.placeholder,
-    ).toBe("placeholder artist");
+    ).toBe("Placeholder Artist");
     expect(textContent(tree)).toContain("create album");
 
     const form = findElement(tree, (element) => element.type === "form");

--- a/tests/unit/features/editor/errorPresentation.test.ts
+++ b/tests/unit/features/editor/errorPresentation.test.ts
@@ -3,24 +3,7 @@ import coverArtSource from "@/features/editor/coverArt.tsx?raw";
 import trackMetadataEditorSource from "@/features/editor/TrackMetadataEditor.tsx?raw";
 
 describe("local error presentation", () => {
-  it("associates every track field label with its input", () => {
-    for (const id of [
-      "track-title",
-      "track-artist",
-      "track-album",
-      "track-year",
-      "track-genre",
-      "track-number",
-      "track-album-artist",
-      "track-disc-number",
-      "track-bpm",
-      "track-composer",
-      "track-comment",
-    ]) {
-      expect(trackMetadataEditorSource).toContain(`<label htmlFor="${id}"`);
-      expect(trackMetadataEditorSource).toContain(`id="${id}"`);
-    }
-
+  it("associates the synced title error with its input", () => {
     expect(trackMetadataEditorSource).toContain(
       'syncFilenames && filenameInvalid ? "track-filename-error" : undefined',
     );

--- a/tests/unit/features/editor/trackMetadataEditor.test.tsx
+++ b/tests/unit/features/editor/trackMetadataEditor.test.tsx
@@ -222,13 +222,14 @@ describe("track metadata editor form seam", () => {
     expect(unlinkedInput).not.toContain("aria-describedby");
   });
 
-  it("lowercases metadata placeholders", () => {
+  it("preserves sample metadata placeholder casing", () => {
     const markup = renderToStaticMarkup(<EditorHarness />);
 
+    expect(markup).toContain('placeholder="Died But Came Back"');
+    expect(markup).toContain('placeholder="Digicore"');
     expect(markup).toContain('placeholder="album artist"');
     expect(markup).toContain('placeholder="composer"');
     expect(markup).toContain('placeholder="add a comment"');
-    expect(markup).not.toMatch(/placeholder="[A-Z]/);
   });
 
   it("describes a synced filename error from the title field", () => {


### PR DESCRIPTION
## problem

Metadata labels sat above short inputs, which made the editor feel dense and separated labels from the values they describe.

## solution

- add reusable 56px outlined metadata inputs and textareas
- seat the persistent label inside each control above the value, keeping one uninterrupted outline
- use the treatment across track and album metadata forms
- preserve real-track placeholders and their casing
- retain validation, synced-field tooltips, disabled states, and accessible label associations
- give the inset caption enough line height for descenders such as `g`, `p`, and `y`

## preview

[open the Cloudflare version preview](https://5cd86983-tagium.oliver-boorstein.workers.dev)

## review

1. Open the preview and upload an mp3, flac, or m4a/mp4 track with one or more empty metadata fields.
2. Confirm the track editor uses larger controls, labels sit inside the upper part of an uninterrupted border, and real-track placeholders remain visible until values are entered.
3. Check labels with descenders, especially `genre`, and confirm no glyphs are clipped.
4. Enable advanced fields under settings → editing, then check album artist, disc number, bpm, composer, and comment.
5. Create or edit an album and confirm title, artist, genre, and year use the same treatment.
6. Check a compact viewport and dark mode.

Expected edge states:

- linked album fields remain disabled with their existing explanation and dashed outline
- invalid disc and bpm values retain local errors and focus behavior
- required album fields show errors only after interaction
- resizing the comment field continues to push the file summary down without overlap

The reusable control is intentionally limited to metadata forms; URL import and share-link utilities keep their specialized input treatments.

## verification

- 782 unit tests
- 3 Chromium metadata layout tests at desktop and compact sizes
- TypeScript
- lint
- production and Cloudflare preview builds
- Impeccable layout detector
- deployed preview smoke test with a synthetic mp3
- deployed glyph-box measurement confirms the 13.5px caption glyph fits inside its 13.75px line box

Manual verification is still recommended for visual feel in Safari and Firefox.

---

Design refinement implemented with Claude Opus via Claude Code, then reviewed and published with OpenAI gpt-5.6-sol in T3 Code through the Codex harness.