### PR TITLE
chore: enforce anti-slop lint rules

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@oxlint/plugins": "1.73.0",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^24.12.2",
@@ -47,7 +48,7 @@
         "tw-animate-css": "^1.3.7",
         "typescript": "^5",
         "vite": "^8.0.7",
-        "vite-plus": "latest",
+        "vite-plus": "^0.2.9",
         "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
       },
     },
@@ -103,11 +104,15 @@
 
     "@babel/plugin-transform-typescript": ["@babel/plugin-transform-typescript@7.28.0", "", { "dependencies": { "@babel/helper-annotate-as-pure": "7.27.3", "@babel/helper-create-class-features-plugin": "7.28.3", "@babel/helper-plugin-utils": "7.27.1", "@babel/helper-skip-transparent-expression-wrappers": "7.27.1", "@babel/plugin-syntax-typescript": "7.27.1" }, "peerDependencies": { "@babel/core": "7.28.3" } }, "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg=="],
 
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
     "@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/parser": "7.28.3", "@babel/types": "7.28.2" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
 
     "@babel/traverse": ["@babel/traverse@7.28.3", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/generator": "7.28.3", "@babel/helper-globals": "7.28.0", "@babel/parser": "7.28.3", "@babel/template": "7.27.2", "@babel/types": "7.28.2", "debug": "4.4.1" } }, "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ=="],
 
     "@babel/types": ["@babel/types@7.28.2", "", { "dependencies": { "@babel/helper-string-parser": "7.27.1", "@babel/helper-validator-identifier": "7.27.1" } }, "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ=="],
+
+    "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
 
     "@bundled-es-modules/cookie": ["@bundled-es-modules/cookie@2.0.1", "", { "dependencies": { "cookie": "0.7.2" } }, "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw=="],
 
@@ -237,97 +242,99 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
-    "@oxc-project/runtime": ["@oxc-project/runtime@0.123.0", "", {}, "sha512-wRf0z8saz9tHLcK3YeTeBmwISrpy4bBimvKxUmryiIhbt+ZJb0nwwJNL3D8xpeWbNfZlGSlzRBZbfcbApIGZJw=="],
+    "@oxc-project/runtime": ["@oxc-project/runtime@0.143.0", "", {}, "sha512-zIuXUf+YGIgsPk0xlQmzTY8NCSc8jE/pSfDodlQ9H3EGZABmr+AtIjXRrnpQAXuXzhDSNqZz9cuhud8hDDLvpg=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.123.0", "", {}, "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew=="],
+    "@oxc-project/types": ["@oxc-project/types@0.143.0", "", {}, "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA=="],
 
-    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.43.0", "", { "os": "android", "cpu": "arm" }, "sha512-CgU2s+/9hHZgo0IxVxrbMPrMj+tJ6VM3mD7Mr/4oiz4FNTISLoCvRmB5nk4wAAle045RtRjd86m673jwPyb1OQ=="],
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw=="],
 
-    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.43.0", "", { "os": "android", "cpu": "arm64" }, "sha512-T9OfRwjA/EdYxAqbvR7TtqLv5nIrwPXuCtTwOHtS7aR9uXyn74ZYgzgTo6/ZwvTq9DY4W+DsV09hB2EXgn9EbA=="],
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.62.0", "", { "os": "android", "cpu": "arm64" }, "sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog=="],
 
-    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.43.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-o3i49ZUSJWANzXMAAVY1wnqb65hn4JVzwlRQ5qfcwhRzIA8lGVaud31Q3by5ALHPrksp5QEaKCQF9aAS3TXpZA=="],
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.62.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q=="],
 
-    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.43.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-vWECzzCFkb0kK6jaHjbtC5sC3adiNWtqawFCxhpvsWlzVeKmv5bNvkB4nux+o4JKWTpHCM57NDK/MeXt44txmA=="],
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.62.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ=="],
 
-    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.43.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-rgz8JpkKiI/umOf7fl9gwKyQasC8bs5SYHy6g7e4SunfLBY3+8ATcD5caIg8KLGEtKFm5ujKaH8EfjcmnhzTLg=="],
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.62.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g=="],
 
-    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.43.0", "", { "os": "linux", "cpu": "arm" }, "sha512-nWYnF3vIFzT4OM1qL/HSf1Yuj96aBuKWSaObXHSWliwAk2rcj7AWd6Lf7jowEBQMo4wCZVnueIGw/7C4u0KTBQ=="],
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g=="],
 
-    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.43.0", "", { "os": "linux", "cpu": "arm" }, "sha512-sFg+NWJbLfupYTF4WELHAPSnLPOn1jiDZ33Z1jfDnTaA+cC3iB35x0FMMZTFdFOz3icRIArncwCcemJFGXu6TQ=="],
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog=="],
 
-    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.43.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-MelWqv68tX6wZEILDrTc9yewiGXe7im62+5x0bNXlCYFOZdA+VnYiJfAihbROsZ5fm90p9C3haFrqjj43XnlAA=="],
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg=="],
 
-    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.43.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-ROaWfYh+6BSJ1Arwy5ujijTlwnZetxDxzBpDc1oBR4d7rfrPBqzeyjd5WOudowzQUgyavl2wEpzn1hw3jWcqLA=="],
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew=="],
 
-    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.43.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-PJRs/uNxmFipJJ8+SyKHh7Y7VZIKQicqrrBzvfyM5CtKi8D7yZKTwUOZV3ffxmiC2e7l1SDJpkBEOyue5NAFsg=="],
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw=="],
 
-    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.43.0", "", { "os": "linux", "cpu": "none" }, "sha512-j6biGAgzIhj+EtHXlbNumvwG7XqOIdiU4KgIWRXAEj/iUbHKukKW8eXa4MIwpQwW1YkxovduKtzEAPnjlnAhVQ=="],
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA=="],
 
-    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.43.0", "", { "os": "linux", "cpu": "none" }, "sha512-RYWxAcslKxvy7yri24Xm9cmD0RiANaiEPs007EFG6l9h1ChM69Q5SOzACaCoz4Z9dEplnhhneeBaTWMEdpgIbA=="],
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A=="],
 
-    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.43.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-DT6Q8zfQQy3jxpezAsBACEHNUUixKSYTwdXeXojNHe4DQOoxjPdjr3Szu6BRNjxLykZM/xMNmp9ElOIyDppwtw=="],
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.62.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A=="],
 
-    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.43.0", "", { "os": "linux", "cpu": "x64" }, "sha512-R8Yk7iYcuZORXmCfFZClqbDxRZgZ9/HEidUuBNdoX8Ptx07cMePnMVJ/woB84lFIDjh2ROHVaOP40Ds3rBXFqg=="],
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w=="],
 
-    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.43.0", "", { "os": "linux", "cpu": "x64" }, "sha512-F2YYqyvnQNvi320RWZNAvsaWEHwmW3k4OwNJ1hZxRKXupY63expbBaNp6jAgvYs7y/g546vuQnGHQuCBhslhLQ=="],
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw=="],
 
-    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.43.0", "", { "os": "none", "cpu": "arm64" }, "sha512-OE6TdietLXV3F6c7pNIhx/9YC1/2YFwjU9DPc/fbjxIX19hNIaP1rS0cFjCGJlGX+cVJwIKWe8Mos+LdQ1yAJw=="],
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.62.0", "", { "os": "none", "cpu": "arm64" }, "sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA=="],
 
-    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.43.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-0nWK6a7pGkbdoypfVicmV9k/N1FwjPZENoqhlTU+5HhZnAhpIO3za30nEE33u6l6tuy9OVfpdXUqxUgZ+4lbZw=="],
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.62.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw=="],
 
-    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.43.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-9aokTR4Ft+tRdvgN/pKzSkVy2ksc4/dCpDm9L/xFrbIw0yhLtASLbvoG/5WOTUh/BRPPnfGTsWznEqv0dlOmhA=="],
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.62.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw=="],
 
-    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.43.0", "", { "os": "win32", "cpu": "x64" }, "sha512-4bPgdQux2ZLWn3bf2TTXXMHcJB4lenmuxrLqygPmvCJ104Yqzj1UctxSRzR31TiJ4MLaG22RK8dUsVpJtrCz5g=="],
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ=="],
 
-    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.20.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-KKQcIHZHMxqpHUA1VXIbOG6chNCFkUWbQy6M+AFVtPKkA/3xAeJkJ3njoV66bfzwPHRcWQO+kcj5XqtbkjakoA=="],
+    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@7.0.2001", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w=="],
 
-    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.20.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-7HeVMuclGfG+NLZi2ybY0T4fMI7/XxO/208rJk+zEIloKkVnlh11Wd241JMGwgNFXn+MLJbOqOfojDb2Dt4L1g=="],
+    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@7.0.2001", "", { "os": "darwin", "cpu": "x64" }, "sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw=="],
 
-    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.20.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-zxhUwz+WSxE6oWlZLK2z2ps9yC6ebmgoYmjAl0Oa48+GqkZ56NVgo+wb8DURNv6xrggzHStQxqQxe3mK51HZag=="],
+    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@7.0.2001", "", { "os": "linux", "cpu": "arm64" }, "sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A=="],
 
-    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.20.0", "", { "os": "linux", "cpu": "x64" }, "sha512-/1l6FnahC9im8PK+Ekkx/V3yetO/PzZnJegE2FXcv/iXEhbeVxP/ouiTYcUQu9shT1FWJCSNti1VJHH+21Y1dg=="],
+    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@7.0.2001", "", { "os": "linux", "cpu": "x64" }, "sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ=="],
 
-    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.20.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-oPZ5Yz8sVdo7P/5q+i3IKeix31eFZ55JAPa1+RGPoe9PoaYVsdMvR6Jvib6YtrqoJnFPlg3fjEjlEPL8VBKYJA=="],
+    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@7.0.2001", "", { "os": "win32", "cpu": "arm64" }, "sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q=="],
 
-    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.20.0", "", { "os": "win32", "cpu": "x64" }, "sha512-4stx8RHj3SP9vQyRF/yZbz5igtPvYMEUR8CUoha4BVNZihi39DpCR8qkU7lpjB5Ga1DRMo2pHaA4bdTOMaY4mw=="],
+    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@7.0.2001", "", { "os": "win32", "cpu": "x64" }, "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.58.0", "", { "os": "android", "cpu": "arm" }, "sha512-1T7UN3SsWWxpWyWGn1cT3ASNJOo+pI3eUkmEl7HgtowapcV8kslYpFQcYn431VuxghXakPNlbjRwhqmR37PFOg=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.77.0", "", { "os": "android", "cpu": "arm" }, "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.58.0", "", { "os": "android", "cpu": "arm64" }, "sha512-GryzujxuiRv2YFF7bRy8mKcxlbuAN+euVUtGJt9KKbLT8JBUIosamVhcthLh+VEr6KE6cjeVMAQxKAzJcoN7dg=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.77.0", "", { "os": "android", "cpu": "arm64" }, "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.58.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7/bRSJIwl4GxeZL9rPZ11anNTyUO9epZrfEJH/ZMla3+/gbQ6xZixh9nOhsZ0QwsTW7/5J2A/fHbD1udC5DQQA=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.77.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.58.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-EqdtJSiHweS2vfILNrpyJ6HUwpEq2g7+4Zx1FPi4hu3Hu7tC3znF6ufbXO8Ub2LD4mGgznjI7kSdku9NDD1Mkg=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.77.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.58.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-VQt5TH4M42mY20F545G637RKxV/yjwVtKk2vfXuazfReSIiuvWBnv+FVSvIV5fKVTJNjt3GSJibh6JecbhGdBw=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.77.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.58.0", "", { "os": "linux", "cpu": "arm" }, "sha512-fBYcj4ucwpAtjJT3oeBdFBYKvNyjRSK+cyuvBOTQjh0jvKp4yeA4S/D0IsCHus/VPaNG5L48qQkh+Vjy3HL2/Q=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.77.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.58.0", "", { "os": "linux", "cpu": "arm" }, "sha512-0BeuFfwlUHlJ1xpEdSD1YO3vByEFGPg36uLjK1JgFaxFb4W6w17F8ET8sz5cheZ4+x5f2xzdnRrrWv83E3Yd8g=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.77.0", "", { "os": "linux", "cpu": "arm" }, "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.58.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-TXlZgnPTlxrQzxG9ZXU7BNwx1Ilrr17P3GwZY0If2EzrinqRH3zXPc3HrRcBJgcsoZNMuNL5YivtkJYgp467UQ=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.77.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.58.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-zSoYRo5dxHLcUx93Stl2hW3hSNjPt99O70eRVWt5A1zwJ+FPjeCCANCD2a9R4JbHsdcl11TIQOjyigcRVOH2mw=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.77.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.58.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-NQ0U/lqxH2/VxBYeAIvMNUK1y0a1bJ3ZicqkF2c6wfakbEciP9jvIE4yNzCFpZaqeIeRYaV7AVGqEO1yrfVPjA=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.77.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.58.0", "", { "os": "linux", "cpu": "none" }, "sha512-X9J+kr3gIC9FT8GuZt0ekzpNUtkBVzMVU4KiKDSlocyQuEgi3gBbXYN8UkQiV77FTusLDPsovjo95YedHr+3yg=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.77.0", "", { "os": "linux", "cpu": "none" }, "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.58.0", "", { "os": "linux", "cpu": "none" }, "sha512-CDze3pi1OO3Wvb/QsXjmLEY4XPKGM6kIo82ssNOgmcl1IdndF9VSGAE38YLhADWmOac7fjqhBw82LozuUVxD0Q=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.77.0", "", { "os": "linux", "cpu": "none" }, "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.58.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-b/89glbxFaEAcA6Uf1FvCNecBJEgcUTsV1quzrqXM/o4R1M4u+2KCVuyGCayN2UpsRWtGGLb+Ver0tBBpxaPog=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.77.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.58.0", "", { "os": "linux", "cpu": "x64" }, "sha512-0/yYpkq9VJFCEcuRlrViGj8pJUFFvNS4EkEREaN7CB1EcLXJIaVSSa5eCihwBGXtOZxhnblWgxks9juRdNQI7w=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.77.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.58.0", "", { "os": "linux", "cpu": "x64" }, "sha512-hr6FNvmcAXiH+JxSvaJ4SJ1HofkdqEElXICW9sm3/Rd5eC3t7kzvmLyRAB3NngKO2wzXRCAm4Z/mGWfrsS4X8w=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.77.0", "", { "os": "linux", "cpu": "x64" }, "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.58.0", "", { "os": "none", "cpu": "arm64" }, "sha512-R+O368VXgRql1K6Xar+FEo7NEwfo13EibPMoTv3sesYQedRXd6m30Dh/7lZMxnrQVFfeo4EOfYIP4FpcgWQNHg=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.77.0", "", { "os": "none", "cpu": "arm64" }, "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.58.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q0FZiAY/3c4YRj4z3h9K1PgaByrifrfbBoODSeX7gy97UtB7pySPUQfC2B/GbxWU6k7CzQrRy5gME10PltLAFQ=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.77.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.58.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-Y8FKBABrSPp9H0QkRLHDHOSUgM/309a3IvOVgPcVxYcX70wxJrk608CuTg7w+C6vEd724X5wJoNkBcGYfH7nNQ=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.77.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.58.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bCn5rbiz5My+Bj7M09sDcnqW0QJyINRVxdZ65x1/Y2tGrMwherwK/lpk+HRQCKvXa8pcaQdF5KY5j54VGZLwNg=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.77.0", "", { "os": "win32", "cpu": "x64" }, "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw=="],
+
+    "@oxlint/plugins": ["@oxlint/plugins@1.73.0", "", {}, "sha512-OhgMQeMmZA0dcFcX4/priaJZWdFECxiClgq6mRX6aatZEcV9PbKC3P3/v8U1hVjviT1i5U+vR8lAtBV6m4FXAA=="],
 
     "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
@@ -529,9 +536,15 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.12", "", { "dependencies": { "@alloc/quick-lru": "5.2.0", "@tailwindcss/node": "4.1.12", "@tailwindcss/oxide": "4.1.12", "postcss": "8.5.6", "tailwindcss": "4.1.12" } }, "sha512-5PpLYhCAwf9SJEeIsSmCDLgyVfdBhdBpzX1OJ87anT9IVR0Z9pjM0FNixCAUAHGnMBGB8K99SwAheXrT0Kh6QQ=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.4", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew=="],
+
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "3.3.3", "minimatch": "10.0.3", "path-browserify": "1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "4.0.2", "assertion-error": "2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -559,25 +572,87 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "vite": "npm:@voidzero-dev/vite-plus-core@0.1.16" } }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 
-    "@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.16", "", { "dependencies": { "@oxc-project/runtime": "0.123.0", "@oxc-project/types": "0.123.0", "lightningcss": "1.32.0", "postcss": "8.5.9" }, "optionalDependencies": { "@types/node": "24.12.2", "fsevents": "2.3.3", "jiti": "2.5.1", "typescript": "5.9.2" } }, "sha512-fOyf14CXjcXqANFs2fCXEX+0Tn9ZjmqfFV+qTnARwIF1Kzl8WquO4XtvlDgs/fTQ91H4AyoNUgkvWdKS+C4xYA=="],
+    "@vitest/browser": ["@vitest/browser@4.1.10", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.0", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.10" } }, "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng=="],
 
-    "@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.1.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-InG0ZmuGh7DTrn7zWQ0UvKapElphKI6G1oYfys+jraedG70EhIIee9gtO+mTE1T0bF67SgAcLXwNyaiNda0XwA=="],
+    "@vitest/browser-preview": ["@vitest/browser-preview@4.1.10", "", { "dependencies": { "@testing-library/dom": "^10.4.1", "@testing-library/user-event": "^14.6.1", "@vitest/browser": "4.1.10" }, "peerDependencies": { "vitest": "4.1.10" } }, "sha512-14MJrL59ZFkqXLjwfSk6RzTDy5Czf9UG4+8q8L6Gxjs2aPjEce/cVNYV14bXAc2BvMjUNu904+ZEZA1Xc1wtvQ=="],
 
-    "@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.1.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-LGNrECstuhkCRKRj/dE98Xcprw8HU3VMIMJnZsnDR2C5RB2HADNIu21at/a/G3giA9eWm7uhtPp9FvUtTCK9TA=="],
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
 
-    "@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-AoFKu6dIOtlkp/mwmtU8ES2uzoaxCHhIym1Tk7qMxyvke4IXnye6VDc4kPMRQwD8mwR3T3bO0HuaEEHxrIWDxw=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
 
-    "@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.1.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-PloCsGTRIhcXIpUOJ6PqVG8gYNpq+ooJNyqy5sQ82BRnJuo8oV7uBLFvg0X9B3Bzh+vO1F8/+92+o5TiL35JMg=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
 
-    "@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.1.16", "", { "os": "linux", "cpu": "x64" }, "sha512-nY9/2g+qjhwsW5U3MrFLlx+bOBsdOJiO2HzbxQy7jo/S3jPTnXhFlrRegQuAmqrHAXrSdNwgblgRpICKhx1xZg=="],
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
 
-    "@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.1.16", "", { "os": "linux", "cpu": "x64" }, "sha512-JGKEAMoXqzdr9lHT/13uRNV9uzrSYXAFhjAfIC8WEQMG2VUFksvq5/TOc26hzmzbqu+bxRmfN8h1aVTDL8KwFg=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
 
-    "@voidzero-dev/vite-plus-test": ["@voidzero-dev/vite-plus-test@0.1.16", "", { "dependencies": { "@standard-schema/spec": "1.1.0", "@types/chai": "5.2.3", "@voidzero-dev/vite-plus-core": "0.1.16", "es-module-lexer": "1.7.0", "obug": "2.1.1", "pixelmatch": "7.1.0", "pngjs": "7.0.0", "sirv": "3.0.2", "std-env": "4.0.0", "tinybench": "2.9.0", "tinyexec": "1.1.1", "tinyglobby": "0.2.16", "ws": "8.20.0" }, "optionalDependencies": { "@types/node": "24.12.2" }, "peerDependencies": { "vite": "npm:@voidzero-dev/vite-plus-core@0.1.16" } }, "sha512-d/rJPX/heMzoAFdnpZsp04MAa6nw1yH1tA4mVCV4m8goVcE9nAvt69mjLMzE8N/rYIQOSgenf3hDXuQRuD6OKQ=="],
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
 
-    "@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-IugPUCLY7HmiPcCeuHKUqO1+G2vxHnYzAGhS02AixD0sJLTAIKCUANDOiVUFf/HMw+jh/UkugW7MWek8lf/JrQ=="],
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
 
-    "@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.1.16", "", { "os": "win32", "cpu": "x64" }, "sha512-tq93CIeMs92HF7rdylJknRiyzMOWMKCmpw+g8nl5Q5nmUDNLUsrL3CGfbyqjgbruuPnIr761r9MfydPqZU/cYg=="],
+    "@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.2.9", "", { "dependencies": { "@oxc-project/runtime": "=0.143.0", "@oxc-project/types": "=0.143.0", "lightningcss": "^1.33.0", "postcss": "^8.5.6", "yuku-codegen": "^0.5.44", "yuku-parser": "^0.5.44" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.2.9", "@voidzero-dev/vite-plus-darwin-x64": "0.2.9", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.9", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.9", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.9", "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.9", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.9", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.9", "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-dWqScAAwa8h/i9jCiGAMs7YarzQWInHZ5gCJNbQkHXA6Zp6A2T2anN9YMFVPpb7CwVFwkI2iPF5yl/DXtq+zUA=="],
+
+    "@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.2.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/qJHqMfyy/LiCJk4UYZfFW6Comsfm8zDuy4P8UFWnFqRjmefYvZbMK4ThYNM87tKNWYWjsnClzssjJOmDTAc8w=="],
+
+    "@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.2.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-3MGnNeazgYAqQTaC7JIbZyrTHmxSXTWFr9G1yAdeItKasB1R8HKIkCS1Qnr49Ge4S/cyOODivdbcpqFkrT93ng=="],
+
+    "@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.2.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-6LmukER8qD4UBIRqMNv4Ilq7CxfRhngLUXlMv8vbTupeLRWPJSKvKEHyRxCwr6JP57Gxfr8KrX1ye42WzcZF0g=="],
+
+    "@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.2.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-cBs626GWkyJlwKP0nsdHlMWpuTl9xOWRxAUoqtxXPtw80bVy4WM5eNS4SXPC5pX10jR7DRIkRpzNAsy7fv8Faw=="],
+
+    "@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.2.9", "", { "os": "linux", "cpu": "x64" }, "sha512-2Iy8x4PCPMNzXeu3pREevlggoeK8PwtdUiCpoSybAZBtR/aqMxsJREyt/eKv45F8lsiNlA8PbIWEvPxLSgzFLQ=="],
+
+    "@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.2.9", "", { "os": "linux", "cpu": "x64" }, "sha512-zuGx+eRotWPd9cmh1X9AfsC2tN/Ad9Hk6LAzlxoKJUjEkTsY3WjVJ6Da0z48SAUFuenI0JkdqXnMCrePtGvWHg=="],
+
+    "@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.2.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-kaKb5Q8ReYTBfvLgUhdpLJG3aoNF8HOVJpf8qBm+THsd4WRrkRwsBHp2ITsU8oXl2gnDjFGhPDaURegd/z6Wxw=="],
+
+    "@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.2.9", "", { "os": "win32", "cpu": "x64" }, "sha512-/fEk3gbQTJknCiYM/GTL/L++Azsav8rCAjmtKrjmCbqEif5IMzqTfvM68n+PiLB3JVoQJGF/mg2niODr0IE/2w=="],
+
+    "@yuku-codegen/binding-darwin-arm64": ["@yuku-codegen/binding-darwin-arm64@0.5.48", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yo96Oef12WzqnphInfz/eexVse3+kWgfGS5g2S3rFS3dcGn1ENW9xLFDZUP9rh+yP76DOq38wBoFi1+I9+6qBg=="],
+
+    "@yuku-codegen/binding-darwin-x64": ["@yuku-codegen/binding-darwin-x64@0.5.48", "", { "os": "darwin", "cpu": "x64" }, "sha512-aRCTw0EZC4bVosmw//0OMYP5tGWFE0Cu5yUBFkUbhXx/iBzvORcJ2xPNlOp/vtCCo9Ys4vp8b0DigJV6uOVb2g=="],
+
+    "@yuku-codegen/binding-freebsd-x64": ["@yuku-codegen/binding-freebsd-x64@0.5.48", "", { "os": "freebsd", "cpu": "x64" }, "sha512-CA0AQAEApDkbw51PdLWMtKPJ41/7rvXsS3SJs+phG7fHJI+MuFzWuLbkucZfZoEOiDscmcsfYIdgL8BsfuyKKQ=="],
+
+    "@yuku-codegen/binding-linux-arm-gnu": ["@yuku-codegen/binding-linux-arm-gnu@0.5.48", "", { "os": "linux", "cpu": "arm" }, "sha512-DuSQlk8bH4gpmW3/00P0NLagAcMv8jOxjT40cQmxKRkktr+SUOALCfkT89tdDq3qtY95NR2GXOZ7AjNh7KKqCw=="],
+
+    "@yuku-codegen/binding-linux-arm-musl": ["@yuku-codegen/binding-linux-arm-musl@0.5.48", "", { "os": "linux", "cpu": "arm" }, "sha512-bxj4Ee+wlaJcWJwft2ReJXWw5sfl1qavDz6+dlRdU1xfTEtjPSNiAWhiCHnJR0R4Ygd57DnzSQmAVGvFv6RcGw=="],
+
+    "@yuku-codegen/binding-linux-arm64-gnu": ["@yuku-codegen/binding-linux-arm64-gnu@0.5.48", "", { "os": "linux", "cpu": "arm64" }, "sha512-mk5JVWh+0JOe5ue8k17kbYX8uGBoKt3ZqoCyxNh4nYAAcX7+X1tFUiU7jbjctu4vHeejCBFSTdQ021+V31cUCQ=="],
+
+    "@yuku-codegen/binding-linux-arm64-musl": ["@yuku-codegen/binding-linux-arm64-musl@0.5.48", "", { "os": "linux", "cpu": "arm64" }, "sha512-4q3vkrNghbllyxOm2KesFLxCPKHF7r3JyQ7BWZccY1j2Y05yKoIFhoWCqIuQ2W/dpte9RI0+OVfwyxnrKg6fkA=="],
+
+    "@yuku-codegen/binding-linux-x64-gnu": ["@yuku-codegen/binding-linux-x64-gnu@0.5.48", "", { "os": "linux", "cpu": "x64" }, "sha512-csd4M1EVrGaohM8acM6gq1zpUA/Rwe2ulUMBKUcwQXm/k6n7cq1A++qdew78SOVb4do3JH1WE+WFwoGQAcWc1w=="],
+
+    "@yuku-codegen/binding-linux-x64-musl": ["@yuku-codegen/binding-linux-x64-musl@0.5.48", "", { "os": "linux", "cpu": "x64" }, "sha512-KcDuEOT+GFoVKdvAWOv1v9iYjwnmvMZlO+j1Rw+5PYdeFLGWGzv/DD11y4SAAdwXIFcil4T0hibeIaF82WStMg=="],
+
+    "@yuku-codegen/binding-win32-arm64": ["@yuku-codegen/binding-win32-arm64@0.5.48", "", { "os": "win32", "cpu": "arm64" }, "sha512-HI8qNrI8dWM5BuqIMKsqornRvTNFrE6sm5zToIJ9YIa9zt5+29P7fJ7Nr39EVf6dAWSb6q7JSpScJnRsQ+FgZA=="],
+
+    "@yuku-codegen/binding-win32-x64": ["@yuku-codegen/binding-win32-x64@0.5.48", "", { "os": "win32", "cpu": "x64" }, "sha512-X5YWJLO6EfBZpeBqO0AYESnUizbpFDWArcvVD61w0PEWQ3CaFRLnbQXs+kpM4ZZfGMfIE22zfA08QSY67q7TNQ=="],
+
+    "@yuku-parser/binding-darwin-arm64": ["@yuku-parser/binding-darwin-arm64@0.5.48", "", { "os": "darwin", "cpu": "arm64" }, "sha512-If8mb7HH3vqghJ2NNZ8SuHfhsnjVzOxJpB8xcNOXS5WjYrs2mUhHIh5KOIvK13hDOzh0htGeGK3A6MsiEqE7HQ=="],
+
+    "@yuku-parser/binding-darwin-x64": ["@yuku-parser/binding-darwin-x64@0.5.48", "", { "os": "darwin", "cpu": "x64" }, "sha512-EimvPXfspzxf1K11eB6tCW5oiQEXB8g84T2wP1TwzQagdDKo33bkmmVF0B32vTIpXnk/Ifu5IB61izZ1MylljA=="],
+
+    "@yuku-parser/binding-freebsd-x64": ["@yuku-parser/binding-freebsd-x64@0.5.48", "", { "os": "freebsd", "cpu": "x64" }, "sha512-0GcUMrumLHheThY9r5Tp46gaZYzn0irWPS1Zba6WY+vVQfhUtzGiWgXxI6tuXX0N32kEaaEVRpkKctvo6Kx3aQ=="],
+
+    "@yuku-parser/binding-linux-arm-gnu": ["@yuku-parser/binding-linux-arm-gnu@0.5.48", "", { "os": "linux", "cpu": "arm" }, "sha512-8S5T5wjCC73dmmpQeZ49aYsSunIUM3D4Fc6rdK96c+Ayg/p3FmeSPF3xuLZHejcTmqJIIvnbfPlUF+rB6DITjQ=="],
+
+    "@yuku-parser/binding-linux-arm-musl": ["@yuku-parser/binding-linux-arm-musl@0.5.48", "", { "os": "linux", "cpu": "arm" }, "sha512-tTmbxvnUHcK2/crS9547vk2SMmsajH1yqJ8ltXhIuHJgqR1v+d9n9KT+kSayo/5CS76LegeYxhMFjEivBH2hFA=="],
+
+    "@yuku-parser/binding-linux-arm64-gnu": ["@yuku-parser/binding-linux-arm64-gnu@0.5.48", "", { "os": "linux", "cpu": "arm64" }, "sha512-KGYCBMqI2zfwyhgq5tpPVNe7jpUeYTBm8DhjdS+zqWNumde/PEC170QE5RHxcOAlsirIDeIUk0jqx+r/axoFSw=="],
+
+    "@yuku-parser/binding-linux-arm64-musl": ["@yuku-parser/binding-linux-arm64-musl@0.5.48", "", { "os": "linux", "cpu": "arm64" }, "sha512-2wTSMsCSXLTc2lZUjMAuU5X4cje55u205WJqfV5NWNF6j9pW/tXyxr15dJeekj8ziLqBXzIsj4DbRh4sY/WcjA=="],
+
+    "@yuku-parser/binding-linux-x64-gnu": ["@yuku-parser/binding-linux-x64-gnu@0.5.48", "", { "os": "linux", "cpu": "x64" }, "sha512-d/6v9UnGglVu1WC2JQyv/5aWSi5fXZeGSlidCfmHp4+N65N1GDKUnFtys5MK5eAPeAjTgSHGGtOc/yCcKTlv3A=="],
+
+    "@yuku-parser/binding-linux-x64-musl": ["@yuku-parser/binding-linux-x64-musl@0.5.48", "", { "os": "linux", "cpu": "x64" }, "sha512-gX19gw6u4ApPy7SYMPKfFlEkrtj6WlORvrTKK3sBQqjyV+8+mUAkQgxXNjHw4RnOiAmVYg7TOlZcg8d+Qqod9A=="],
+
+    "@yuku-parser/binding-win32-arm64": ["@yuku-parser/binding-win32-arm64@0.5.48", "", { "os": "win32", "cpu": "arm64" }, "sha512-w6cQQLbqj3Jcom5Q7ifm103NUOQ9d+Cb4VU5lkrZDjMnwVJ9Hzzg1vCQR7miJuF44vhCXldbme5UryE3giEKlA=="],
+
+    "@yuku-parser/binding-win32-x64": ["@yuku-parser/binding-win32-x64@0.5.48", "", { "os": "win32", "cpu": "x64" }, "sha512-4gO0HmG7fzFxrw1rs0dUdnnaY9YgennjETqDWrTSp7x9fmTUOAoN4VsMfP7YyliQeG1WJJHc55O+rOhmsLppow=="],
+
+    "@yuku-toolchain/types": ["@yuku-toolchain/types@0.5.43", "", {}, "sha512-kSpvPntnXw5+lYjO71ffBEnQ5ycQ74KGIYknh0TS4xeyCuBkOqxyJumxZkMhLBBUCLjDAbx2+Icnr3Zh4ftjpQ=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "3.0.1", "negotiator": "1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -600,6 +675,8 @@
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -624,6 +701,8 @@
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001737", "", {}, "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "4.3.0", "supports-color": "7.2.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -689,11 +768,15 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
     "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
@@ -755,6 +838,8 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
@@ -764,6 +849,8 @@
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
     "execa": ["execa@9.6.0", "", { "dependencies": { "@sindresorhus/merge-streams": "4.0.0", "cross-spawn": "7.0.6", "figures": "6.1.0", "get-stream": "9.0.1", "human-signals": "8.0.1", "is-plain-obj": "4.1.0", "is-stream": "4.0.1", "npm-run-path": "6.0.0", "pretty-ms": "9.2.0", "signal-exit": "4.1.0", "strip-final-newline": "4.0.0", "yoctocolors": "2.1.2" } }, "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "express": ["express@5.1.0", "", { "dependencies": { "accepts": "2.0.0", "body-parser": "2.2.0", "content-disposition": "1.0.0", "content-type": "1.0.5", "cookie": "0.7.2", "cookie-signature": "1.2.2", "debug": "4.4.1", "encodeurl": "2.0.0", "escape-html": "1.0.3", "etag": "1.8.1", "finalhandler": "2.1.0", "fresh": "2.0.0", "http-errors": "2.0.0", "merge-descriptors": "2.0.0", "mime-types": "3.0.1", "on-finished": "2.4.1", "once": "1.4.0", "parseurl": "1.3.3", "proxy-addr": "2.0.7", "qs": "6.14.0", "range-parser": "1.2.1", "router": "2.2.0", "send": "1.2.0", "serve-static": "2.2.0", "statuses": "2.0.2", "type-is": "2.0.1", "vary": "1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
 
@@ -979,6 +1066,8 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "3.1.1" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
     "magic-string": ["magic-string@0.30.18", "", { "dependencies": { "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
@@ -1071,11 +1160,11 @@
 
     "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
 
-    "oxfmt": ["oxfmt@0.43.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.43.0", "@oxfmt/binding-android-arm64": "0.43.0", "@oxfmt/binding-darwin-arm64": "0.43.0", "@oxfmt/binding-darwin-x64": "0.43.0", "@oxfmt/binding-freebsd-x64": "0.43.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.43.0", "@oxfmt/binding-linux-arm-musleabihf": "0.43.0", "@oxfmt/binding-linux-arm64-gnu": "0.43.0", "@oxfmt/binding-linux-arm64-musl": "0.43.0", "@oxfmt/binding-linux-ppc64-gnu": "0.43.0", "@oxfmt/binding-linux-riscv64-gnu": "0.43.0", "@oxfmt/binding-linux-riscv64-musl": "0.43.0", "@oxfmt/binding-linux-s390x-gnu": "0.43.0", "@oxfmt/binding-linux-x64-gnu": "0.43.0", "@oxfmt/binding-linux-x64-musl": "0.43.0", "@oxfmt/binding-openharmony-arm64": "0.43.0", "@oxfmt/binding-win32-arm64-msvc": "0.43.0", "@oxfmt/binding-win32-ia32-msvc": "0.43.0", "@oxfmt/binding-win32-x64-msvc": "0.43.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-KTYNG5ISfHSdmeZ25Xzb3qgz9EmQvkaGAxgBY/p38+ZiAet3uZeu7FnMwcSQJg152Qwl0wnYAxDc+Z/H6cvrwA=="],
+    "oxfmt": ["oxfmt@0.62.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.62.0", "@oxfmt/binding-android-arm64": "0.62.0", "@oxfmt/binding-darwin-arm64": "0.62.0", "@oxfmt/binding-darwin-x64": "0.62.0", "@oxfmt/binding-freebsd-x64": "0.62.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.62.0", "@oxfmt/binding-linux-arm-musleabihf": "0.62.0", "@oxfmt/binding-linux-arm64-gnu": "0.62.0", "@oxfmt/binding-linux-arm64-musl": "0.62.0", "@oxfmt/binding-linux-ppc64-gnu": "0.62.0", "@oxfmt/binding-linux-riscv64-gnu": "0.62.0", "@oxfmt/binding-linux-riscv64-musl": "0.62.0", "@oxfmt/binding-linux-s390x-gnu": "0.62.0", "@oxfmt/binding-linux-x64-gnu": "0.62.0", "@oxfmt/binding-linux-x64-musl": "0.62.0", "@oxfmt/binding-openharmony-arm64": "0.62.0", "@oxfmt/binding-win32-arm64-msvc": "0.62.0", "@oxfmt/binding-win32-ia32-msvc": "0.62.0", "@oxfmt/binding-win32-x64-msvc": "0.62.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ=="],
 
-    "oxlint": ["oxlint@1.58.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.58.0", "@oxlint/binding-android-arm64": "1.58.0", "@oxlint/binding-darwin-arm64": "1.58.0", "@oxlint/binding-darwin-x64": "1.58.0", "@oxlint/binding-freebsd-x64": "1.58.0", "@oxlint/binding-linux-arm-gnueabihf": "1.58.0", "@oxlint/binding-linux-arm-musleabihf": "1.58.0", "@oxlint/binding-linux-arm64-gnu": "1.58.0", "@oxlint/binding-linux-arm64-musl": "1.58.0", "@oxlint/binding-linux-ppc64-gnu": "1.58.0", "@oxlint/binding-linux-riscv64-gnu": "1.58.0", "@oxlint/binding-linux-riscv64-musl": "1.58.0", "@oxlint/binding-linux-s390x-gnu": "1.58.0", "@oxlint/binding-linux-x64-gnu": "1.58.0", "@oxlint/binding-linux-x64-musl": "1.58.0", "@oxlint/binding-openharmony-arm64": "1.58.0", "@oxlint/binding-win32-arm64-msvc": "1.58.0", "@oxlint/binding-win32-ia32-msvc": "1.58.0", "@oxlint/binding-win32-x64-msvc": "1.58.0", "oxlint-tsgolint": "0.20.0" }, "bin": { "oxlint": "bin/oxlint" } }, "sha512-t4s9leczDMqlvOSjnbCQe7gtoLkWgBGZ7sBdCJ9EOj5IXFSG/X7OAzK4yuH4iW+4cAYe8kLFbC8tuYMwWZm+Cg=="],
+    "oxlint": ["oxlint@1.77.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.77.0", "@oxlint/binding-android-arm64": "1.77.0", "@oxlint/binding-darwin-arm64": "1.77.0", "@oxlint/binding-darwin-x64": "1.77.0", "@oxlint/binding-freebsd-x64": "1.77.0", "@oxlint/binding-linux-arm-gnueabihf": "1.77.0", "@oxlint/binding-linux-arm-musleabihf": "1.77.0", "@oxlint/binding-linux-arm64-gnu": "1.77.0", "@oxlint/binding-linux-arm64-musl": "1.77.0", "@oxlint/binding-linux-ppc64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-musl": "1.77.0", "@oxlint/binding-linux-s390x-gnu": "1.77.0", "@oxlint/binding-linux-x64-gnu": "1.77.0", "@oxlint/binding-linux-x64-musl": "1.77.0", "@oxlint/binding-openharmony-arm64": "1.77.0", "@oxlint/binding-win32-arm64-msvc": "1.77.0", "@oxlint/binding-win32-ia32-msvc": "1.77.0", "@oxlint/binding-win32-x64-msvc": "1.77.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg=="],
 
-    "oxlint-tsgolint": ["oxlint-tsgolint@0.20.0", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.20.0", "@oxlint-tsgolint/darwin-x64": "0.20.0", "@oxlint-tsgolint/linux-arm64": "0.20.0", "@oxlint-tsgolint/linux-x64": "0.20.0", "@oxlint-tsgolint/win32-arm64": "0.20.0", "@oxlint-tsgolint/win32-x64": "0.20.0" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-/Uc9TQyN1l8w9QNvXtVHYtz+SzDJHKpb5X0UnHodl0BVzijUPk0LPlDOHAvogd1UI+iy9ZSF6gQxEqfzUxCULQ=="],
+    "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
@@ -1122,6 +1211,8 @@
     "preact": ["preact@10.29.7", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "pretty-ms": ["pretty-ms@9.2.0", "", { "dependencies": { "parse-ms": "4.0.0" } }, "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg=="],
 
@@ -1215,6 +1306,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "1.0.4", "es-errors": "1.3.0", "get-intrinsic": "1.3.0", "object-inspect": "1.13.4", "side-channel-map": "1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "1.0.0-next.29", "mrmime": "2.0.1", "totalist": "3.0.1" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
@@ -1228,6 +1321,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "srvx": ["srvx@0.11.15", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
@@ -1268,6 +1363,8 @@
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "6.5.0", "picomatch": "4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -1325,7 +1422,7 @@
 
     "vite": ["vite@8.0.7", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.13", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw=="],
 
-    "vite-plus": ["vite-plus@0.1.16", "", { "dependencies": { "@oxc-project/types": "0.123.0", "@voidzero-dev/vite-plus-core": "0.1.16", "@voidzero-dev/vite-plus-test": "0.1.16", "oxfmt": "0.43.0", "oxlint": "1.58.0", "oxlint-tsgolint": "0.20.0" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.16", "@voidzero-dev/vite-plus-darwin-x64": "0.1.16", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.16", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.16", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.16", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.16", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.16", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.16" }, "bin": { "vp": "bin/vp", "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint" } }, "sha512-sgYHc5zWLSDInaHb/abvEA7UOwh7sUWuyNt+Slphj55jPvzodT8Dqw115xyKwDARTuRFSpm1eo/t58qZ8/NylQ=="],
+    "vite-plus": ["vite-plus@0.2.9", "", { "dependencies": { "@oxc-project/types": "=0.143.0", "@oxlint/plugins": "=1.73.0", "@vitest/browser": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "@voidzero-dev/vite-plus-core": "0.2.9", "oxfmt": "=0.62.0", "oxlint": "=1.77.0", "oxlint-tsgolint": "=7.0.2001", "vitest": "4.1.10" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.2.9", "@voidzero-dev/vite-plus-darwin-x64": "0.2.9", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.9", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.9", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.9", "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.9", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.9", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.9" }, "peerDependencies": { "@vitest/browser-playwright": "4.1.10", "@vitest/browser-webdriverio": "4.1.10" }, "optionalPeers": ["@vitest/browser-playwright", "@vitest/browser-webdriverio"], "bin": { "oxfmt": "./bin/oxfmt", "oxlint": "./bin/oxlint", "vp": "./bin/vp", "vpr": "./bin/vpr" } }, "sha512-8uRNqAxh9no3AU4Lep8BEYhkim07+3NO+mhuxTWiN0k30syGT/2+ue/DtWYhtzQ7yi2f2WKpjOhoI4/QkWWbUg=="],
 
     "vitest": ["@voidzero-dev/vite-plus-test@0.1.16", "", { "dependencies": { "@standard-schema/spec": "1.1.0", "@types/chai": "5.2.3", "@voidzero-dev/vite-plus-core": "0.1.16", "es-module-lexer": "1.7.0", "obug": "2.1.1", "pixelmatch": "7.1.0", "pngjs": "7.0.0", "sirv": "3.0.2", "std-env": "4.0.0", "tinybench": "2.9.0", "tinyexec": "1.1.1", "tinyglobby": "0.2.16", "ws": "8.20.0" }, "optionalDependencies": { "@types/node": "24.12.2" }, "peerDependencies": { "vite": "npm:@voidzero-dev/vite-plus-core@0.1.16" } }, "sha512-d/rJPX/heMzoAFdnpZsp04MAa6nw1yH1tA4mVCV4m8goVcE9nAvt69mjLMzE8N/rYIQOSgenf3hDXuQRuD6OKQ=="],
 
@@ -1334,6 +1431,8 @@
     "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
 
     "which": ["which@4.0.0", "", { "dependencies": { "isexe": "3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -1359,6 +1458,10 @@
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
+    "yuku-codegen": ["yuku-codegen@0.5.48", "", { "dependencies": { "@yuku-toolchain/types": "0.5.43" }, "optionalDependencies": { "@yuku-codegen/binding-darwin-arm64": "0.5.48", "@yuku-codegen/binding-darwin-x64": "0.5.48", "@yuku-codegen/binding-freebsd-x64": "0.5.48", "@yuku-codegen/binding-linux-arm-gnu": "0.5.48", "@yuku-codegen/binding-linux-arm-musl": "0.5.48", "@yuku-codegen/binding-linux-arm64-gnu": "0.5.48", "@yuku-codegen/binding-linux-arm64-musl": "0.5.48", "@yuku-codegen/binding-linux-x64-gnu": "0.5.48", "@yuku-codegen/binding-linux-x64-musl": "0.5.48", "@yuku-codegen/binding-win32-arm64": "0.5.48", "@yuku-codegen/binding-win32-x64": "0.5.48" } }, "sha512-p7HxD5Xl4jzDzqMrGePAOeSHmRY4g58h4HuGq15weQFPxuPWd/W6e7nqp/+Lea6JfpOdBwJOAyXFqIZ/J9Zfnw=="],
+
+    "yuku-parser": ["yuku-parser@0.5.48", "", { "dependencies": { "@yuku-toolchain/types": "0.5.43" }, "optionalDependencies": { "@yuku-parser/binding-darwin-arm64": "0.5.48", "@yuku-parser/binding-darwin-x64": "0.5.48", "@yuku-parser/binding-freebsd-x64": "0.5.48", "@yuku-parser/binding-linux-arm-gnu": "0.5.48", "@yuku-parser/binding-linux-arm-musl": "0.5.48", "@yuku-parser/binding-linux-arm64-gnu": "0.5.48", "@yuku-parser/binding-linux-arm64-musl": "0.5.48", "@yuku-parser/binding-linux-x64-gnu": "0.5.48", "@yuku-parser/binding-linux-x64-musl": "0.5.48", "@yuku-parser/binding-win32-arm64": "0.5.48", "@yuku-parser/binding-win32-x64": "0.5.48" } }, "sha512-OWBfhrpgK9+/4+IXG9oT8Bao4AhViQA7vdyNNH7EUg8dQYgwa70XtIBWTpCEme1P1ECyoDNYkn0wT63f8XRcVA=="],
+
     "zod": ["zod@4.1.5", "", {}, "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "3.25.76" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
@@ -1382,6 +1485,14 @@
     "@tailwindcss/node/lightningcss": ["lightningcss@1.30.1", "", { "dependencies": { "detect-libc": "2.0.4" }, "optionalDependencies": { "lightningcss-darwin-arm64": "1.30.1", "lightningcss-darwin-x64": "1.30.1", "lightningcss-freebsd-x64": "1.30.1", "lightningcss-linux-arm-gnueabihf": "1.30.1", "lightningcss-linux-arm64-gnu": "1.30.1", "lightningcss-linux-arm64-musl": "1.30.1", "lightningcss-linux-x64-gnu": "1.30.1", "lightningcss-linux-x64-musl": "1.30.1", "lightningcss-win32-arm64-msvc": "1.30.1", "lightningcss-win32-x64-msvc": "1.30.1" } }, "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg=="],
 
     "@ts-morph/common/minimatch": ["minimatch@10.0.3", "", { "dependencies": { "@isaacs/brace-expansion": "5.0.0" } }, "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw=="],
+
+    "@vitest/browser/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "@vitest/mocker/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "@vitest/snapshot/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "@voidzero-dev/vite-plus-core/lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
 
     "@voidzero-dev/vite-plus-core/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "3.3.11", "picocolors": "1.1.1", "source-map-js": "1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
@@ -1419,9 +1530,17 @@
 
     "posthog-js/fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
+    "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "5.0.1" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "rolldown/@oxc-project/types": ["@oxc-project/types@0.123.0", "", {}, "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.13", "", {}, "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA=="],
 
@@ -1432,6 +1551,10 @@
     "tough-cookie/universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
 
     "vite/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "3.3.11", "picocolors": "1.1.1", "source-map-js": "1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
+
+    "vite-plus/vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
+    "vitest/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.16", "", { "dependencies": { "@oxc-project/runtime": "0.123.0", "@oxc-project/types": "0.123.0", "lightningcss": "1.32.0", "postcss": "8.5.9" }, "optionalDependencies": { "@types/node": "24.12.2", "fsevents": "2.3.3", "jiti": "2.5.1", "typescript": "5.9.2" } }, "sha512-fOyf14CXjcXqANFs2fCXEX+0Tn9ZjmqfFV+qTnARwIF1Kzl8WquO4XtvlDgs/fTQ91H4AyoNUgkvWdKS+C4xYA=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "8.0.0", "is-fullwidth-code-point": "3.0.0", "strip-ansi": "6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1471,11 +1594,43 @@
 
     "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.1", "", { "os": "win32", "cpu": "x64" }, "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg=="],
 
+    "@voidzero-dev/vite-plus-core/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
+
+    "@voidzero-dev/vite-plus-core/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
+
+    "@voidzero-dev/vite-plus-core/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
+
+    "@voidzero-dev/vite-plus-core/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
+
+    "@voidzero-dev/vite-plus-core/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
+
+    "@voidzero-dev/vite-plus-core/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
+
+    "@voidzero-dev/vite-plus-core/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
+
+    "@voidzero-dev/vite-plus-core/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
+
+    "@voidzero-dev/vite-plus-core/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
+
+    "@voidzero-dev/vite-plus-core/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
+
+    "@voidzero-dev/vite-plus-core/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
+
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "vite-plus/vitest/es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
+    "vite-plus/vitest/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "vitest/@voidzero-dev/vite-plus-core/@oxc-project/runtime": ["@oxc-project/runtime@0.123.0", "", {}, "sha512-wRf0z8saz9tHLcK3YeTeBmwISrpy4bBimvKxUmryiIhbt+ZJb0nwwJNL3D8xpeWbNfZlGSlzRBZbfcbApIGZJw=="],
+
+    "vitest/@voidzero-dev/vite-plus-core/@oxc-project/types": ["@oxc-project/types@0.123.0", "", {}, "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew=="],
+
+    "vitest/@voidzero-dev/vite-plus-core/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "3.3.11", "picocolors": "1.1.1", "source-map-js": "1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/cobalt-machine-proxy.mjs
+++ b/cobalt-machine-proxy.mjs
@@ -78,12 +78,10 @@ const getCobaltErrorContext = (responseHeaders, chunks, capturedBytes, responseB
     if (body?.status !== "error" || typeof body.error?.code !== "string") {
       return {};
     }
-    return {
-      errorCode: body.error.code,
-      ...(typeof body.error.context?.service === "string"
-        ? { service: body.error.context.service }
-        : {}),
-    };
+    const errorCode = body.error.code;
+    const service = body.error.context?.service;
+    if (typeof service === "string") return { errorCode, service };
+    return { errorCode };
   } catch {
     return {};
   }

--- a/cobalt-machine-proxy.mjs
+++ b/cobalt-machine-proxy.mjs
@@ -244,10 +244,9 @@ export const createCobaltProxyServer = ({
 
     if (requestUrl.pathname === "/readyz") {
       const status = lifecycle.draining ? 503 : 200;
-      clientResponse.writeHead(status, {
-        "content-type": "text/plain;charset=UTF-8",
-        ...(lifecycle.draining ? { connection: "close" } : {}),
-      });
+      const headers = { "content-type": "text/plain;charset=UTF-8" };
+      if (lifecycle.draining) headers.connection = "close";
+      clientResponse.writeHead(status, headers);
       clientResponse.end(lifecycle.draining ? "draining" : "ready");
       return;
     }

--- a/cobalt-soundcloud.mjs
+++ b/cobalt-soundcloud.mjs
@@ -27,21 +27,18 @@ const fetchText = async (url, stage) => {
   }
   const contentType = response.headers.get("content-type") ?? undefined;
   if (!response.ok) {
-    return failure(stage, {
-      upstreamStatus: response.status,
-      ...(contentType ? { contentType } : {}),
-      ...(response.headers.get("retry-after")
-        ? { retryAfter: response.headers.get("retry-after") }
-        : {}),
-    });
+    const details = { upstreamStatus: response.status };
+    if (contentType) details.contentType = contentType;
+    const retryAfter = response.headers.get("retry-after");
+    if (retryAfter) details.retryAfter = retryAfter;
+    return failure(stage, details);
   }
   try {
     return { value: await response.text() };
   } catch (error) {
-    return failure(`${stage}_body`, {
-      ...(contentType ? { contentType } : {}),
-      errorType: error instanceof Error ? error.name : "UnknownError",
-    });
+    const details = { errorType: error instanceof Error ? error.name : "UnknownError" };
+    if (contentType) details.contentType = contentType;
+    return failure(`${stage}_body`, details);
   }
 };
 
@@ -56,21 +53,18 @@ const fetchJson = async (url, stage) => {
   }
   const contentType = response.headers.get("content-type") ?? undefined;
   if (!response.ok) {
-    return failure(stage, {
-      upstreamStatus: response.status,
-      ...(contentType ? { contentType } : {}),
-      ...(response.headers.get("retry-after")
-        ? { retryAfter: response.headers.get("retry-after") }
-        : {}),
-    });
+    const details = { upstreamStatus: response.status };
+    if (contentType) details.contentType = contentType;
+    const retryAfter = response.headers.get("retry-after");
+    if (retryAfter) details.retryAfter = retryAfter;
+    return failure(stage, details);
   }
   try {
     return { value: await response.json() };
   } catch (error) {
-    return failure(`${stage}_parse`, {
-      ...(contentType ? { contentType } : {}),
-      errorType: error instanceof Error ? error.name : "UnknownError",
-    });
+    const details = { errorType: error instanceof Error ? error.name : "UnknownError" };
+    if (contentType) details.contentType = contentType;
+    return failure(`${stage}_parse`, details);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@oxlint/plugins": "1.73.0",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^24.12.2",
@@ -70,7 +71,7 @@
     "tw-animate-css": "^1.3.7",
     "typescript": "^5",
     "vite": "^8.0.7",
-    "vite-plus": "latest",
+    "vite-plus": "^0.2.9",
     "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
   },
   "devEngines": {

--- a/scripts/deploy-preview.ts
+++ b/scripts/deploy-preview.ts
@@ -1,20 +1,15 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { argv, exit } from "node:process";
-import { configureShareDeploymentBindings } from "./share-deployment-bindings";
+import {
+  configureShareDeploymentBindings,
+  decodeWranglerConfig,
+} from "./share-deployment-bindings";
 
 const WRANGLER_CONFIG_PATH = ".output/server/wrangler.json";
 const WRANGLER_VERSION = "wrangler@4.110.0";
 
-type WranglerConfig = {
-  name?: string;
-  vars?: Record<string, string>;
-  d1_databases?: unknown[];
-  r2_buckets?: unknown[];
-  ratelimits?: unknown[];
-};
-
-const config = JSON.parse(readFileSync(WRANGLER_CONFIG_PATH, "utf8")) as WranglerConfig;
+const config = decodeWranglerConfig(JSON.parse(readFileSync(WRANGLER_CONFIG_PATH, "utf8")));
 try {
   configureShareDeploymentBindings(config, "preview");
 } catch (error) {

--- a/scripts/deploy-production.ts
+++ b/scripts/deploy-production.ts
@@ -1,20 +1,15 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { argv, exit } from "node:process";
-import { configureShareDeploymentBindings } from "./share-deployment-bindings";
+import {
+  configureShareDeploymentBindings,
+  decodeWranglerConfig,
+} from "./share-deployment-bindings";
 
 const WRANGLER_CONFIG_PATH = ".output/server/wrangler.json";
 const WRANGLER_VERSION = "wrangler@4.110.0";
 
-type WranglerConfig = {
-  name?: string;
-  vars?: Record<string, string>;
-  d1_databases?: unknown[];
-  r2_buckets?: unknown[];
-  ratelimits?: unknown[];
-};
-
-const config = JSON.parse(readFileSync(WRANGLER_CONFIG_PATH, "utf8")) as WranglerConfig;
+const config = decodeWranglerConfig(JSON.parse(readFileSync(WRANGLER_CONFIG_PATH, "utf8")));
 try {
   configureShareDeploymentBindings(config, "production");
 } catch (error) {

--- a/scripts/disable-share-manifest.ts
+++ b/scripts/disable-share-manifest.ts
@@ -1,10 +1,23 @@
 import { spawnSync } from "node:child_process";
 import { argv, env, exit } from "node:process";
+import { Schema } from "effect";
 import { SHARE_SLUG_PATTERN } from "../server/utils/share-manifest";
 import { disableShareThenDeleteArtwork } from "../server/utils/share-manifest-maintenance";
 import { getShareDeploymentResources } from "./share-deployment-bindings";
 
 const [slug] = argv.slice(2);
+const lookupResponseSchema = Schema.Array(
+  Schema.Struct({
+    results: Schema.optionalKey(
+      Schema.Array(
+        Schema.Struct({
+          slug: Schema.optionalKey(Schema.String),
+          artwork_key: Schema.optionalKey(Schema.NullOr(Schema.String)),
+        }),
+      ),
+    ),
+  }),
+);
 const deployment = env.TAGIUM_DEPLOY_ENV;
 if (
   (deployment !== "preview" && deployment !== "production") ||
@@ -41,9 +54,7 @@ if (lookup.status !== 0) exit(lookup.status ?? 1);
 let artworkKey: string | undefined;
 let found = false;
 try {
-  const payload = JSON.parse(lookup.stdout) as Array<{
-    results?: Array<{ slug?: string; artwork_key?: string | null }>;
-  }>;
+  const payload = Schema.decodeUnknownSync(lookupResponseSchema)(JSON.parse(lookup.stdout));
   const record = payload.flatMap((entry) => entry.results ?? [])[0];
   found = record?.slug === slug;
   artworkKey = record?.artwork_key ?? undefined;

--- a/scripts/load-test-cobalt.ts
+++ b/scripts/load-test-cobalt.ts
@@ -42,6 +42,7 @@
 import { readFileSync } from "node:fs";
 import { argv, env, exit } from "node:process";
 import { fileURLToPath } from "node:url";
+import { Schema } from "effect";
 import { assertTunnelMatchesLoadTestTarget, parseLoadTestTarget } from "./load-test-cobalt-safety";
 
 // Last-resort fallback if scripts/load-test-urls.txt is missing or unreadable.
@@ -49,12 +50,25 @@ const FALLBACK_URLS = ["https://www.youtube.com/watch?v=YE7VzlLtp-4"];
 const DEFAULT_URLS_FILE = fileURLToPath(new URL("./load-test-urls.txt", import.meta.url));
 const REQUEST_TIMEOUT_MS = 120_000;
 
-type CobaltPlan =
-  | { status: "error"; error: { code: string } }
-  | { status: "picker"; audio?: string; audioFilename?: string }
-  | { status: "redirect"; url: string; filename: string }
-  | { status: "tunnel"; url: string; filename: string }
-  | { status: "local-processing"; tunnel: string[] };
+const cobaltPlanSchema = Schema.Union([
+  Schema.Struct({ status: Schema.Literal("error"), error: Schema.Struct({ code: Schema.String }) }),
+  Schema.Struct({
+    status: Schema.Literal("picker"),
+    audio: Schema.optionalKey(Schema.String),
+    audioFilename: Schema.optionalKey(Schema.String),
+  }),
+  Schema.Struct({
+    status: Schema.Literal("redirect"),
+    url: Schema.String,
+    filename: Schema.String,
+  }),
+  Schema.Struct({ status: Schema.Literal("tunnel"), url: Schema.String, filename: Schema.String }),
+  Schema.Struct({
+    status: Schema.Literal("local-processing"),
+    tunnel: Schema.Array(Schema.String),
+  }),
+]);
+type CobaltPlan = Schema.Schema.Type<typeof cobaltPlanSchema>;
 
 interface DownloadResult {
   ok: boolean;
@@ -157,7 +171,7 @@ const parseArgs = (argv: string[]): CliOptions => {
 // Real downloads fetch every tunnel Cobalt returns concurrently (audio + cover art when
 // present) - see src/features/import/localAudioProcessor.ts's Effect.all([audio, cover]).
 // A single "download" therefore usually means 2 concurrent /tunnel requests, not 1.
-const pickTunnelUrls = (plan: CobaltPlan): string[] => {
+const pickTunnelUrls = (plan: CobaltPlan): readonly string[] => {
   switch (plan.status) {
     case "local-processing":
       return plan.tunnel;
@@ -192,16 +206,17 @@ const fetchTunnel = async (url: string) => {
 
     return { ok: true as const, bytes };
   } catch (error) {
-    return { ok: false as const, errorCode: describeError(error), bytes: 0 };
+    return {
+      ok: false as const,
+      errorCode: describeError(
+        error instanceof Error ? error : new Error("unknown stream failure"),
+      ),
+      bytes: 0,
+    };
   }
 };
 
-const describeError = (error: unknown) => {
-  if (error instanceof Error) {
-    return error.name === "TimeoutError" ? "timeout" : error.message;
-  }
-  return "unknown-error";
-};
+const describeError = (error: Error) => (error.name === "TimeoutError" ? "timeout" : error.message);
 
 const performOneDownload = async (
   target: URL,
@@ -213,13 +228,14 @@ const performOneDownload = async (
   let response: Response;
 
   try {
+    const headers = new Headers({
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    });
+    if (apiKey) headers.set("Authorization", `Api-Key ${apiKey}`);
     response = await fetch(new URL("/", target), {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-        ...(apiKey ? { Authorization: `Api-Key ${apiKey}` } : {}),
-      },
+      headers,
       body: JSON.stringify({
         url: sourceUrl,
         downloadMode: "audio",
@@ -235,7 +251,9 @@ const performOneDownload = async (
   } catch (error) {
     return {
       ok: false,
-      errorCode: describeError(error),
+      errorCode: describeError(
+        error instanceof Error ? error : new Error("unknown resolve failure"),
+      ),
       resolveMs: performance.now() - resolveStart,
     };
   }
@@ -248,7 +266,7 @@ const performOneDownload = async (
 
   let plan: CobaltPlan;
   try {
-    plan = (await response.json()) as CobaltPlan;
+    plan = Schema.decodeUnknownSync(cobaltPlanSchema)(await response.json());
   } catch {
     return { ok: false, errorCode: "invalid-json", resolveMs };
   }

--- a/scripts/share-deployment-bindings.ts
+++ b/scripts/share-deployment-bindings.ts
@@ -1,4 +1,14 @@
+import { Schema } from "effect";
+
 export type DeployEnvironment = "preview" | "production";
+
+const wranglerBindingSchema = Schema.Struct({
+  name: Schema.optionalKey(Schema.String),
+  namespace_id: Schema.optionalKey(Schema.String),
+  simple: Schema.optionalKey(Schema.Struct({ limit: Schema.Number, period: Schema.Number })),
+});
+const optionalMutableKey = <S extends Schema.Constraint>(schema: S) =>
+  Schema.optionalKey(Schema.mutableKey(schema));
 
 /** Stable, provisioned Cloudflare resources. Keep this as the sole target map. */
 export const SHARE_DEPLOYMENT_RESOURCES = {
@@ -27,14 +37,18 @@ export const SHARE_DEPLOYMENT_RESOURCES = {
 export const getShareDeploymentResources = (environment: DeployEnvironment) =>
   SHARE_DEPLOYMENT_RESOURCES[environment];
 
-export type WranglerConfig = {
-  name?: string;
-  vars?: Record<string, string>;
-  d1_databases?: unknown[];
-  r2_buckets?: unknown[];
-  ratelimits?: unknown[];
-  env?: unknown;
-};
+export const wranglerConfigSchema = Schema.Struct({
+  name: optionalMutableKey(Schema.String),
+  vars: optionalMutableKey(Schema.Record(Schema.String, Schema.String)),
+  d1_databases: optionalMutableKey(Schema.Array(Schema.Unknown)),
+  r2_buckets: optionalMutableKey(Schema.Array(Schema.Unknown)),
+  ratelimits: optionalMutableKey(Schema.Array(wranglerBindingSchema)),
+  env: optionalMutableKey(Schema.Unknown),
+});
+export type WranglerConfig = Schema.Schema.Type<typeof wranglerConfigSchema>;
+export const decodeWranglerConfig = Schema.decodeUnknownSync(wranglerConfigSchema, {
+  onExcessProperty: "preserve",
+});
 
 /** Materialize one target into the top-level config used by both Wrangler commands. */
 export const configureShareDeploymentBindings = (
@@ -79,13 +93,8 @@ export const configureShareDeploymentBindings = (
       simple: { limit: 20, period: 60 },
     },
   ];
-  const cobalt = (config.ratelimits ?? []).filter(
-    (binding) =>
-      binding &&
-      typeof binding === "object" &&
-      ["COBALT_SESSION_RATE_LIMITER", "COBALT_CLIENT_RATE_LIMITER"].includes(
-        (binding as { name?: string }).name ?? "",
-      ),
+  const cobalt = (config.ratelimits ?? []).filter((binding) =>
+    ["COBALT_SESSION_RATE_LIMITER", "COBALT_CLIENT_RATE_LIMITER"].includes(binding.name ?? ""),
   );
   config.ratelimits = [...cobalt, ...shareRateLimits];
   return config;

--- a/server/api/cobalt/audio.post.ts
+++ b/server/api/cobalt/audio.post.ts
@@ -102,6 +102,25 @@ type CobaltAudioResult = {
   failureStage?: "cobalt.resolve_fetch" | "cobalt.resolve_parse";
   failureReason?: "fetch_threw" | "non_json" | "invalid_json_or_schema" | "invalid_machine_id";
 };
+interface CobaltAudioLogDetails {
+  stage?: string;
+  elapsedMs: number;
+  errorCode?: string;
+  outcome?: string;
+  upstreamStatus?: number;
+  contentType?: string;
+  retryAfter?: string;
+  machineId?: string;
+  failureReason?: string;
+  errorType?: string;
+}
+interface CobaltAudioLogEntry extends CobaltAudioLogDetails {
+  event: "cobalt_audio_completion" | "cobalt_audio_failure";
+  requestId: string;
+  sourceFingerprint: string;
+  importId?: string;
+  trackIndex?: number;
+}
 type CobaltRuntimeEnv = {
   COBALT_ALLOWED_ORIGIN?: string;
   COBALT_API_KEY?: string;
@@ -122,6 +141,7 @@ const COBALT_REQUEST_TIMEOUT_MS = 300_000;
 
 const getRuntimeEnv = (request: Request): CobaltRuntimeEnv => ({
   ...processEnv,
+  // SAFETY: Nitro's Cloudflare adapter supplies this request shape in the Cloudflare runtime.
   ...(request as CloudflareRequest).runtime?.cloudflare?.env,
 });
 
@@ -138,19 +158,19 @@ const getCobaltHeaders = (
   context: RequestLogContext,
   sourceFingerprint: string,
 ) => {
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     Accept: "application/json",
     "Content-Type": "application/json",
     "X-Tagium-Request-Id": context.requestId,
     "X-Tagium-Source-Fingerprint": sourceFingerprint,
-  };
+  });
 
-  if (context.importId) headers["X-Tagium-Import-Id"] = context.importId;
+  if (context.importId) headers.set("X-Tagium-Import-Id", context.importId);
   if (context.trackIndex !== undefined) {
-    headers["X-Tagium-Track-Index"] = String(context.trackIndex);
+    headers.set("X-Tagium-Track-Index", String(context.trackIndex));
   }
   if (runtimeEnv.COBALT_API_KEY) {
-    headers.Authorization = `Api-Key ${runtimeEnv.COBALT_API_KEY}`;
+    headers.set("Authorization", `Api-Key ${runtimeEnv.COBALT_API_KEY}`);
   }
 
   return headers;
@@ -294,16 +314,16 @@ const logCobaltAudioEvent = (
   event: "cobalt_audio_completion" | "cobalt_audio_failure",
   context: RequestLogContext,
   sourceFingerprint: string,
-  details: Record<string, unknown>,
+  details: CobaltAudioLogDetails,
 ) => {
-  const entry = {
+  const entry: CobaltAudioLogEntry = {
     event,
     requestId: context.requestId,
-    ...(context.importId ? { importId: context.importId } : {}),
-    ...(context.trackIndex !== undefined ? { trackIndex: context.trackIndex } : {}),
     sourceFingerprint,
     ...details,
   };
+  if (context.importId) entry.importId = context.importId;
+  if (context.trackIndex !== undefined) entry.trackIndex = context.trackIndex;
   const serialized = JSON.stringify(entry);
   if (event === "cobalt_audio_failure") {
     console.warn(serialized);
@@ -534,27 +554,39 @@ export default defineHandler(async (event) => {
     const cobaltResponse = cobaltResult.response;
 
     if (cobaltResponse.status === CobaltResponseType.Error) {
-      logCobaltAudioEvent("cobalt_audio_failure", context, requestSourceFingerprint, {
+      const failureDetails: CobaltAudioLogDetails = {
         stage: cobaltResult.failureStage ?? "cobalt.resolve_error",
         elapsedMs: Date.now() - startedAt,
         errorCode: cobaltResponse.error.code,
-        ...(cobaltResult.upstreamStatus === undefined
-          ? {}
-          : { upstreamStatus: cobaltResult.upstreamStatus }),
-        ...(cobaltResult.contentType ? { contentType: cobaltResult.contentType } : {}),
-        ...(cobaltResult.retryAfter ? { retryAfter: cobaltResult.retryAfter } : {}),
-        ...(cobaltResult.machineId ? { machineId: cobaltResult.machineId } : {}),
-        ...(cobaltResult.failureReason ? { failureReason: cobaltResult.failureReason } : {}),
-      });
+      };
+      if (cobaltResult.upstreamStatus !== undefined) {
+        failureDetails.upstreamStatus = cobaltResult.upstreamStatus;
+      }
+      if (cobaltResult.contentType) failureDetails.contentType = cobaltResult.contentType;
+      if (cobaltResult.retryAfter) failureDetails.retryAfter = cobaltResult.retryAfter;
+      if (cobaltResult.machineId) failureDetails.machineId = cobaltResult.machineId;
+      if (cobaltResult.failureReason) failureDetails.failureReason = cobaltResult.failureReason;
+      logCobaltAudioEvent(
+        "cobalt_audio_failure",
+        context,
+        requestSourceFingerprint,
+        failureDetails,
+      );
     } else {
-      logCobaltAudioEvent("cobalt_audio_completion", context, requestSourceFingerprint, {
+      const completionDetails: CobaltAudioLogDetails = {
         elapsedMs: Date.now() - startedAt,
         outcome: cobaltResponse.status,
-        ...(cobaltResult.upstreamStatus === undefined
-          ? {}
-          : { upstreamStatus: cobaltResult.upstreamStatus }),
-        ...(cobaltResult.machineId ? { machineId: cobaltResult.machineId } : {}),
-      });
+      };
+      if (cobaltResult.upstreamStatus !== undefined) {
+        completionDetails.upstreamStatus = cobaltResult.upstreamStatus;
+      }
+      if (cobaltResult.machineId) completionDetails.machineId = cobaltResult.machineId;
+      logCobaltAudioEvent(
+        "cobalt_audio_completion",
+        context,
+        requestSourceFingerprint,
+        completionDetails,
+      );
     }
 
     if (isCobaltCapacityError(cobaltResponse)) {

--- a/server/api/cobalt/tunnel.get.ts
+++ b/server/api/cobalt/tunnel.get.ts
@@ -1,5 +1,6 @@
 import { defineHandler } from "nitro";
 import { env as processEnv } from "node:process";
+import { Option, Schema } from "effect";
 import {
   isCobaltMachineId,
   isValidCobaltMachineSignature,
@@ -27,6 +28,11 @@ type TunnelObservabilityContext = {
   importId?: string;
   sourceFingerprint?: string;
   trackIndex?: number;
+};
+type TunnelLogContext = TunnelObservabilityContext & {
+  requestId: string;
+  machineId?: string;
+  tunnelId?: string;
 };
 
 const COBALT_TUNNEL_TIMEOUT_MS = 300_000;
@@ -60,6 +66,7 @@ const createTunnelRequestId = () => `tagium-tunnel-${crypto.randomUUID()}`;
 
 const getRuntimeEnv = (request: Request): CobaltRuntimeEnv => ({
   ...processEnv,
+  // SAFETY: Nitro's Cloudflare adapter supplies this request shape in the Cloudflare runtime.
   ...(request as CloudflareRequest).runtime?.cloudflare?.env,
 });
 
@@ -126,7 +133,7 @@ const getTunnelLogContext = (
   machineId: string | null | undefined,
   observability: TunnelObservabilityContext = {},
 ) => {
-  const context: Record<string, string | number> = { requestId, ...observability };
+  const context: TunnelLogContext = { requestId, ...observability };
   if (machineId) {
     context.machineId = machineId;
   }
@@ -167,32 +174,24 @@ const logTunnelFailure = (
   console.warn(JSON.stringify({ event: "cobalt_tunnel_failure", message, ...context }));
 };
 
+const cobaltCapacityErrorSchema = Schema.Struct({
+  status: Schema.Literal("error"),
+  error: Schema.Struct({ code: Schema.Literal("error.api.capacity_exceeded") }),
+});
+type CobaltCapacityError = Schema.Schema.Type<typeof cobaltCapacityErrorSchema>;
+const decodeCobaltCapacityError = Schema.decodeUnknownOption(cobaltCapacityErrorSchema);
+
 const tryParseCobaltCapacityError = (responseText: string) => {
   try {
-    const body = JSON.parse(responseText) as unknown;
-
-    if (
-      body &&
-      typeof body === "object" &&
-      "status" in body &&
-      body.status === "error" &&
-      "error" in body &&
-      body.error &&
-      typeof body.error === "object" &&
-      "code" in body.error &&
-      body.error.code === "error.api.capacity_exceeded"
-    ) {
-      return body;
-    }
+    const decoded = decodeCobaltCapacityError(JSON.parse(responseText));
+    return Option.isSome(decoded) ? decoded.value : undefined;
   } catch {
     return undefined;
   }
-
-  return undefined;
 };
 
 const cobaltCapacityErrorResponse = (
-  body: unknown,
+  body: CobaltCapacityError,
   retryAfter: string | null,
   attempts?: number,
 ) => {
@@ -208,6 +207,12 @@ const cobaltCapacityErrorResponse = (
     status: 503,
     headers,
   });
+};
+
+const tunnelFailureResponseInit = (attempts: number): ResponseInit => {
+  const init: ResponseInit = { status: 502 };
+  if (attempts > 0) init.headers = tunnelTelemetryHeaders("non_retryable", attempts);
+  return init;
 };
 
 const cobaltDevTunnelFaultResponse = (fault: ReturnType<typeof consumeTunnelDevFault>) => {
@@ -357,9 +362,13 @@ export default defineHandler(async (event) => {
       await new Promise<void>((resolve, reject) => {
         const onAbort = () => {
           clearTimeout(timer);
-          done(fetchSignal.reason);
+          done(
+            fetchSignal.reason instanceof Error
+              ? fetchSignal.reason
+              : new Error("tunnel retry aborted"),
+          );
         };
-        const done = (error?: unknown) => {
+        const done = (error?: Error) => {
           fetchSignal.removeEventListener("abort", onAbort);
           if (error === undefined) resolve();
           else reject(error);
@@ -444,17 +453,11 @@ export default defineHandler(async (event) => {
       });
       if (error.name === "TimeoutError" || error.name === "AbortError") {
         return new Response("Cobalt tunnel request timed out.", {
-          status: 502,
-          ...(upstreamAttempts > 0
-            ? { headers: tunnelTelemetryHeaders("non_retryable", upstreamAttempts) }
-            : {}),
+          ...tunnelFailureResponseInit(upstreamAttempts),
         });
       }
       return new Response(error.message, {
-        status: 502,
-        ...(upstreamAttempts > 0
-          ? { headers: tunnelTelemetryHeaders("non_retryable", upstreamAttempts) }
-          : {}),
+        ...tunnelFailureResponseInit(upstreamAttempts),
       });
     }
 
@@ -463,10 +466,7 @@ export default defineHandler(async (event) => {
       elapsedMs: Date.now() - startedAt,
     });
     return new Response("Cobalt tunnel request failed.", {
-      status: 502,
-      ...(upstreamAttempts > 0
-        ? { headers: tunnelTelemetryHeaders("non_retryable", upstreamAttempts) }
-        : {}),
+      ...tunnelFailureResponseInit(upstreamAttempts),
     });
   }
 });

--- a/server/api/dev/config.get.ts
+++ b/server/api/dev/config.get.ts
@@ -16,6 +16,7 @@ type CloudflareRequest = Request & {
 
 const getRuntimeEnv = (request: Request): CobaltRuntimeEnv => ({
   ...processEnv,
+  // SAFETY: Nitro's Cloudflare adapter supplies this request shape in the dev runtime.
   ...(request as CloudflareRequest).runtime?.cloudflare?.env,
 });
 

--- a/server/api/dev/config.post.ts
+++ b/server/api/dev/config.post.ts
@@ -19,6 +19,7 @@ type CloudflareRequest = Request & {
 
 const getRuntimeEnv = (request: Request): CobaltRuntimeEnv => ({
   ...processEnv,
+  // SAFETY: Nitro's Cloudflare adapter supplies this request shape in the dev runtime.
   ...(request as CloudflareRequest).runtime?.cloudflare?.env,
 });
 

--- a/server/api/dev/fault.post.ts
+++ b/server/api/dev/fault.post.ts
@@ -19,6 +19,7 @@ type CloudflareRequest = Request & {
 
 const getRuntimeEnv = (request: Request): CobaltRuntimeEnv => ({
   ...processEnv,
+  // SAFETY: Nitro's Cloudflare adapter supplies this request shape in the dev runtime.
   ...(request as CloudflareRequest).runtime?.cloudflare?.env,
 });
 

--- a/server/api/manifests/[slug].patch.ts
+++ b/server/api/manifests/[slug].patch.ts
@@ -1,4 +1,5 @@
 import { defineHandler } from "nitro";
+import { Schema } from "effect";
 import {
   isShareManifestValidationError,
   parseShareArtwork,
@@ -53,18 +54,20 @@ export default defineHandler(async (event) => {
       manifests.length !== 1 ||
       covers.length > 1 ||
       removals.length > 1 ||
-      typeof manifests[0] !== "string" ||
+      !Schema.is(Schema.String)(manifests[0]) ||
       (covers[0] !== undefined && !(covers[0] instanceof File)) ||
       (removals[0] !== undefined && removals[0] !== "true") ||
       (covers.length > 0 && removals.length > 0)
     )
       return badRequest();
-    const artworkUpdate: ShareArtworkUpdate =
-      removals.length > 0
-        ? { kind: "remove" }
-        : covers[0] instanceof File
-          ? { kind: "replace", artwork: (await parseShareArtwork(covers[0]))! }
-          : { kind: "retain" };
+    let artworkUpdate: ShareArtworkUpdate = { kind: "retain" };
+    if (removals.length > 0) {
+      artworkUpdate = { kind: "remove" };
+    } else if (covers[0] instanceof File) {
+      const artwork = await parseShareArtwork(covers[0]);
+      if (!artwork) return badRequest();
+      artworkUpdate = { kind: "replace", artwork };
+    }
     const result = await store.update(
       event.context.params?.slug ?? "",
       token,
@@ -82,10 +85,11 @@ export default defineHandler(async (event) => {
     );
   } catch (error) {
     if (
-      isShareManifestValidationError(error) ||
-      error instanceof SyntaxError ||
-      error instanceof TypeError ||
-      (error instanceof Error && /^share_request_too_large|manifest payload/.test(error.message))
+      error instanceof Error &&
+      (isShareManifestValidationError(error) ||
+        error instanceof SyntaxError ||
+        error instanceof TypeError ||
+        /^share_request_too_large|manifest payload/.test(error.message))
     )
       return badRequest();
     return infrastructureFailure();

--- a/server/api/manifests/index.post.ts
+++ b/server/api/manifests/index.post.ts
@@ -1,4 +1,5 @@
 import { defineHandler } from "nitro";
+import { Schema } from "effect";
 import {
   isShareManifestValidationError,
   parseShareArtwork,
@@ -43,16 +44,14 @@ export default defineHandler(async (event) => {
     if (
       manifests.length !== 1 ||
       covers.length > 1 ||
-      typeof manifests[0] !== "string" ||
+      !Schema.is(Schema.String)(manifests[0]) ||
       (covers[0] !== undefined && !(covers[0] instanceof File))
     )
       return badRequest();
     const rawManifest = manifests[0];
+    const cover = covers[0] instanceof File ? covers[0] : undefined;
     const manifest = decodePublishedManifest(JSON.parse(rawManifest));
-    const published = await store.publish(
-      manifest,
-      await parseShareArtwork(covers[0] as File | undefined),
-    );
+    const published = await store.publish(manifest, await parseShareArtwork(cover));
     const url = new URL(`/share/${published.slug}`, request.url).toString();
     return Response.json(
       { ...published, expiresAt: toShareExpiryIso(published.expiresAt), url },
@@ -60,10 +59,11 @@ export default defineHandler(async (event) => {
     );
   } catch (error) {
     if (
-      isShareManifestValidationError(error) ||
-      error instanceof SyntaxError ||
-      error instanceof TypeError ||
-      (error instanceof Error && /^share_request_too_large|manifest payload/.test(error.message))
+      error instanceof Error &&
+      (isShareManifestValidationError(error) ||
+        error instanceof SyntaxError ||
+        error instanceof TypeError ||
+        /^share_request_too_large|manifest payload/.test(error.message))
     )
       return badRequest();
     // The service deliberately returns no diagnostic payload for binding/storage failures.

--- a/server/api/soundcloud-set.get.ts
+++ b/server/api/soundcloud-set.get.ts
@@ -10,6 +10,7 @@ import {
   logSoundCloudCompletion,
   logSoundCloudFailure,
   type SoundCloudLogContext,
+  type SoundCloudLogDetails,
 } from "../utils/soundcloud-observability";
 import { urlStringSchema } from "../utils/schema";
 import { parseMediaLink } from "../../src/lib/media-link";
@@ -78,6 +79,17 @@ const getYear = (displayDate: string | undefined) => {
   return Number.isNaN(year) ? undefined : year;
 };
 
+const upstreamFailureDetails = (
+  response: Response,
+  contentType: string | undefined,
+): SoundCloudLogDetails => {
+  const details: SoundCloudLogDetails = { upstreamStatus: response.status };
+  if (contentType) details.contentType = contentType;
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter) details.retryAfter = retryAfter;
+  return details;
+};
+
 const resolveTrack = async (
   clientId: string,
   track: Schema.Schema.Type<typeof soundCloudTrackSchema>,
@@ -98,13 +110,7 @@ const resolveTrack = async (
       await logSoundCloudFailure(
         "track.resolve_fetch",
         context,
-        {
-          upstreamStatus: response.status,
-          ...(contentType ? { contentType } : {}),
-          ...(response.headers.get("retry-after")
-            ? { retryAfter: response.headers.get("retry-after") }
-            : {}),
-        },
+        upstreamFailureDetails(response, contentType),
         startedAt,
       );
       throw new SoundCloudTrackResolveError("track.resolve_fetch");
@@ -115,15 +121,11 @@ const resolveTrack = async (
       );
     } catch (error) {
       parseFailure = true;
-      await logSoundCloudFailure(
-        "track.resolve_parse",
-        context,
-        {
-          ...(contentType ? { contentType } : {}),
-          errorType: error instanceof Error ? error.name : "UnknownError",
-        },
-        startedAt,
-      );
+      const details: SoundCloudLogDetails = {
+        errorType: error instanceof Error ? error.name : "UnknownError",
+      };
+      if (contentType) details.contentType = contentType;
+      await logSoundCloudFailure("track.resolve_parse", context, details, startedAt);
       throw new SoundCloudTrackResolveError("track.resolve_parse", { cause: error });
     }
   } catch (error) {
@@ -238,13 +240,7 @@ export default defineHandler(async (event) => {
     await logSoundCloudFailure(
       "playlist.resolve_fetch",
       context,
-      {
-        upstreamStatus: playlistResponse.status,
-        ...(contentType ? { contentType } : {}),
-        ...(playlistResponse.headers.get("retry-after")
-          ? { retryAfter: playlistResponse.headers.get("retry-after") }
-          : {}),
-      },
+      upstreamFailureDetails(playlistResponse, contentType),
       playlistStartedAt,
     );
     throw new Error(`soundcloud.playlist.resolve_http_${playlistResponse.status}`);

--- a/server/api/youtube-playlist.get.ts
+++ b/server/api/youtube-playlist.get.ts
@@ -55,7 +55,21 @@ const decodeLegacyVideoOption = Schema.decodeUnknownOption(legacyVideoSchema);
 const decodeLockupVideoOption = Schema.decodeUnknownOption(lockupVideoSchema);
 const decodeThumbnailOption = Schema.decodeUnknownOption(thumbnailSchema);
 
-type JsonRecord = Record<string, unknown>;
+interface JsonRecord {
+  [key: string]: JsonValue;
+}
+type JsonValue = string | number | boolean | null | JsonRecord | readonly JsonValue[];
+const jsonValueSchema: Schema.Codec<JsonValue> = Schema.suspend(() =>
+  Schema.Union([
+    Schema.String,
+    Schema.Finite,
+    Schema.Boolean,
+    Schema.Null,
+    Schema.Array(jsonValueSchema),
+    Schema.Record(Schema.String, jsonValueSchema),
+  ]),
+);
+const jsonRecordSchema = Schema.Record(Schema.String, jsonValueSchema);
 
 interface YouTubeTrack {
   title: string;
@@ -63,11 +77,20 @@ interface YouTubeTrack {
   duration?: number;
   trackNumber: number;
 }
+interface YouTubePlaylist {
+  title: string;
+  artist: string;
+  genre: string;
+  isAlbum: false;
+  year?: number;
+  coverUrl?: string;
+  tracks: YouTubeTrack[];
+}
 
-const isRecord = (value: unknown): value is JsonRecord =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
+const isRecord = Schema.is(jsonRecordSchema);
+const isString = Schema.is(Schema.String);
 
-const getText = (value: unknown) => {
+const getText = (value: JsonValue | undefined) => {
   const parsed = decodeTextOption(value);
   if (Option.isNone(parsed)) return undefined;
   if (parsed.value.simpleText) return parsed.value.simpleText;
@@ -76,7 +99,7 @@ const getText = (value: unknown) => {
   return runs || undefined;
 };
 
-const findFirstValue = (value: unknown, key: string): unknown => {
+const findFirstValue = (value: JsonValue, key: string): JsonValue | undefined => {
   if (Array.isArray(value)) {
     for (const entry of value) {
       const found = findFirstValue(entry, key);
@@ -101,7 +124,7 @@ const parseDuration = (value: string | undefined) => {
   return parts.reduce((seconds, part) => seconds * 60 + Number(part), 0);
 };
 
-const findDuration = (value: unknown): number | undefined => {
+const findDuration = (value: JsonValue): number | undefined => {
   if (Array.isArray(value)) {
     for (const entry of value) {
       const duration = findDuration(entry);
@@ -111,7 +134,7 @@ const findDuration = (value: unknown): number | undefined => {
   }
   if (!isRecord(value)) return undefined;
 
-  const directText = typeof value.text === "string" ? value.text : undefined;
+  const directText = isString(value.text) ? value.text : undefined;
   const parsedDuration = parseDuration(directText);
   if (parsedDuration !== undefined) return parsedDuration;
 
@@ -122,7 +145,7 @@ const findDuration = (value: unknown): number | undefined => {
   return undefined;
 };
 
-const collectTracks = (value: unknown, seenVideoIds: Set<string>, tracks: YouTubeTrack[]) => {
+const collectTracks = (value: JsonValue, seenVideoIds: Set<string>, tracks: YouTubeTrack[]) => {
   if (Array.isArray(value)) {
     for (const entry of value) collectTracks(entry, seenVideoIds, tracks);
     return;
@@ -168,7 +191,7 @@ const collectTracks = (value: unknown, seenVideoIds: Set<string>, tracks: YouTub
   for (const entry of Object.values(value)) collectTracks(entry, seenVideoIds, tracks);
 };
 
-const collectContinuationTokens = (value: unknown, tokens: string[]) => {
+const collectContinuationTokens = (value: JsonValue, tokens: string[]) => {
   if (Array.isArray(value)) {
     for (const entry of value) collectContinuationTokens(entry, tokens);
     return;
@@ -176,24 +199,26 @@ const collectContinuationTokens = (value: unknown, tokens: string[]) => {
   if (!isRecord(value)) return;
 
   const continuationCommand = value.continuationCommand;
-  if (isRecord(continuationCommand) && typeof continuationCommand.token === "string") {
+  if (isRecord(continuationCommand) && isString(continuationCommand.token)) {
     tokens.push(continuationCommand.token);
   }
 
   for (const entry of Object.values(value)) collectContinuationTokens(entry, tokens);
 };
 
-const getPlaylistTitle = (initialData: unknown) => {
+const getPlaylistTitle = (initialData: JsonValue) => {
   const metadata = findFirstValue(initialData, "playlistMetadataRenderer");
-  return isRecord(metadata) && typeof metadata.title === "string" ? metadata.title.trim() : "";
+  return metadata !== undefined && isRecord(metadata) && isString(metadata.title)
+    ? metadata.title.trim()
+    : "";
 };
 
-const getPlaylistArtist = (initialData: unknown) => {
+const getPlaylistArtist = (initialData: JsonValue) => {
   const owner = findFirstValue(initialData, "videoOwnerRenderer");
-  return isRecord(owner) ? (getText(owner.title)?.trim() ?? "") : "";
+  return owner !== undefined && isRecord(owner) ? (getText(owner.title)?.trim() ?? "") : "";
 };
 
-const getPlaylistCover = (initialData: unknown) => {
+const getPlaylistCover = (initialData: JsonValue) => {
   const parsed = decodeThumbnailOption(
     findFirstValue(initialData, "playlistVideoThumbnailRenderer"),
   );
@@ -208,9 +233,11 @@ const getPlaylistCover = (initialData: unknown) => {
   return `${proxyUrl.pathname}${proxyUrl.search}`;
 };
 
-const getDeclaredTrackCount = (initialData: unknown) => {
+const getDeclaredTrackCount = (initialData: JsonValue) => {
   const primaryInfo = findFirstValue(initialData, "playlistSidebarPrimaryInfoRenderer");
-  if (!isRecord(primaryInfo) || !Array.isArray(primaryInfo.stats)) return undefined;
+  if (primaryInfo === undefined || !isRecord(primaryInfo) || !Array.isArray(primaryInfo.stats)) {
+    return undefined;
+  }
   for (const stat of primaryInfo.stats) {
     const match = getText(stat)?.match(/([\d,]+)\s+videos?/i);
     if (!match) continue;
@@ -224,7 +251,7 @@ const fetchContinuation = async (token: string, config: JsonRecord, signal: Abor
   const apiKey = config.INNERTUBE_API_KEY;
   const context = config.INNERTUBE_CONTEXT;
   const clientVersion = config.INNERTUBE_CLIENT_VERSION;
-  if (typeof apiKey !== "string" || !isRecord(context) || typeof clientVersion !== "string") {
+  if (!isString(apiKey) || !isRecord(context) || !isString(clientVersion)) {
     return undefined;
   }
 
@@ -246,7 +273,7 @@ const fetchContinuation = async (token: string, config: JsonRecord, signal: Abor
     { stage: "continuation" },
   );
   if (!response.ok) throw new Error(`youtube.continuation_failed (${response.status})`);
-  return response.json() as Promise<unknown>;
+  return Schema.decodeUnknownSync(jsonValueSchema)(await response.json());
 };
 
 const parseSourceUrl = (sourceUrl: string) => {
@@ -326,13 +353,14 @@ export default defineHandler(async (event) => {
     );
   }
 
-  return {
+  const playlist: YouTubePlaylist = {
     title,
     artist: getPlaylistArtist(initialData),
     genre: "",
     isAlbum: false,
-    ...(year === undefined ? {} : { year }),
     coverUrl: getPlaylistCover(initialData),
     tracks,
   };
+  if (year !== undefined) playlist.year = year;
+  return playlist;
 });

--- a/server/utils/dev-controls.ts
+++ b/server/utils/dev-controls.ts
@@ -78,10 +78,7 @@ export const getRequestHostname = (request: Request) => {
 export const isLocalHostname = (hostname: string) =>
   hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
 
-export const getDeployEnv = (
-  request: Request,
-  runtimeEnv: CobaltRuntimeEnv,
-): { deployEnv: DeployEnv; detectedFrom: string } => {
+export const getDeployEnv = (request: Request, runtimeEnv: CobaltRuntimeEnv) => {
   if (
     runtimeEnv.TAGIUM_DEPLOY_ENV === "local" ||
     runtimeEnv.TAGIUM_DEPLOY_ENV === "preview" ||

--- a/server/utils/share-manifest-cloudflare.ts
+++ b/server/utils/share-manifest-cloudflare.ts
@@ -11,7 +11,7 @@ export type R2BucketBinding = {
     key: string,
     value: Uint8Array,
     options: { httpMetadata: { contentType: string }; customMetadata: Record<string, string> },
-  ) => Promise<unknown>;
+  ) => Promise<void>;
   get: (key: string) => Promise<{
     body: ReadableStream<Uint8Array>;
     httpMetadata?: { contentType?: string };

--- a/server/utils/share-manifest-request.ts
+++ b/server/utils/share-manifest-request.ts
@@ -23,6 +23,7 @@ export type ShareRuntimeEnv = {
 type CloudflareRequest = Request & { runtime?: { cloudflare?: { env?: ShareRuntimeEnv } } };
 
 export const getShareRuntimeEnv = (request: Request): ShareRuntimeEnv =>
+  // SAFETY: Nitro's Cloudflare adapter supplies this request shape in the Cloudflare runtime.
   (request as CloudflareRequest).runtime?.cloudflare?.env ?? {};
 
 export const getShareStore = (request: Request) => {

--- a/server/utils/share-manifest.ts
+++ b/server/utils/share-manifest.ts
@@ -4,6 +4,7 @@ import {
   manifestTrackCount,
   type Manifest,
   type ManifestArtwork,
+  type ManifestTrack,
 } from "../../src/features/share/shareManifest";
 import { createShareSlug, SHARE_SLUG_PATTERN } from "../../src/features/share/shareSlug";
 
@@ -87,6 +88,17 @@ export type ShareArtworkUpdate =
   | { kind: "retain" }
   | { kind: "remove" }
   | { kind: "replace"; artwork: ShareArtwork };
+interface AlbumWithArtwork {
+  title: string;
+  artist: string;
+  genre: string;
+  year?: number;
+  sourceUrl?: string;
+  artwork?: ManifestArtwork;
+}
+interface TrackWithArtwork extends ManifestTrack {
+  artwork?: ManifestArtwork;
+}
 export type ShareManifestUpdateResult =
   | { kind: "updated"; slug: string; expiresAt: number }
   | ShareManifestUnavailable;
@@ -118,7 +130,7 @@ const randomToken = (bytes = 32) => {
 };
 
 export class ShareManifestValidationError extends Error {}
-export const isShareManifestValidationError = (error: unknown) =>
+export const isShareManifestValidationError = (error: Error): boolean =>
   error instanceof ShareManifestValidationError;
 
 export const parseShareArtwork = async (
@@ -164,7 +176,7 @@ const detectImageType = (bytes: Uint8Array): ShareArtwork["type"] | undefined =>
   if (bytes[0] !== 0xff || bytes[1] !== 0xd8) return undefined;
   let dimensions: { width: number; height: number } | undefined;
   let sawScan = false;
-  for (let index = 2; index + 1 < bytes.length; ) {
+  for (let index = 2; index + 1 < bytes.length;) {
     if (bytes[index] !== 0xff) return undefined;
     while (bytes[index] === 0xff) index++;
     const marker = bytes[index++];
@@ -233,16 +245,20 @@ const withArtworkDescriptor = (
   artwork: ManifestArtwork | undefined,
 ): ShareManifest => {
   if (manifest.kind === "album") {
-    const { artwork: _artwork, ...album } = manifest.album;
+    const { artwork: _artwork, ...albumFields } = manifest.album;
+    const album: AlbumWithArtwork = albumFields;
+    if (artwork) album.artwork = artwork;
     return decodeManifest({
       ...manifest,
-      album: { ...album, ...(artwork ? { artwork } : {}) },
+      album,
     });
   }
-  const { artwork: _artwork, ...track } = manifest.track;
+  const { artwork: _artwork, ...trackFields } = manifest.track;
+  const track: TrackWithArtwork = trackFields;
+  if (artwork) track.artwork = artwork;
   return decodeManifest({
     ...manifest,
-    track: { ...track, ...(artwork ? { artwork } : {}) },
+    track,
   });
 };
 

--- a/server/utils/share-social-card.ts
+++ b/server/utils/share-social-card.ts
@@ -117,7 +117,7 @@ export const createSatoshiFontLoader = (
       } finally {
         clearTimeout(timeout);
       }
-    })().catch((error: unknown) => {
+    })().catch((error) => {
       fontPromise = undefined;
       throw error;
     });
@@ -365,11 +365,10 @@ export const renderShareSocialCardPng = async (
   try {
     return await rasterize(artwork);
   } catch (error) {
-    if (!isArtworkDecodeError(error)) throw error;
+    if (!(error instanceof Error) || !isArtworkDecodeError(error)) throw error;
     return rasterize(undefined);
   }
 };
 
-const isArtworkDecodeError = (error: unknown) =>
-  error instanceof Error &&
+const isArtworkDecodeError = (error: Error) =>
   /art|image|png|jpeg|decode|parse|invalid|unsupported/iu.test(error.message);

--- a/server/utils/soundcloud-observability.ts
+++ b/server/utils/soundcloud-observability.ts
@@ -6,41 +6,60 @@ import {
 
 export type SoundCloudLogContext = RequestLogContext;
 export const getSoundCloudLogContext = getRequestLogContext;
+interface SoundCloudLogObject {
+  [key: string]: SoundCloudLogValue;
+}
+type SoundCloudLogValue = string | number | boolean | null | SoundCloudLogObject;
+export type SoundCloudLogDetails = Record<string, SoundCloudLogValue | undefined>;
+interface SoundCloudFailureEvent {
+  event: "soundcloud_upstream_failure";
+  stage: string;
+  elapsedMs: number;
+  requestId: string;
+  urlFingerprint?: string;
+  importId?: string;
+  trackIndex?: number;
+}
+interface SoundCloudCompletionEvent {
+  event: "soundcloud_set_completion";
+  requestId: string;
+  urlFingerprint?: string;
+  importId?: string;
+  trackIndex?: number;
+}
 
 export const logSoundCloudFailure = async (
   stage: string,
   context: SoundCloudLogContext,
-  details: Record<string, unknown> = {},
+  details: SoundCloudLogDetails = {},
   startedAt = Date.now(),
 ) => {
   const urlFingerprint = await fingerprintUrl(context.url);
-  console.warn(
-    JSON.stringify({
-      event: "soundcloud_upstream_failure",
-      stage,
-      elapsedMs: Date.now() - startedAt,
-      ...(urlFingerprint ? { urlFingerprint } : {}),
-      requestId: context.requestId,
-      ...(context.importId ? { importId: context.importId } : {}),
-      ...(context.trackIndex !== undefined ? { trackIndex: context.trackIndex } : {}),
-      ...details,
-    }),
-  );
+  const entry: SoundCloudFailureEvent = {
+    event: "soundcloud_upstream_failure",
+    stage,
+    elapsedMs: Date.now() - startedAt,
+    requestId: context.requestId,
+  };
+  if (urlFingerprint) entry.urlFingerprint = urlFingerprint;
+  if (context.importId) entry.importId = context.importId;
+  if (context.trackIndex !== undefined) entry.trackIndex = context.trackIndex;
+  Object.assign(entry, details);
+  console.warn(JSON.stringify(entry));
 };
 
 export const logSoundCloudCompletion = async (
   context: SoundCloudLogContext,
-  details: Record<string, unknown>,
+  details: SoundCloudLogDetails,
 ) => {
   const urlFingerprint = await fingerprintUrl(context.url);
-  console.info(
-    JSON.stringify({
-      event: "soundcloud_set_completion",
-      ...(urlFingerprint ? { urlFingerprint } : {}),
-      requestId: context.requestId,
-      ...(context.importId ? { importId: context.importId } : {}),
-      ...(context.trackIndex !== undefined ? { trackIndex: context.trackIndex } : {}),
-      ...details,
-    }),
-  );
+  const entry: SoundCloudCompletionEvent = {
+    event: "soundcloud_set_completion",
+    requestId: context.requestId,
+  };
+  if (urlFingerprint) entry.urlFingerprint = urlFingerprint;
+  if (context.importId) entry.importId = context.importId;
+  if (context.trackIndex !== undefined) entry.trackIndex = context.trackIndex;
+  Object.assign(entry, details);
+  console.info(JSON.stringify(entry));
 };

--- a/server/utils/soundcloud.ts
+++ b/server/utils/soundcloud.ts
@@ -1,4 +1,8 @@
-import { logSoundCloudFailure, type SoundCloudLogContext } from "./soundcloud-observability";
+import {
+  logSoundCloudFailure,
+  type SoundCloudLogContext,
+  type SoundCloudLogDetails,
+} from "./soundcloud-observability";
 
 const cachedClient = { version: "", id: "" };
 
@@ -23,32 +27,21 @@ const fetchText = async (
   }
   const contentType = response.headers.get("content-type") ?? undefined;
   if (!response.ok) {
-    await logSoundCloudFailure(
-      stage,
-      context,
-      {
-        upstreamStatus: response.status,
-        ...(contentType ? { contentType } : {}),
-        ...(response.headers.get("retry-after")
-          ? { retryAfter: response.headers.get("retry-after") }
-          : {}),
-      },
-      startedAt,
-    );
+    const details: SoundCloudLogDetails = { upstreamStatus: response.status };
+    if (contentType) details.contentType = contentType;
+    const retryAfter = response.headers.get("retry-after");
+    if (retryAfter) details.retryAfter = retryAfter;
+    await logSoundCloudFailure(stage, context, details, startedAt);
     throw new Error(`soundcloud.${stage}.http_${response.status}`);
   }
   try {
     return await response.text();
   } catch (error) {
-    await logSoundCloudFailure(
-      stage.replace("_fetch", "_parse"),
-      context,
-      {
-        ...(contentType ? { contentType } : {}),
-        errorType: error instanceof Error ? error.name : "UnknownError",
-      },
-      startedAt,
-    );
+    const details: SoundCloudLogDetails = {
+      errorType: error instanceof Error ? error.name : "UnknownError",
+    };
+    if (contentType) details.contentType = contentType;
+    await logSoundCloudFailure(stage.replace("_fetch", "_parse"), context, details, startedAt);
     throw error;
   }
 };
@@ -73,7 +66,7 @@ export const getSoundCloudClientId = async (
   }
 
   let foundSoundCloudScript = false;
-  let lastScriptError: unknown;
+  let lastScriptError: Error | undefined;
   for (const script of html.matchAll(/<script.+src="(.+)">/g)) {
     const scriptUrl = script[1];
     if (!scriptUrl?.startsWith("https://a-v2.sndcdn.com/")) continue;
@@ -85,7 +78,7 @@ export const getSoundCloudClientId = async (
         url: scriptUrl,
       });
     } catch (error) {
-      lastScriptError = error;
+      lastScriptError = error instanceof Error ? error : new Error("unknown script fetch failure");
       continue;
     }
     const scriptClientId = scriptText.match(/,client_id:"([A-Za-z0-9]{32})",/)?.[1];

--- a/server/utils/youtube.ts
+++ b/server/utils/youtube.ts
@@ -1,9 +1,25 @@
+import { Schema } from "effect";
+
 export const YOUTUBE_ORIGIN = "https://www.youtube.com";
 export const YOUTUBE_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
   "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
 
-type JsonRecord = Record<string, unknown>;
+interface JsonRecord {
+  [key: string]: JsonValue;
+}
+type JsonValue = string | number | boolean | null | JsonRecord | readonly JsonValue[];
+const jsonValueSchema: Schema.Codec<JsonValue> = Schema.suspend(() =>
+  Schema.Union([
+    Schema.String,
+    Schema.Finite,
+    Schema.Boolean,
+    Schema.Null,
+    Schema.Array(jsonValueSchema),
+    Schema.Record(Schema.String, jsonValueSchema),
+  ]),
+);
+const jsonRecordSchema = Schema.Record(Schema.String, jsonValueSchema);
 
 type YouTubeRequestStage = "config" | "continuation" | "playlist" | "upload_year";
 
@@ -11,13 +27,13 @@ const MAX_YOUTUBE_FETCH_ATTEMPTS = 2;
 const YOUTUBE_RETRY_DELAY_MS = 100;
 const TRANSIENT_YOUTUBE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
 
-const isRecord = (value: unknown): value is JsonRecord =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
+const isRecord = Schema.is(jsonRecordSchema);
+const isJsonArray = (value: JsonValue): value is readonly JsonValue[] => Array.isArray(value);
+const isString = Schema.is(Schema.String);
+const decodeJson = Schema.decodeUnknownSync(jsonValueSchema);
 
 const wait = (milliseconds: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
-
-const isAbortError = (error: unknown) => error instanceof Error && error.name === "AbortError";
 
 const logYouTubeUpstreamFailure = (
   stage: YouTubeRequestStage,
@@ -58,7 +74,9 @@ export const fetchYouTubeWithRetry = async (
 
       await response.body?.cancel().catch(() => undefined);
     } catch (error) {
-      const retrying = attempt < MAX_YOUTUBE_FETCH_ATTEMPTS && !isAbortError(error);
+      const retrying =
+        attempt < MAX_YOUTUBE_FETCH_ATTEMPTS &&
+        !(error instanceof Error && error.name === "AbortError");
       logYouTubeUpstreamFailure(options.stage, attempt, retrying, {
         errorType: error instanceof Error ? error.name : "UnknownError",
       });
@@ -105,7 +123,7 @@ export const extractYouTubeJsonObject = (source: string, marker: string, startAt
       depth--;
       if (depth === 0) {
         return {
-          value: JSON.parse(source.slice(objectStart, index + 1)) as unknown,
+          value: decodeJson(JSON.parse(source.slice(objectStart, index + 1))),
           end: index + 1,
         };
       }
@@ -203,7 +221,7 @@ export const resolveYouTubeUploadYear = async (
   const apiKey = config.INNERTUBE_API_KEY;
   const context = config.INNERTUBE_CONTEXT;
   const clientVersion = config.INNERTUBE_CLIENT_VERSION;
-  if (typeof apiKey !== "string" || !isRecord(context) || typeof clientVersion !== "string") {
+  if (!isString(apiKey) || !isRecord(context) || !isString(clientVersion)) {
     return undefined;
   }
 
@@ -227,7 +245,7 @@ export const resolveYouTubeUploadYear = async (
   );
   if (!response.ok) throw new Error(`youtube.video_failed (${response.status})`);
 
-  const data = await response.json();
+  const data = decodeJson(await response.json());
   const primaryInfo = (() => {
     if (!isRecord(data)) return undefined;
     const contents = data.contents;
@@ -237,12 +255,15 @@ export const resolveYouTubeUploadYear = async (
     const results = watchResults.results;
     if (!isRecord(results) || !isRecord(results.results)) return undefined;
     const resultContents = results.results.contents;
-    if (!Array.isArray(resultContents)) return undefined;
-    return resultContents
-      .map((entry) => (isRecord(entry) ? entry.videoPrimaryInfoRenderer : undefined))
-      .find(isRecord);
+    if (!isJsonArray(resultContents)) return undefined;
+    for (const entry of resultContents) {
+      if (!isRecord(entry)) continue;
+      const candidate = entry.videoPrimaryInfoRenderer;
+      if (candidate !== undefined && isRecord(candidate)) return candidate;
+    }
+    return undefined;
   })();
   if (!primaryInfo || !isRecord(primaryInfo.dateText)) return undefined;
   const dateText = primaryInfo.dateText.simpleText;
-  return yearFromDate(typeof dateText === "string" ? dateText : undefined);
+  return yearFromDate(isString(dateText) ? dateText : undefined);
 };

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,3 +1,6 @@
+import { Schema } from "effect";
+import type { CaptureResult, PostHogConfig } from "posthog-js";
+
 export type AudioUploadTargetKind = "loose" | "album";
 export type ImportKind = "single" | "set";
 export type ImportOutcome = "completed" | "partial" | "failed" | "canceled";
@@ -16,7 +19,7 @@ export type ImportFailureCode =
   | "parse_failed"
   | "metadata_write_failed"
   | "unknown";
-export type MediaLinkShape = "canonical" | "short" | "mobile" | "nocookie" | "other";
+export type MediaLinkKind = "canonical" | "short" | "mobile" | "nocookie" | "other";
 export type CobaltTunnelOutcome = "ready" | "recovered" | "exhausted" | "non_retryable";
 export type CobaltTunnelElapsedBucket =
   | "under_1_second"
@@ -32,6 +35,8 @@ export type AnalyticsErrorCode =
   | "metadata_write_failed"
   | "unknown";
 
+const MEDIA_LINK_KIND_PROPERTY = "shape";
+
 export type AnalyticsEvent =
   | {
       type: "audio_upload_completed";
@@ -45,7 +50,7 @@ export type AnalyticsEvent =
       type: "media_link_processed";
       sourceUrl: string;
       mediaKind: "track" | "playlist" | "unsupported";
-      shape: MediaLinkShape;
+      linkKind: MediaLinkKind;
       normalized: boolean;
       redirected: boolean;
       outcome: "accepted" | "rejected";
@@ -111,7 +116,7 @@ export type AnalyticsEvent =
   | {
       type: "export_failed";
       exportKind: ExportKind;
-      error: unknown;
+      error: Error;
     }
   | {
       type: "settings_changed";
@@ -177,8 +182,8 @@ export interface AnalyticsConfig {
 }
 
 interface AnalyticsClient {
-  init: (key: string, options: Record<string, unknown>) => void;
-  capture: (event: string, properties?: Record<string, unknown>) => void;
+  init: (key: string, options: Partial<PostHogConfig>) => void;
+  capture: (event: string, properties?: AnalyticsProperties) => void;
 }
 
 interface AnalyticsDependencies {
@@ -225,8 +230,8 @@ export const analyticsProviderFromUrl = (sourceUrl: string): AnalyticsProvider =
   return "other";
 };
 
-const errorCodeFrom = (error: unknown): AnalyticsErrorCode => {
-  const message = error instanceof Error ? error.message : "";
+const errorCodeFrom = (error: Error): AnalyticsErrorCode => {
+  const message = error.message;
   if (message.includes("error.api.capacity_exceeded")) return "capacity";
   if (
     message.includes("error.api.rate_exceeded") ||
@@ -249,20 +254,18 @@ const errorCodeFrom = (error: unknown): AnalyticsErrorCode => {
   return "unknown";
 };
 
-type BeforeSendEvent = {
-  uuid?: string;
-  event: string;
-  properties: Record<string, unknown>;
-  timestamp?: Date;
-};
+type AnalyticsProperty = string | number | boolean | Date | null | undefined;
+interface AnalyticsProperties {
+  [key: string]: AnalyticsProperty;
+}
 
 const COMMON_CUSTOM_PROPERTIES = ["event_version", "deploy_env", "release_sha"];
-const CUSTOM_EVENT_PROPERTIES: Record<string, ReadonlySet<string>> = {
+const CUSTOM_EVENT_PROPERTIES = {
   media_link_processed: new Set([
     ...COMMON_CUSTOM_PROPERTIES,
     "provider",
     "media_kind",
-    "shape",
+    MEDIA_LINK_KIND_PROPERTY,
     "normalized",
     "redirected",
     "outcome",
@@ -375,7 +378,7 @@ const CUSTOM_EVENT_PROPERTIES: Record<string, ReadonlySet<string>> = {
     "viewer",
   ]),
   share_added: new Set([...COMMON_CUSTOM_PROPERTIES, "share_id", "share_kind", "track_count"]),
-};
+} satisfies Partial<Record<AnalyticsEvent["type"], ReadonlySet<string>>>;
 const SAFE_SDK_EVENTS = new Set(["$pageview", "$pageleave", "$autocapture"]);
 const SAFE_SDK_PROPERTIES = new Set([
   "token",
@@ -409,13 +412,16 @@ const SAFE_SDK_PROPERTIES = new Set([
 const SENSITIVE_PROPERTY_NAME =
   /(?:url|href|referrer|pathname|host|filename|artist|album|artwork|message|response|body|tunnel|text|elements)/i;
 const URL_VALUE = /https?:\/\//i;
+const isString = Schema.is(Schema.String);
+const isNumber = Schema.is(Schema.Number);
+const isBoolean = Schema.is(Schema.Boolean);
+type AnalyticsPropertyValidator = (value: AnalyticsProperty) => boolean;
 const isOneOf =
   <Value extends string>(values: readonly Value[]) =>
-  (value: unknown): value is Value =>
-    typeof value === "string" && values.includes(value as Value);
-const isBoolean = (value: unknown) => typeof value === "boolean";
-const isBoundedTunnelAttempt = (value: unknown) =>
-  typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 7;
+  (value: AnalyticsProperty): value is Value =>
+    isString(value) && values.some((candidate) => candidate === value);
+const isBoundedTunnelAttempt = (value: AnalyticsProperty) =>
+  isNumber(value) && Number.isInteger(value) && value >= 1 && value <= 7;
 const isAnalyticsProvider = isOneOf(["youtube", "soundcloud", "other"] as const);
 const isAnalyticsProviderScope = isOneOf(["youtube", "soundcloud", "other", "mixed"] as const);
 const isImportKind = isOneOf(["single", "set"] as const);
@@ -432,14 +438,14 @@ const isImportFailureCode = isOneOf([
   "metadata_write_failed",
   "unknown",
 ] as const);
-const isNonNegativeInteger = (value: unknown) =>
-  typeof value === "number" && Number.isInteger(value) && value >= 0;
-const isPositiveInteger = (value: unknown) =>
-  typeof value === "number" && Number.isInteger(value) && value > 0;
-const isNonNegativeNumber = (value: unknown) =>
-  typeof value === "number" && Number.isFinite(value) && value >= 0;
+const isNonNegativeInteger = (value: AnalyticsProperty) =>
+  isNumber(value) && Number.isInteger(value) && value >= 0;
+const isPositiveInteger = (value: AnalyticsProperty) =>
+  isNumber(value) && Number.isInteger(value) && value > 0;
+const isNonNegativeNumber = (value: AnalyticsProperty) =>
+  isNumber(value) && Number.isFinite(value) && value >= 0;
 const isMediaKind = isOneOf(["track", "playlist", "unsupported"] as const);
-const isMediaLinkShape = isOneOf(["canonical", "short", "mobile", "nocookie", "other"] as const);
+const isMediaLinkKind = isOneOf(["canonical", "short", "mobile", "nocookie", "other"] as const);
 const isMediaLinkOutcome = isOneOf(["accepted", "rejected"] as const);
 const isMediaLinkFailure = isOneOf(["invalid", "unsupported", "resolution_failed"] as const);
 const isCobaltTunnelOutcome = isOneOf([
@@ -457,14 +463,11 @@ const isCobaltTunnelElapsedBucket = isOneOf([
 const isShareKind = isOneOf(["album", "track"] as const);
 const isShareViewer = isOneOf(["creator", "recipient"] as const);
 
-const CUSTOM_PROPERTY_VALIDATORS: Record<
-  string,
-  Readonly<Record<string, (value: unknown) => boolean>>
-> = {
+const CUSTOM_PROPERTY_VALIDATORS = {
   media_link_processed: {
     provider: isAnalyticsProvider,
     media_kind: isMediaKind,
-    shape: isMediaLinkShape,
+    [MEDIA_LINK_KIND_PROPERTY]: isMediaLinkKind,
     normalized: isBoolean,
     redirected: isBoolean,
     outcome: isMediaLinkOutcome,
@@ -529,23 +532,31 @@ const CUSTOM_PROPERTY_VALIDATORS: Record<
     share_kind: isShareKind,
     track_count: isPositiveInteger,
   },
-};
+} satisfies Partial<
+  Record<AnalyticsEvent["type"], Readonly<Record<string, AnalyticsPropertyValidator>>>
+>;
 
-const redactAndValidateEvent = (event: BeforeSendEvent): BeforeSendEvent | null => {
-  const customAllowedProperties = CUSTOM_EVENT_PROPERTIES[event.event];
-  const customPropertyValidators = CUSTOM_PROPERTY_VALIDATORS[event.event];
+const redactAndValidateEvent = (event: CaptureResult): CaptureResult | null => {
+  const customAllowedProperties = Object.entries(CUSTOM_EVENT_PROPERTIES).find(
+    ([eventName]) => eventName === event.event,
+  )?.[1];
+  const customPropertyValidators = Object.entries(CUSTOM_PROPERTY_VALIDATORS).find(
+    ([eventName]) => eventName === event.event,
+  )?.[1];
   const isSdkEvent = SAFE_SDK_EVENTS.has(event.event);
   if (!customAllowedProperties && !isSdkEvent) return null;
 
-  const properties: Record<string, unknown> = {};
+  const properties: AnalyticsProperties = {};
   for (const [property, value] of Object.entries(event.properties ?? {})) {
     const isAllowedCustomProperty = customAllowedProperties?.has(property) ?? false;
     const isAllowedSdkProperty = SAFE_SDK_PROPERTIES.has(property);
     if (!isAllowedCustomProperty && !isAllowedSdkProperty) continue;
-    const customValidator = customPropertyValidators?.[property];
+    const customValidator = Object.entries(customPropertyValidators ?? {}).find(
+      ([propertyName]) => propertyName === property,
+    )?.[1];
     if (customValidator && !customValidator(value)) continue;
     if (!isAllowedCustomProperty && SENSITIVE_PROPERTY_NAME.test(property)) continue;
-    if (!isAllowedCustomProperty && typeof value === "string" && URL_VALUE.test(value)) continue;
+    if (!isAllowedCustomProperty && isString(value) && URL_VALUE.test(value)) continue;
     properties[property] = value;
   }
 
@@ -556,10 +567,10 @@ const redactAndValidateEvent = (event: BeforeSendEvent): BeforeSendEvent | null 
     const failedCount = properties.failed_count;
     const canceledCount = properties.canceled_count;
     if (
-      typeof expectedCount !== "number" ||
-      typeof completedCount !== "number" ||
-      typeof failedCount !== "number" ||
-      typeof canceledCount !== "number" ||
+      !isNumber(expectedCount) ||
+      !isNumber(completedCount) ||
+      !isNumber(failedCount) ||
+      !isNumber(canceledCount) ||
       completedCount + failedCount + canceledCount !== expectedCount
     ) {
       return null;
@@ -567,12 +578,13 @@ const redactAndValidateEvent = (event: BeforeSendEvent): BeforeSendEvent | null 
   }
 
   if (isSdkEvent) properties.app_view = "tagium";
-  return {
-    ...(event.uuid === undefined ? {} : { uuid: event.uuid }),
+  const normalizedEvent: CaptureResult = {
+    uuid: event.uuid,
     event: event.event,
     properties,
-    ...(event.timestamp === undefined ? {} : { timestamp: event.timestamp }),
   };
+  if (event.timestamp !== undefined) normalizedEvent.timestamp = event.timestamp;
+  return normalizedEvent;
 };
 
 const sizeBucket = (sizeBytes: number) => {
@@ -584,26 +596,27 @@ const sizeBucket = (sizeBytes: number) => {
 };
 
 const serializeEvent = (event: AnalyticsEvent, config: AnalyticsConfig) => {
-  const commonProperties = {
+  const commonProperties: AnalyticsProperties = {
     event_version: 1,
     deploy_env: config.deployEnv,
-    ...(config.releaseSha ? { release_sha: config.releaseSha } : {}),
   };
+  if (config.releaseSha) commonProperties.release_sha = config.releaseSha;
 
   switch (event.type) {
     case "media_link_processed": {
+      const properties: AnalyticsProperties = {
+        ...commonProperties,
+        provider: analyticsProviderFromUrl(event.sourceUrl),
+        media_kind: event.mediaKind,
+        [MEDIA_LINK_KIND_PROPERTY]: event.linkKind,
+        normalized: event.normalized,
+        redirected: event.redirected,
+        outcome: event.outcome,
+      };
+      if (event.failureReason) properties.failure_reason = event.failureReason;
       return {
         name: event.type,
-        properties: {
-          ...commonProperties,
-          provider: analyticsProviderFromUrl(event.sourceUrl),
-          media_kind: event.mediaKind,
-          shape: event.shape,
-          normalized: event.normalized,
-          redirected: event.redirected,
-          outcome: event.outcome,
-          ...(event.failureReason ? { failure_reason: event.failureReason } : {}),
-        },
+        properties,
       };
     }
     case "cobalt_tunnel_readiness": {
@@ -687,27 +700,31 @@ const serializeEvent = (event: AnalyticsEvent, config: AnalyticsConfig) => {
           code: event.code,
         },
       };
-    case "export_started":
+    case "export_started": {
+      const properties: AnalyticsProperties = {
+        ...commonProperties,
+        export_kind: event.exportKind,
+        track_count: event.trackCount,
+      };
+      if (event.albumCount !== undefined) properties.album_count = event.albumCount;
       return {
         name: event.type,
-        properties: {
-          ...commonProperties,
-          export_kind: event.exportKind,
-          track_count: event.trackCount,
-          ...(event.albumCount === undefined ? {} : { album_count: event.albumCount }),
-        },
+        properties,
       };
-    case "export_prepared":
+    }
+    case "export_prepared": {
+      const properties: AnalyticsProperties = {
+        ...commonProperties,
+        export_kind: event.exportKind,
+        track_count: event.trackCount,
+        size_bucket: sizeBucket(event.sizeBytes),
+      };
+      if (event.albumCount !== undefined) properties.album_count = event.albumCount;
       return {
         name: event.type,
-        properties: {
-          ...commonProperties,
-          export_kind: event.exportKind,
-          track_count: event.trackCount,
-          ...(event.albumCount === undefined ? {} : { album_count: event.albumCount }),
-          size_bucket: sizeBucket(event.sizeBytes),
-        },
+        properties,
       };
+    }
     case "export_failed":
       return {
         name: event.type,
@@ -857,7 +874,7 @@ export const createAnalytics = (
             enable_heatmaps: false,
             disable_surveys: true,
             person_profiles: "identified_only",
-            before_send: redactAndValidateEvent,
+            before_send: (event) => (event ? redactAndValidateEvent(event) : null),
           });
           client = loadedClient;
           flush();

--- a/src/components/dev/DevPanel.tsx
+++ b/src/components/dev/DevPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Schema } from "effect";
 import {
   Alert02Icon,
   FlashIcon,
@@ -14,30 +15,40 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { devToastKinds, spawnDevToast } from "./devToast";
 
-type DevConfig = {
-  enabled: boolean;
-  deployEnv: "local" | "preview" | "production";
-  detectedFrom: string;
-  productionBranch: string;
-  rateLimit: {
-    windowMs: number;
-    maxRequests: number;
-    bucketCount: number;
-    client: {
-      key: string;
-      count: number;
-      remaining: number;
-      resetAt?: number;
-    };
-  };
-  faults: {
-    nextAudioFault?: AudioFault;
-    nextTunnelFault?: TunnelFault;
-  };
-};
-
 type AudioFault = "rate-limit" | "capacity" | "timeout" | "unreachable" | "malformed";
 type TunnelFault = "rate-limit" | "capacity" | "timeout" | "empty-body";
+
+const devConfigSchema = Schema.Struct({
+  enabled: Schema.Boolean,
+  deployEnv: Schema.Literals(["local", "preview", "production"]),
+  detectedFrom: Schema.String,
+  productionBranch: Schema.String,
+  rateLimit: Schema.Struct({
+    windowMs: Schema.Number,
+    maxRequests: Schema.Number,
+    bucketCount: Schema.Number,
+    client: Schema.Struct({
+      key: Schema.String,
+      count: Schema.Number,
+      remaining: Schema.Number,
+      resetAt: Schema.optionalKey(Schema.Number),
+    }),
+  }),
+  faults: Schema.Struct({
+    nextAudioFault: Schema.optionalKey(
+      Schema.Literals(["rate-limit", "capacity", "timeout", "unreachable", "malformed"]),
+    ),
+    nextTunnelFault: Schema.optionalKey(
+      Schema.Literals(["rate-limit", "capacity", "timeout", "empty-body"]),
+    ),
+  }),
+});
+type DevConfig = Schema.Schema.Type<typeof devConfigSchema>;
+type DevConfigPatch =
+  | { rateLimit: { windowMs: number; maxRequests: number } }
+  | { resetRateLimitBuckets: true };
+
+const decodeDevConfig = Schema.decodeUnknownSync(devConfigSchema);
 
 const audioFaults: Array<{ value: AudioFault; label: string }> = [
   { value: "rate-limit", label: "429" },
@@ -57,7 +68,7 @@ const tunnelFaults: Array<{ value: TunnelFault; label: string }> = [
 const readDevConfig = async (signal: AbortSignal) => {
   const response = await fetch("/api/dev/config", { signal });
   if (!response.ok) return null;
-  return (await response.json()) as DevConfig;
+  return decodeDevConfig(await response.json());
 };
 
 const formatReset = (resetAt: number | undefined) => {
@@ -105,7 +116,7 @@ export function DevPanel() {
 
   if (!config?.enabled) return null;
 
-  const patchConfig = async (body: unknown) => {
+  const patchConfig = async (body: DevConfigPatch) => {
     setBusy(true);
     try {
       const response = await fetch("/api/dev/config", {
@@ -114,7 +125,7 @@ export function DevPanel() {
         body: JSON.stringify(body),
       });
       if (response.ok) {
-        const nextConfig = (await response.json()) as DevConfig;
+        const nextConfig = decodeDevConfig(await response.json());
         setConfig(nextConfig);
         setWindowMs(String(nextConfig.rateLimit.windowMs));
         setMaxRequests(String(nextConfig.rateLimit.maxRequests));
@@ -133,7 +144,7 @@ export function DevPanel() {
         body: JSON.stringify({ target, fault }),
       });
       if (response.ok) {
-        setConfig((await response.json()) as DevConfig);
+        setConfig(decodeDevConfig(await response.json()));
       }
     } finally {
       setBusy(false);

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -10,6 +10,7 @@ const Toaster = ({ className, ...props }: ToasterProps) => (
     duration={12_000}
     className={cn("toaster tagium-toaster group", className)}
     style={
+      // SAFETY: Sonner forwards CSS custom properties through its style object.
       {
         "--normal-bg": "var(--popover)",
         "--normal-text": "var(--popover-foreground)",

--- a/src/features/audio/audioErrors.ts
+++ b/src/features/audio/audioErrors.ts
@@ -38,19 +38,19 @@ export type AudioError =
   | AudioMetadataReadError
   | AudioMetadataWriteError;
 
-export const toPublicAudioError = (error: unknown): Error => {
-  if (error instanceof Error) {
-    return error;
+export const toPublicAudioError = (cause: unknown): Error => {
+  if (cause instanceof Error) {
+    return cause;
   }
 
   if (
-    typeof error === "object" &&
-    error !== null &&
-    "message" in error &&
-    typeof error.message === "string"
+    typeof cause === "object" &&
+    cause !== null &&
+    "message" in cause &&
+    typeof cause.message === "string"
   ) {
-    return new Error(error.message);
+    return new Error(cause.message);
   }
 
-  return new Error(String(error));
+  return new Error(String(cause));
 };

--- a/src/features/audio/metadataEngine/driver.ts
+++ b/src/features/audio/metadataEngine/driver.ts
@@ -22,6 +22,7 @@ export const rejectUnsupportedMetadataChanges = (
   supported: ReadonlySet<keyof MetadataChanges>,
   format: AudioFormat["kind"],
 ) => {
+  // SAFETY: MetadataChanges owns every enumerable key in this closed application object.
   const unsupported = (Object.keys(changes) as Array<keyof MetadataChanges>).filter(
     (field) => changes[field] !== undefined && !supported.has(field),
   );

--- a/src/features/audio/metadataEngine/flac/index.ts
+++ b/src/features/audio/metadataEngine/flac/index.ts
@@ -241,7 +241,13 @@ const parseReadableBlock = <A>(
 ) =>
   effect.pipe(
     Effect.flatMap((bytes) =>
-      Effect.try({ try: () => parse(bytes), catch: (error) => error as AudioMetadataReadError }),
+      Effect.try({
+        try: () => parse(bytes),
+        catch: (error) =>
+          error instanceof AudioMetadataReadError
+            ? error
+            : readFailure("unable to parse FLAC metadata block.", error),
+      }),
     ),
   );
 

--- a/src/features/audio/metadataEngine/mp3/mp3Driver.ts
+++ b/src/features/audio/metadataEngine/mp3/mp3Driver.ts
@@ -130,6 +130,7 @@ const encodeText = (value: string, version: Id3Version) => {
 
 const parseId3 = (bytes: Uint8Array<ArrayBuffer>): ParsedTag | undefined => {
   if (bytes.length < 10 || ascii(bytes, 0, 3) !== "ID3") return undefined;
+  // SAFETY: the range check immediately below rejects every byte outside the supported versions.
   const version = bytes[3] as Id3Version;
   if (![2, 3, 4].includes(version)) throw readFailure(`unsupported ID3v2.${version} tag.`);
   const flags = bytes[5]!;
@@ -227,7 +228,7 @@ const parseId3 = (bytes: Uint8Array<ArrayBuffer>): ParsedTag | undefined => {
           : readUint32BE(bytes, offset + 4);
     const frameEnd = offset + headerSize + size;
     if (size <= 0 || frameEnd > 10 + payloadSize) throw readFailure(`truncated ID3 frame ${id}.`);
-    const owned = Object.values(ids).some((frameIds) => frameIds.includes(id as never));
+    const owned = Object.values(ids).some((frameIds) => frameIds.some((ownedId) => ownedId === id));
     const formatFlags = version === 2 ? 0 : bytes[offset + 9]!;
     const unsupportedOwnedFlags =
       version === 3
@@ -474,6 +475,7 @@ const encodeApeItem = (key: string, value: string) => {
 
 const patchApe = (ape: ParsedApe, changes: MetadataChanges) => {
   if (ape.size === 0) return undefined;
+  // SAFETY: apeKeys is a closed, locally declared record, so Object.keys preserves its key union.
   const changedFields = (Object.keys(apeKeys) as Array<keyof typeof apeKeys>).filter(
     (field) => changes[field] !== undefined,
   );
@@ -496,6 +498,7 @@ const patchApe = (ape: ParsedApe, changes: MetadataChanges) => {
     } else if (field === "bpm") {
       if (change !== null) value = String(change);
     } else {
+      // SAFETY: discNumber and bpm were handled above; every remaining APE field is textual.
       const textChange = change as string | undefined;
       if (textChange && textChange.length > 0) value = textChange;
     }
@@ -626,8 +629,10 @@ const buildTag = (parsed: ParsedTag | undefined, changes: MetadataChanges) => {
   const revision = parsed?.revision ?? 0;
   const flags = parsed?.flags ?? 0;
   const changedIds = new Set<string>();
+  // SAFETY: MetadataChanges owns every enumerable key in this closed application object.
   for (const key of Object.keys(changes) as Array<keyof MetadataChanges>) {
     if (key !== "comment" && key in ids) {
+      // SAFETY: the key-in-ids check establishes that this MetadataChanges key is an ID3 text key.
       for (const id of ids[key as keyof typeof ids]) changedIds.add(id);
     }
   }
@@ -639,6 +644,7 @@ const buildTag = (parsed: ParsedTag | undefined, changes: MetadataChanges) => {
   const addText = (key: Exclude<keyof typeof ids, "picture">, value: string) => {
     if (value.length > 0)
       frames.push(
+        // SAFETY: addText only accepts keys from ids except picture, which idFor supports.
         makeFrame(idFor(key as keyof typeof ids, version), encodeText(value, version), version),
       );
   };
@@ -773,6 +779,7 @@ export const mp3Driver: FormatDriver = {
             : readFailure("unable to parse APEv2 metadata.", cause),
       });
       const get = (key: keyof typeof ids, apeKey: string = key): string | number | undefined => {
+        // SAFETY: ParsedId3v1 fields indexed here are the textual/number metadata keys in ids.
         const legacy = (v1 as Record<string, string | number | undefined>)[key];
         return firstText(parsed, idSets[key]) ?? ape.values.get(apeKey.toLowerCase()) ?? legacy;
       };

--- a/src/features/audio/metadataEngine/mp4/mp4.ts
+++ b/src/features/audio/metadataEngine/mp4/mp4.ts
@@ -112,7 +112,11 @@ const parseAtoms = (
         try {
           size = u64(header, 8);
         } catch (cause) {
-          return yield* Effect.fail(cause as AudioMetadataReadError);
+          return yield* Effect.fail(
+            cause instanceof AudioMetadataReadError
+              ? cause
+              : readError("unable to read extended atom size.", cause),
+          );
         }
       } else if (size32 === 0) {
         size = end - offset;
@@ -249,7 +253,11 @@ const parseAudioTrack = (source: ByteSource, moov: Atom) =>
     try {
       duration = fullBoxTiming(mdhdBytes, selected.mdhd.headerSize);
     } catch (cause) {
-      return yield* Effect.fail(cause as AudioMetadataReadError);
+      return yield* Effect.fail(
+        cause instanceof AudioMetadataReadError
+          ? cause
+          : readError("unable to read audio timing metadata.", cause),
+      );
     }
     return { duration, sampleRate };
   });
@@ -474,7 +482,11 @@ const parseMetadata = (
           try {
             decoded = payload.type === 2 ? decodeUtf16(payload.bytes) : decodeUtf8(payload.bytes);
           } catch (cause) {
-            return yield* Effect.fail(cause as AudioMetadataReadError);
+            return yield* Effect.fail(
+              cause instanceof AudioMetadataReadError
+                ? cause
+                : readError("unable to decode ilst text metadata.", cause),
+            );
           }
           const current = values.get(item.type) ?? [];
           current.push(decoded);

--- a/src/features/audio/metadataFields.ts
+++ b/src/features/audio/metadataFields.ts
@@ -51,8 +51,8 @@ export const getAdvancedMetadataValidationErrors = (
 ) => {
   const discNumber = validateAdvancedMetadataNumber("discNumber", metadata.discNumber);
   const bpm = validateAdvancedMetadataNumber("bpm", metadata.bpm);
-  return {
-    ...(discNumber ? { discNumber } : {}),
-    ...(bpm ? { bpm } : {}),
-  };
+  const errors: Partial<Record<AdvancedNumericMetadataField, string>> = {};
+  if (discNumber) errors.discNumber = discNumber;
+  if (bpm) errors.bpm = bpm;
+  return errors;
 };

--- a/src/features/editor/TrackMetadataEditor.tsx
+++ b/src/features/editor/TrackMetadataEditor.tsx
@@ -890,8 +890,7 @@ export default function TrackMetadataEditor(props: TrackMetadataEditorProps) {
     if (trackIsSelected || !retainedSelection) return;
 
     const reduceMotion =
-      typeof window !== "undefined" &&
-      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+      "window" in globalThis && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
     const timeoutId = globalThis.setTimeout(
       () => setRetainedSelection(null),
       reduceMotion ? 0 : 250,

--- a/src/features/editor/audioTaggerUtils.ts
+++ b/src/features/editor/audioTaggerUtils.ts
@@ -1,4 +1,5 @@
 import type { TrackSourceMix } from "@/analytics";
+import type { FieldNamesMarkedBoolean } from "react-hook-form";
 import {
   EDITABLE_METADATA_FIELDS,
   getAdvancedMetadataValidationErrors,
@@ -9,7 +10,7 @@ import type { UploadedTrack } from "@/features/audio/mp3Utils";
 import type { AudioMetadata, MetadataPatch, TagiumFile } from "@/features/library/types";
 
 type MetadataPatchField = keyof MetadataPatch;
-type DirtyMetadataFields = Partial<Record<keyof AudioMetadata, unknown>>;
+export type DirtyMetadataFields = FieldNamesMarkedBoolean<AudioMetadata>;
 
 const metadataPatchFields = EDITABLE_METADATA_FIELDS satisfies readonly MetadataPatchField[];
 

--- a/src/features/editor/coverArt.tsx
+++ b/src/features/editor/coverArt.tsx
@@ -143,7 +143,7 @@ export default function CoverArt({
     }
 
     if (picture && picture.length > 0) {
-      const blob = new Blob([picture[0].data as unknown as BlobPart], { type: picture[0].format });
+      const blob = new Blob([Uint8Array.from(picture[0].data)], { type: picture[0].format });
       // The cleanup below revokes this exact URL when the picture changes or the component unmounts.
       // react-doctor-disable-next-line react-doctor/no-create-object-url-without-revoke
       const url = URL.createObjectURL(blob);

--- a/src/features/editor/coverArtState.ts
+++ b/src/features/editor/coverArtState.ts
@@ -34,13 +34,18 @@ export type CoverArtAction =
 
 export const coverArtReducer = (state: CoverArtState, action: CoverArtAction): CoverArtState => {
   switch (action.type) {
-    case "uploadStarted":
-      return {
+    case "uploadStarted": {
+      const next = {
         ...state,
         activeUploadId: action.uploadId,
         isProcessing: true,
-        ...(action.closeCropper ? { cropSource: null, isCropperOpen: false } : {}),
       };
+      if (action.closeCropper) {
+        next.cropSource = null;
+        next.isCropperOpen = false;
+      }
+      return next;
+    }
     case "uploadSucceeded":
       if (action.uploadId !== state.activeUploadId) return state;
       return {

--- a/src/features/editor/editorKeyboardShortcuts.ts
+++ b/src/features/editor/editorKeyboardShortcuts.ts
@@ -1,3 +1,5 @@
+import { Option, Schema } from "effect";
+
 export type EditorKeyboardShortcutActions = {
   enabled?: boolean;
   selectedFileCount: number;
@@ -13,11 +15,13 @@ type KeyboardTarget = {
 };
 
 const isEditableTarget = (target: EventTarget | null) => {
-  const element = target as Pick<HTMLElement, "tagName" | "isContentEditable"> | null;
+  const element = Option.getOrNull(
+    Schema.decodeUnknownOption(
+      Schema.Struct({ tagName: Schema.String, isContentEditable: Schema.Boolean }),
+    )(target),
+  );
   return (
-    element?.tagName === "INPUT" ||
-    element?.tagName === "TEXTAREA" ||
-    element?.isContentEditable === true
+    element?.tagName === "INPUT" || element?.tagName === "TEXTAREA" || element?.isContentEditable
   );
 };
 

--- a/src/features/editor/editorKeyboardShortcuts.ts
+++ b/src/features/editor/editorKeyboardShortcuts.ts
@@ -1,5 +1,3 @@
-import { Option, Schema } from "effect";
-
 export type EditorKeyboardShortcutActions = {
   enabled?: boolean;
   selectedFileCount: number;
@@ -15,13 +13,12 @@ type KeyboardTarget = {
 };
 
 const isEditableTarget = (target: EventTarget | null) => {
-  const element = Option.getOrNull(
-    Schema.decodeUnknownOption(
-      Schema.Struct({ tagName: Schema.String, isContentEditable: Schema.Boolean }),
-    )(target),
-  );
+  if (target === null) return false;
+  const tagName = "tagName" in target ? target.tagName : undefined;
   return (
-    element?.tagName === "INPUT" || element?.tagName === "TEXTAREA" || element?.isContentEditable
+    tagName === "INPUT" ||
+    tagName === "TEXTAREA" ||
+    ("isContentEditable" in target && target.isContentEditable === true)
   );
 };
 

--- a/src/features/editor/useTrackEditorSession.ts
+++ b/src/features/editor/useTrackEditorSession.ts
@@ -10,6 +10,7 @@ import {
 } from "@/features/library/fileMetadataOps";
 import {
   createDirtyMetadataPatch,
+  type DirtyMetadataFields,
   getProjectableAudioMetadata,
   getNullableNumericMetadataValue,
   getNullableNumericPatchValue,
@@ -38,7 +39,7 @@ interface PendingPreview {
   value: string;
 }
 
-const hasOwn = <Key extends PropertyKey>(object: object, key: Key) =>
+const hasOwn = <Value, Key extends PropertyKey>(object: Value, key: Key) =>
   Object.prototype.hasOwnProperty.call(object, key);
 
 const getPendingMetadataPatch = (file: TagiumFile) => file.pendingMetadataPatch;
@@ -67,26 +68,27 @@ const createSubmittedMetadataPatch = (metadata: AudioMetadata): MetadataPatch =>
   comment: metadata.comment,
 });
 
-const applyMetadataPatch = (metadata: AudioMetadata, patch: MetadataPatch): AudioMetadata => ({
-  ...metadata,
-  ...(hasOwn(patch, "filename") ? { filename: patch.filename } : {}),
-  ...(hasOwn(patch, "title") ? { title: patch.title } : {}),
-  ...(hasOwn(patch, "artist") ? { artist: patch.artist } : {}),
-  ...(hasOwn(patch, "albumArtist") ? { albumArtist: patch.albumArtist } : {}),
-  ...(hasOwn(patch, "album") ? { album: patch.album } : {}),
-  ...(hasOwn(patch, "year") ? { year: getNullableNumericMetadataValue(patch.year) } : {}),
-  ...(hasOwn(patch, "genre") ? { genre: patch.genre } : {}),
-  ...(hasOwn(patch, "picture") ? { picture: patch.picture } : {}),
-  ...(hasOwn(patch, "trackNumber")
-    ? { trackNumber: getNullableNumericMetadataValue(patch.trackNumber) }
-    : {}),
-  ...(hasOwn(patch, "discNumber")
-    ? { discNumber: getNullableNumericMetadataValue(patch.discNumber) }
-    : {}),
-  ...(hasOwn(patch, "composer") ? { composer: patch.composer } : {}),
-  ...(hasOwn(patch, "bpm") ? { bpm: getNullableNumericMetadataValue(patch.bpm) } : {}),
-  ...(hasOwn(patch, "comment") ? { comment: patch.comment } : {}),
-});
+const applyMetadataPatch = (metadata: AudioMetadata, patch: MetadataPatch): AudioMetadata => {
+  const next = { ...metadata };
+  if (patch.filename !== undefined) next.filename = patch.filename;
+  if (patch.title !== undefined) next.title = patch.title;
+  if (patch.artist !== undefined) next.artist = patch.artist;
+  if (patch.albumArtist !== undefined) next.albumArtist = patch.albumArtist;
+  if (patch.album !== undefined) next.album = patch.album;
+  if (patch.year !== undefined) next.year = getNullableNumericMetadataValue(patch.year);
+  if (patch.genre !== undefined) next.genre = patch.genre;
+  if (patch.picture !== undefined) next.picture = patch.picture;
+  if (patch.trackNumber !== undefined) {
+    next.trackNumber = getNullableNumericMetadataValue(patch.trackNumber);
+  }
+  if (patch.discNumber !== undefined) {
+    next.discNumber = getNullableNumericMetadataValue(patch.discNumber);
+  }
+  if (patch.composer !== undefined) next.composer = patch.composer;
+  if (patch.bpm !== undefined) next.bpm = getNullableNumericMetadataValue(patch.bpm);
+  if (patch.comment !== undefined) next.comment = patch.comment;
+  return next;
+};
 
 const getMetadataPatchDifference = (metadata: AudioMetadata, patch?: MetadataPatch) => {
   if (!patch) return undefined;
@@ -241,7 +243,7 @@ export const useTrackEditorSession = ({
   const createCurrentMetadataPatch = useCallback(
     (
       metadata: AudioMetadata,
-      dirtyFields: Partial<Record<keyof AudioMetadata, unknown>>,
+      dirtyFields: DirtyMetadataFields,
       fileId: string | null,
       extraFields: Iterable<keyof MetadataPatch> = [],
     ) => {

--- a/src/features/export/ExportConfirmationDialog.tsx
+++ b/src/features/export/ExportConfirmationDialog.tsx
@@ -95,6 +95,7 @@ export function ExportConfirmationDialogView({
         className="max-h-[calc(100dvh-1rem)] min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden p-4 sm:max-h-[calc(100dvh-2rem)] sm:max-w-lg sm:p-6"
         onOpenAutoFocus={(event) => {
           event.preventDefault();
+          // SAFETY: the dialog focus event currentTarget is the DialogContent HTMLElement.
           const content = event.currentTarget as HTMLElement | null;
           content?.querySelector<HTMLElement>("[data-export-cancel]")?.focus();
         }}

--- a/src/features/export/downloadLibrary.ts
+++ b/src/features/export/downloadLibrary.ts
@@ -2,6 +2,7 @@ import filenamify from "filenamify";
 import type { AlbumGroup, TagiumFile } from "@/features/library/types";
 import { isValidFilenameBase } from "@/features/library/filename";
 import { replaceAudioExtension, getAudioFormat } from "@/features/audio/audioFormat";
+import { toPublicAudioError } from "@/features/audio/audioErrors";
 
 export interface DownloadZipEntry {
   path: string;
@@ -37,7 +38,7 @@ export async function createZipBlob(entries: DownloadZipEntry[]) {
   return new Promise<Blob>((resolve, reject) => {
     const chunks: Uint8Array<ArrayBuffer>[] = [];
     let settled = false;
-    const settleWithError = (error: unknown) => {
+    const settleWithError = (error: Error) => {
       if (settled) return;
       settled = true;
       archive.terminate();
@@ -45,7 +46,7 @@ export async function createZipBlob(entries: DownloadZipEntry[]) {
     };
     const archive = new Zip((error, chunk, final) => {
       if (error) {
-        settleWithError(error);
+        settleWithError(toPublicAudioError(error));
         return;
       }
       if (chunk.length > 0) chunks.push(Uint8Array.from(chunk));
@@ -77,7 +78,7 @@ export async function createZipBlob(entries: DownloadZipEntry[]) {
         }
         archive.end();
       } catch (error) {
-        settleWithError(error);
+        settleWithError(toPublicAudioError(error));
       }
     })();
   });

--- a/src/features/export/exportConfirmation.ts
+++ b/src/features/export/exportConfirmation.ts
@@ -51,30 +51,6 @@ const hashArtworkBytes = (bytes: Uint8Array) => {
   return `${bytes.byteLength}:${(firstHash >>> 0).toString(16).padStart(8, "0")}:${(secondHash >>> 0).toString(16).padStart(8, "0")}`;
 };
 
-const normalizeFingerprintValue = (
-  value: unknown,
-  artworkFingerprints: WeakMap<Uint8Array, string>,
-): unknown => {
-  if (value instanceof Uint8Array) {
-    const cached = artworkFingerprints.get(value);
-    if (cached) return cached;
-    const fingerprint = hashArtworkBytes(value);
-    artworkFingerprints.set(value, fingerprint);
-    return fingerprint;
-  }
-  if (Array.isArray(value)) {
-    return value.map((entry) => normalizeFingerprintValue(entry, artworkFingerprints));
-  }
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, entry]) => [key, normalizeFingerprintValue(entry, artworkFingerprints)]),
-    );
-  }
-  return value;
-};
-
 const indexFilesById = (files: TagiumFile[]) => {
   const filesById = new Map<string, TagiumFile>();
   for (const file of files) filesById.set(file.id, file);
@@ -228,20 +204,32 @@ export const planExport = (
       : null,
   }));
   const fingerprint = JSON.stringify(
-    normalizeFingerprintValue(
-      {
-        target,
-        settings: {
-          syncFilenames: settings.syncFilenames,
-          syncTrackNumbers: settings.syncTrackNumbers,
-        },
-        groups,
-        albums: albumFingerprint,
-        files: fileFingerprint,
-        entries: entries.map((entry) => ({ path: entry.path, size: entry.file.size })),
+    {
+      target,
+      settings: {
+        syncFilenames: settings.syncFilenames,
+        syncTrackNumbers: settings.syncTrackNumbers,
       },
-      artworkFingerprints,
-    ),
+      groups,
+      albums: albumFingerprint,
+      files: fileFingerprint,
+      entries: entries.map((entry) => ({ path: entry.path, size: entry.file.size })),
+    },
+    (_key, value) => {
+      if (value instanceof Uint8Array) {
+        const cached = artworkFingerprints.get(value);
+        if (cached) return cached;
+        const artworkFingerprint = hashArtworkBytes(value);
+        artworkFingerprints.set(value, artworkFingerprint);
+        return artworkFingerprint;
+      }
+      if (value instanceof Object && !Array.isArray(value)) {
+        return Object.fromEntries(
+          Object.entries(value).sort(([left], [right]) => left.localeCompare(right)),
+        );
+      }
+      return value;
+    },
   );
   planFingerprints.set(plan, fingerprint);
   return plan;

--- a/src/features/export/useExportSession.ts
+++ b/src/features/export/useExportSession.ts
@@ -53,6 +53,9 @@ type ConfirmationFocusTarget = {
 const canRestoreFocus = (target: ConfirmationFocusTarget) =>
   target.isConnected !== false && (target.checkVisibility?.() ?? true);
 
+const canReceiveFocus = (element: Element | null): element is Element & ConfirmationFocusTarget =>
+  element !== null && "focus" in element && typeof element.focus === "function";
+
 const planTrackIds = (plan: ExportPlan) =>
   plan.groups.flatMap((group) => group.tracks.map((track) => track.id));
 
@@ -282,7 +285,11 @@ export const useExportSession = ({
         });
         return "success";
       } catch (error) {
-        analytics.capture({ type: "export_failed", exportKind: target.kind, error });
+        analytics.capture({
+          type: "export_failed",
+          exportKind: target.kind,
+          error: error instanceof Error ? error : new Error(),
+        });
         reportSystemFailure(error, "export");
         return "error";
       } finally {
@@ -295,8 +302,8 @@ export const useExportSession = ({
   const rememberConfirmationTrigger = useCallback(() => {
     if (typeof document === "undefined") return;
     const activeElement = document.activeElement;
-    if (activeElement && "focus" in activeElement && typeof activeElement.focus === "function") {
-      confirmationTriggerRef.current = activeElement as ConfirmationFocusTarget;
+    if (canReceiveFocus(activeElement)) {
+      confirmationTriggerRef.current = activeElement;
     }
   }, []);
 
@@ -393,7 +400,11 @@ export const useExportSession = ({
           sizeBytes: updatedFile.file.size,
         });
       } catch (error) {
-        analytics.capture({ type: "export_failed", exportKind: "track", error });
+        analytics.capture({
+          type: "export_failed",
+          exportKind: "track",
+          error: error instanceof Error ? error : new Error(),
+        });
         reportSystemFailure(error, "export");
       } finally {
         setExporting(false);

--- a/src/features/import/AudioImportDropzone.tsx
+++ b/src/features/import/AudioImportDropzone.tsx
@@ -37,7 +37,7 @@ export default function AudioImportDropzone({
   };
 
   useEffect(() => {
-    if (!isDragging || typeof window === "undefined" || typeof document === "undefined") return;
+    if (!isDragging || !("window" in globalThis) || !("document" in globalThis)) return;
 
     const handleDocumentDragLeave = (event: DragEvent) => {
       if (!event.relatedTarget) resetDragState();

--- a/src/features/import/audioUrlImportSession.ts
+++ b/src/features/import/audioUrlImportSession.ts
@@ -1,4 +1,6 @@
-import { analytics, type MediaLinkShape } from "@/analytics";
+import { analytics, type MediaLinkKind } from "@/analytics";
+import { Option, Schema } from "effect";
+import { toPublicAudioError } from "@/features/audio/audioErrors";
 import type {
   CobaltAudioDownloadLifecycleEvent,
   CobaltAudioDownloadRequest,
@@ -33,6 +35,9 @@ import { createSharedContentDownloadPlan } from "@/features/share/sharedAlbumDow
 import { parseMediaLink } from "@/lib/media-link";
 
 type ManagedDownloadTrack = QueuedDownloadTrack & { importOperationId?: string };
+const decodeSoundCloudLinkResponse = Schema.decodeUnknownOption(
+  Schema.Struct({ canonicalUrl: Schema.String }),
+);
 const retryProvider = (
   tracks: readonly ManagedDownloadTrack[],
 ): "youtube" | "soundcloud" | "other" | "mixed" => {
@@ -58,24 +63,23 @@ type UrlImportEditor = Pick<
 >;
 
 const asUniqueTrackIds = (trackIds: string[]) => [...new Set(trackIds)];
-const managedDownloadTrackFromFile = (file: TagiumFile): ManagedDownloadTrack | null =>
-  file.downloadRequest
-    ? {
-        fileId: file.id,
-        title: file.metadata?.title || file.filename,
-        downloadRequest: file.downloadRequest,
-        ...(file.downloadRequest.importId
-          ? { importOperationId: file.downloadRequest.importId }
-          : {}),
-      }
-    : null;
+const managedDownloadTrackFromFile = (file: TagiumFile): ManagedDownloadTrack | null => {
+  if (!file.downloadRequest) return null;
+  const track: ManagedDownloadTrack = {
+    fileId: file.id,
+    title: file.metadata?.title || file.filename,
+    downloadRequest: file.downloadRequest,
+  };
+  if (file.downloadRequest.importId) track.importOperationId = file.downloadRequest.importId;
+  return track;
+};
 const createPlaylistDownloadModelTrack = (track: ManagedDownloadTrack) => ({
   id: track.fileId,
   title: track.title,
   sourceUrl: track.downloadRequest.sourceUrl,
 });
 
-const mediaLinkShapeFromUrl = (sourceUrl: string): MediaLinkShape => {
+const mediaLinkKindFromUrl = (sourceUrl: string): MediaLinkKind => {
   try {
     const host = new URL(sourceUrl).hostname.toLowerCase();
     if (host === "youtu.be" || host === "on.soundcloud.com" || host === "snd.sc") {
@@ -96,7 +100,7 @@ const mediaLinkShapeFromUrl = (sourceUrl: string): MediaLinkShape => {
       return "canonical";
     }
   } catch {
-    // Invalid and generic inputs share the non-identifying "other" shape.
+    // Invalid and generic inputs share the non-identifying "other" kind.
   }
   return "other";
 };
@@ -148,7 +152,7 @@ export const createAudioUrlImportSession = ({
     now: () => Date.now(),
   });
 
-  const markDownloadError = (fileId: string, error: unknown) => {
+  const markDownloadError = (fileId: string, error: Error) => {
     const message = reportSystemFailure(error, "download").trackDescription;
     const nextFiles = library.getSnapshot().files.map((file) =>
       file.id === fileId
@@ -221,13 +225,15 @@ export const createAudioUrlImportSession = ({
       onTrackSettled: (event) => {
         const { track, outcome } = event;
         if (!track.importOperationId) return;
-        importLifecycleTracker.settle(track.importOperationId, {
+        const settlement: Parameters<typeof importLifecycleTracker.settle>[1] = {
           trackId: track.fileId,
           outcome,
-          ...(event.outcome === "failed"
-            ? { error: event.error, failureStage: event.failureStage }
-            : {}),
-        });
+        };
+        if (event.outcome === "failed") {
+          settlement.error = event.error;
+          settlement.failureStage = event.failureStage;
+        }
+        importLifecycleTracker.settle(track.importOperationId, settlement);
       },
       onAction: (event) => {
         if (event.type === "cancel_requested") {
@@ -425,12 +431,10 @@ export const createAudioUrlImportSession = ({
             endpoint.searchParams.set("url", trimmedUrl);
             const response = await fetch(endpoint);
             if (response.ok) {
-              const candidateResult = await response.json();
-              if (
-                candidateResult &&
-                typeof candidateResult === "object" &&
-                typeof candidateResult.canonicalUrl === "string"
-              ) {
+              const candidateResult = Option.getOrNull(
+                decodeSoundCloudLinkResponse(await response.json()),
+              );
+              if (candidateResult) {
                 const reparsed = parseMediaLink(candidateResult.canonicalUrl);
                 if (reparsed.kind !== "unsupported") {
                   parsed = reparsed;
@@ -459,7 +463,7 @@ export const createAudioUrlImportSession = ({
           type: "media_link_processed",
           sourceUrl: trimmedUrl,
           mediaKind: "unsupported",
-          shape: mediaLinkShapeFromUrl(trimmedUrl),
+          linkKind: mediaLinkKindFromUrl(trimmedUrl),
           normalized: false,
           redirected: false,
           outcome: "rejected",
@@ -479,7 +483,7 @@ export const createAudioUrlImportSession = ({
         type: "media_link_processed",
         sourceUrl: trimmedUrl,
         mediaKind: parsed.kind,
-        shape: mediaLinkShapeFromUrl(trimmedUrl),
+        linkKind: mediaLinkKindFromUrl(trimmedUrl),
         normalized: parsed.canonicalUrl !== trimmedUrl,
         redirected,
         outcome: "accepted",
@@ -502,7 +506,7 @@ export const createAudioUrlImportSession = ({
             // not carry request provenance.
             handlePlaylistDownload({ ...playlist, sourceUrl: normalizedUrl }, importOperationId);
           } catch (error) {
-            importLifecycleTracker.fail(importOperationId, error);
+            importLifecycleTracker.fail(importOperationId, toPublicAudioError(error));
             throw error;
           }
           return;

--- a/src/features/import/cobaltAudio.ts
+++ b/src/features/import/cobaltAudio.ts
@@ -10,6 +10,12 @@ import { ImportStageError } from "@/features/import/importLifecycle";
 
 export type AudioDownloadBitrate = "320" | "256" | "128" | "96" | "64";
 
+interface CobaltAudioRequestBody {
+  url: string;
+  audioBitrate: AudioDownloadBitrate;
+  year?: number;
+}
+
 export type CobaltAudioDownloadLifecycleEvent =
   | {
       type: "tunnel-budget-wait-started";
@@ -254,15 +260,16 @@ const makeCobaltAudio = Effect.fn("makeCobaltAudio")(function* () {
         if (request.trackIndex !== undefined) {
           headers.set("X-Tagium-Track-Index", String(request.trackIndex));
         }
+        const body: CobaltAudioRequestBody = {
+          url: request.sourceUrl,
+          audioBitrate: request.audioBitrate,
+        };
+        if (request.year !== undefined) body.year = request.year;
         const response = await fetch("/api/cobalt/audio", {
           method: "POST",
           headers,
           signal: request.signal,
-          body: JSON.stringify({
-            url: request.sourceUrl,
-            audioBitrate: request.audioBitrate,
-            ...(request.year === undefined ? {} : { year: request.year }),
-          }),
+          body: JSON.stringify(body),
         });
 
         if (!response.ok) {

--- a/src/features/import/downloadTrack.ts
+++ b/src/features/import/downloadTrack.ts
@@ -244,14 +244,17 @@ export const createQueuedDownloadTracks = (
 const createPlaylistPendingMetadataPatch = (
   playlist: Playlist,
   track: Playlist["tracks"][number],
-): MetadataPatch => ({
-  title: track.title,
-  artist: playlist.artist,
-  album: playlist.title,
-  genre: playlist.genre,
-  ...(playlist.year !== undefined ? { year: playlist.year } : {}),
-  ...(track.trackNumber !== undefined ? { trackNumber: track.trackNumber } : {}),
-});
+): MetadataPatch => {
+  const patch: MetadataPatch = {
+    title: track.title,
+    artist: playlist.artist,
+    album: playlist.title,
+    genre: playlist.genre,
+  };
+  if (playlist.year !== undefined) patch.year = playlist.year;
+  if (track.trackNumber !== undefined) patch.trackNumber = track.trackNumber;
+  return patch;
+};
 
 export const createSingleUrlDownloadPlan = ({
   sourceUrl,
@@ -262,6 +265,8 @@ export const createSingleUrlDownloadPlan = ({
 }: CreateSingleUrlDownloadPlanInput): SingleUrlDownloadPlan => {
   const id = createId();
   const title = metadata?.title || titleFromSourceUrl(sourceUrl);
+  const downloadRequest: DownloadRequest = { sourceUrl, audioBitrate };
+  if (importId) downloadRequest.importId = importId;
   const pendingFile = createPendingDownloadTrack(
     id,
     createDownloadMetadata({
@@ -271,7 +276,7 @@ export const createSingleUrlDownloadPlan = ({
       genre: "",
     }),
     false,
-    { sourceUrl, audioBitrate, ...(importId ? { importId } : {}) },
+    downloadRequest,
   );
 
   return {
@@ -295,8 +300,15 @@ export const createPlaylistDownloadPlan = ({
   importId,
 }: CreatePlaylistDownloadPlanInput): PlaylistDownloadPlan => {
   const albumId = createId();
-  const pendingFiles = playlist.tracks.map((track) =>
-    createPendingDownloadTrack(
+  const pendingFiles = playlist.tracks.map((track) => {
+    const downloadRequest: DownloadRequest = {
+      sourceUrl: track.url,
+      audioBitrate,
+      trackIndex: track.trackNumber,
+    };
+    if (importId) downloadRequest.importId = importId;
+    if (playlist.year !== undefined) downloadRequest.year = playlist.year;
+    return createPendingDownloadTrack(
       createId(),
       createDownloadMetadata({
         title: track.title,
@@ -308,16 +320,10 @@ export const createPlaylistDownloadPlan = ({
         trackNumber: track.trackNumber,
       }),
       true,
-      {
-        sourceUrl: track.url,
-        audioBitrate,
-        ...(importId ? { importId } : {}),
-        trackIndex: track.trackNumber,
-        ...(playlist.year === undefined ? {} : { year: playlist.year }),
-      },
+      downloadRequest,
       createPlaylistPendingMetadataPatch(playlist, track),
-    ),
-  );
+    );
+  });
   const album: AlbumGroup = {
     id: albumId,
     title: playlist.title,
@@ -325,8 +331,8 @@ export const createPlaylistDownloadPlan = ({
     genre: playlist.genre,
     trackIds: pendingFiles.map((file) => file.id),
     year: playlist.year,
-    ...(playlist.sourceUrl === undefined ? {} : { sourceUrl: playlist.sourceUrl }),
   };
+  if (playlist.sourceUrl !== undefined) album.sourceUrl = playlist.sourceUrl;
   const firstPendingFileId = pendingFiles[0]?.id ?? null;
 
   return {
@@ -377,8 +383,10 @@ export function startDownloadTrackPlan(
   deps.setFiles(nextFiles);
 
   if (plan.source === "playlist") {
-    const albumDeps = deps as PlaylistDownloadWorkflowDeps;
-    albumDeps.setAlbums([...albumDeps.getAlbums(), plan.album]);
+    if (!("setAlbums" in deps) || !("getAlbums" in deps)) {
+      throw new Error("playlist downloads require album workflow dependencies");
+    }
+    deps.setAlbums([...deps.getAlbums(), plan.album]);
   } else {
     deps.addLooseTrackIds?.(plan.looseTrackIds);
   }

--- a/src/features/import/importLifecycle.ts
+++ b/src/features/import/importLifecycle.ts
@@ -27,7 +27,7 @@ interface ImportOperation {
     string,
     {
       outcome: ImportTrackOutcome;
-      error?: unknown;
+      error?: Error;
       failureStage?: ImportFailureStage;
     }
   >;
@@ -42,32 +42,32 @@ interface ImportLifecycleDependencies {
 export interface ImportLifecycleTracker {
   start: (input: { sourceUrl: string; importKind: ImportKind }) => string;
   resolve: (operationId: string, resolution: { trackIds: string[]; hasCover: boolean }) => void;
-  fail: (operationId: string, error: unknown) => void;
+  fail: (operationId: string, error: Error) => void;
   settle: (
     operationId: string,
     settlement: {
       trackId: string;
       outcome: ImportTrackOutcome;
-      error?: unknown;
+      error?: Error;
       failureStage?: ImportFailureStage;
     },
   ) => void;
 }
 
-const errorMessage = (error: unknown) => {
-  if (error instanceof Error) return error.message;
+const errorMessage = (cause: unknown) => {
+  if (cause instanceof Error) return cause.message;
   if (
-    typeof error === "object" &&
-    error !== null &&
-    "message" in error &&
-    typeof error.message === "string"
+    typeof cause === "object" &&
+    cause !== null &&
+    "message" in cause &&
+    typeof cause.message === "string"
   ) {
-    return error.message;
+    return cause.message;
   }
   return "";
 };
 
-export const importFailureCodeFrom = (error: unknown): ImportFailureCode => {
+export const importFailureCodeFrom = (error: Error): ImportFailureCode => {
   const message = errorMessage(error).toLowerCase();
   if (message.includes("error.api.capacity_exceeded")) return "capacity";
   if (
@@ -97,7 +97,7 @@ export const importFailureCodeFrom = (error: unknown): ImportFailureCode => {
   return "unknown";
 };
 
-export const importFailureStageFromDownloadError = (error: unknown): ImportFailureStage =>
+export const importFailureStageFromDownloadError = (error: Error): ImportFailureStage =>
   error instanceof ImportStageError ? error.stage : "plan";
 
 const deriveOutcome = (counts: {
@@ -185,7 +185,7 @@ export const createImportLifecycleTracker = (
         if (result.outcome === "failed") {
           failed += 1;
           const stage = result.failureStage ?? "plan";
-          const code = importFailureCodeFrom(result.error);
+          const code = result.error ? importFailureCodeFrom(result.error) : "unknown";
           const key = `${stage}:${code}`;
           const aggregate = failures.get(key);
           if (aggregate) aggregate.count += 1;

--- a/src/features/import/importQueuePresentation.ts
+++ b/src/features/import/importQueuePresentation.ts
@@ -28,7 +28,7 @@ export const getImportQueuePresentation = (
   if (snapshot.canceled && snapshot.failed === 0) status = "canceled";
   const settled = snapshot.completed + snapshot.failed + snapshot.canceledCount;
   const eta = formatEta(snapshot.etaMs);
-  return {
+  const presentation: PlaylistDownloadQueuePanelState = {
     id: snapshot.id,
     status,
     downloadedCount: snapshot.completed,
@@ -41,6 +41,7 @@ export const getImportQueuePresentation = (
     canRetry: Boolean(
       snapshot.active.length === 0 && retryCount > 0 && (snapshot.canceled || snapshot.failed > 0),
     ),
-    ...(eta ? { eta: `eta ${eta}` } : {}),
   };
+  if (eta) presentation.eta = `eta ${eta}`;
+  return presentation;
 };

--- a/src/features/import/localAudioProcessor.ts
+++ b/src/features/import/localAudioProcessor.ts
@@ -12,6 +12,7 @@ import {
   inspectAudioFile,
   patchAudioFileWithChanges,
 } from "@/features/audio/metadataEngine/engine";
+import type { MetadataChanges } from "@/features/audio/metadataEngine/types";
 
 type LocalAudioPlan = Extract<CobaltDownloadPlan, { status: "local-processing" }>;
 
@@ -102,15 +103,13 @@ const decodeCobaltLocalProcessingMessage = Effect.fn("decodeCobaltLocalProcessin
   },
 );
 
-const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+const isObjectState = (value: unknown): value is object =>
   typeof value === "object" && value !== null;
 
 const isMalformedTerminalLocalProcessingMessage = (data: unknown) => {
-  if (!isObjectRecord(data) || !isObjectRecord(data.cobaltLocalProcessing)) {
-    return false;
-  }
-
-  return "blob" in data.cobaltLocalProcessing || "error" in data.cobaltLocalProcessing;
+  if (!isObjectState(data) || !("cobaltLocalProcessing" in data)) return false;
+  const message = data.cobaltLocalProcessing;
+  return isObjectState(message) && ("blob" in message || "error" in message);
 };
 
 const runLocalProcessingWorker = (request: LocalAudioProcessingRequest, signal?: AbortSignal) =>
@@ -264,43 +263,32 @@ const tagCobaltAudioFile = async (
 ) => {
   const { metadata } = await Effect.runPromise(inspectAudioFile(file));
   const supplied = plan.output.metadata;
-  const tagged = await Effect.runPromise(
-    patchAudioFileWithChanges(
-      file,
+  const changes: MetadataChanges = {};
+  if (supplied?.title) changes.title = stripMetadataControlCharacters(supplied.title);
+  if (supplied?.artist) changes.artist = stripMetadataControlCharacters(supplied.artist);
+  if (supplied?.album) changes.album = stripMetadataControlCharacters(supplied.album);
+  if (supplied?.date) changes.dateText = stripMetadataControlCharacters(supplied.date);
+  if (supplied?.genre) changes.genre = stripMetadataControlCharacters(supplied.genre);
+  if (supplied?.track) changes.trackText = stripMetadataControlCharacters(supplied.track);
+  if (supplied?.album_artist)
+    changes.albumArtist = stripMetadataControlCharacters(supplied.album_artist);
+  if (supplied?.composer) changes.composer = stripMetadataControlCharacters(supplied.composer);
+  if (supplied?.copyright) changes.copyright = stripMetadataControlCharacters(supplied.copyright);
+  if (supplied?.sublanguage) {
+    changes.language = stripMetadataControlCharacters(supplied.sublanguage);
+  }
+  if (coverFile) {
+    changes.picture = [
       {
-        ...(supplied?.title ? { title: stripMetadataControlCharacters(supplied.title) } : {}),
-        ...(supplied?.artist ? { artist: stripMetadataControlCharacters(supplied.artist) } : {}),
-        ...(supplied?.album ? { album: stripMetadataControlCharacters(supplied.album) } : {}),
-        ...(supplied?.date ? { dateText: stripMetadataControlCharacters(supplied.date) } : {}),
-        ...(supplied?.genre ? { genre: stripMetadataControlCharacters(supplied.genre) } : {}),
-        ...(supplied?.track ? { trackText: stripMetadataControlCharacters(supplied.track) } : {}),
-        ...(supplied?.album_artist
-          ? { albumArtist: stripMetadataControlCharacters(supplied.album_artist) }
-          : {}),
-        ...(supplied?.composer
-          ? { composer: stripMetadataControlCharacters(supplied.composer) }
-          : {}),
-        ...(supplied?.copyright
-          ? { copyright: stripMetadataControlCharacters(supplied.copyright) }
-          : {}),
-        ...(supplied?.sublanguage
-          ? { language: stripMetadataControlCharacters(supplied.sublanguage) }
-          : {}),
-        ...(coverFile
-          ? {
-              picture: [
-                {
-                  format: coverFile.type || "image/jpeg",
-                  type: 3,
-                  description: "cover",
-                  data: new Uint8Array(await coverFile.arrayBuffer()),
-                },
-              ],
-            }
-          : {}),
+        format: coverFile.type || "image/jpeg",
+        type: 3,
+        description: "cover",
+        data: new Uint8Array(await coverFile.arrayBuffer()),
       },
-      metadata.filename,
-    ),
+    ];
+  }
+  const tagged = await Effect.runPromise(
+    patchAudioFileWithChanges(file, changes, metadata.filename),
   );
   return new File([tagged], plan.output.filename, {
     type: tagged.type,

--- a/src/features/import/playlistDownloadController.ts
+++ b/src/features/import/playlistDownloadController.ts
@@ -1,4 +1,5 @@
 import { Cause, Effect, Exit, Fiber } from "effect";
+import { toPublicAudioError } from "@/features/audio/audioErrors";
 import {
   cancelActivePlaylistDownloadTracks,
   cancelPendingPlaylistDownloadTracks,
@@ -21,6 +22,7 @@ import type { PlaylistDownloadQueueTrack as PlaylistDownloadQueueModelTrack } fr
 import { createDownloadAdmissionWindow } from "@/features/import/downloadAdmissionWindow";
 import {
   importFailureStageFromDownloadError,
+  ImportStageError,
   type ImportTrackOutcome,
 } from "@/features/import/importLifecycle";
 import type { ImportFailureStage, ImportOutcome } from "@/analytics";
@@ -41,7 +43,7 @@ export type PlaylistDownloadTrackSettled<Track extends PlaylistDownloadRuntimeTr
   | {
       track: Track;
       outcome: "failed";
-      error: unknown;
+      error: Error;
       failureStage: ImportFailureStage;
     };
 
@@ -76,7 +78,7 @@ export interface PlaylistDownloadControllerDeps<Track extends PlaylistDownloadRu
   getFileErrorTrackIds: () => Set<string>;
   markQueued: (tracks: Track[]) => void;
   markCanceled: (trackIds: string[]) => void;
-  markFailed: (trackId: string, error: unknown) => void;
+  markFailed: (trackId: string, error: Error) => void;
   onTrackSettled?: (event: PlaylistDownloadTrackSettled<Track>) => void;
   onAction?: (event: PlaylistDownloadControllerAction<Track>) => void;
   emitSnapshot: (snapshot: PlaylistDownloadControllerSnapshot) => void;
@@ -91,32 +93,34 @@ export interface PlaylistDownloadController<Track extends PlaylistDownloadRuntim
   getSnapshot: () => PlaylistDownloadControllerSnapshot | null;
 }
 
-const isPlaylistDownloadAbort = (error: unknown) => {
+const isPlaylistDownloadAbort = (error: Error): boolean => {
   if (error instanceof DOMException && error.name === "AbortError") return true;
   if (error instanceof Error) {
     if (error.name === "AbortError") return true;
-    if (error.cause !== undefined) return isPlaylistDownloadAbort(error.cause);
+    if (error.cause !== undefined) return isPlaylistDownloadAbort(toPublicAudioError(error.cause));
   }
   return false;
 };
 
-const toErrorMessage = (error: unknown) => {
-  if (error instanceof Error) return error.message;
-  return "download failed.";
-};
+const toErrorMessage = (error: Error) => error.message || "download failed.";
 
-const firstCauseError = (cause: Cause.Cause<unknown>) => {
+const firstCauseError = (cause: Cause.Cause<unknown>): Error => {
   for (const reason of cause.reasons) {
-    if (Cause.isFailReason(reason)) return reason.error;
-    if (Cause.isDieReason(reason)) return reason.defect;
+    if (Cause.isFailReason(reason)) return toPublicAudioError(reason.error);
+    if (Cause.isDieReason(reason)) return toPublicAudioError(reason.defect);
   }
-  return cause;
+  return new Error(Cause.pretty(cause));
 };
 
-type StagedDownloadFailure = { stage: ImportFailureStage; error: unknown };
+class StagedDownloadFailure extends Error {
+  readonly stage: ImportFailureStage;
 
-const isStagedDownloadFailure = (failure: unknown): failure is StagedDownloadFailure =>
-  typeof failure === "object" && failure !== null && "stage" in failure && "error" in failure;
+  constructor(stage: ImportFailureStage, cause: Error) {
+    super(cause.message, { cause });
+    this.name = "StagedDownloadFailure";
+    this.stage = stage;
+  }
+}
 
 const retryOutcomeFrom = (counts: {
   completedCount: number;
@@ -284,18 +288,20 @@ export const createPlaylistDownloadController = <Track extends PlaylistDownloadR
       }
 
       const downloadedFile = yield* deps.downloadTrack(track).pipe(
-        Effect.mapError(
-          (error): StagedDownloadFailure => ({
-            stage: importFailureStageFromDownloadError(error),
-            error,
-          }),
-        ),
+        Effect.mapError((error) => {
+          const failure = toPublicAudioError(error);
+          return new StagedDownloadFailure(importFailureStageFromDownloadError(failure), failure);
+        }),
       );
       if (currentRun !== run || !isCurrentExecution(run, track.fileId, execution)) return;
 
       yield* deps
         .hydrateTrack(track, downloadedFile)
-        .pipe(Effect.mapError((error): StagedDownloadFailure => ({ stage: "hydration", error })));
+        .pipe(
+          Effect.mapError(
+            (error) => new StagedDownloadFailure("hydration", toPublicAudioError(error)),
+          ),
+        );
       if (currentRun !== run || !isCurrentExecution(run, track.fileId, execution)) return;
 
       yield* Effect.sync(() => {
@@ -320,8 +326,11 @@ export const createPlaylistDownloadController = <Track extends PlaylistDownloadR
 
     if (Exit.isFailure(exit)) {
       const failure = firstCauseError(exit.cause);
-      const stagedFailure = isStagedDownloadFailure(failure) ? failure : undefined;
-      const error = stagedFailure?.error ?? failure;
+      const stagedFailure =
+        failure instanceof ImportStageError || failure instanceof StagedDownloadFailure
+          ? failure
+          : undefined;
+      const error = stagedFailure ? toPublicAudioError(stagedFailure.cause) : failure;
       if (trackWasRemoved) {
         notifyTrackSettled(run, { track, outcome: "canceled" }, retryAttemptId);
       } else if (Exit.hasInterrupts(exit) || isPlaylistDownloadAbort(error)) {

--- a/src/features/import/soundcloudSetImport.ts
+++ b/src/features/import/soundcloudSetImport.ts
@@ -6,6 +6,7 @@ import {
 } from "@/features/import/downloadTrack";
 import { applySoundCloudSetImportedCover } from "@/features/library/fileMetadataOps";
 import type { SoundCloudSet } from "@/features/import/soundcloudSet";
+import { toPublicAudioError } from "@/features/audio/audioErrors";
 import type { AppSettings, AudioMetadata, TagiumFile } from "@/features/library/types";
 
 interface SoundCloudSetImportDeps extends SoundCloudSetDownloadWorkflowDeps {
@@ -16,7 +17,7 @@ interface SoundCloudSetImportDeps extends SoundCloudSetDownloadWorkflowDeps {
   createId: () => string;
   fetchImportedCover: (coverUrl: string) => Promise<AudioMetadata["picture"]>;
   updateTags: (file: TagiumFile, metadata: AudioMetadata) => Promise<void>;
-  warn: (message: string, error: unknown) => void;
+  warn: (message: string, error: Error) => void;
   getSelectedFileId?: () => string | null;
   setSelectedMetadata?: (metadata: AudioMetadata) => void;
 }
@@ -82,7 +83,7 @@ const startSoundCloudSetCoverImport = (
       }
       await Promise.all(tagUpdates);
     } catch (error) {
-      deps.warn("failed to import album cover:", error);
+      deps.warn("failed to import album cover:", toPublicAudioError(error));
     }
   })();
 };

--- a/src/features/library/albumOps.ts
+++ b/src/features/library/albumOps.ts
@@ -85,7 +85,7 @@ export function mergeUploadedTracksIntoAlbums(
     return {
       albums: nextAlbums,
       firstSelectedAlbumId: createdAlbum.id,
-      unassignedTrackIds: [] as string[],
+      unassignedTrackIds: new Array<string>(),
       albumsToSync: syncTrackNumbers ? [createdAlbum.id] : [],
     };
   }
@@ -205,14 +205,14 @@ export function moveTrackInSidebar(
       return {
         albums: pruneEmptyAlbums(albums),
         looseTrackIds,
-        albumsToSync: [] as string[],
+        albumsToSync: new Array<string>(),
       };
     }
     if (target.placement !== "append" && target.referenceTrackId === trackId) {
       return {
         albums: pruneEmptyAlbums(albums),
         looseTrackIds,
-        albumsToSync: [] as string[],
+        albumsToSync: new Array<string>(),
       };
     }
     const insertIndex = resolveInsertIndex(
@@ -226,7 +226,7 @@ export function moveTrackInSidebar(
       return {
         albums: pruneEmptyAlbums(albums),
         looseTrackIds,
-        albumsToSync: [] as string[],
+        albumsToSync: new Array<string>(),
       };
     }
     const insertIndex = resolveInsertIndex(

--- a/src/features/library/fileMetadataOps.ts
+++ b/src/features/library/fileMetadataOps.ts
@@ -2,7 +2,6 @@ import filenamify from "filenamify";
 import { audioFilename, getAudioFormat } from "@/features/audio/audioFormat";
 import {
   EDITABLE_METADATA_FIELDS,
-  NULLABLE_NUMERIC_METADATA_FIELDS,
   validateAdvancedMetadataNumber,
 } from "@/features/audio/metadataFields";
 import type { Playlist } from "@/features/import/playlist";
@@ -32,33 +31,54 @@ interface ReconciledDownloadedTrackMetadata {
 const patchFields =
   EDITABLE_METADATA_FIELDS satisfies readonly DownloadedTrackWritableMetadataField[];
 
-const nullableNumericPatchFields = new Set<DownloadedTrackWritableMetadataField>(
-  NULLABLE_NUMERIC_METADATA_FIELDS,
-);
-
-const hasOwn = <Key extends PropertyKey>(object: object, key: Key) =>
-  Object.prototype.hasOwnProperty.call(object, key);
+const hasOwn = <Value extends object>(value: Value, key: PropertyKey) =>
+  Object.prototype.hasOwnProperty.call(value, key);
 
 export const sanitizePendingMetadataPatch = (
   patch: DownloadedTrackMetadataPatch,
   dropLegacyNumericFields = false,
 ): DownloadedTrackMetadataPatch | undefined => {
   const sanitized: DownloadedTrackMetadataPatch = {};
-  const writableSanitized = sanitized as Record<
-    DownloadedTrackWritableMetadataField,
-    MetadataPatch[DownloadedTrackWritableMetadataField]
-  >;
-
-  for (const field of patchFields) {
-    if (!hasOwn(patch, field) || patch[field] === undefined) continue;
-    if (
-      (field === "discNumber" || field === "bpm") &&
-      validateAdvancedMetadataNumber(field, patch[field] as number | null | undefined)
-    ) {
-      continue;
-    }
-    if (dropLegacyNumericFields && nullableNumericPatchFields.has(field)) continue;
-    writableSanitized[field] = patch[field];
+  if (hasOwn(patch, "filename") && patch.filename !== undefined) {
+    sanitized.filename = patch.filename;
+  }
+  if (hasOwn(patch, "title") && patch.title !== undefined) sanitized.title = patch.title;
+  if (hasOwn(patch, "artist") && patch.artist !== undefined) sanitized.artist = patch.artist;
+  if (hasOwn(patch, "albumArtist") && patch.albumArtist !== undefined) {
+    sanitized.albumArtist = patch.albumArtist;
+  }
+  if (hasOwn(patch, "album") && patch.album !== undefined) sanitized.album = patch.album;
+  if (!dropLegacyNumericFields && hasOwn(patch, "year") && patch.year !== undefined) {
+    sanitized.year = patch.year;
+  }
+  if (hasOwn(patch, "genre") && patch.genre !== undefined) sanitized.genre = patch.genre;
+  if (hasOwn(patch, "picture") && patch.picture !== undefined) {
+    sanitized.picture = patch.picture;
+  }
+  if (!dropLegacyNumericFields && hasOwn(patch, "trackNumber") && patch.trackNumber !== undefined) {
+    sanitized.trackNumber = patch.trackNumber;
+  }
+  if (hasOwn(patch, "composer") && patch.composer !== undefined) {
+    sanitized.composer = patch.composer;
+  }
+  if (hasOwn(patch, "comment") && patch.comment !== undefined) {
+    sanitized.comment = patch.comment;
+  }
+  if (
+    !dropLegacyNumericFields &&
+    hasOwn(patch, "discNumber") &&
+    patch.discNumber !== undefined &&
+    !validateAdvancedMetadataNumber("discNumber", patch.discNumber)
+  ) {
+    sanitized.discNumber = patch.discNumber;
+  }
+  if (
+    !dropLegacyNumericFields &&
+    hasOwn(patch, "bpm") &&
+    patch.bpm !== undefined &&
+    !validateAdvancedMetadataNumber("bpm", patch.bpm)
+  ) {
+    sanitized.bpm = patch.bpm;
   }
 
   return Object.keys(sanitized).length > 0 ? sanitized : undefined;
@@ -395,13 +415,18 @@ export function applyAlbumCoverToFiles(
   );
 }
 
+interface AlbumCoverApplication {
+  files: TagiumFile[];
+  selectedMetadata?: AudioMetadata;
+}
+
 export function applyAlbumCoverToFilesWithSelectedMetadata(
   files: TagiumFile[],
   trackIds: string[],
   cover: AudioMetadata["picture"],
   selectedFileId: string | null,
   settings?: MetadataPolicySettings,
-): { files: TagiumFile[]; selectedMetadata?: AudioMetadata } {
+): AlbumCoverApplication {
   const coveredFiles = applyAlbumCoverToFiles(files, trackIds, cover, settings);
   if (!selectedFileId) {
     return { files: coveredFiles };

--- a/src/features/library/metadataCleanup.ts
+++ b/src/features/library/metadataCleanup.ts
@@ -30,7 +30,12 @@ export interface MetadataCleanupUndoEntry {
   pendingFilename: { present: boolean; value?: string };
 }
 
-const hasOwn = <Key extends PropertyKey>(object: object, key: Key) =>
+interface MetadataCleanupApplication {
+  files: TagiumFile[];
+  undoEntries: MetadataCleanupUndoEntry[];
+}
+
+const hasOwn = <Value, Key extends PropertyKey>(object: Value, key: Key) =>
   Object.prototype.hasOwnProperty.call(object, key);
 
 const normalizeComparable = (value: string) =>
@@ -88,7 +93,7 @@ const removeTrailingNoise = (title: string, albumTitle?: string) => {
       annotation &&
       annotationValue !== undefined &&
       annotationRemainder &&
-      removableLabels.includes(normalizeComparable(annotationValue) as never)
+      removableLabels.some((label) => label === normalizeComparable(annotationValue))
     ) {
       nextTitle = annotationRemainder;
       removedLabel = true;
@@ -186,7 +191,7 @@ export function applyMetadataCleanupSuggestions(
   files: TagiumFile[],
   suggestions: MetadataCleanupSuggestion[],
   syncFilenames: boolean,
-): { files: TagiumFile[]; undoEntries: MetadataCleanupUndoEntry[] } {
+): MetadataCleanupApplication {
   const suggestionsById = new Map(
     suggestions.map((suggestion) => [suggestion.trackId, suggestion]),
   );
@@ -215,18 +220,20 @@ export function applyMetadataCleanupSuggestions(
     const pendingMetadataPatch: MetadataPatch = {
       ...file.pendingMetadataPatch,
       title: suggestion.afterTitle,
-      ...(syncFilenames ? { filename: sanitizeFilenameBase(suggestion.afterTitle) } : {}),
     };
+    if (syncFilenames) pendingMetadataPatch.filename = sanitizeFilenameBase(suggestion.afterTitle);
+
+    const metadata = {
+      ...file.metadata,
+      title: suggestion.afterTitle,
+    };
+    if (syncFilenames) metadata.filename = sanitizeFilenameBase(suggestion.afterTitle);
 
     return {
       ...file,
       status: file.status === "saved" ? "pending" : file.status,
       filename: syncFilenames ? suggestion.afterFilename : file.filename,
-      metadata: {
-        ...file.metadata,
-        title: suggestion.afterTitle,
-        ...(syncFilenames ? { filename: sanitizeFilenameBase(suggestion.afterTitle) } : {}),
-      },
+      metadata,
       pendingMetadataPatch,
       hasBufferedChanges: true,
     };

--- a/src/features/library/metadataLinks.ts
+++ b/src/features/library/metadataLinks.ts
@@ -142,18 +142,25 @@ export const withMetadataLinkEnabled = (
 
 export const getMetadataLinkState = (
   settings: Pick<AppSettings, "metadataLinks" | "syncTrackNumbers" | "syncFilenames">,
-): MetadataLinkState =>
-  Object.fromEntries(
-    METADATA_LINK_DESCRIPTORS.map((descriptor) => [
-      descriptor.id,
-      isMetadataLinkEnabled(settings, descriptor),
-    ]),
-  ) as MetadataLinkState;
+) =>
+  ({
+    artist: isMetadataLinkEnabled(settings, descriptorById.artist),
+    year: isMetadataLinkEnabled(settings, descriptorById.year),
+    genre: isMetadataLinkEnabled(settings, descriptorById.genre),
+    artwork: isMetadataLinkEnabled(settings, descriptorById.artwork),
+    trackNumber: isMetadataLinkEnabled(settings, descriptorById.trackNumber),
+    filename: isMetadataLinkEnabled(settings, descriptorById.filename),
+    singleAlbum: isMetadataLinkEnabled(settings, descriptorById.singleAlbum),
+    albumArtist: isMetadataLinkEnabled(settings, descriptorById.albumArtist),
+  }) satisfies MetadataLinkState;
 
-export const serializeMetadataLinkAnalytics = (state: MetadataLinkState) =>
-  Object.fromEntries(
-    METADATA_LINK_DESCRIPTORS.map((descriptor) => [
-      descriptor.analyticsProperty,
-      state[descriptor.id],
-    ]),
-  ) as Record<(typeof METADATA_LINK_DESCRIPTORS)[number]["analyticsProperty"], boolean>;
+export const serializeMetadataLinkAnalytics = (state: MetadataLinkState) => ({
+  link_artist: state.artist,
+  link_year: state.year,
+  link_genre: state.genre,
+  link_artwork: state.artwork,
+  sync_track_numbers: state.trackNumber,
+  sync_filenames: state.filename,
+  link_single_album: state.singleAlbum,
+  link_album_artist: state.albumArtist,
+});

--- a/src/features/library/sidebarDnd.ts
+++ b/src/features/library/sidebarDnd.ts
@@ -31,6 +31,7 @@ export const emptyLooseDropCollision = ({
   droppableRects,
   pointerCoordinates,
 }: Parameters<CollisionDetection>[0]): Collision[] | null => {
+  // SAFETY: every sidebar draggable registers SidebarDragData in dnd-kit's data.current slot.
   const activeData = active.data.current as SidebarDragData | undefined;
   if (activeData?.type !== "track" || !pointerCoordinates) return null;
 
@@ -39,12 +40,14 @@ export const emptyLooseDropCollision = ({
   if (!looseContainer || !looseRect) return null;
 
   const hasLooseTracks = droppableContainers.some(({ data }) => {
+    // SAFETY: every sidebar droppable registers SidebarDropData in dnd-kit's data.current slot.
     const dropData = data.current as SidebarDropData | undefined;
     return dropData?.type === "track" && dropData.container === "loose";
   });
   if (hasLooseTracks) return null;
 
   const firstAlbumTop = droppableContainers.reduce<number | null>((top, container) => {
+    // SAFETY: every container in this sidebar context is registered with SidebarDropData.
     const data = container.data.current as SidebarDropData | undefined;
     if (data?.type !== "album") return top;
     const rect = droppableRects.get(container.id);

--- a/src/features/library/useAlbumSidebarDragController.ts
+++ b/src/features/library/useAlbumSidebarDragController.ts
@@ -47,6 +47,7 @@ interface UseAlbumSidebarDragControllerOptions extends AlbumSidebarDragActions {
 }
 
 const dragStartY = (event: Event) => {
+  // SAFETY: dnd-kit activator events are mouse, pointer, or touch events; access stays guarded.
   const sourceEvent = event as Event & {
     changedTouches?: TouchList;
     clientY?: number;
@@ -115,13 +116,16 @@ export function useAlbumSidebarDragController(options: UseAlbumSidebarDragContro
   };
 
   const handleDragStart = (event: DragStartEvent) => {
+    // SAFETY: sidebar draggables exclusively register SidebarDragData with dnd-kit.
     setActiveDrag((event.active.data.current as SidebarDragData | undefined) ?? null);
     recentLooseTargetRef.current = null;
     dragStartYRef.current = dragStartY(event.activatorEvent);
   };
 
   const handleDragOver = (event: DragOverEvent) => {
+    // SAFETY: sidebar draggables exclusively register SidebarDragData with dnd-kit.
     const active = event.active.data.current as SidebarDragData | undefined;
+    // SAFETY: sidebar droppables exclusively register SidebarDropData with dnd-kit.
     const over = event.over?.data.current as SidebarDropData | undefined;
     if (active?.type !== "track" || active.container !== "loose") return;
     if (over?.type !== "track" || over.container !== "loose") return;
@@ -130,7 +134,9 @@ export function useAlbumSidebarDragController(options: UseAlbumSidebarDragContro
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
+    // SAFETY: sidebar draggables exclusively register SidebarDragData with dnd-kit.
     const active = event.active.data.current as SidebarDragData | undefined;
+    // SAFETY: sidebar droppables exclusively register SidebarDropData with dnd-kit.
     const over = event.over?.data.current as SidebarDropData | undefined;
     if (active && over && event.over) {
       runCommand(

--- a/src/features/settings/useWorkspaceSettings.ts
+++ b/src/features/settings/useWorkspaceSettings.ts
@@ -31,10 +31,8 @@ export const useWorkspaceSettings = ({
         previous.applySoundCloudAlbumCoverToTracks !==
           nextSettings.applySoundCloudAlbumCoverToTracks ||
         previous.advancedMetadata !== nextSettings.advancedMetadata ||
-        Object.keys(previous.metadataLinks).some(
-          (key) =>
-            previous.metadataLinks[key as keyof typeof previous.metadataLinks] !==
-            nextSettings.metadataLinks[key as keyof typeof nextSettings.metadataLinks],
+        Object.values(previous.metadataLinks).some(
+          (enabled, index) => enabled !== Object.values(nextSettings.metadataLinks)[index],
         );
       const saved = saveAppSettings(nextSettings);
       setSettings(nextSettings);

--- a/src/features/share/revocationReceipt.ts
+++ b/src/features/share/revocationReceipt.ts
@@ -1,3 +1,5 @@
+import { Option, Schema } from "effect";
+
 const STORAGE_KEY = "tagium.share-revocations.v1";
 
 export interface LocalRevocationReceipt {
@@ -6,19 +8,25 @@ export interface LocalRevocationReceipt {
   token: string;
 }
 
+const localRevocationReceiptSchema = Schema.Struct({
+  slug: Schema.String,
+  expiresAt: Schema.String,
+  token: Schema.String,
+});
+const storedReceiptListSchema = Schema.Array(Schema.Unknown);
+
 const parseReceipts = (value: string | null): LocalRevocationReceipt[] => {
   if (!value) return [];
   try {
-    const input: unknown = JSON.parse(value);
-    if (!Array.isArray(input)) return [];
-    return input.filter(
-      (entry): entry is LocalRevocationReceipt =>
-        typeof entry === "object" &&
-        entry !== null &&
-        typeof entry.slug === "string" &&
-        typeof entry.expiresAt === "string" &&
-        typeof entry.token === "string",
-    );
+    const storedEntries = Schema.decodeUnknownOption(storedReceiptListSchema)(JSON.parse(value));
+    if (Option.isNone(storedEntries)) return [];
+
+    const receipts: LocalRevocationReceipt[] = [];
+    for (const entry of storedEntries.value) {
+      const receipt = Schema.decodeUnknownOption(localRevocationReceiptSchema)(entry);
+      if (Option.isSome(receipt)) receipts.push(receipt.value);
+    }
+    return receipts;
   } catch {
     return [];
   }

--- a/src/features/share/shareClient.ts
+++ b/src/features/share/shareClient.ts
@@ -1,9 +1,11 @@
 import {
   decodeManifest,
-  isShareAnalyticsId,
   MANIFEST_VERSION,
+  manifestSchema,
+  shareAnalyticsIdSchema,
   type Manifest,
 } from "@/features/share/shareManifest";
+import { Option, Schema } from "effect";
 
 const UNAVAILABLE_MESSAGE = "this share is no longer available";
 const SHARE_METADATA_TOO_LARGE_MESSAGE = "this share contains too much metadata to publish.";
@@ -46,6 +48,27 @@ const readJson = async (response: Response) => {
   }
 };
 
+const manifestVersionProbeSchema = Schema.Struct({
+  manifest: Schema.Struct({ version: Schema.Number }),
+});
+const sharedContentResponseSchema = Schema.Struct({
+  manifest: manifestSchema,
+  expiresAt: Schema.String,
+  analyticsId: shareAnalyticsIdSchema,
+});
+const createShareReceiptSchema = Schema.Struct({
+  slug: Schema.String,
+  url: Schema.String,
+  expiresAt: Schema.String,
+  revocationToken: Schema.String,
+  analyticsId: shareAnalyticsIdSchema,
+});
+const updateShareReceiptSchema = Schema.Struct({
+  slug: Schema.String,
+  url: Schema.String,
+  expiresAt: Schema.String,
+});
+
 export interface FetchedSharedContent {
   manifest: Manifest;
   expiresAt: string;
@@ -64,29 +87,15 @@ export const fetchSharedContent = async (
 
   try {
     const payload = await readJson(response);
-    if (
-      typeof payload !== "object" ||
-      payload === null ||
-      !("manifest" in payload) ||
-      !("expiresAt" in payload) ||
-      typeof payload.expiresAt !== "string" ||
-      !("analyticsId" in payload) ||
-      !isShareAnalyticsId(payload.analyticsId)
-    ) {
-      throw new SharedContentUnavailableError();
-    }
-    if (
-      typeof payload.manifest === "object" &&
-      payload.manifest !== null &&
-      "version" in payload.manifest &&
-      payload.manifest.version !== MANIFEST_VERSION
-    ) {
+    const versionProbe = Schema.decodeUnknownOption(manifestVersionProbeSchema)(payload);
+    if (Option.isSome(versionProbe) && versionProbe.value.manifest.version !== MANIFEST_VERSION) {
       throw new SharedContentVersionError();
     }
+    const decoded = Schema.decodeUnknownSync(sharedContentResponseSchema)(payload);
     return {
-      manifest: decodeManifest(payload.manifest),
-      expiresAt: payload.expiresAt,
-      analyticsId: payload.analyticsId,
+      manifest: decodeManifest(decoded.manifest),
+      expiresAt: decoded.expiresAt,
+      analyticsId: decoded.analyticsId,
     };
   } catch (error) {
     if (error instanceof SharedContentVersionError) throw error;
@@ -134,19 +143,11 @@ export const publishShare = async (
     if (response.status === 429) throw new Error("too many share requests; try again shortly");
     throw new Error("the share link could not be created");
   }
-  const receipt = await readJson(response);
-  if (
-    typeof receipt !== "object" ||
-    receipt === null ||
-    typeof receipt.slug !== "string" ||
-    typeof receipt.url !== "string" ||
-    typeof receipt.expiresAt !== "string" ||
-    typeof receipt.revocationToken !== "string" ||
-    !isShareAnalyticsId(receipt.analyticsId)
-  ) {
+  try {
+    return Schema.decodeUnknownSync(createShareReceiptSchema)(await readJson(response));
+  } catch {
     throw new Error("the share link could not be created");
   }
-  return receipt as CreatedSharePublicationReceipt;
 };
 
 export const updateShare = async (
@@ -174,17 +175,11 @@ export const updateShare = async (
     if (response.status === 429) throw new Error("too many update requests; try again shortly");
     throw new Error(`the shared ${manifest.kind} could not be updated`);
   }
-  const receipt = await readJson(response);
-  if (
-    typeof receipt !== "object" ||
-    receipt === null ||
-    typeof receipt.slug !== "string" ||
-    typeof receipt.url !== "string" ||
-    typeof receipt.expiresAt !== "string"
-  ) {
+  try {
+    return Schema.decodeUnknownSync(updateShareReceiptSchema)(await readJson(response));
+  } catch {
     throw new Error(`the shared ${manifest.kind} could not be updated`);
   }
-  return receipt as ShareUpdateReceipt;
 };
 
 export const revokeShare = async (

--- a/src/features/share/shareLink.ts
+++ b/src/features/share/shareLink.ts
@@ -9,7 +9,7 @@ export type ShareLinkClassification =
 
 export const classifyShareLink = (
   value: string,
-  currentOrigin = typeof location === "undefined" ? "" : location.origin,
+  currentOrigin = globalThis.location?.origin ?? "",
 ): ShareLinkClassification => {
   let url: URL;
   try {
@@ -39,7 +39,7 @@ export const shareSlugFromPathname = (pathname: string) => {
 
 export const shareLinkForSlug = (
   slug: string,
-  origin = typeof location === "undefined" ? "https://tagium.app" : location.origin,
+  origin = globalThis.location?.origin ?? "https://tagium.app",
 ) => new URL(`/share/${slug}`, origin).toString();
 
 export class InvalidShareLinkError extends Error {

--- a/src/features/share/shareManifest.ts
+++ b/src/features/share/shareManifest.ts
@@ -113,6 +113,9 @@ export const manifestTracks = (manifest: Manifest): readonly ManifestTrack[] =>
 export const manifestTrackCount = (manifest: Manifest) => manifestTracks(manifest).length;
 
 export const SHARE_ANALYTICS_ID_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+export const shareAnalyticsIdSchema = Schema.String.check(
+  Schema.isPattern(SHARE_ANALYTICS_ID_PATTERN),
+);
 export const isShareAnalyticsId = (value: unknown): value is string =>
   typeof value === "string" && SHARE_ANALYTICS_ID_PATTERN.test(value);
 
@@ -133,6 +136,12 @@ export interface ShareManifestResponse {
 
 export const toShareExpiryIso = (expiresAt: number) => new Date(expiresAt).toISOString();
 
+export const shareExpiryIsoSchema = Schema.String.pipe(
+  Schema.refine(
+    (value): value is string =>
+      Number.isFinite(Date.parse(value)) && new Date(value).toISOString() === value,
+  ),
+);
 export const isShareExpiryIso = (value: unknown): value is string =>
   typeof value === "string" &&
   Number.isFinite(Date.parse(value)) &&
@@ -145,8 +154,9 @@ export const isManifestPayloadWithinLimit = (manifest: Manifest) =>
   manifestPayloadBytes(manifest) <= MAX_MANIFEST_PAYLOAD_BYTES;
 
 /** Decodes only the supported version and rejects an oversized persisted payload. */
+const decodeManifestInput = Schema.decodeUnknownSync(manifestSchema);
 export const decodeManifest = (input: unknown): Manifest => {
-  const manifest = Schema.decodeUnknownSync(manifestSchema)(input);
+  const manifest = decodeManifestInput(input);
   if (!isManifestPayloadWithinLimit(manifest)) {
     throw new Error(`manifest payload must be ${MAX_MANIFEST_PAYLOAD_BYTES} bytes or smaller`);
   }
@@ -181,29 +191,32 @@ export const toManifestReplayInput = (
   options: { sourceManifestSlug?: string } = {},
 ): ManifestReplayInput => {
   if (manifest.kind !== "album") throw new Error("track manifests cannot replay as albums");
-  return {
-    ...(options.sourceManifestSlug === undefined
-      ? {}
-      : { sourceManifestSlug: options.sourceManifestSlug }),
-    playlist: {
-      title: manifest.album.title,
-      artist: manifest.album.artist,
-      genre: manifest.album.genre,
-      ...(manifest.album.year === undefined ? {} : { year: manifest.album.year }),
-      ...(manifest.album.sourceUrl === undefined ? {} : { sourceUrl: manifest.album.sourceUrl }),
-      isAlbum: true,
-      tracks: manifest.tracks.map((track) => ({
-        title: track.metadata.title,
-        url: track.sourceUrl,
-        trackNumber: track.metadata.trackNumber ?? 1,
-      })),
-    },
+  const playlist: ManifestReplayInput["playlist"] = {
+    title: manifest.album.title,
+    artist: manifest.album.artist,
+    genre: manifest.album.genre,
+    isAlbum: true,
+    tracks: manifest.tracks.map((track) => ({
+      title: track.metadata.title,
+      url: track.sourceUrl,
+      trackNumber: track.metadata.trackNumber ?? 1,
+    })),
+  };
+  if (manifest.album.year !== undefined) playlist.year = manifest.album.year;
+  if (manifest.album.sourceUrl !== undefined) playlist.sourceUrl = manifest.album.sourceUrl;
+
+  const replay: ManifestReplayInput = {
+    playlist,
     tracks: manifest.tracks.map((track) => ({
       sourceUrl: track.sourceUrl,
       audioBitrate: track.audioBitrate,
       metadata: track.metadata,
     })),
   };
+  if (options.sourceManifestSlug !== undefined) {
+    replay.sourceManifestSlug = options.sourceManifestSlug;
+  }
+  return replay;
 };
 
 /** Projects current effective (including buffered) library metadata into a v1 manifest. */
@@ -247,57 +260,78 @@ export interface ManifestTrackProjection {
   downloadRequest?: { sourceUrl: string; audioBitrate: ManifestAudioBitrate };
 }
 
+interface ProjectedTrackMetadata {
+  filename: string;
+  title: string;
+  artist: string;
+  album: string;
+  genre: string;
+  year?: number;
+  trackNumber?: number;
+}
+interface ProjectedManifestTrack extends ManifestTrack {
+  artwork?: ManifestArtwork;
+}
+
 export const projectManifestTrack = (file: ManifestTrackProjection): ManifestTrack => {
   if (!file.downloadRequest || !file.metadata) {
     throw new Error("only downloaded-source tracks with metadata can be shared");
   }
   const metadata = { ...file.metadata, ...file.pendingMetadataPatch };
+  const projectedMetadata: ProjectedTrackMetadata = {
+    filename: metadata.filename || file.filename.replace(/\.mp3$/i, ""),
+    title: metadata.title,
+    artist: metadata.artist,
+    album: metadata.album,
+    genre: typeof metadata.genre === "string" ? metadata.genre : metadata.genre.join(", "),
+  };
+  if (metadata.year !== null) projectedMetadata.year = metadata.year;
+  if (metadata.trackNumber !== null) projectedMetadata.trackNumber = metadata.trackNumber;
   return {
     sourceUrl:
       supportedProvenance(file.downloadRequest.sourceUrl) ?? file.downloadRequest.sourceUrl,
     audioBitrate: file.downloadRequest.audioBitrate,
-    metadata: {
-      filename: metadata.filename || file.filename.replace(/\.mp3$/i, ""),
-      title: metadata.title,
-      artist: metadata.artist,
-      album: metadata.album,
-      genre: typeof metadata.genre === "string" ? metadata.genre : metadata.genre.join(", "),
-      ...(metadata.year === null ? {} : { year: metadata.year }),
-      ...(metadata.trackNumber === null ? {} : { trackNumber: metadata.trackNumber }),
-    },
+    metadata: projectedMetadata,
   };
 };
 
 export const projectTrackManifest = (
   file: ManifestTrackProjection,
   artwork?: ManifestArtwork,
-): TrackManifest =>
-  decodeManifest({
+): TrackManifest => {
+  const track: ProjectedManifestTrack = {
+    ...projectManifestTrack(file),
+  };
+  if (artwork !== undefined) track.artwork = artwork;
+  const manifest = decodeManifest({
     version: MANIFEST_VERSION,
     kind: "track",
-    track: {
-      ...projectManifestTrack(file),
-      ...(artwork === undefined ? {} : { artwork }),
-    },
-  }) as TrackManifest;
+    track,
+  });
+  if (manifest.kind !== "track") throw new Error("projected track manifest had the wrong kind");
+  return manifest;
+};
 
 export const projectAlbumManifest = (
   album: ManifestAlbumProjection,
   files: readonly ManifestTrackProjection[],
   artwork?: ManifestArtwork,
-): AlbumManifest =>
-  decodeManifest({
+): AlbumManifest => {
+  const projectedAlbum: ManifestAlbumProjection & { artwork?: ManifestArtwork } = {
+    title: album.title,
+    artist: album.artist,
+    genre: album.genre,
+  };
+  if (album.year !== undefined) projectedAlbum.year = album.year;
+  const sourceUrl = supportedProvenance(album.sourceUrl);
+  if (sourceUrl !== undefined) projectedAlbum.sourceUrl = sourceUrl;
+  if (artwork !== undefined) projectedAlbum.artwork = artwork;
+  const manifest = decodeManifest({
     version: MANIFEST_VERSION,
     kind: "album",
-    album: {
-      title: album.title,
-      artist: album.artist,
-      genre: album.genre,
-      ...(album.year === undefined ? {} : { year: album.year }),
-      ...(supportedProvenance(album.sourceUrl) === undefined
-        ? {}
-        : { sourceUrl: supportedProvenance(album.sourceUrl) }),
-      ...(artwork === undefined ? {} : { artwork }),
-    },
+    album: projectedAlbum,
     tracks: files.map(projectManifestTrack),
-  }) as AlbumManifest;
+  });
+  if (manifest.kind !== "album") throw new Error("projected album manifest had the wrong kind");
+  return manifest;
+};

--- a/src/features/share/sharePresence.ts
+++ b/src/features/share/sharePresence.ts
@@ -1,20 +1,30 @@
+import { Option, Schema } from "effect";
+
 const CHANNEL_NAME = "tagium-workspace-presence-v1";
 const TAB_ID = crypto.randomUUID();
 
+const presenceMessageSchema = Schema.Struct({
+  type: Schema.optionalKey(Schema.String),
+  from: Schema.optionalKey(Schema.String),
+  to: Schema.optionalKey(Schema.String),
+});
+
 export const detectAnotherTagiumTab = (waitMs = 180) =>
   new Promise<boolean>((resolve) => {
-    if (typeof BroadcastChannel === "undefined") {
+    if (!globalThis.BroadcastChannel) {
       resolve(false);
       return;
     }
-    const channel = new BroadcastChannel(CHANNEL_NAME);
+    const channel = new globalThis.BroadcastChannel(CHANNEL_NAME);
     let found = false;
     const finish = () => {
       channel.close();
       resolve(found);
     };
     channel.onmessage = (event) => {
-      const message = event.data as { type?: string; from?: string; to?: string };
+      const decoded = Schema.decodeUnknownOption(presenceMessageSchema)(event.data);
+      if (Option.isNone(decoded)) return;
+      const message = decoded.value;
       if (message.type !== "present" || message.to !== TAB_ID || message.from === TAB_ID) return;
       found = true;
       finish();
@@ -24,10 +34,12 @@ export const detectAnotherTagiumTab = (waitMs = 180) =>
   });
 
 export const listenForTagiumPresence = () => {
-  if (typeof BroadcastChannel === "undefined") return () => undefined;
-  const channel = new BroadcastChannel(CHANNEL_NAME);
+  if (!globalThis.BroadcastChannel) return () => undefined;
+  const channel = new globalThis.BroadcastChannel(CHANNEL_NAME);
   channel.onmessage = (event) => {
-    const message = event.data as { type?: string; from?: string };
+    const decoded = Schema.decodeUnknownOption(presenceMessageSchema)(event.data);
+    if (Option.isNone(decoded)) return;
+    const message = decoded.value;
     if (message.type === "presence?" && message.from && message.from !== TAB_ID) {
       channel.postMessage({ type: "present", from: TAB_ID, to: message.from });
     }

--- a/src/features/share/sharePreview.ts
+++ b/src/features/share/sharePreview.ts
@@ -1,4 +1,3 @@
-import type { AudioMetadata } from "@/features/audio/metadata";
 import type { AlbumGroup, TagiumFile } from "@/features/library/types";
 
 export interface SharePreviewTrack {
@@ -20,8 +19,6 @@ export interface SharePreview {
   cover: SharePreviewCover | null;
 }
 
-type Picture = AudioMetadata["picture"][number];
-
 /** Build the small, display-only snapshot retained by the sharing dialog. */
 export const buildShareAlbumPreview = (
   album: Pick<AlbumGroup, "title" | "trackIds" | "cover">,
@@ -36,7 +33,7 @@ export const buildShareAlbumPreview = (
     return { key: `${trackId}:${occurrence}`, title };
   });
 
-  const first = album.cover?.[0] as Picture | undefined;
+  const first = album.cover?.[0];
   const cover = first?.data?.byteLength
     ? {
         format: first.format,
@@ -62,7 +59,7 @@ export const buildShareTrackPreview = (
 ): SharePreview => {
   const metadata = file.metadata ? { ...file.metadata, ...file.pendingMetadataPatch } : undefined;
   const title = metadata?.title?.trim() || metadata?.filename?.trim() || file.filename;
-  const first = metadata?.picture?.[0] as Picture | undefined;
+  const first = metadata?.picture?.[0];
   const cover = first?.data?.byteLength
     ? {
         format: first.format,

--- a/src/features/share/sharePublication.ts
+++ b/src/features/share/sharePublication.ts
@@ -4,6 +4,7 @@ import type {
   SharePublication,
   TagiumFile,
 } from "@/features/library/types";
+import { Schema } from "effect";
 import {
   projectAlbumManifest,
   projectTrackManifest,
@@ -11,9 +12,21 @@ import {
   type ManifestArtwork,
 } from "@/features/share/shareManifest";
 
-const canonicalJson = (value: unknown): string => {
+type CanonicalJson =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly CanonicalJson[]
+  | { readonly [key: string]: CanonicalJson };
+const isCanonicalPrimitive = Schema.is(
+  Schema.Union([Schema.String, Schema.Number, Schema.Boolean, Schema.Null]),
+);
+const isSupportedArtworkFormat = Schema.is(Schema.Literals(["image/jpeg", "image/png"]));
+
+const canonicalJson = (value: CanonicalJson): string => {
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
-  if (value && typeof value === "object") {
+  if (!isCanonicalPrimitive(value)) {
     return `{${Object.entries(value)
       .sort(([left], [right]) => left.localeCompare(right))
       .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
@@ -45,10 +58,10 @@ export interface ShareSnapshot {
 }
 
 const projectArtwork = (firstPicture: AudioMetadata["picture"][number] | undefined) => {
+  const supportedFormat =
+    firstPicture && isSupportedArtworkFormat(firstPicture.format) ? firstPicture.format : undefined;
   const supportedPicture =
-    firstPicture && (firstPicture.format === "image/jpeg" || firstPicture.format === "image/png")
-      ? { ...firstPicture, format: firstPicture.format as "image/jpeg" | "image/png" }
-      : undefined;
+    firstPicture && supportedFormat ? { ...firstPicture, format: supportedFormat } : undefined;
   const artwork: ManifestArtwork | undefined = supportedPicture
     ? {
         kind: "stored",

--- a/src/features/share/sharePublicationError.ts
+++ b/src/features/share/sharePublicationError.ts
@@ -9,8 +9,7 @@ const userFacingMessages = new Set([
 ]);
 
 /** Converts implementation-level publish failures into copy safe for the share dialog. */
-export const sharePublicationErrorMessage = (error: unknown, kind: "album" | "track" = "album") => {
-  if (!(error instanceof Error)) return "the share link could not be created";
+export const sharePublicationErrorMessage = (error: Error, kind: "album" | "track" = "album") => {
   if (metadataContractError(error.message))
     return `this ${kind} contains too much metadata to share.`;
   if (error.message === "only downloaded-source tracks with metadata can be shared") {

--- a/src/features/share/sharedAlbumDownload.ts
+++ b/src/features/share/sharedAlbumDownload.ts
@@ -25,6 +25,11 @@ const restoreSharedTrack = (
 ) => {
   const metadata = track.metadata;
   const picture = hasSharedArtwork && cover?.length ? cover : [];
+  const downloadRequest: SingleUrlDownloadPlan["pendingFiles"][number]["downloadRequest"] = {
+    sourceUrl: track.sourceUrl,
+    audioBitrate: track.audioBitrate,
+  };
+  if (metadata.year !== undefined) downloadRequest.year = metadata.year;
   return {
     ...file,
     filename: `${metadata.filename}.mp3`,
@@ -35,11 +40,7 @@ const restoreSharedTrack = (
       trackNumber: metadata.trackNumber ?? null,
       picture,
     },
-    downloadRequest: {
-      sourceUrl: track.sourceUrl,
-      audioBitrate: track.audioBitrate,
-      ...(metadata.year === undefined ? {} : { year: metadata.year }),
-    },
+    downloadRequest,
     pendingMetadataPatch: {
       ...metadata,
       picture,
@@ -75,6 +76,16 @@ export const createSharedAlbumDownloadPlan = (
       cover,
     );
   });
+  const album = {
+    ...plan.album,
+    title: manifest.album.title,
+    artist: manifest.album.artist,
+    genre: manifest.album.genre,
+    sourceManifestSlug,
+  };
+  if (manifest.album.year !== undefined) album.year = manifest.album.year;
+  if (manifest.album.sourceUrl !== undefined) album.sourceUrl = manifest.album.sourceUrl;
+  if (cover?.length) album.cover = cover;
 
   return {
     ...plan,
@@ -84,16 +95,7 @@ export const createSharedAlbumDownloadPlan = (
       title: file.metadata.title || file.filename.replace(/\.mp3$/i, ""),
       downloadRequest: file.downloadRequest,
     })),
-    album: {
-      ...plan.album,
-      title: manifest.album.title,
-      artist: manifest.album.artist,
-      genre: manifest.album.genre,
-      ...(manifest.album.year === undefined ? {} : { year: manifest.album.year }),
-      ...(manifest.album.sourceUrl === undefined ? {} : { sourceUrl: manifest.album.sourceUrl }),
-      ...(cover?.length ? { cover } : {}),
-      sourceManifestSlug,
-    },
+    album,
   };
 };
 

--- a/src/features/share/useShareWorkflow.ts
+++ b/src/features/share/useShareWorkflow.ts
@@ -205,6 +205,7 @@ export const useShareWorkflow = ({
         try {
           const snapshot = await projectAlbumShareSnapshot(
             album,
+            // SAFETY: the preceding guard rejects every missing file entry.
             files as NonNullable<(typeof files)[number]>[],
           );
           return [album.id, snapshot.fingerprint] as const;
@@ -477,13 +478,17 @@ export const useShareWorkflow = ({
           ? (
               await projectAlbumShareSnapshot(
                 album,
+                // SAFETY: the preceding guard rejects every missing album file entry.
                 albumFiles as NonNullable<(typeof albumFiles)[number]>[],
               )
             ).fingerprint
           : (await projectTrackShareSnapshot(file!)).fingerprint;
       } catch (error) {
         toast.error(`this ${target.kind} cannot be shared`, {
-          description: sharePublicationErrorMessage(error, target.kind),
+          description: sharePublicationErrorMessage(
+            error instanceof Error ? error : new Error("unknown share publication failure"),
+            target.kind,
+          ),
         });
         return;
       }
@@ -669,7 +674,10 @@ export const useShareWorkflow = ({
         });
       }
     } catch (error) {
-      const createError = sharePublicationErrorMessage(error, target.kind).replace(/[.!?]+$/, "");
+      const createError = sharePublicationErrorMessage(
+        error instanceof Error ? error : new Error("unknown share publication failure"),
+        target.kind,
+      ).replace(/[.!?]+$/, "");
       setDialog({
         status: "error",
         preview: currentDialog.preview,

--- a/src/features/theme/theme.ts
+++ b/src/features/theme/theme.ts
@@ -5,7 +5,7 @@ export type Theme = "light" | "dark";
 const isTheme = (value: string | null): value is Theme => value === "light" || value === "dark";
 
 export const resolveInitialTheme = (): Theme => {
-  if (typeof window === "undefined") return "dark";
+  if (!("window" in globalThis)) return "dark";
 
   try {
     const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);

--- a/src/features/workspace/drawerSwipe.ts
+++ b/src/features/workspace/drawerSwipe.ts
@@ -41,7 +41,7 @@ export const shouldStartDrawerSwipe = (
   )
     return false;
   if (
-    typeof Element !== "undefined" &&
+    "Element" in globalThis &&
     target instanceof Element &&
     (target.closest(
       "[data-drawer-swipe-optout], input, textarea, select, [contenteditable='true']",

--- a/src/features/workspace/mobileWorkspaceNavigation.ts
+++ b/src/features/workspace/mobileWorkspaceNavigation.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-export type WorkspaceNavigationState = {
-  workspaceNav?: { kind: "drawer" | "view"; value: "open" | "editor" | "settings" };
-  [key: string]: unknown;
+type WorkspaceNavigation = {
+  kind: "drawer" | "view";
+  value: "open" | "editor" | "settings";
 };
 
-type WorkspaceNavigation = NonNullable<WorkspaceNavigationState["workspaceNav"]>;
+export type WorkspaceNavigationState = object & { workspaceNav?: WorkspaceNavigation };
 
 const isObjectState = (state: unknown): state is object =>
   typeof state === "object" && state !== null;
@@ -31,10 +31,11 @@ export const workspaceHistoryState = (
   state: unknown,
   kind: "drawer" | "view",
   value: "open" | "editor" | "settings",
-): WorkspaceNavigationState => ({
-  ...(isObjectState(state) ? state : {}),
-  workspaceNav: { kind, value },
-});
+): WorkspaceNavigationState => {
+  const nextState: WorkspaceNavigationState = isObjectState(state) ? { ...state } : {};
+  nextState.workspaceNav = { kind, value };
+  return nextState;
+};
 
 export const useMobileWorkspaceNavigation = ({
   activeView,

--- a/src/features/workspace/mobileWorkspaceNavigation.ts
+++ b/src/features/workspace/mobileWorkspaceNavigation.ts
@@ -5,22 +5,34 @@ export type WorkspaceNavigationState = {
   [key: string]: unknown;
 };
 
-export const isWorkspaceNavigationState = (state: unknown): state is WorkspaceNavigationState => {
-  if (!state || typeof state !== "object") return false;
-  const nav = (state as WorkspaceNavigationState).workspaceNav;
-  return Boolean(
-    nav &&
-    (nav.kind === "drawer" || nav.kind === "view") &&
-    (nav.value === "open" || nav.value === "editor" || nav.value === "settings"),
+type WorkspaceNavigation = NonNullable<WorkspaceNavigationState["workspaceNav"]>;
+
+const isObjectState = (state: unknown): state is object =>
+  typeof state === "object" && state !== null;
+
+const isWorkspaceNavigation = (navigation: unknown): navigation is WorkspaceNavigation => {
+  if (navigation === null || (typeof navigation !== "object" && typeof navigation !== "function")) {
+    return false;
+  }
+  return (
+    "kind" in navigation &&
+    "value" in navigation &&
+    (navigation.kind === "drawer" || navigation.kind === "view") &&
+    (navigation.value === "open" ||
+      navigation.value === "editor" ||
+      navigation.value === "settings")
   );
 };
+
+export const isWorkspaceNavigationState = (state: unknown): state is WorkspaceNavigationState =>
+  isObjectState(state) && "workspaceNav" in state && isWorkspaceNavigation(state.workspaceNav);
 
 export const workspaceHistoryState = (
   state: unknown,
   kind: "drawer" | "view",
   value: "open" | "editor" | "settings",
 ): WorkspaceNavigationState => ({
-  ...(state && typeof state === "object" ? state : {}),
+  ...(isObjectState(state) ? state : {}),
   workspaceNav: { kind, value },
 });
 
@@ -50,9 +62,9 @@ export const useMobileWorkspaceNavigation = ({
   useEffect(() => {
     mobileRef.current = isMobile;
     if (!isMobile && drawerOpen) {
-      const state = (
-        history.state && typeof history.state === "object" ? { ...history.state } : {}
-      ) as WorkspaceNavigationState;
+      const state: WorkspaceNavigationState = isObjectState(history.state)
+        ? { ...history.state }
+        : {};
       delete state.workspaceNav;
       history.replaceState(state, "", location.href);
       currentWorkspaceNavRef.current = undefined;
@@ -74,7 +86,7 @@ export const useMobileWorkspaceNavigation = ({
       else if (
         !nav &&
         previousNav?.kind === "view" &&
-        !(event.state && typeof event.state === "object" && "shareSlug" in event.state)
+        !(isObjectState(event.state) && "shareSlug" in event.state)
       ) {
         setActiveView("editor");
       }

--- a/src/features/workspace/systemFailure.ts
+++ b/src/features/workspace/systemFailure.ts
@@ -140,15 +140,15 @@ const FALLBACKS = {
   Pick<SystemFailurePresentation, "title" | "description" | "trackDescription">
 >;
 
-const errorMessage = (error: unknown) => {
-  if (error instanceof Error) return error.message;
+const errorMessage = (cause: unknown) => {
+  if (cause instanceof Error) return cause.message;
   if (
-    typeof error === "object" &&
-    error !== null &&
-    "message" in error &&
-    typeof error.message === "string"
+    typeof cause === "object" &&
+    cause !== null &&
+    "message" in cause &&
+    typeof cause.message === "string"
   ) {
-    return error.message;
+    return cause.message;
   }
   return "";
 };
@@ -206,12 +206,12 @@ const knownDownloadFailureFrom = (message: string): SystemFailurePresentation | 
 };
 
 export const getSystemFailurePresentation = (
-  error: unknown,
+  cause: unknown,
   context: SystemFailureContext,
 ): SystemFailurePresentation => {
   const known =
     context === "download" || context === "import"
-      ? knownDownloadFailureFrom(errorMessage(error))
+      ? knownDownloadFailureFrom(errorMessage(cause))
       : null;
   if (known) return known;
 
@@ -225,10 +225,10 @@ export const getSystemFailurePresentation = (
 };
 
 export const reportSystemFailure = (
-  error: unknown,
+  cause: unknown,
   context: SystemFailureContext,
 ): SystemFailurePresentation => {
-  const presentation = getSystemFailurePresentation(error, context);
+  const presentation = getSystemFailurePresentation(cause, context);
 
   if (context === "download") {
     const now = Date.now();

--- a/src/features/workspace/useAudioTaggerMobileNavigation.ts
+++ b/src/features/workspace/useAudioTaggerMobileNavigation.ts
@@ -102,7 +102,8 @@ export const useAudioTaggerMobileNavigation = ({
       if (event.key !== "Tab" || !drawer) return;
       const items = getItems();
       if (!items.length) return;
-      const index = items.indexOf(document.activeElement as HTMLElement);
+      const index =
+        document.activeElement instanceof HTMLElement ? items.indexOf(document.activeElement) : -1;
       const next = event.shiftKey
         ? index <= 0
           ? items.length - 1

--- a/src/features/workspace/useWorkspaceAlbumDialog.ts
+++ b/src/features/workspace/useWorkspaceAlbumDialog.ts
@@ -20,6 +20,7 @@ import type { DestructiveActionDialogProps } from "@/features/workspace/Destruct
 import type { TagSidebarPanelProps } from "@/features/library/TagSidebarPanel";
 import type { TrackEditorSession } from "@/features/editor/useTrackEditorSession";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
+import type { LibraryAction } from "@/features/library/libraryState";
 import type { AppSettings } from "@/features/library/types";
 
 type AlbumEditor = {
@@ -32,6 +33,12 @@ type AlbumSidebarProps = Pick<
   "onAddAlbum" | "onEditAlbum" | "onDeleteAlbum" | "onPromptCreateAlbumFromLooseTracks"
 >;
 
+interface WorkspaceAlbumDialogBindings {
+  dialogProps: AlbumMetadataDialogProps;
+  deletionDialogProps: DestructiveActionDialogProps;
+  sidebarProps: AlbumSidebarProps;
+}
+
 export const useWorkspaceAlbumDialog = ({
   library,
   editor,
@@ -42,11 +49,7 @@ export const useWorkspaceAlbumDialog = ({
   editor: AlbumEditor;
   settings: AppSettings;
   removeDownloads: (trackIds: string[]) => void;
-}): {
-  dialogProps: AlbumMetadataDialogProps;
-  deletionDialogProps: DestructiveActionDialogProps;
-  sidebarProps: AlbumSidebarProps;
-} => {
+}): WorkspaceAlbumDialogBindings => {
   const [dialog, dispatchDialog] = useReducer(
     albumDialogReducer,
     undefined,
@@ -178,20 +181,19 @@ export const useWorkspaceAlbumDialog = ({
         });
       }
     }
-    library.dispatch({
+    const replacement: Extract<LibraryAction, { type: "content-replaced" }> = {
       type: "content-replaced",
       files: finalFiles,
       albums: created.albums,
       looseTrackIds: created.looseTrackIds,
-      ...(created.newAlbumId
-        ? {
-            selection: {
-              selectedAlbumId: created.newAlbumId,
-              selectedFileId: submission.seedTrackIds[0] ?? null,
-            },
-          }
-        : {}),
-    });
+    };
+    if (created.newAlbumId) {
+      replacement.selection = {
+        selectedAlbumId: created.newAlbumId,
+        selectedFileId: submission.seedTrackIds[0] ?? null,
+      };
+    }
+    library.dispatch(replacement);
     dispatchDialog({ type: "saved" });
   }, [dialog, library]);
 

--- a/src/features/workspace/useWorkspaceSelection.ts
+++ b/src/features/workspace/useWorkspaceSelection.ts
@@ -39,6 +39,11 @@ type SelectionSidebarProps = Pick<
   | "onReorderAlbums"
 >;
 
+interface WorkspaceSelectionBindings {
+  removalDialogProps: DestructiveActionDialogProps;
+  sidebarProps: SelectionSidebarProps;
+}
+
 export const useWorkspaceSelection = ({
   library,
   editor,
@@ -51,10 +56,7 @@ export const useWorkspaceSelection = ({
   settings: AppSettings;
   navigation: Pick<WorkspaceNavigation, "destination" | "showEditor" | "goHome">;
   removeDownloads: (trackIds: string[]) => void;
-}): {
-  removalDialogProps: DestructiveActionDialogProps;
-  sidebarProps: SelectionSidebarProps;
-} => {
+}): WorkspaceSelectionBindings => {
   const [removalDialog, setRemovalDialog] = useState<{
     open: boolean;
     trackIds: string[];

--- a/tests/e2e/session-safety.spec.ts
+++ b/tests/e2e/session-safety.spec.ts
@@ -20,9 +20,8 @@ test("allows unloading an empty session", async ({ page }) => {
 
   const unloadWasPrevented = await page.evaluate(() => {
     const event = new Event("beforeunload", { cancelable: true });
-    const browserGlobal = globalThis as unknown as EventTarget;
     return {
-      dispatchResult: browserGlobal.dispatchEvent(event),
+      dispatchResult: window.dispatchEvent(event),
       defaultPrevented: event.defaultPrevented,
     };
   });

--- a/tests/e2e/session-safety.spec.ts
+++ b/tests/e2e/session-safety.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 import { Buffer } from "node:buffer";
 
-const uploadTrack = async (page: Page) => {
+const importTrack = async (page: Page) => {
   const mp3Bytes = new Uint8Array(834);
   mp3Bytes.set([0xff, 0xfb, 0x90, 0x00], 0);
   mp3Bytes.set([0xff, 0xfb, 0x90, 0x00], 417);
@@ -12,6 +12,10 @@ const uploadTrack = async (page: Page) => {
     mimeType: "audio/mpeg",
     buffer: Buffer.from(mp3Bytes),
   });
+};
+
+const uploadTrack = async (page: Page) => {
+  await importTrack(page);
   await expect(page.getByRole("button", { name: "remove track" })).toBeAttached();
 };
 
@@ -64,4 +68,18 @@ test("requires confirmation before removing an imported track", async ({ page })
   await page.getByRole("button", { name: "remove track" }).click();
   await confirmation.getByRole("button", { name: "remove track" }).click();
   await expect(page.getByText("no tracks yet", { exact: true })).toBeVisible();
+});
+
+test("keeps the selected track while deleting characters from its title", async ({ page }) => {
+  await importTrack(page);
+  const title = page.locator("#track-title");
+  await expect(title).toBeVisible();
+  await title.fill("track");
+  await title.press("Home");
+
+  await title.press("Delete");
+
+  await expect(title).toHaveValue("rack");
+  await expect(page.getByRole("dialog", { name: "remove track?" })).toBeHidden();
+  await expect(page.getByText("library (1)", { exact: true })).toBeVisible();
 });

--- a/tests/e2e/support/audioFixtures.ts
+++ b/tests/e2e/support/audioFixtures.ts
@@ -119,7 +119,7 @@ const flacPayload = (bytes: Uint8Array) => {
 
 const mp4Payload = (bytes: Uint8Array) => {
   const payloads: Uint8Array[] = [];
-  for (let offset = 0; offset < bytes.length; ) {
+  for (let offset = 0; offset < bytes.length;) {
     const size = readU32be(bytes, offset) || bytes.length - offset;
     if (new TextDecoder("latin1").decode(bytes.subarray(offset + 4, offset + 8)) === "mdat") {
       payloads.push(bytes.slice(offset + 8, offset + size));

--- a/tests/e2e/title-editing-performance.spec.ts
+++ b/tests/e2e/title-editing-performance.spec.ts
@@ -4,6 +4,12 @@ import { materializeFixture } from "./support/audioFixtures";
 
 const sampleText = "abcdefghijklmnopqrstuvwx";
 
+declare global {
+  interface Window {
+    __tagiumInputProcessing?: Array<{ id: string; processingMs: number }>;
+  }
+}
+
 const enableAdvancedMetadata = async (page: Page) => {
   await page.getByRole("button", { name: "settings" }).click();
   await page.getByRole("button", { name: "editing", exact: true }).click();
@@ -28,10 +34,8 @@ const typeMeasuredText = async (page: Page, input: Locator) => {
   await input.focus();
   const inputId = await input.getAttribute("id");
   await page.evaluate((id) => {
-    const entries = Reflect.get(window, "__tagiumInputProcessing") as {
-      id: string;
-      processingMs: number;
-    }[];
+    const entries = window.__tagiumInputProcessing;
+    if (!entries) throw new Error("input processing measurement was not installed");
     for (let index = entries.length - 1; index >= 0; index--) {
       if (entries[index]?.id === id) entries.splice(index, 1);
     }
@@ -51,9 +55,7 @@ const typeMeasuredText = async (page: Page, input: Locator) => {
 const readP95ProcessingTime = async (page: Page, targetId: string) =>
   page.evaluate(
     ({ id, sampleCount }) => {
-      const entries = Reflect.get(window, "__tagiumInputProcessing") as
-        | { id: string; processingMs: number }[]
-        | undefined;
+      const entries = window.__tagiumInputProcessing;
       if (!entries) throw new Error("input processing measurement was not installed");
 
       const samples = entries.filter((entry) => entry.id === id).map((entry) => entry.processingMs);
@@ -74,7 +76,7 @@ test("keeps track title editing responsive in a large album", async ({ page, bro
   await page.evaluate(() => {
     const startedAt = new WeakMap<Event, number>();
     const entries: { id: string; processingMs: number }[] = [];
-    Reflect.set(window, "__tagiumInputProcessing", entries);
+    window.__tagiumInputProcessing = entries;
     document.addEventListener(
       "input",
       (event) => {

--- a/tests/server/cobalt/audio.post.test.ts
+++ b/tests/server/cobalt/audio.post.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { HTTPError } from "nitro";
+import { mockEvent } from "h3";
+import { Schema } from "effect";
 import handler from "../../../server/api/cobalt/audio.post";
 
 type RuntimeRequest = Request & {
@@ -21,6 +23,7 @@ type RateLimitBinding = {
 };
 
 const machineAffinitySecret = "test-machine-affinity-secret";
+const cobaltRequestSchema = Schema.Struct({ youtubeHLS: Schema.Boolean });
 
 const createRateLimitBinding = (limit: number): RateLimitBinding => {
   const counts = new Map<string, number>();
@@ -41,11 +44,15 @@ const makeAudioRequest = (signal?: AbortSignal, year: number | null = 2020) => {
       Origin: "https://tagium.test",
       "X-Tagium-Request-Id": "request-test",
     },
-    body: JSON.stringify({
-      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-      audioBitrate: "128",
-      ...(year === null ? {} : { year }),
-    }),
+    body: JSON.stringify(
+      Object.assign(
+        {
+          url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          audioBitrate: "128",
+        },
+        year === null ? undefined : { year },
+      ),
+    ),
     signal,
   }) as RuntimeRequest;
 
@@ -63,7 +70,7 @@ const makeAudioRequest = (signal?: AbortSignal, year: number | null = 2020) => {
 };
 
 const makeEvent = (request: RuntimeRequest) => {
-  return { req: request } as unknown as Parameters<typeof handler>[0];
+  return mockEvent(request);
 };
 
 describe("cobalt audio endpoint", () => {
@@ -93,13 +100,14 @@ describe("cobalt audio endpoint", () => {
   });
 
   it("requests non-HLS Cobalt audio", async () => {
-    const cobaltBodies: unknown[] = [];
+    const cobaltBodies: Array<Schema.Schema.Type<typeof cobaltRequestSchema>> = [];
     const audioTunnel =
       "https://cobalt.test/tunnel?id=123456789012345678901&exp=1234567890123&sig=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&sec=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb&iv=cccccccccccccccccccccc";
     const coverTunnel =
       "https://cobalt.test/tunnel?id=223456789012345678901&exp=1234567890123&sig=ddddddddddddddddddddddddddddddddddddddddddd&sec=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee&iv=ffffffffffffffffffffff";
     const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
-      cobaltBodies.push(JSON.parse(init?.body as string));
+      const serializedBody = Schema.decodeUnknownSync(Schema.String)(init?.body);
+      cobaltBodies.push(Schema.decodeUnknownSync(cobaltRequestSchema)(JSON.parse(serializedBody)));
 
       return Response.json({
         status: "local-processing",

--- a/tests/server/cobalt/tunnel.get.test.ts
+++ b/tests/server/cobalt/tunnel.get.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { mockEvent } from "h3";
 import handler from "../../../server/api/cobalt/tunnel.get";
 import { setDevFault } from "../../../server/utils/dev-controls";
 
@@ -71,7 +72,7 @@ const withObservability = (request: RuntimeRequest) => {
 };
 
 const makeEvent = (request: RuntimeRequest) => {
-  return { req: request } as unknown as Parameters<typeof handler>[0];
+  return mockEvent(request);
 };
 
 describe("cobalt tunnel endpoint", () => {

--- a/tests/server/manifests.test.ts
+++ b/tests/server/manifests.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
+import { mockEvent } from "h3";
 import artworkHandler from "../../server/api/manifests/[slug]/artwork.get";
 import previewArtworkHandler from "../../server/api/manifests/[slug]/preview-artwork.get";
 import { createShareSocialCardHandler } from "../../server/api/manifests/[slug]/social-card.get";
@@ -165,9 +166,7 @@ const createRuntime = () => {
 };
 
 const event = (request: Request, slug?: string) =>
-  ({ req: request, context: { params: { slug } } }) as unknown as Parameters<
-    typeof publishHandler
-  >[0];
+  Object.assign(mockEvent(request), { context: { params: slug === undefined ? {} : { slug } } });
 
 const request = (
   url: string,

--- a/tests/server/soundcloud-set.get.test.ts
+++ b/tests/server/soundcloud-set.get.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { mockEvent } from "h3";
 import handler from "../../server/api/soundcloud-set.get";
 
 const makeEvent = (headers?: HeadersInit) => {
@@ -7,7 +8,7 @@ const makeEvent = (headers?: HeadersInit) => {
     { headers },
   );
 
-  return { req: request } as unknown as Parameters<typeof handler>[0];
+  return mockEvent(request);
 };
 
 describe("soundcloud set endpoint", () => {

--- a/tests/server/utils/media-link.test.ts
+++ b/tests/server/utils/media-link.test.ts
@@ -79,7 +79,7 @@ describe("bounded SoundCloud short links", () => {
     await expect(
       resolveSoundCloudShortLink("http://snd.sc/x", {
         fetch: async (url) => {
-          seen = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+          seen = url instanceof URL ? url.href : url instanceof Request ? url.url : url;
           return response(200);
         },
       }),

--- a/tests/server/youtube-cover.get.test.ts
+++ b/tests/server/youtube-cover.get.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { mockEvent } from "h3";
 import handler from "../../server/api/youtube-cover.get";
 
 const makeEvent = (coverUrl: string) => {
   const request = new Request(
     `https://tagium.test/api/youtube-cover?url=${encodeURIComponent(coverUrl)}`,
   );
-  return { req: request } as unknown as Parameters<typeof handler>[0];
+  return mockEvent(request);
 };
 
 describe("youtube cover endpoint", () => {

--- a/tests/server/youtube-playlist.get.test.ts
+++ b/tests/server/youtube-playlist.get.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { Schema } from "effect";
+import { mockEvent } from "h3";
 import handler from "../../server/api/youtube-playlist.get";
 
 const sourceUrl = "https://www.youtube.com/playlist?list=PLESiES1i-ThqUjxot6jWLDu90fxtkcpA0";
@@ -7,7 +9,7 @@ const makeEvent = (url = sourceUrl) => {
   const request = new Request(
     `https://tagium.test/api/youtube-playlist?url=${encodeURIComponent(url)}`,
   );
-  return { req: request } as unknown as Parameters<typeof handler>[0];
+  return mockEvent(request);
 };
 
 const lockupVideo = (videoId: string, title: string, duration: string) => ({
@@ -97,8 +99,8 @@ describe("youtube playlist endpoint", () => {
         return new Response(html);
       }
       if (url.startsWith("https://www.youtube.com/youtubei/v1/next?")) {
-        expect(typeof init?.body).toBe("string");
-        expect(JSON.parse(init?.body as string)).toMatchObject({ videoId: "first-video" });
+        const body = Schema.decodeUnknownSync(Schema.String)(init?.body);
+        expect(JSON.parse(body)).toMatchObject({ videoId: "first-video" });
         return Response.json({
           contents: {
             twoColumnWatchNextResults: {
@@ -115,8 +117,8 @@ describe("youtube playlist endpoint", () => {
       }
 
       expect(url).toContain("https://www.youtube.com/youtubei/v1/browse?key=api-key");
-      expect(typeof init?.body).toBe("string");
-      expect(JSON.parse(init?.body as string)).toMatchObject({ continuation: "next-page" });
+      const body = Schema.decodeUnknownSync(Schema.String)(init?.body);
+      expect(JSON.parse(body)).toMatchObject({ continuation: "next-page" });
       return Response.json({
         continuationContents: {
           playlistVideoListContinuation: {

--- a/tests/support/domFixtures.ts
+++ b/tests/support/domFixtures.ts
@@ -1,0 +1,11 @@
+export const buttonElementFixture = (
+  focus: HTMLButtonElement["focus"],
+  isConnected = true,
+): HTMLButtonElement => {
+  const button = new EventTarget() as HTMLButtonElement;
+  Object.defineProperties(button, {
+    focus: { value: focus },
+    isConnected: { value: isConnected, writable: true },
+  });
+  return button;
+};

--- a/tests/support/reactTestNodes.ts
+++ b/tests/support/reactTestNodes.ts
@@ -1,0 +1,18 @@
+import { Children, isValidElement, type ReactElement, type ReactNode } from "react";
+import { Match } from "effect";
+
+export const reactChildren = (node: ReactElement<{ children?: ReactNode }>): ReactNode[] =>
+  Children.toArray(node.props.children);
+
+export const reactText = (node: ReactNode): string =>
+  Children.toArray(node)
+    .map((child) =>
+      isValidElement<{ children?: ReactNode }>(child)
+        ? reactText(child.props.children)
+        : Match.value(child).pipe(
+            Match.when(Match.string, (value) => value),
+            Match.when(Match.number, (value) => String(value)),
+            Match.orElse(() => ""),
+          ),
+    )
+    .join("");

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vite-plus/test";
+import type { BeforeSendFn } from "posthog-js";
 import { createAnalytics } from "@/analytics";
+
+type AnalyticsInitOptions = { before_send: BeforeSendFn };
 
 describe("analytics", () => {
   it.each([
@@ -204,14 +207,14 @@ describe("analytics", () => {
       ["https://youtube.com.evil/private-id", "other", "other"],
     ] as const;
 
-    for (const [sourceUrl, provider, shape] of linkCases) {
+    for (const [sourceUrl, provider, linkForm] of linkCases) {
       analytics.capture({
         type: "media_link_processed",
         sourceUrl,
         mediaKind: "track",
-        shape,
-        normalized: shape !== "canonical",
-        redirected: shape === "short",
+        linkKind: linkForm,
+        normalized: linkForm !== "canonical",
+        redirected: linkForm === "short",
         outcome: "accepted",
       });
       expect(capture.mock.calls.at(-1)).toEqual([
@@ -219,9 +222,9 @@ describe("analytics", () => {
         expect.objectContaining({
           provider,
           media_kind: "track",
-          shape,
-          normalized: shape !== "canonical",
-          redirected: shape === "short",
+          ["shape"]: linkForm,
+          normalized: linkForm !== "canonical",
+          redirected: linkForm === "short",
           outcome: "accepted",
         }),
       ]);
@@ -231,7 +234,7 @@ describe("analytics", () => {
       type: "media_link_processed",
       sourceUrl: "https://on.soundcloud.com/private-token",
       mediaKind: "unsupported",
-      shape: "short",
+      linkKind: "short",
       normalized: false,
       redirected: false,
       outcome: "rejected",
@@ -285,13 +288,9 @@ describe("analytics", () => {
       expect(serialized).not.toContain(sensitiveValue);
     }
 
-    const options = init.mock.calls[0]?.[1] as {
-      before_send: (event: {
-        event: string;
-        properties: Record<string, unknown>;
-      }) => { properties: Record<string, unknown> } | null;
-    };
+    const options = init.mock.calls[0]?.[1] as AnalyticsInitOptions;
     const redacted = options.before_send({
+      uuid: "capture-uuid",
       event: "cobalt_tunnel_readiness",
       properties: {
         event_version: 1,
@@ -398,20 +397,7 @@ describe("analytics", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    const options = init.mock.calls[0]?.[1] as {
-      before_send: (event: {
-        uuid?: string;
-        event: string;
-        properties: Record<string, unknown>;
-        timestamp?: Date;
-        $set?: Record<string, unknown>;
-      }) => {
-        uuid?: string;
-        event: string;
-        properties: Record<string, unknown>;
-        timestamp?: Date;
-      } | null;
-    };
+    const options = init.mock.calls[0]?.[1] as AnalyticsInitOptions;
     const timestamp = new Date("2026-07-09T00:00:00.000Z");
     const custom = options.before_send({
       uuid: "capture-uuid",
@@ -437,6 +423,7 @@ describe("analytics", () => {
       },
     });
     const pageview = options.before_send({
+      uuid: "capture-uuid",
       event: "$pageview",
       properties: {
         $browser: "Chrome",
@@ -465,6 +452,7 @@ describe("analytics", () => {
       },
     });
     expect(pageview).toEqual({
+      uuid: "capture-uuid",
       event: "$pageview",
       properties: {
         $browser: "Chrome",
@@ -473,10 +461,15 @@ describe("analytics", () => {
       },
     });
     expect(
-      options.before_send({ event: "made_up_event", properties: { private: "value" } }),
+      options.before_send({
+        uuid: "capture-uuid",
+        event: "made_up_event",
+        properties: { private: "value" },
+      }),
     ).toBeNull();
     expect(
       options.before_send({
+        uuid: "capture-uuid",
         event: "import_failure_category",
         properties: {
           provider: "soundcloud",
@@ -487,11 +480,13 @@ describe("analytics", () => {
         },
       }),
     ).toEqual({
+      uuid: "capture-uuid",
       event: "import_failure_category",
       properties: { provider: "soundcloud", import_kind: "set", track_count: 1 },
     });
     expect(
       options.before_send({
+        uuid: "capture-uuid",
         event: "share_opened",
         properties: {
           share_id: "a".repeat(43),
@@ -502,6 +497,7 @@ describe("analytics", () => {
         },
       }),
     ).toEqual({
+      uuid: "capture-uuid",
       event: "share_opened",
       properties: {
         share_id: "a".repeat(43),
@@ -512,15 +508,18 @@ describe("analytics", () => {
     });
     expect(
       options.before_send({
+        uuid: "capture-uuid",
         event: "share_opened",
         properties: { share_id: "k7m4q2", share_kind: "album", track_count: 4 },
       }),
     ).toEqual({
+      uuid: "capture-uuid",
       event: "share_opened",
       properties: { share_kind: "album", track_count: 4 },
     });
     expect(
       options.before_send({
+        uuid: "capture-uuid",
         event: "import_retry_finished",
         properties: {
           provider: "mixed",

--- a/tests/unit/components/dev/DevPanel.test.tsx
+++ b/tests/unit/components/dev/DevPanel.test.tsx
@@ -1,6 +1,7 @@
-import type { ReactElement, ReactNode } from "react";
+import { isValidElement, type ReactElement, type ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { DevPanel } from "@/components/dev/DevPanel";
+import { reactChildren } from "../../../support/reactTestNodes";
 
 const reactHookMocks = vi.hoisted(() => ({
   useCallback: vi.fn(),
@@ -20,17 +21,20 @@ vi.mock("react", async (importOriginal) => {
   };
 });
 
-type TestElement = ReactElement<Record<string, unknown> & { children?: ReactNode }>;
+type TestElementProps = {
+  children?: ReactNode;
+  onClick?: () => void;
+  step?: number;
+  type?: string;
+  value?: string;
+  "aria-label"?: string;
+};
+type TestElement = ReactElement<TestElementProps>;
 type EffectSetup = () => void | (() => void);
 
-const isElement = (node: ReactNode): node is TestElement =>
-  typeof node === "object" && node !== null && "props" in node;
+const isElement = (node: ReactNode): node is TestElement => isValidElement<TestElementProps>(node);
 
-const childrenOf = (node: TestElement): ReactNode[] => {
-  const children = node.props.children;
-  if (children === undefined || children === null || typeof children === "boolean") return [];
-  return Array.isArray(children) ? children : [children];
-};
+const childrenOf = (node: TestElement): ReactNode[] => reactChildren(node);
 
 const findElement = (
   node: ReactNode,
@@ -56,22 +60,23 @@ const createHookHarness = () => {
   let refCursor = 0;
   let effect: EffectSetup | undefined;
 
-  reactHookMocks.useCallback.mockImplementation((callback: unknown) => callback);
+  reactHookMocks.useCallback.mockImplementation(<Callback,>(callback: Callback) => callback);
   reactHookMocks.useEffect.mockImplementation((setup: EffectSetup) => {
     effect = setup;
   });
-  reactHookMocks.useRef.mockImplementation((initial: unknown) => {
+  reactHookMocks.useRef.mockImplementation(<Value,>(initial: Value) => {
     const index = refCursor++;
     refs[index] ??= { current: initial };
     return refs[index];
   });
-  reactHookMocks.useState.mockImplementation((initial: unknown) => {
+  reactHookMocks.useState.mockImplementation(<Value,>(initial: Value | (() => Value)) => {
     const index = stateCursor++;
-    if (!(index in states)) states[index] = typeof initial === "function" ? initial() : initial;
+    if (!(index in states)) states[index] = initial instanceof Function ? initial() : initial;
     return [
       states[index],
-      (next: unknown) => {
-        states[index] = typeof next === "function" ? next(states[index]) : next;
+      (next: Value | ((previous: Value) => Value)) => {
+        const previous = states[index] as Value;
+        states[index] = next instanceof Function ? next(previous) : next;
       },
     ];
   });
@@ -91,12 +96,10 @@ const createHookHarness = () => {
 
 const createDeferred = <T,>() => {
   let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+  const promise = new Promise<T>((resolvePromise) => {
     resolve = resolvePromise;
-    reject = rejectPromise;
   });
-  return { promise, resolve, reject };
+  return { promise, resolve };
 };
 
 const config = (windowMs: number) => ({
@@ -113,12 +116,11 @@ const config = (windowMs: number) => ({
   faults: {},
 });
 
-const response = (body: unknown, ok = true) =>
-  ({ ok, json: vi.fn(async () => body) }) as unknown as Response;
+const response = (body: ReturnType<typeof config> | undefined, ok = true) =>
+  Response.json(body ?? null, { status: ok ? 200 : 500 });
 
 const flushPromises = async () => {
-  await Promise.resolve();
-  await Promise.resolve();
+  for (let index = 0; index < 8; index += 1) await Promise.resolve();
 };
 
 const refreshButton = (tree: ReactNode) =>
@@ -145,8 +147,9 @@ describe("DevPanel config loading", () => {
 
     expect(hooks.render()).toBeNull();
     const cleanup = hooks.runEffect();
-    expect(typeof cleanup).toBe("function");
-    cleanup?.();
+    expect(cleanup).toBeInstanceOf(Function);
+    if (!cleanup) throw new Error("effect cleanup was not registered");
+    cleanup();
     hooks.runEffect();
 
     const firstSignal = (fetchMock.mock.calls[0][1] as RequestInit).signal;
@@ -176,8 +179,8 @@ describe("DevPanel config loading", () => {
     await flushPromises();
     const button = refreshButton(hooks.render());
 
-    (button.props.onClick as () => void)();
-    (button.props.onClick as () => void)();
+    button.props.onClick?.();
+    button.props.onClick?.();
 
     const firstRefreshSignal = (fetchMock.mock.calls[1][1] as RequestInit).signal;
     expect(firstRefreshSignal?.aborted).toBe(true);
@@ -218,7 +221,7 @@ describe("DevPanel config loading", () => {
     hooks.runEffect();
     await flushPromises();
     const button = refreshButton(hooks.render());
-    (button.props.onClick as () => void)();
+    button.props.onClick?.();
     await flushPromises();
 
     expect(windowInput(hooks.render()).props.value).toBe("1000");

--- a/tests/unit/features/audio/metadataEngine/mp3Driver.test.ts
+++ b/tests/unit/features/audio/metadataEngine/mp3Driver.test.ts
@@ -34,7 +34,7 @@ const commentFrame = (description: string, value: string, language = "eng") =>
     ),
   );
 const apeItem = (key: string, value: string | Uint8Array, flags = 0) => {
-  const bytes = typeof value === "string" ? encoder.encode(value) : value;
+  const bytes = value instanceof Uint8Array ? value : encoder.encode(value);
   return concat(
     uint32LE(bytes.length),
     uint32LE(flags),

--- a/tests/unit/features/audio/metadataEngine/mp4Driver.test.ts
+++ b/tests/unit/features/audio/metadataEngine/mp4Driver.test.ts
@@ -170,7 +170,7 @@ const includes = (haystack: Uint8Array, needle: Uint8Array) => {
 
 const topAtoms = (bytes: Uint8Array) => {
   const result: { type: string; start: number; size: number }[] = [];
-  for (let offset = 0; offset < bytes.length; ) {
+  for (let offset = 0; offset < bytes.length;) {
     const size =
       bytes[offset]! * 0x1000000 +
       bytes[offset + 1]! * 0x10000 +

--- a/tests/unit/features/editor/albumMetadataDialog.test.tsx
+++ b/tests/unit/features/editor/albumMetadataDialog.test.tsx
@@ -1,8 +1,9 @@
-import type { ReactElement, ReactNode } from "react";
+import { isValidElement, type ReactElement, type ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import AlbumMetadataDialog, {
   type AlbumMetadataDraft,
 } from "@/features/editor/AlbumMetadataDialog";
+import { reactChildren, reactText } from "../../../support/reactTestNodes";
 
 const reactHookMocks = vi.hoisted(() => ({
   useEffect: vi.fn(),
@@ -20,16 +21,33 @@ vi.mock("react", async (importOriginal) => {
   };
 });
 
-type TestElement = ReactElement<Record<string, unknown> & { children?: ReactNode }>;
-
-const isElement = (node: ReactNode): node is TestElement =>
-  typeof node === "object" && node !== null && "props" in node;
-
-const childrenOf = (node: TestElement): ReactNode[] => {
-  const children = node.props.children;
-  if (children === undefined || children === null || typeof children === "boolean") return [];
-  return Array.isArray(children) ? children : [children];
+type SubmitEvent = { preventDefault: () => void };
+type TestElementProps = {
+  children?: ReactNode;
+  className?: string;
+  disabled?: boolean;
+  id?: string;
+  label?: string;
+  onBlur?: () => void;
+  onClick?: () => void;
+  onCoverUpload?: (picture: NonNullable<AlbumMetadataDraft["cover"]>) => void;
+  onOpenChange?: (open: boolean) => void;
+  onProcessingChange?: (processing: boolean) => void;
+  onSubmit?: (event: SubmitEvent) => void;
+  open?: boolean;
+  placeholder?: string;
+  required?: boolean;
+  type?: string;
+  "aria-busy"?: boolean;
+  "aria-describedby"?: string;
+  "aria-invalid"?: boolean;
+  "aria-required"?: string;
 };
+type TestElement = ReactElement<TestElementProps>;
+
+const isElement = (node: ReactNode): node is TestElement => isValidElement<TestElementProps>(node);
+
+const childrenOf = (node: TestElement): ReactNode[] => reactChildren(node);
 
 const findElement = (
   node: ReactNode,
@@ -48,24 +66,21 @@ const findElement = (
   throw new Error("element not found");
 };
 
-const textContent = (node: ReactNode): string => {
-  if (typeof node === "string" || typeof node === "number") return String(node);
-  if (!isElement(node)) return "";
-  return childrenOf(node).map(textContent).join("");
-};
+const textContent = reactText;
 
 const createHookHarness = () => {
   const states: unknown[] = [];
   let cursor = 0;
   reactHookMocks.useEffect.mockImplementation(() => undefined);
-  reactHookMocks.useRef.mockImplementation((initial: unknown) => ({ current: initial }));
-  reactHookMocks.useState.mockImplementation((initial: unknown) => {
+  reactHookMocks.useRef.mockImplementation(<Value,>(initial: Value) => ({ current: initial }));
+  reactHookMocks.useState.mockImplementation(<Value,>(initial: Value | (() => Value)) => {
     const index = cursor++;
-    if (!(index in states)) states[index] = typeof initial === "function" ? initial() : initial;
+    if (!(index in states)) states[index] = initial instanceof Function ? initial() : initial;
     return [
       states[index],
-      (next: unknown) => {
-        states[index] = typeof next === "function" ? next(states[index]) : next;
+      (next: Value | ((previous: Value) => Value)) => {
+        const previous = states[index] as Value;
+        states[index] = next instanceof Function ? next(previous) : next;
       },
     ];
   });
@@ -123,7 +138,7 @@ describe("album metadata validation layout", () => {
 
     const dialog = findElement(
       tree,
-      (element) => element.props.open === true && typeof element.props.onOpenChange === "function",
+      (element) => element.props.open === true && element.props.onOpenChange !== undefined,
     );
     (dialog.props.onOpenChange as (open: boolean) => void)(false);
     tree = render();
@@ -199,10 +214,7 @@ describe("album metadata validation layout", () => {
       );
 
     let tree = render();
-    const coverArt = findElement(
-      tree,
-      (element) => typeof element.props.onProcessingChange === "function",
-    );
+    const coverArt = findElement(tree, (element) => element.props.onProcessingChange !== undefined);
     (coverArt.props.onProcessingChange as (processing: boolean) => void)(true);
 
     tree = render();
@@ -226,10 +238,7 @@ describe("album metadata validation layout", () => {
         placeholder: { title: "Album", artist: "Artist", genre: "Genre", year: "2026" },
       }),
     );
-    const coverArt = findElement(
-      tree,
-      (element) => typeof element.props.onCoverUpload === "function",
-    );
+    const coverArt = findElement(tree, (element) => element.props.onCoverUpload !== undefined);
     const cover = [{ format: "image/jpeg", data: new Uint8Array([1]) }];
 
     (coverArt.props.onCoverUpload as (picture: typeof cover) => void)(cover);
@@ -282,7 +291,7 @@ describe("album metadata validation layout", () => {
 
     const cancel = findElement(
       tree,
-      (element) => textContent(element) === "cancel" && typeof element.props.onClick === "function",
+      (element) => textContent(element) === "cancel" && element.props.onClick !== undefined,
     );
     (cancel.props.onClick as () => void)();
     expect(onClose).toHaveBeenCalledOnce();

--- a/tests/unit/features/editor/albumMetadataDialogLifecycle.test.tsx
+++ b/tests/unit/features/editor/albumMetadataDialogLifecycle.test.tsx
@@ -77,7 +77,7 @@ describe("AlbumMetadataDialog cover sync lifecycle", () => {
     });
     expect(renderer!.root.findByProps({ "aria-busy": true })).toBeDefined();
 
-    const dialog = renderer!.root.find((node) => typeof node.props.onOpenChange === "function");
+    const dialog = renderer!.root.find((node) => node.props.onOpenChange !== undefined);
     act(() => {
       dialog.props.onOpenChange(false);
     });

--- a/tests/unit/features/editor/editorKeyboardShortcuts.test.ts
+++ b/tests/unit/features/editor/editorKeyboardShortcuts.test.ts
@@ -41,6 +41,16 @@ const keyboardEvent = (
 };
 const preventDefaultFor = (event: KeyboardEvent) => preventDefaultMocks.get(event);
 
+class DomShapedInputTarget {
+  get tagName() {
+    return "INPUT";
+  }
+
+  get isContentEditable() {
+    return false;
+  }
+}
+
 const actions = (
   overrides: Partial<EditorKeyboardShortcutActions> = {},
 ): EditorKeyboardShortcutActions => ({
@@ -164,6 +174,18 @@ describe("editor keyboard shortcuts", () => {
     const target = createKeyboardTarget();
     const currentActions = actions({ selectedFileCount: 1 });
     const event = keyboardEvent("Delete", { target: targetElement });
+    subscribeToEditorKeyboardShortcuts(target, () => currentActions);
+
+    target.dispatch(event);
+
+    expect(preventDefaultFor(event)).not.toHaveBeenCalled();
+    expect(currentActions.requestRemoveSelectedFiles).not.toHaveBeenCalled();
+  });
+
+  it("ignores Delete from an input whose DOM properties live on its prototype", () => {
+    const target = createKeyboardTarget();
+    const currentActions = actions({ selectedFileCount: 1 });
+    const event = keyboardEvent("Delete", { target: new DomShapedInputTarget() });
     subscribeToEditorKeyboardShortcuts(target, () => currentActions);
 
     target.dispatch(event);

--- a/tests/unit/features/editor/editorKeyboardShortcuts.test.ts
+++ b/tests/unit/features/editor/editorKeyboardShortcuts.test.ts
@@ -28,15 +28,14 @@ const keyboardEvent = (
     target?: Pick<HTMLElement, "tagName" | "isContentEditable">;
   } = {},
 ) => {
-  const preventDefault = vi.fn();
-  const event = {
-    key,
-    ctrlKey: false,
-    metaKey: false,
-    target: null,
-    preventDefault,
-    ...options,
-  } as unknown as KeyboardEvent;
+  const event = new Event("keydown", { cancelable: true }) as KeyboardEvent;
+  Object.defineProperties(event, {
+    key: { value: key },
+    ctrlKey: { value: options.ctrlKey ?? false },
+    metaKey: { value: options.metaKey ?? false },
+    target: { value: options.target ?? null },
+  });
+  const preventDefault = vi.spyOn(event, "preventDefault");
   preventDefaultMocks.set(event, preventDefault);
   return event;
 };

--- a/tests/unit/features/editor/editorKeyboardShortcuts.test.ts
+++ b/tests/unit/features/editor/editorKeyboardShortcuts.test.ts
@@ -41,7 +41,7 @@ const keyboardEvent = (
 };
 const preventDefaultFor = (event: KeyboardEvent) => preventDefaultMocks.get(event);
 
-class DomShapedInputTarget {
+class InheritedInputTarget {
   get tagName() {
     return "INPUT";
   }
@@ -185,7 +185,7 @@ describe("editor keyboard shortcuts", () => {
   it("ignores Delete from an input whose DOM properties live on its prototype", () => {
     const target = createKeyboardTarget();
     const currentActions = actions({ selectedFileCount: 1 });
-    const event = keyboardEvent("Delete", { target: new DomShapedInputTarget() });
+    const event = keyboardEvent("Delete", { target: new InheritedInputTarget() });
     subscribeToEditorKeyboardShortcuts(target, () => currentActions);
 
     target.dispatch(event);

--- a/tests/unit/features/export/ExportConfirmationDialog.test.tsx
+++ b/tests/unit/features/export/ExportConfirmationDialog.test.tsx
@@ -1,6 +1,7 @@
-import type { ReactElement, ReactNode } from "react";
+import { isValidElement, type ReactElement, type ReactNode } from "react";
 import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
 import { describe, expect, it, vi } from "vite-plus/test";
+import { Schema } from "effect";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -17,15 +18,34 @@ import ExportConfirmationDialog, {
   ExportPlanDisclosure,
 } from "@/features/export/ExportConfirmationDialog";
 import { Button } from "@/components/ui/button";
+import { reactChildren, reactText } from "../../../support/reactTestNodes";
 
-type TestElement = ReactElement<Record<string, unknown> & { children?: ReactNode }>;
-const isElement = (node: ReactNode): node is TestElement =>
-  typeof node === "object" && node !== null && "props" in node;
-const childrenOf = (node: TestElement): ReactNode[] => {
-  const children = node.props.children;
-  if (children === undefined || children === null || typeof children === "boolean") return [];
-  return Array.isArray(children) ? children : [children];
+type FocusEventFixture = {
+  preventDefault: () => void;
+  currentTarget?: { querySelector: () => { focus: () => void } };
 };
+type TestElementProps = {
+  children?: ReactNode;
+  group?: (typeof plan.groups)[number];
+  disabled?: boolean;
+  role?: string;
+  className?: string;
+  id?: string;
+  inert?: boolean;
+  "aria-busy"?: boolean;
+  "aria-expanded"?: boolean;
+  "aria-controls"?: string;
+  "aria-hidden"?: boolean;
+  "data-testid"?: string;
+  onClick?: () => void;
+  onEscapeKeyDown?: (event: FocusEventFixture) => void;
+  onInteractOutside?: (event: FocusEventFixture) => void;
+  onOpenAutoFocus?: (event: FocusEventFixture) => void;
+  onCloseAutoFocus?: (event: FocusEventFixture) => void;
+};
+type TestElement = ReactElement<TestElementProps>;
+const isElement = (node: ReactNode): node is TestElement => isValidElement<TestElementProps>(node);
+const childrenOf = (node: TestElement): ReactNode[] => reactChildren(node);
 const findAll = (node: ReactNode, predicate: (element: TestElement) => boolean): TestElement[] => {
   if (!isElement(node)) return [];
   return [
@@ -33,13 +53,11 @@ const findAll = (node: ReactNode, predicate: (element: TestElement) => boolean):
     ...childrenOf(node).flatMap((child) => findAll(child, predicate)),
   ];
 };
-const textContent = (node: ReactNode): string => {
-  if (typeof node === "string" || typeof node === "number") return String(node);
-  if (!isElement(node)) return "";
-  return childrenOf(node).map(textContent).join("");
-};
+const textContent = reactText;
 const renderedText = (node: ReactTestInstance): string =>
-  node.children.map((child) => (typeof child === "string" ? child : renderedText(child))).join("");
+  node.children
+    .map((child) => (Schema.is(Schema.String)(child) ? child : renderedText(child)))
+    .join("");
 
 const plan = {
   target: { kind: "library" as const },
@@ -165,13 +183,10 @@ describe("ExportConfirmationDialog", () => {
   it("focuses cancel, restores focus, and confines mobile scrolling to the manifest", () => {
     const onRestoreFocus = vi.fn();
     const tree = render({ onRestoreFocus });
-    const content = findAll(
-      tree,
-      (element) => typeof element.props.onOpenAutoFocus === "function",
-    )[0]!;
+    const content = findAll(tree, (element) => element.props.onOpenAutoFocus !== undefined)[0]!;
     const focus = vi.fn();
     const preventOpen = vi.fn();
-    (content.props.onOpenAutoFocus as (event: unknown) => void)({
+    content.props.onOpenAutoFocus?.({
       preventDefault: preventOpen,
       currentTarget: { querySelector: () => ({ focus }) },
     });
@@ -179,7 +194,7 @@ describe("ExportConfirmationDialog", () => {
     expect(focus).toHaveBeenCalledOnce();
 
     const preventClose = vi.fn();
-    (content.props.onCloseAutoFocus as (event: unknown) => void)({ preventDefault: preventClose });
+    content.props.onCloseAutoFocus?.({ preventDefault: preventClose });
     expect(preventClose).toHaveBeenCalledOnce();
     expect(onRestoreFocus).toHaveBeenCalledOnce();
     expect(content.props.className).toContain("overflow-hidden");

--- a/tests/unit/features/export/exportMetadataWrites.test.ts
+++ b/tests/unit/features/export/exportMetadataWrites.test.ts
@@ -32,7 +32,7 @@ const readyFile = (id: string): TagiumFile => ({
 
 const deferred = () => {
   let resolve!: () => void;
-  let reject!: (error: unknown) => void;
+  let reject!: (error: Error) => void;
   const promise = new Promise<void>((promiseResolve, promiseReject) => {
     resolve = promiseResolve;
     reject = promiseReject;
@@ -109,7 +109,7 @@ describe("writeExportMetadata", () => {
         settled = true;
         return undefined;
       },
-      (error: unknown) => {
+      (error: Error) => {
         settled = true;
         return error;
       },
@@ -143,7 +143,7 @@ describe("writeExportMetadata", () => {
       },
     ).then(
       () => undefined,
-      (error: unknown) => error,
+      (error: Error) => error,
     );
     await flushMicrotasks();
 

--- a/tests/unit/features/export/useExportSession.test.ts
+++ b/tests/unit/features/export/useExportSession.test.ts
@@ -12,11 +12,12 @@ const exportMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/analytics", () => ({ analytics: { capture: exportMocks.capture } }));
-vi.mock("@/features/workspace/systemFailure", () => ({
+vi.mock("@/features/workspace/systemFailure", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/features/workspace/systemFailure")>()),
   reportSystemFailure: exportMocks.reportFailure,
 }));
 vi.mock("@/features/export/downloadLibrary", () => {
-  const ready = (file: TagiumFile) =>
+  const ready = (file: TagiumFile): file is TagiumFile & { file: File; metadata: AudioMetadata } =>
     Boolean(file.file && file.metadata && file.metadata.filename.trim());
   return {
     allTracksReadyForDownload: (files: TagiumFile[]) => files.every(ready),
@@ -25,7 +26,7 @@ vi.mock("@/features/export/downloadLibrary", () => {
     downloadBlob: exportMocks.downloadBlob,
     getAlbumCoverDownload: () => null,
     getLibraryDownloadEntries: ({ files }: { files: TagiumFile[] }) =>
-      files.filter(ready).map((file) => ({ path: file.filename, file: file.file as File })),
+      files.filter(ready).map((file) => ({ path: file.filename, file: file.file })),
     isTrackReadyForDownload: ready,
   };
 });
@@ -128,15 +129,20 @@ describe("export session", () => {
   });
 
   it("restores the initiating control or a safe fallback", () => {
-    const trigger: {
+    type FocusTrigger = {
       focus: ReturnType<typeof vi.fn>;
       isConnected: boolean;
       checkVisibility?: () => boolean;
-    } = { focus: vi.fn(), isConnected: true };
+    };
+    const trigger: FocusTrigger = { focus: vi.fn(), isConnected: true };
     const fallback = {
       focus: vi.fn(),
       checkVisibility: () => true,
     };
+    class TestHTMLElement {}
+    Object.setPrototypeOf(trigger, TestHTMLElement.prototype);
+    Object.setPrototypeOf(fallback, TestHTMLElement.prototype);
+    vi.stubGlobal("HTMLElement", TestHTMLElement);
     vi.stubGlobal("document", {
       activeElement: trigger,
       querySelectorAll: vi.fn(() => [fallback]),

--- a/tests/unit/features/import/audioUrlImportSession.test.ts
+++ b/tests/unit/features/import/audioUrlImportSession.test.ts
@@ -23,7 +23,7 @@ vi.mock("@/analytics", async (importOriginal) => ({
 }));
 vi.mock("@/features/audio/audioBackend", () => ({
   downloadFromCobalt: mocks.downloadFromCobalt,
-  provideAudioBackend: (operation: unknown) => operation,
+  provideAudioBackend: <Operation>(operation: Operation) => operation,
   parseUploads: vi.fn(),
   runAudioBackendEffect: mocks.runAudioBackendEffect,
   writeTags: mocks.writeTags,
@@ -145,7 +145,7 @@ describe("audio URL import session", () => {
       type: "media_link_processed",
       sourceUrl: "https://www.youtube.com/watch?v=abcdefghijk",
       mediaKind: "track",
-      shape: "canonical",
+      linkKind: "canonical",
       normalized: false,
       redirected: false,
       outcome: "accepted",
@@ -158,7 +158,7 @@ describe("audio URL import session", () => {
       type: "media_link_processed",
       sourceUrl: "https://soundcloud.com/discover",
       mediaKind: "unsupported",
-      shape: "canonical",
+      linkKind: "canonical",
       normalized: false,
       redirected: false,
       outcome: "rejected",
@@ -192,7 +192,7 @@ describe("audio URL import session", () => {
       type: "media_link_processed",
       sourceUrl: "https://on.soundcloud.com/private-token",
       mediaKind: "unsupported",
-      shape: "short",
+      linkKind: "short",
       normalized: false,
       redirected: false,
       outcome: "rejected",
@@ -218,7 +218,7 @@ describe("audio URL import session", () => {
     ["https://youtube.com:444/watch?v=abcdefghijk", "invalid", "canonical"],
   ] as const)(
     "rejects unsupported providers before starting an import (%s)",
-    async (sourceUrl, failureReason, shape) => {
+    async (sourceUrl, failureReason, linkForm) => {
       const hook = renderHook(() => {
         const library = useLibraryStore();
         const editor = useTrackEditorSession({ library, settings: settings("320") });
@@ -238,7 +238,7 @@ describe("audio URL import session", () => {
         type: "media_link_processed",
         sourceUrl,
         mediaKind: "unsupported",
-        shape,
+        linkKind: linkForm,
         normalized: false,
         redirected: false,
         outcome: "rejected",

--- a/tests/unit/features/import/cobaltAudio.test.ts
+++ b/tests/unit/features/import/cobaltAudio.test.ts
@@ -34,9 +34,10 @@ interface FakeMP3TagInstance {
   save: () => void;
 }
 
-const mp3tagMock = vi.hoisted(() => ({
-  instances: [] as FakeMP3TagInstance[],
-}));
+const mp3tagMock = vi.hoisted(() => {
+  const instances: FakeMP3TagInstance[] = [];
+  return { instances };
+});
 
 vi.mock("mp3tag.js", () => ({
   default: class FakeMP3Tag implements FakeMP3TagInstance {
@@ -56,6 +57,17 @@ vi.mock("mp3tag.js", () => ({
 }));
 
 type LocalAudioPlan = Extract<CobaltDownloadPlan, { status: "local-processing" }>;
+type LocalProcessingWorkerRequest = {
+  cobaltLocalProcessing: {
+    audioFile: File;
+    audio: { copy: boolean; format: string; bitrate: string };
+    output: {
+      type: string;
+      format: string;
+      metadata?: Record<string, string | undefined>;
+    };
+  };
+};
 
 const localAudioPlan = (overrides: Partial<LocalAudioPlan> = {}): LocalAudioPlan => ({
   status: "local-processing",
@@ -558,7 +570,7 @@ describe("CobaltAudio download", () => {
 
   it("processes local audio with cover art through the bounded metadata engine", async () => {
     const fetchedUrls: string[] = [];
-    const workerMessages: unknown[] = [];
+    const workerMessages: LocalProcessingWorkerRequest[] = [];
 
     vi.stubGlobal(
       "fetch",
@@ -598,7 +610,7 @@ describe("CobaltAudio download", () => {
         onmessage?: (event: MessageEvent) => void;
         onerror?: (event: ErrorEvent) => void;
 
-        postMessage(message: unknown) {
+        postMessage(message: LocalProcessingWorkerRequest) {
           workerMessages.push(message);
           queueMicrotask(() => {
             this.onmessage?.({
@@ -642,10 +654,7 @@ describe("CobaltAudio download", () => {
         },
       },
     });
-    expect(
-      (workerMessages[0] as { cobaltLocalProcessing: { audioFile: File } }).cobaltLocalProcessing
-        .audioFile,
-    ).toMatchObject({
+    expect(workerMessages[0]?.cobaltLocalProcessing.audioFile).toMatchObject({
       name: "input-0",
       type: "audio/mpeg",
     });
@@ -665,7 +674,7 @@ describe("CobaltAudio download", () => {
 
   it("returns non-mp3 local audio without fetching cover or using mp3tag", async () => {
     const fetchedUrls: string[] = [];
-    const workerMessages: unknown[] = [];
+    const workerMessages: LocalProcessingWorkerRequest[] = [];
 
     vi.stubGlobal(
       "fetch",
@@ -708,7 +717,7 @@ describe("CobaltAudio download", () => {
       class FakeWorker {
         onmessage?: (event: MessageEvent) => void;
 
-        postMessage(message: unknown) {
+        postMessage(message: LocalProcessingWorkerRequest) {
           workerMessages.push(message);
           queueMicrotask(() => {
             this.onmessage?.({

--- a/tests/unit/features/import/downloadPresentation.test.tsx
+++ b/tests/unit/features/import/downloadPresentation.test.tsx
@@ -58,12 +58,12 @@ describe("download presentation", () => {
   });
 
   it("keeps canceled track rows compact without a repeated status line", () => {
-    const track = {
+    const track: TagiumFile = {
       id: "track-1",
       filename: "Summer Fling.mp3",
       status: "pending",
       downloadStatus: "canceled",
-    } as TagiumFile;
+    };
     const markup = renderToStaticMarkup(
       <SortableTrackRow
         track={track}
@@ -121,12 +121,12 @@ describe("download presentation", () => {
 
   it("shows saved feedback for three seconds after a status transition and cleans timers up", () => {
     vi.useFakeTimers();
-    const pendingTrack = {
+    const pendingTrack: TagiumFile = {
       id: "track-saved-feedback",
       filename: "Saved Track.mp3",
       status: "pending",
       downloadStatus: "ready",
-    } as TagiumFile;
+    };
     let renderer: ReactTestRenderer;
 
     act(() => {
@@ -168,12 +168,12 @@ describe("download presentation", () => {
 
   it("does not announce an initially saved track", () => {
     vi.useFakeTimers();
-    const savedTrack = {
+    const savedTrack: TagiumFile = {
       id: "already-saved-track",
       filename: "Already Saved.mp3",
       status: "saved",
       downloadStatus: "ready",
-    } as TagiumFile;
+    };
     let renderer: ReactTestRenderer;
 
     act(() => {

--- a/tests/unit/features/import/importLifecycle.test.ts
+++ b/tests/unit/features/import/importLifecycle.test.ts
@@ -130,11 +130,12 @@ describe("import lifecycle", () => {
       });
       tracker.resolve(operationId, { trackIds: ["track-1", "track-2"], hasCover: false });
       tracker.settle(operationId, { trackId: "track-1", outcome: settlements[0] });
-      tracker.settle(operationId, {
+      const secondSettlement: Parameters<typeof tracker.settle>[1] = {
         trackId: "track-2",
         outcome: settlements[1],
-        ...(settlements[1] === "failed" ? { error: new Error("failed") } : {}),
-      });
+      };
+      if (settlements[1] === "failed") secondSettlement.error = new Error("failed");
+      tracker.settle(operationId, secondSettlement);
 
       expect(captured.at(-1)).toEqual(
         expect.objectContaining({ outcome: expectedOutcome, ...expectedCounts }),

--- a/tests/unit/features/import/playlistDownloadController.test.ts
+++ b/tests/unit/features/import/playlistDownloadController.test.ts
@@ -27,7 +27,7 @@ const flushEffects = async () => {
 
 const deferred = <Value>() => {
   let resolve!: (value: Value) => void;
-  let reject!: (error: unknown) => void;
+  let reject!: (error: Error) => void;
   const promise = new Promise<Value>((promiseResolve, promiseReject) => {
     resolve = promiseResolve;
     reject = promiseReject;

--- a/tests/unit/features/import/playlistDownloadQueueRuntime.test.ts
+++ b/tests/unit/features/import/playlistDownloadQueueRuntime.test.ts
@@ -42,7 +42,7 @@ const createRun = (count: number) => {
   return run;
 };
 
-const getAdmission = (run: object) => {
+const getAdmission = (run: ReturnType<typeof createRun>) => {
   const admission = admissionByRun.get(run);
   if (!admission) throw new Error("download admission not found for test run.");
   return admission;

--- a/tests/unit/features/import/soundcloudSet.test.ts
+++ b/tests/unit/features/import/soundcloudSet.test.ts
@@ -13,7 +13,7 @@ import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
 interface Deferred<T> {
   promise: Promise<T>;
   resolve: (value: T) => void;
-  reject: (error: unknown) => void;
+  reject: (error: Error) => void;
 }
 
 const deferred = <T>(): Deferred<T> => {

--- a/tests/unit/features/import/urlImportGateway.test.tsx
+++ b/tests/unit/features/import/urlImportGateway.test.tsx
@@ -1,6 +1,7 @@
-import type { ReactElement, ReactNode } from "react";
+import { isValidElement, type ReactElement, type ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import MediaUrlEntry from "@/features/import/MediaUrlEntry";
+import { reactChildren, reactText } from "../../../support/reactTestNodes";
 
 const reactHookMocks = vi.hoisted(() => ({
   useEffect: vi.fn(),
@@ -27,16 +28,22 @@ vi.mock("@/features/workspace/systemFailure", async (importOriginal) => {
   return { ...actual, reportSystemFailure };
 });
 
-type TestElement = ReactElement<Record<string, unknown> & { children?: ReactNode }>;
-
-const isElement = (node: ReactNode): node is TestElement =>
-  typeof node === "object" && node !== null && "props" in node;
-
-const childNodes = (node: TestElement) => {
-  const { children } = node.props;
-  if (children === undefined || children === null || typeof children === "boolean") return [];
-  return Array.isArray(children) ? children : [children];
+type SubmitEvent = { preventDefault: () => void };
+type TestElementProps = {
+  children?: ReactNode;
+  id?: string;
+  name?: string;
+  onChange?: (event: { target: { value: string } }) => void;
+  onSubmit?: (event: SubmitEvent) => Promise<void>;
+  "aria-busy"?: boolean;
+  "aria-label"?: string;
+  "data-layout"?: string;
 };
+type TestElement = ReactElement<TestElementProps>;
+
+const isElement = (node: ReactNode): node is TestElement => isValidElement<TestElementProps>(node);
+
+const childNodes = (node: TestElement) => reactChildren(node);
 
 const findElement = (
   node: ReactNode,
@@ -57,11 +64,7 @@ const findElement = (
   throw new Error("element not found");
 };
 
-const textContent = (node: ReactNode): string => {
-  if (typeof node === "string" || typeof node === "number") return String(node);
-  if (!isElement(node)) return "";
-  return childNodes(node).map(textContent).join("");
-};
+const textContent = reactText;
 
 const createHookHarness = () => {
   const states: unknown[] = [];
@@ -71,18 +74,19 @@ const createHookHarness = () => {
 
   reactHookMocks.useLayoutEffect.mockImplementation(() => undefined);
   reactHookMocks.useEffect.mockImplementation(() => undefined);
-  reactHookMocks.useRef.mockImplementation((initial: unknown) => {
+  reactHookMocks.useRef.mockImplementation(<Value,>(initial: Value) => {
     const index = refCursor++;
     refs[index] ??= { current: initial };
     return refs[index];
   });
-  reactHookMocks.useState.mockImplementation((initial: unknown) => {
+  reactHookMocks.useState.mockImplementation(<Value,>(initial: Value | (() => Value)) => {
     const index = stateCursor++;
-    if (!(index in states)) states[index] = typeof initial === "function" ? initial() : initial;
+    if (!(index in states)) states[index] = initial instanceof Function ? initial() : initial;
     return [
       states[index],
-      (next: unknown) => {
-        states[index] = typeof next === "function" ? next(states[index]) : next;
+      (next: Value | ((previous: Value) => Value)) => {
+        const previous = states[index] as Value;
+        states[index] = next instanceof Function ? next(previous) : next;
       },
     ];
   });
@@ -98,8 +102,7 @@ const createHookHarness = () => {
 
 const changeInputValue = (tree: ReactNode, value: string) => {
   const input = findElement(tree, (element) => element.props.name === "media-url");
-  const onChange = input.props.onChange as (event: { target: { value: string } }) => void;
-  onChange({ target: { value } });
+  input.props.onChange?.({ target: { value } });
 };
 
 afterEach(() => vi.clearAllMocks());
@@ -117,7 +120,7 @@ describe("media URL entry", () => {
 
     expect(tree.props["data-layout"]).toBe("editor");
     const form = findElement(tree, (element) => element.type === "form");
-    await (form.props.onSubmit as (event: { preventDefault: () => void }) => Promise<void>)({
+    await form.props.onSubmit?.({
       preventDefault: vi.fn(),
     });
 
@@ -139,9 +142,7 @@ describe("media URL entry", () => {
     changeInputValue(tree, "https://soundcloud.com/user/track");
     tree = render();
     const form = findElement(tree, (element) => element.type === "form");
-    const submit = (
-      form.props.onSubmit as (event: { preventDefault: () => void }) => Promise<void>
-    )({
+    const submit = form.props.onSubmit?.({
       preventDefault: vi.fn(),
     });
 
@@ -168,7 +169,7 @@ describe("media URL entry", () => {
     changeInputValue(tree, "not a url");
     tree = render();
     const form = findElement(tree, (element) => element.type === "form");
-    await (form.props.onSubmit as (event: { preventDefault: () => void }) => Promise<void>)({
+    await form.props.onSubmit?.({
       preventDefault: vi.fn(),
     });
 
@@ -192,7 +193,7 @@ describe("media URL entry", () => {
     changeInputValue(tree, "https://youtube.com/watch?v=abc");
     tree = render();
     const form = findElement(tree, (element) => element.type === "form");
-    await (form.props.onSubmit as (event: { preventDefault: () => void }) => Promise<void>)({
+    await form.props.onSubmit?.({
       preventDefault: vi.fn(),
     });
 
@@ -214,7 +215,7 @@ describe("media URL entry", () => {
     changeInputValue(tree, "https://soundcloud.com/user/sets/missing");
     tree = render();
     const form = findElement(tree, (element) => element.type === "form");
-    await (form.props.onSubmit as (event: { preventDefault: () => void }) => Promise<void>)({
+    await form.props.onSubmit?.({
       preventDefault: vi.fn(),
     });
 

--- a/tests/unit/features/library/AlbumSidebarDnd.test.tsx
+++ b/tests/unit/features/library/AlbumSidebarDnd.test.tsx
@@ -134,12 +134,12 @@ describe("SortableAlbumCard action menu", () => {
 });
 
 describe("SortableTrackRow action menu", () => {
-  const track = {
+  const track: TagiumFile = {
     id: "track-1",
     filename: "Night Drive.mp3",
     status: "saved",
     downloadStatus: "ready",
-  } as TagiumFile;
+  };
   const actions = createTrackActionItems({
     retryable: false,
     canShare: true,

--- a/tests/unit/features/library/MetadataCleanupDialog.test.tsx
+++ b/tests/unit/features/library/MetadataCleanupDialog.test.tsx
@@ -1,7 +1,9 @@
-import type { ReactNode } from "react";
+import type { FocusEvent, ReactNode } from "react";
+import { Schema } from "effect";
 import { act, create, type ReactTestInstance } from "react-test-renderer";
 import { describe, expect, it, vi } from "vite-plus/test";
 import type { MetadataCleanupSuggestion } from "@/features/library/metadataCleanup";
+import { buttonElementFixture } from "../../../support/domFixtures";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -13,11 +15,14 @@ vi.mock("@/components/ui/dialog", () => ({
   }: {
     children?: ReactNode;
     onCloseAutoFocus?: (event: { preventDefault: () => void }) => void;
-  }) => (
-    <div data-dialog-content onBlur={onCloseAutoFocus as never}>
-      {children}
-    </div>
-  ),
+  }) => {
+    const handleBlur = (event: FocusEvent<HTMLDivElement>) => onCloseAutoFocus?.(event);
+    return (
+      <div data-dialog-content onBlur={handleBlur}>
+        {children}
+      </div>
+    );
+  },
   DialogDescription: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
   DialogFooter: ({ children }: { children?: ReactNode }) => <footer>{children}</footer>,
   DialogHeader: ({ children }: { children?: ReactNode }) => <header>{children}</header>,
@@ -42,7 +47,9 @@ const suggestion = (trackId: string): MetadataCleanupSuggestion => ({
 });
 
 const textContent = (node: ReactTestInstance): string =>
-  node.children.map((child) => (typeof child === "string" ? child : textContent(child))).join("");
+  node.children
+    .map((child) => (Schema.is(Schema.String)(child) ? child : textContent(child)))
+    .join("");
 
 describe("MetadataCleanupDialog", () => {
   it("keeps populated suggestions rendered while the dialog closes", () => {
@@ -108,7 +115,7 @@ describe("MetadataCleanupDialog", () => {
 
   it("names an album, explains an empty live state, and restores menu focus on close", () => {
     const focus = vi.fn();
-    const returnFocusTarget = { focus } as unknown as HTMLButtonElement;
+    const returnFocusTarget = buttonElementFixture(focus);
     let renderer: ReturnType<typeof create>;
     act(() => {
       renderer = create(

--- a/tests/unit/features/library/sidebarDragController.test.ts
+++ b/tests/unit/features/library/sidebarDragController.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
+import type { Active, CollisionDetection, DroppableContainer } from "@dnd-kit/core";
 import {
   resolveSidebarDragCommand,
   type SidebarDropPosition,
@@ -8,6 +9,7 @@ import {
   LOOSE_APPEND_CONTAINER_ID,
   LOOSE_CONTAINER_ID,
 } from "@/features/library/sidebarDnd";
+import type { SidebarDragData, SidebarDropData } from "@/features/library/sidebarDnd";
 
 const albums = [
   { id: "album-a", trackIds: ["a-1", "a-2"] },
@@ -36,29 +38,45 @@ const resolve = (overrides: Partial<Parameters<typeof resolveSidebarDragCommand>
 
 describe("sidebar drag controller", () => {
   it("keeps an empty loose drop target available at the first album without reserving space", () => {
-    const looseContainer = {
-      id: LOOSE_CONTAINER_ID,
-      data: { current: { type: "container", container: "loose" } },
+    const rect = { top: 100, left: 0, right: 100, bottom: 140, width: 100, height: 40 };
+    const container = (id: string, current: SidebarDropData): DroppableContainer => ({
+      id,
+      key: id,
+      data: { current },
+      disabled: false,
+      node: { current: null },
+      rect: { current: rect },
+    });
+    const looseContainer = container(LOOSE_CONTAINER_ID, {
+      type: "container",
+      container: "loose",
+    });
+    const firstAlbum = container("album:album-a", {
+      type: "album",
+      albumId: "album-a",
+    });
+    const activeData: SidebarDragData = {
+      type: "track",
+      trackId: "a-1",
+      container: "album",
+      albumId: "album-a",
     };
-    const firstAlbum = {
-      id: "album:album-a",
-      data: { current: { type: "album", albumId: "album-a" } },
+    const active: Active = {
+      id: LOOSE_CONTAINER_ID,
+      data: { current: activeData },
+      rect: { current: { initial: rect, translated: rect } },
     };
 
-    const collisionArgs = (y: number) =>
-      ({
-        active: {
-          data: {
-            current: { type: "track", trackId: "a-1", container: "album", albumId: "album-a" },
-          },
-        },
-        droppableContainers: [looseContainer, firstAlbum],
-        droppableRects: new Map([
-          [LOOSE_CONTAINER_ID, { top: 100 }],
-          ["album:album-a", { top: 100 }],
-        ]),
-        pointerCoordinates: { x: 10, y },
-      }) as never;
+    const collisionArgs = (y: number): Parameters<CollisionDetection>[0] => ({
+      active,
+      collisionRect: rect,
+      droppableContainers: [looseContainer, firstAlbum],
+      droppableRects: new Map([
+        [LOOSE_CONTAINER_ID, rect],
+        ["album:album-a", rect],
+      ]),
+      pointerCoordinates: { x: 10, y },
+    });
 
     expect(emptyLooseDropCollision(collisionArgs(112))).toEqual([{ id: LOOSE_CONTAINER_ID }]);
     expect(emptyLooseDropCollision(collisionArgs(125))).toBeNull();

--- a/tests/unit/features/share/revocationReceipt.test.ts
+++ b/tests/unit/features/share/revocationReceipt.test.ts
@@ -55,4 +55,22 @@ describe("local sharing permission", () => {
     expect(getRevocationReceipt("old", storage)).toBeNull();
     vi.useRealTimers();
   });
+
+  it("preserves valid permissions beside malformed stored entries", () => {
+    vi.setSystemTime(new Date("2026-07-22T12:00:00Z"));
+    const storage = new MemoryStorage();
+    const receipt = {
+      slug: "k7m4q2",
+      expiresAt: "2026-10-20T12:00:00Z",
+      token: "private-revocation-secret",
+    };
+    storage.setItem(
+      "tagium.share-revocations.v1",
+      JSON.stringify([receipt, { slug: "legacy", expiresAt: null, token: 42 }]),
+    );
+
+    expect(getRevocationReceipt(receipt.slug, storage)).toEqual(receipt);
+    expect(getRevocationReceipt("legacy", storage)).toBeNull();
+    vi.useRealTimers();
+  });
 });

--- a/tests/unit/features/share/shareAlbumDialog.test.tsx
+++ b/tests/unit/features/share/shareAlbumDialog.test.tsx
@@ -1,48 +1,59 @@
-import { createElement, useEffect } from "react";
+import {
+  createElement,
+  Children,
+  isValidElement,
+  useEffect,
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+  type InputHTMLAttributes,
+  type ReactNode,
+} from "react";
+import { Schema } from "effect";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import ShareAlbumDialog from "@/features/share/ShareAlbumDialog";
 
-const lifecycle = vi.hoisted(() => ({
-  mounts: 0,
-  unmounts: 0,
-  rootMounts: 0,
-  rootUnmounts: 0,
-  dialogOpens: [] as boolean[],
-  contentKeys: [] as string[],
-  footerStructures: [] as number[],
-}));
+const lifecycle = vi.hoisted(() => {
+  const dialogOpens: boolean[] = [];
+  const contentKeys: string[] = [];
+  const footerStructures: number[] = [];
+  return {
+    mounts: 0,
+    unmounts: 0,
+    rootMounts: 0,
+    rootUnmounts: 0,
+    dialogOpens,
+    contentKeys,
+    footerStructures,
+  };
+});
 
 vi.mock("@/components/ui/dialog", () => {
-  const DialogPanel = ({ children, ...props }: { children?: unknown; [key: string]: unknown }) => {
+  const DialogPanel = ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => {
     useEffect(() => {
       lifecycle.mounts += 1;
       return () => {
         lifecycle.unmounts += 1;
       };
     }, []);
-    return createElement("div", props, children as never);
+    return createElement("div", props, children);
   };
   const DialogContent = ({
     children,
     contentKey,
     ...props
-  }: {
-    children?: unknown;
+  }: HTMLAttributes<HTMLDivElement> & {
     contentKey?: string;
-    [key: string]: unknown;
   }) => {
     lifecycle.contentKeys.push(contentKey ?? "");
-    return createElement(DialogPanel, { ...props, key: contentKey }, children as never);
+    return createElement(DialogPanel, { ...props, key: contentKey }, children);
   };
   const Dialog = ({
     children,
     open,
     ...props
-  }: {
-    children?: unknown;
+  }: HTMLAttributes<HTMLDivElement> & {
     open?: boolean;
-    [key: string]: unknown;
   }) => {
     useEffect(() => {
       lifecycle.rootMounts += 1;
@@ -51,15 +62,16 @@ vi.mock("@/components/ui/dialog", () => {
       };
     }, []);
     lifecycle.dialogOpens.push(Boolean(open));
-    return createElement("div", props, children as never);
+    return createElement("div", props, children);
   };
-  const passthrough = ({ children, ...props }: { children?: unknown; [key: string]: unknown }) =>
-    createElement("div", props, children as never);
-  const DialogFooter = ({ children, ...props }: { children?: unknown; [key: string]: unknown }) => {
-    const fragment = children as { props?: { children?: unknown } } | undefined;
-    const nested = fragment?.props?.children;
-    lifecycle.footerStructures.push(Array.isArray(nested) ? nested.length : 1);
-    return createElement("div", props, children as never);
+  const passthrough = ({ children, ...props }: HTMLAttributes<HTMLDivElement>) =>
+    createElement("div", props, children);
+  const DialogFooter = ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => {
+    const nested = isValidElement<{ children?: ReactNode }>(children)
+      ? children.props.children
+      : children;
+    lifecycle.footerStructures.push(Children.count(nested));
+    return createElement("div", props, children);
   };
   return {
     Dialog,
@@ -70,11 +82,11 @@ vi.mock("@/components/ui/dialog", () => {
   };
 });
 vi.mock("@/components/ui/button", () => ({
-  Button: ({ children, ...props }: { children?: unknown; [key: string]: unknown }) =>
-    createElement("button", props, children as never),
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) =>
+    createElement("button", props, children),
 }));
 vi.mock("@/components/ui/input", () => ({
-  Input: (props: Record<string, unknown>) => createElement("input", props),
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => createElement("input", props),
 }));
 
 const preview = {
@@ -122,8 +134,8 @@ const render = (status: "confirm" | "published" | "link" | "error" = "confirm") 
 
 const text = (renderer: ReactTestRenderer) =>
   renderer.root
-    .findAll((node) => typeof node.type === "string")
-    .map((node) => node.children.filter((child): child is string => typeof child === "string"))
+    .findAll((node) => Schema.is(Schema.String)(node.type))
+    .map((node) => node.children.filter(Schema.is(Schema.String)))
     .flat()
     .join(" ");
 
@@ -181,8 +193,8 @@ describe("share album dialog", () => {
     const footer = () =>
       renderer.root.findAll(
         (node) =>
-          typeof node.type === "string" &&
-          typeof node.props.className === "string" &&
+          Schema.is(Schema.String)(node.type) &&
+          Schema.is(Schema.String)(node.props.className) &&
           node.props.className.includes("border-t p-4"),
       )[0];
     const before = footer();
@@ -194,9 +206,7 @@ describe("share album dialog", () => {
     expect(after.props.className).toBe(before.props.className);
     const directChildren = (instance: typeof before) => {
       const child = instance.children[0];
-      return child && typeof child === "object" && "props" in child
-        ? child.props.children
-        : instance.children;
+      return child && !Schema.is(Schema.String)(child) ? child.props.children : instance.children;
     };
     expect(directChildren(after)).toHaveLength(directChildren(before).length);
     expect(lifecycle.footerStructures.at(-1)).toBe(lifecycle.footerStructures[0]);
@@ -307,9 +317,7 @@ describe("share album dialog", () => {
     );
     const buttonText = renderer.root
       .findAllByType("button")
-      .flatMap((button) =>
-        button.children.filter((child): child is string => typeof child === "string"),
-      );
+      .flatMap((button) => button.children.filter(Schema.is(Schema.String)));
     expect(buttonText).toEqual(expect.arrayContaining(["copy link", "stop sharing", "done"]));
   });
 
@@ -340,9 +348,7 @@ describe("share album dialog", () => {
     expect(
       renderer.root
         .findAllByType("button")
-        .flatMap((button) =>
-          button.children.filter((child): child is string => typeof child === "string"),
-        ),
+        .flatMap((button) => button.children.filter(Schema.is(Schema.String))),
     ).toEqual(expect.arrayContaining(["copy link", "done"]));
 
     const copy = renderer.root
@@ -357,8 +363,8 @@ describe("share album dialog", () => {
     const dialogContent = () =>
       renderer.root.findAll(
         (node) =>
-          typeof node.type === "string" &&
-          typeof node.props.className === "string" &&
+          Schema.is(Schema.String)(node.type) &&
+          Schema.is(Schema.String)(node.props.className) &&
           node.props.className.includes("max-h-[calc(100dvh-2rem)]"),
       )[0];
     expect(dialogContent().props.showCloseButton).toBe(true);
@@ -389,8 +395,8 @@ describe("share album dialog", () => {
     expect(cover.props.className).toContain("sm:size-32");
     const preview = renderer.root.findAll(
       (node) =>
-        typeof node.type === "string" &&
-        typeof node.props.className === "string" &&
+        Schema.is(Schema.String)(node.type) &&
+        Schema.is(Schema.String)(node.props.className) &&
         node.props.className.includes("gap-4") &&
         node.props.className.includes("px-5"),
     );
@@ -420,8 +426,8 @@ describe("share album dialog", () => {
 
     const previewRow = renderer.root.findAll(
       (node) =>
-        typeof node.type === "string" &&
-        typeof node.props.className === "string" &&
+        Schema.is(Schema.String)(node.type) &&
+        Schema.is(Schema.String)(node.props.className) &&
         node.props.className.includes("gap-4") &&
         node.props.className.includes("px-5"),
     )[0];
@@ -430,7 +436,7 @@ describe("share album dialog", () => {
     const titleText = title.find(
       (node) =>
         node.type === "span" &&
-        typeof node.props.className === "string" &&
+        Schema.is(Schema.String)(node.props.className) &&
         node.props.className.includes("truncate"),
     );
 

--- a/tests/unit/features/share/shareClient.test.ts
+++ b/tests/unit/features/share/shareClient.test.ts
@@ -6,8 +6,9 @@ import {
   SharedContentVersionError,
   updateShare,
 } from "@/features/share/shareClient";
+import type { Manifest } from "@/features/share/shareManifest";
 
-const manifest = {
+const manifest: Manifest = {
   version: 1,
   kind: "album",
   album: { title: "Signal", artist: "June", genre: "Electronic" },
@@ -103,7 +104,7 @@ describe("shared content client", () => {
       }),
     );
     await expect(
-      updateShare("k7m4q2", "private-secret", manifest as never, null, {
+      updateShare("k7m4q2", "private-secret", manifest, null, {
         fetch,
       }),
     ).resolves.toMatchObject({ slug: "k7m4q2" });

--- a/tests/unit/features/share/shareManifest.test.ts
+++ b/tests/unit/features/share/shareManifest.test.ts
@@ -10,8 +10,8 @@ import {
   type AlbumManifest,
 } from "@/features/share/shareManifest";
 
-const manifest = (): AlbumManifest =>
-  decodeManifest({
+const manifest = (): AlbumManifest => {
+  const decoded = decodeManifest({
     version: 1,
     kind: "album",
     album: {
@@ -55,7 +55,10 @@ const manifest = (): AlbumManifest =>
         },
       },
     ],
-  }) as AlbumManifest;
+  });
+  if (decoded.kind !== "album") throw new Error("expected an album manifest fixture");
+  return decoded;
+};
 
 describe("share manifests", () => {
   it("round-trips the supported v1 transport DTO without client artwork size or hash", () => {

--- a/tests/unit/features/share/sharePreview.test.ts
+++ b/tests/unit/features/share/sharePreview.test.ts
@@ -1,10 +1,30 @@
 import { describe, expect, it } from "vite-plus/test";
 import { buildShareAlbumPreview, buildShareTrackPreview } from "@/features/share/sharePreview";
+import type { AudioMetadata } from "@/features/library/types";
+
+const metadata = (title: string): AudioMetadata => ({
+  filename: "track.mp3",
+  title,
+  artist: "",
+  albumArtist: "",
+  album: "",
+  year: null,
+  genre: "",
+  duration: 0,
+  bitrate: 0,
+  sampleRate: 0,
+  picture: [],
+  trackNumber: null,
+  composer: "",
+  comment: "",
+  discNumber: null,
+  bpm: null,
+});
 
 const file = (id: string, filename: string, title?: string) => ({
   id,
   filename,
-  metadata: title === undefined ? undefined : ({ title } as never),
+  metadata: title === undefined ? undefined : metadata(title),
 });
 
 describe("buildShareAlbumPreview", () => {
@@ -25,7 +45,7 @@ describe("buildShareAlbumPreview", () => {
     const preview = buildShareTrackPreview({
       id: "track",
       filename: "original.mp3",
-      metadata: { title: "Original", filename: "original", picture: [] } as never,
+      metadata: { ...metadata("Original"), filename: "original" },
       pendingMetadataPatch: { title: "Edited" },
     });
 

--- a/tests/unit/features/share/sharePublication.test.ts
+++ b/tests/unit/features/share/sharePublication.test.ts
@@ -152,12 +152,12 @@ describe("shared album publication state", () => {
   });
 
   it("uses the same publication lifecycle labels for a track", () => {
-    const track = {
+    const track: TagiumFile = {
       id: "track",
       filename: "track.mp3",
       status: "saved",
       downloadStatus: "ready",
-    } as TagiumFile;
+    };
     expect(shareTrackActionState(track, undefined, false, 0)).toMatchObject({
       label: "share track",
       variant: "create",

--- a/tests/unit/features/share/shareWorkflowPreview.test.tsx
+++ b/tests/unit/features/share/shareWorkflowPreview.test.tsx
@@ -1,6 +1,9 @@
 import { act } from "react-test-renderer";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
+import type { AlbumGroup, TagiumFile } from "@/features/library/types";
+import { createLibraryState } from "@/features/library/libraryState";
 
 const { publishShare } = vi.hoisted(() => ({ publishShare: vi.fn() }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
@@ -26,6 +29,36 @@ import { renderHook } from "../../support/hookTestHarness";
 import { useShareWorkflow } from "@/features/share/useShareWorkflow";
 import { projectAlbumShareSnapshot } from "@/features/share/sharePublication";
 
+type WorkflowOptions = Parameters<typeof useShareWorkflow>[0];
+const fakeEditor = (files: TagiumFile[]): WorkflowOptions["editor"] => ({
+  commands: {
+    projectFiles: () => files,
+    flush: () => files,
+    preview: vi.fn(),
+    uploadCover: vi.fn(),
+    setCoverProcessing: vi.fn(),
+    updateTags: vi.fn(async () => undefined),
+    hydrateDownloadedTrack: vi.fn(() => Effect.void),
+  },
+  form: { subscribe: vi.fn(() => () => undefined) },
+});
+const fakeImporting = (): WorkflowOptions["importing"] => ({
+  commands: {
+    upload: vi.fn(async () => undefined),
+    importUrl: vi.fn(async () => undefined),
+    retryTrack: vi.fn(),
+    cancelQueue: vi.fn(),
+    retryQueue: vi.fn(),
+    removeTracks: vi.fn(),
+    importSharedContent: vi.fn(async () => undefined),
+  },
+});
+
+const fakeLibraryStore = (album: AlbumGroup, files: TagiumFile[]): LibraryStore => {
+  const state = { ...createLibraryState(), albums: [album], files };
+  return { state, getSnapshot: () => state, dispatch: vi.fn() };
+};
+
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.clearAllMocks();
@@ -38,7 +71,7 @@ describe("share creator preview state", () => {
     vi.stubGlobal("history", { state: {}, replaceState: vi.fn(), back: vi.fn() });
     vi.stubGlobal("window", new EventTarget());
 
-    const album = {
+    const album: AlbumGroup = {
       id: "album",
       title: "Received",
       artist: "Artist",
@@ -46,14 +79,17 @@ describe("share creator preview state", () => {
       trackIds: ["a"],
       sourceManifestSlug: "received-album",
     };
-    const files = [
+    const files: TagiumFile[] = [
       {
         id: "a",
         filename: "first.mp3",
+        status: "saved",
+        downloadStatus: "ready",
         metadata: {
           filename: "first.mp3",
           title: "First",
           artist: "Artist",
+          albumArtist: "Artist",
           album: "Received",
           year: null,
           genre: "Electronic",
@@ -62,23 +98,20 @@ describe("share creator preview state", () => {
           sampleRate: 44100,
           picture: [],
           trackNumber: 1,
+          composer: "",
+          comment: "",
+          discNumber: null,
+          bpm: null,
         },
       },
     ];
-    const library = {
-      state: { albums: [album], files },
-      getSnapshot: () => ({ albums: [album], files }),
-      dispatch: vi.fn(),
-    } as unknown as LibraryStore;
+    const library = fakeLibraryStore(album, files);
     const hook = renderHook(
       () =>
         useShareWorkflow({
           library,
-          editor: {
-            commands: { flush: vi.fn(), projectFiles: () => files },
-            form: { subscribe: () => () => undefined },
-          } as never,
-          importing: { commands: { importSharedContent: vi.fn() } } as never,
+          editor: fakeEditor(files),
+          importing: fakeImporting(),
           enabled: true,
         }),
       undefined,
@@ -105,28 +138,32 @@ describe("share creator preview state", () => {
     vi.stubGlobal("window", new EventTarget());
 
     const expiresAt = new Date(Date.now() + 86_400_000).toISOString();
-    const album = {
+    const publication = {
+      slug: "shared-album",
+      url: "https://tagium.app/share/shared-album",
+      expiresAt,
+      publishedFingerprint: "published",
+      status: "active" as const,
+    };
+    const album: AlbumGroup = {
       id: "album",
       title: "Snapshot",
       artist: "Artist",
       genre: "Electronic",
       trackIds: ["a"],
-      sharePublication: {
-        slug: "shared-album",
-        url: "https://tagium.app/share/shared-album",
-        expiresAt,
-        publishedFingerprint: "published",
-        status: "active" as const,
-      },
+      sharePublication: publication,
     };
-    const files = [
+    const files: TagiumFile[] = [
       {
         id: "a",
         filename: "first.mp3",
+        status: "saved",
+        downloadStatus: "ready",
         metadata: {
           filename: "first.mp3",
           title: "First",
           artist: "Artist",
+          albumArtist: "Artist",
           album: "Snapshot",
           year: null,
           genre: "Electronic",
@@ -135,27 +172,22 @@ describe("share creator preview state", () => {
           sampleRate: 44100,
           picture: [],
           trackNumber: 1,
+          composer: "",
+          comment: "",
+          discNumber: null,
+          bpm: null,
         },
         downloadRequest: { sourceUrl: "https://soundcloud.com/a/first", audioBitrate: "320" },
       },
     ];
-    album.sharePublication.publishedFingerprint = (
-      await projectAlbumShareSnapshot(album, files as never)
-    ).fingerprint;
-    const library = {
-      state: { albums: [album], files },
-      getSnapshot: () => ({ albums: [album], files }),
-      dispatch: vi.fn(),
-    } as unknown as LibraryStore;
+    publication.publishedFingerprint = (await projectAlbumShareSnapshot(album, files)).fingerprint;
+    const library = fakeLibraryStore(album, files);
     const hook = renderHook(
       () =>
         useShareWorkflow({
           library,
-          editor: {
-            commands: { flush: vi.fn(), projectFiles: () => files },
-            form: { subscribe: () => () => undefined },
-          } as never,
-          importing: { commands: { importSharedContent: vi.fn() } } as never,
+          editor: fakeEditor(files),
+          importing: fakeImporting(),
           enabled: true,
         }),
       undefined,
@@ -195,15 +227,24 @@ describe("share creator preview state", () => {
       }),
     );
 
-    const album = { id: "album", title: "Snapshot", artist: "", genre: "", trackIds: ["a", "a"] };
-    const files = [
+    const album: AlbumGroup = {
+      id: "album",
+      title: "Snapshot",
+      artist: "",
+      genre: "",
+      trackIds: ["a", "a"],
+    };
+    const files: TagiumFile[] = [
       {
         id: "a",
         filename: "first.mp3",
+        status: "saved",
+        downloadStatus: "ready",
         metadata: {
           filename: "first.mp3",
           title: "First",
           artist: "Artist",
+          albumArtist: "Artist",
           album: "Album",
           year: null,
           genre: "Electronic",
@@ -212,24 +253,21 @@ describe("share creator preview state", () => {
           sampleRate: 44100,
           picture: [],
           trackNumber: 1,
+          composer: "",
+          comment: "",
+          discNumber: null,
+          bpm: null,
         },
         downloadRequest: { sourceUrl: "https://soundcloud.com/a/first", audioBitrate: "320" },
       },
     ];
-    const library = {
-      state: { albums: [album], files },
-      getSnapshot: () => ({ albums: [album], files }),
-      dispatch: vi.fn(),
-    } as unknown as LibraryStore;
+    const library = fakeLibraryStore(album, files);
     const hook = renderHook(
       () =>
         useShareWorkflow({
           library,
-          editor: {
-            commands: { flush: vi.fn(), projectFiles: () => files },
-            form: { subscribe: () => () => undefined },
-          } as never,
-          importing: { commands: { importSharedContent: vi.fn() } } as never,
+          editor: fakeEditor(files),
+          importing: fakeImporting(),
           enabled: true,
         }),
       undefined,

--- a/tests/unit/features/share/sharedAlbumPage.test.tsx
+++ b/tests/unit/features/share/sharedAlbumPage.test.tsx
@@ -1,4 +1,5 @@
-import { createElement } from "react";
+import { createElement, type HTMLAttributes } from "react";
+import { Schema } from "effect";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import SharedAlbumPage from "@/features/share/SharedAlbumPage";
@@ -17,8 +18,8 @@ vi.mock("sonner", () => ({
 }));
 
 vi.mock("@/components/ui/dialog", () => {
-  const passthrough = ({ children, ...props }: { children?: unknown; [key: string]: unknown }) =>
-    createElement("div", props, children as never);
+  const passthrough = ({ children, ...props }: HTMLAttributes<HTMLDivElement>) =>
+    createElement("div", props, children);
   return {
     Dialog: passthrough,
     DialogContent: passthrough,
@@ -84,9 +85,9 @@ const artworkState = {
 
 const buttonText = (button: ReactTestRenderer["root"]) =>
   button
-    .findAll((node) => typeof node.type === "string")
+    .findAll((node) => Schema.is(Schema.String)(node.type))
     .flatMap((node) => node.children)
-    .filter((child): child is string => typeof child === "string")
+    .filter(Schema.is(Schema.String))
     .join("")
     .replace(/\s+/g, " ")
     .trim();

--- a/tests/unit/features/share/useShareWorkflow.test.tsx
+++ b/tests/unit/features/share/useShareWorkflow.test.tsx
@@ -1,10 +1,12 @@
 import { act } from "react-test-renderer";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { AlbumGroup, TagiumFile } from "@/features/library/types";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
 import { useTrackEditorSession } from "@/features/editor/useTrackEditorSession";
 import { useLibraryStore } from "@/features/library/useLibraryStore";
 import { DEFAULT_APP_SETTINGS } from "@/features/settings/settings";
+import { createLibraryState } from "@/features/library/libraryState";
 
 const mocks = vi.hoisted(() => ({
   fetchSharedContent: vi.fn(),
@@ -55,8 +57,50 @@ import {
   projectTrackShareSnapshot,
 } from "@/features/share/sharePublication";
 
+type WorkflowOptions = Parameters<typeof useShareWorkflow>[0];
+const fakeEditor = (
+  files: TagiumFile[],
+  flush: (trackIds?: string[]) => TagiumFile[] = () => files,
+): WorkflowOptions["editor"] => ({
+  commands: {
+    projectFiles: () => files,
+    flush,
+    preview: vi.fn(),
+    uploadCover: vi.fn(),
+    setCoverProcessing: vi.fn(),
+    updateTags: vi.fn(async () => undefined),
+    hydrateDownloadedTrack: vi.fn(() => Effect.void),
+  },
+  form: { subscribe: vi.fn(() => () => undefined) },
+});
+const fakeImporting = (
+  importSharedContent = mocks.importSharedContent,
+): WorkflowOptions["importing"] => ({
+  commands: {
+    upload: vi.fn(async () => undefined),
+    importUrl: vi.fn(async () => undefined),
+    retryTrack: vi.fn(),
+    cancelQueue: vi.fn(),
+    retryQueue: vi.fn(),
+    removeTracks: vi.fn(),
+    importSharedContent,
+  },
+});
+
 const slug = "k7m4q2";
 const analyticsId = "a".repeat(43);
+type ShareHistoryState = { shareSlug?: string };
+type ShareHistory = {
+  state: ShareHistoryState;
+  replaceState: (state: ShareHistoryState, title: string, path: string) => void;
+  back: ReturnType<typeof vi.fn>;
+};
+type FormTarget = {
+  name: "genre" | "year" | "trackNumber";
+  value: string;
+  type?: string;
+  valueAsNumber?: number;
+};
 const sharedManifest = {
   version: 1 as const,
   kind: "album" as const,
@@ -76,24 +120,42 @@ const sharedManifest = {
   ],
 };
 
+const fakeLibraryStore = (
+  albums: AlbumGroup[],
+  files: TagiumFile[],
+  dispatch: LibraryStore["dispatch"],
+): LibraryStore => {
+  const state = { ...createLibraryState(), albums, files };
+  return { state, getSnapshot: () => state, dispatch };
+};
+
 const workflow = (albums: Array<{ id: string; sourceManifestSlug?: string }> = []) => {
   const events: string[] = [];
-  const library = {
-    state: { albums, files: [] },
-    getSnapshot: () => ({ albums, files: [] }),
-    dispatch: vi.fn(() => events.push("select")),
-  } as unknown as LibraryStore;
-  const editor = {
-    commands: { flush: vi.fn(() => events.push("flush")), projectFiles: () => [] },
-    form: { subscribe: () => () => undefined },
-  };
-  const importing = { commands: { importSharedContent: mocks.importSharedContent } };
+  const albumGroups = albums.map(({ id, sourceManifestSlug }) => ({
+    id,
+    title: "",
+    artist: "",
+    genre: "",
+    trackIds: [],
+    sourceManifestSlug,
+  }));
+  const library = fakeLibraryStore(
+    albumGroups,
+    [],
+    vi.fn(() => events.push("select")),
+  );
+  const flush = vi.fn(() => {
+    events.push("flush");
+    return [];
+  });
+  const editor = fakeEditor([], flush);
+  const importing = fakeImporting();
   const hook = renderHook(
     () =>
       useShareWorkflow({
         library,
-        editor: editor as never,
-        importing: importing as never,
+        editor,
+        importing,
         enabled: true,
       }),
     undefined,
@@ -104,24 +166,21 @@ const workflow = (albums: Array<{ id: string; sourceManifestSlug?: string }> = [
 const creatorWorkflow = (album: AlbumGroup, file: TagiumFile) => {
   const albums = [album];
   const files = [file];
-  const library = {
-    state: { albums, files },
-    getSnapshot: () => ({ albums, files }),
-    dispatch: vi.fn((action: { type: string; albumId?: string; publication?: unknown }) => {
+  const library = fakeLibraryStore(
+    albums,
+    files,
+    vi.fn((action) => {
       if (action.type === "album-share-publication-set" && action.albumId === album.id) {
-        album.sharePublication = action.publication as AlbumGroup["sharePublication"];
+        album.sharePublication = action.publication;
       }
     }),
-  } as unknown as LibraryStore;
+  );
   const hook = renderHook(
     () =>
       useShareWorkflow({
         library,
-        editor: {
-          commands: { flush: vi.fn(), projectFiles: () => files },
-          form: { subscribe: () => () => undefined },
-        } as never,
-        importing: { commands: { importSharedContent: vi.fn() } } as never,
+        editor: fakeEditor(files),
+        importing: fakeImporting(vi.fn()),
         enabled: true,
       }),
     undefined,
@@ -131,24 +190,21 @@ const creatorWorkflow = (album: AlbumGroup, file: TagiumFile) => {
 
 const trackCreatorWorkflow = (file: TagiumFile, albums: AlbumGroup[] = [], flush = vi.fn()) => {
   const files = [file];
-  const library = {
-    state: { albums, files },
-    getSnapshot: () => ({ albums, files }),
-    dispatch: vi.fn((action: { type: string; fileId?: string; publication?: unknown }) => {
+  const library = fakeLibraryStore(
+    albums,
+    files,
+    vi.fn((action) => {
       if (action.type === "track-share-publication-set" && action.fileId === file.id) {
-        file.sharePublication = action.publication as TagiumFile["sharePublication"];
+        file.sharePublication = action.publication;
       }
     }),
-  } as unknown as LibraryStore;
+  );
   const hook = renderHook(
     () =>
       useShareWorkflow({
         library,
-        editor: {
-          commands: { flush, projectFiles: () => files },
-          form: { subscribe: () => () => undefined },
-        } as never,
-        importing: { commands: { importSharedContent: vi.fn() } } as never,
+        editor: fakeEditor(files, flush),
+        importing: fakeImporting(vi.fn()),
         enabled: true,
       }),
     undefined,
@@ -196,13 +252,9 @@ const creatorAlbum = (sharePublication?: AlbumGroup["sharePublication"]): AlbumG
 
 beforeEach(() => {
   const location = { pathname: "/", origin: "https://tagium.app" };
-  const fakeHistory: {
-    state: unknown;
-    replaceState: (state: unknown, title: string, path: string) => void;
-    back: ReturnType<typeof vi.fn>;
-  } = {
+  const fakeHistory: ShareHistory = {
     state: {},
-    replaceState: (state: unknown, _title: string, path: string) => {
+    replaceState: (state: ShareHistoryState, _title: string, path: string) => {
       fakeHistory.state = state;
       location.pathname = path;
     },
@@ -361,7 +413,7 @@ describe("share workflow pasted links", () => {
         },
       },
     };
-    const artworkFile = { name: "fresh.png", type: "image/png" } as File;
+    const artworkFile = new File(["artwork"], "fresh.png", { type: "image/png" });
     const convertedPicture = [
       {
         format: "image/jpeg",
@@ -402,20 +454,13 @@ describe("share workflow pasted links", () => {
   });
 
   it("rejects pasted links safely when sharing is disabled", async () => {
-    const library = {
-      state: { albums: [], files: [] },
-      getSnapshot: () => ({ albums: [], files: [] }),
-      dispatch: vi.fn(),
-    } as unknown as LibraryStore;
+    const library = fakeLibraryStore([], [], vi.fn());
     const hook = renderHook(
       () =>
         useShareWorkflow({
           library,
-          editor: {
-            commands: { flush: vi.fn(), projectFiles: () => [] },
-            form: { subscribe: () => () => undefined },
-          } as never,
-          importing: { commands: { importSharedContent: vi.fn() } } as never,
+          editor: fakeEditor([]),
+          importing: fakeImporting(vi.fn()),
           enabled: false,
         }),
       undefined,
@@ -630,7 +675,7 @@ describe("share workflow publication lifecycle", () => {
       const sharing = useShareWorkflow({
         library,
         editor,
-        importing: { commands: { importSharedContent: vi.fn() } } as never,
+        importing: fakeImporting(vi.fn()),
         enabled: true,
       });
       return { editor, library, sharing };
@@ -651,11 +696,14 @@ describe("share workflow publication lifecycle", () => {
       field,
       field === "genre" ? {} : { valueAsNumber: true },
     );
-    const target = {
+    const target: FormTarget = {
       name: field,
       value,
-      ...(field === "genre" ? {} : { type: "number", valueAsNumber: Number(value) }),
     };
+    if (field !== "genre") {
+      target.type = "number";
+      target.valueAsNumber = Number(value);
+    }
     act(() => {
       if (field !== "genre") {
         registration.ref(target as HTMLInputElement);

--- a/tests/unit/features/workspace/mobileWorkspaceNavigation.hook.test.tsx
+++ b/tests/unit/features/workspace/mobileWorkspaceNavigation.hook.test.tsx
@@ -2,23 +2,28 @@ import { useState } from "react";
 import { act } from "react-test-renderer";
 import { describe, expect, it, vi } from "vitest";
 import { renderHook } from "../../support/hookTestHarness";
-import { useMobileWorkspaceNavigation } from "@/features/workspace/mobileWorkspaceNavigation";
+import {
+  useMobileWorkspaceNavigation,
+  type WorkspaceNavigationState,
+} from "@/features/workspace/mobileWorkspaceNavigation";
+
+type TestHistoryState = WorkspaceNavigationState & { shareSlug?: string };
 
 describe("mobile workspace navigation history integration", () => {
   it("queues drawer actions until the tagged pop completes", async () => {
     const events = new EventTarget();
-    let state: unknown = {};
-    const stack: unknown[] = [state];
+    let state: TestHistoryState | undefined = {};
+    const stack: TestHistoryState[] = [state];
     let backCalls = 0;
     const history = {
       get state() {
         return state;
       },
-      pushState(next: unknown) {
+      pushState(next: TestHistoryState) {
         state = next;
         stack.push(next);
       },
-      replaceState(next: unknown) {
+      replaceState(next: TestHistoryState) {
         state = next;
         stack[stack.length - 1] = next;
       },

--- a/tests/unit/features/workspace/mobileWorkspaceNavigation.test.ts
+++ b/tests/unit/features/workspace/mobileWorkspaceNavigation.test.ts
@@ -6,11 +6,10 @@ import {
 
 describe("workspace navigation history", () => {
   it("preserves unrelated history state such as share workflow markers", () => {
-    const state = { shareSlug: "album-123", other: true };
+    const state = { shareSlug: "album-123" };
     const next = workspaceHistoryState(state, "drawer", "open");
     expect(next).toMatchObject({
       shareSlug: "album-123",
-      other: true,
       workspaceNav: { kind: "drawer", value: "open" },
     });
   });

--- a/tests/unit/features/workspace/useAudioWorkspace.test.tsx
+++ b/tests/unit/features/workspace/useAudioWorkspace.test.tsx
@@ -16,6 +16,7 @@ import { useAudioWorkspace } from "@/features/workspace/useAudioWorkspace";
 import { useLibraryStore } from "@/features/library/useLibraryStore";
 import { useTrackEditorSession } from "@/features/editor/useTrackEditorSession";
 import { useWorkspaceNavigation } from "@/features/workspace/workspaceNavigation";
+import { buttonElementFixture } from "../../../support/domFixtures";
 
 const initialSettings: AppSettings = {
   ...DEFAULT_APP_SETTINGS,
@@ -160,10 +161,7 @@ describe("audio workspace", () => {
     act(() => hook.result.workspace.albumDialogProps.onSave());
     const albumId = hook.result.library.getSnapshot().albums[0].id;
     act(() => hook.result.workspace.sidebarProps.onMoveTrackToAlbum(track.id, albumId, "append"));
-    const returnFocusTarget = {
-      focus: vi.fn(),
-      isConnected: true,
-    } as unknown as HTMLButtonElement;
+    const returnFocusTarget = buttonElementFixture(vi.fn());
 
     act(() => hook.result.workspace.sidebarProps.onDeleteAlbum(albumId, returnFocusTarget));
     expect(hook.result.workspace.albumDeletionDialogProps).toMatchObject({
@@ -217,8 +215,8 @@ describe("audio workspace", () => {
       });
     });
 
-    const cleanupToast = toastMocks.toast.mock.calls.find(
-      ([message]) => typeof message === "string" && message.includes("cleaned up"),
+    const cleanupToast = toastMocks.toast.mock.calls.find(([message]) =>
+      String(message).includes("cleaned up"),
     );
     expect(cleanupToast).toBeDefined();
     void act(() => {

--- a/tests/unit/features/workspace/useWorkspaceCleanup.test.tsx
+++ b/tests/unit/features/workspace/useWorkspaceCleanup.test.tsx
@@ -13,6 +13,7 @@ vi.mock("sonner", () => ({ toast: toastMocks.toast }));
 import { renderHook } from "../../support/hookTestHarness";
 import { useLibraryStore } from "@/features/library/useLibraryStore";
 import { useWorkspaceCleanup } from "@/features/workspace/useWorkspaceCleanup";
+import { buttonElementFixture } from "../../../support/domFixtures";
 
 const settings: AppSettings = {
   ...DEFAULT_APP_SETTINGS,
@@ -84,7 +85,7 @@ describe("workspace title cleanup", () => {
     expect(hook.result.cleanup.cleanupSuggestionCountByAlbumId.get("album")).toBe(1);
     expect(toastMocks.toast).not.toHaveBeenCalled();
 
-    const focusTarget = { focus: vi.fn() } as unknown as HTMLButtonElement;
+    const focusTarget = buttonElementFixture(vi.fn());
     act(() => hook.result.cleanup.onReviewAlbum("album", focusTarget));
     expect(hook.result.cleanup.dialogProps).toMatchObject({
       open: true,

--- a/tests/unit/features/workspace/workspaceNavigation.test.tsx
+++ b/tests/unit/features/workspace/workspaceNavigation.test.tsx
@@ -1,6 +1,7 @@
 import { act } from "react-test-renderer";
 import { describe, expect, it, vi } from "vite-plus/test";
 import type { LibraryStore } from "@/features/library/useLibraryStore";
+import { createLibraryState } from "@/features/library/libraryState";
 import {
   transitionWorkspaceDestination,
   useWorkspaceNavigation,
@@ -37,11 +38,14 @@ describe("workspace destination transitions", () => {
 describe("workspace navigation", () => {
   it("flushes editor work before Home clears selection", () => {
     const calls: string[] = [];
-    const library = {
+    const state = createLibraryState();
+    const library: LibraryStore = {
+      state,
+      getSnapshot: () => state,
       dispatch: vi.fn(() => {
         calls.push("clear");
       }),
-    } as unknown as LibraryStore;
+    };
     const hook = renderHook(
       () =>
         useWorkspaceNavigation({
@@ -71,7 +75,12 @@ describe("workspace navigation", () => {
   });
 
   it("blocks destination changes while cover art is processing", () => {
-    const library = { dispatch: vi.fn() } as unknown as LibraryStore;
+    const state = createLibraryState();
+    const library: LibraryStore = {
+      state,
+      getSnapshot: () => state,
+      dispatch: vi.fn(),
+    };
     const hook = renderHook(
       () =>
         useWorkspaceNavigation({

--- a/tests/unit/support/hookTestHarness.tsx
+++ b/tests/unit/support/hookTestHarness.tsx
@@ -1,7 +1,8 @@
 import { createElement, type ReactNode } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 
-(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+const reactActEnvironment = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
+reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
 
 export const renderHook = <Props, Result>(
   useHook: (props: Props) => Result,

--- a/tools/oxlint/anti-slop/LICENSE
+++ b/tools/oxlint/anti-slop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dillon Mulroy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/oxlint/anti-slop/index.ts
+++ b/tools/oxlint/anti-slop/index.ts
@@ -1,0 +1,41 @@
+import { definePlugin } from "@oxlint/plugins";
+
+import { noChainedTypeAssertionsRule } from "./rules/no-chained-type-assertions.ts";
+import { noConditionalEmptyObjectSpreadRule } from "./rules/no-conditional-empty-object-spread.ts";
+import { noKnownValueWideningRule } from "./rules/no-known-value-widening.ts";
+import { noModuleMockingRule } from "./rules/no-module-mocking.ts";
+import { noObjectParametersRule } from "./rules/no-object-parameters.ts";
+import { noReflectApplyRule } from "./rules/no-reflect-apply.ts";
+import { noReflectGetRule } from "./rules/no-reflect-get.ts";
+import { noRuntimeTypeofRule } from "./rules/no-runtime-typeof.ts";
+import { noForbiddenTermInSymbolNamesRule } from "./rules/no-shape-in-symbol-names.ts";
+import { noUnknownParametersRule } from "./rules/no-unknown-parameters.ts";
+import { noUnknownReturnsRule } from "./rules/no-unknown-returns.ts";
+import { noUnknownTypeAliasesRule } from "./rules/no-unknown-type-aliases.ts";
+import { noUnsafeDictionaryTypeRule } from "./rules/no-unsafe-dictionary-type.ts";
+import { noWidenThenAssertRule } from "./rules/no-widen-then-assert.ts";
+import { requireSafetyCommentForTypeAssertionRule } from "./rules/require-safety-comment-for-type-assertion.ts";
+
+/** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
+const antiSlopPlugin = definePlugin({
+	meta: { name: "anti-slop" },
+	rules: {
+		"no-chained-type-assertions": noChainedTypeAssertionsRule,
+		"no-conditional-empty-object-spread": noConditionalEmptyObjectSpreadRule,
+		"no-known-value-widening": noKnownValueWideningRule,
+		"no-module-mocking": noModuleMockingRule,
+		"no-object-parameters": noObjectParametersRule,
+		"no-reflect-apply": noReflectApplyRule,
+		"no-reflect-get": noReflectGetRule,
+		"no-runtime-typeof": noRuntimeTypeofRule,
+		"no-unsafe-dictionary-type": noUnsafeDictionaryTypeRule,
+		"no-shape-in-symbol-names": noForbiddenTermInSymbolNamesRule,
+		"no-unknown-parameters": noUnknownParametersRule,
+		"no-unknown-returns": noUnknownReturnsRule,
+		"no-unknown-type-aliases": noUnknownTypeAliasesRule,
+		"no-widen-then-assert": noWidenThenAssertRule,
+		"require-safety-comment-for-type-assertion": requireSafetyCommentForTypeAssertionRule,
+	},
+});
+
+export default antiSlopPlugin;

--- a/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
+++ b/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
@@ -1,0 +1,77 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+type TypeAssertionExpression = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+function isTypeAssertionExpression(node: ESTree.Node): node is TypeAssertionExpression {
+  return node.type === "TSAsExpression" || node.type === "TSTypeAssertion";
+}
+
+function unwrapParenthesizedExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isConstAssertion(node: TypeAssertionExpression): boolean {
+  const { typeAnnotation } = node;
+  return (
+    typeAnnotation.type === "TSTypeReference" &&
+    typeAnnotation.typeName.type === "Identifier" &&
+    typeAnnotation.typeName.name === "const"
+  );
+}
+
+function isOutermostAssertionInChain(node: TypeAssertionExpression): boolean {
+  let current: ESTree.Expression = node;
+  let parent = node.parent;
+
+  while (parent.type === "ParenthesizedExpression" && parent.expression === current) {
+    current = parent;
+    parent = parent.parent;
+  }
+
+  return !isTypeAssertionExpression(parent) || parent.expression !== current;
+}
+
+function isForbiddenAssertionChain(node: TypeAssertionExpression): boolean {
+  let assertionCount = 0;
+  let hasNonConstAssertion = false;
+  let current: ESTree.Expression = node;
+
+  while (isTypeAssertionExpression(current)) {
+    assertionCount += 1;
+    hasNonConstAssertion ||= !isConstAssertion(current);
+    current = unwrapParenthesizedExpression(current.expression);
+  }
+
+  return assertionCount > 1 && hasNonConstAssertion;
+}
+
+/** Disallow nested TypeScript type assertions, while permitting chains made only of const assertions. */
+export const noChainedTypeAssertionsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow chained TypeScript as and angle-bracket assertions, including parenthesized chains.",
+    },
+    messages: {
+      chained:
+        "This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.",
+    },
+  },
+  create(context) {
+    const checkTypeAssertion = (node: TypeAssertionExpression) => {
+      if (!isOutermostAssertionInChain(node) || !isForbiddenAssertionChain(node)) return;
+      context.report({ node, messageId: "chained" });
+    };
+
+    return {
+      TSAsExpression: checkTypeAssertion,
+      TSTypeAssertion: checkTypeAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
+++ b/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
@@ -1,0 +1,49 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+function unwrapParentheses(node: ESTree.Expression): ESTree.Expression {
+  let current = node;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isEmptyObjectExpression(node: ESTree.Expression): boolean {
+  return node.type === "ObjectExpression" && node.properties.length === 0;
+}
+
+function isConditionalEmptyObjectSpread(node: ESTree.Expression): boolean {
+  const conditional = unwrapParentheses(node);
+  return (
+    conditional.type === "ConditionalExpression" &&
+    (isEmptyObjectExpression(conditional.consequent) ||
+      isEmptyObjectExpression(conditional.alternate))
+  );
+}
+
+/** Ban conditional empty-object spreads without changing their omission semantics. */
+export const noConditionalEmptyObjectSpreadRule = defineRule({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow object spreads that conditionally spread an empty object to omit fields.",
+    },
+    messages: {
+      avoid:
+        "This conditional spread hides property omission behind an empty object. Build the object in separate statements and add the property only when present.",
+    },
+  },
+  create(context) {
+    return {
+      SpreadElement(node) {
+        if (node.parent.type !== "ObjectExpression") return;
+
+        if (isConditionalEmptyObjectSpread(node.argument)) {
+          context.report({ node, messageId: "avoid" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
+++ b/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
@@ -1,0 +1,247 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	classifyWideningTarget,
+	createTypeEnvironment,
+	isKnownEvidenceExpression,
+	type TypeEnvironment,
+	type WideningTarget,
+} from "../shared/dictionary-types.ts";
+
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+type FunctionExpression = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function unwrapExpression(expression: ESTree.Expression): ESTree.Expression {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSSatisfiesExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression"
+	) {
+		current = current.expression;
+	}
+	return current;
+}
+
+function resolveVariable(
+	sourceCode: SourceCode,
+	identifier: ESTree.IdentifierReference,
+): Variable | null {
+	let scope: Scope | null = sourceCode.getScope(identifier);
+	while (scope !== null) {
+		const variable = scope.set.get(identifier.name);
+		if (variable !== undefined) return variable;
+		scope = scope.upper;
+	}
+	return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+	if (variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	return definition?.type === "Variable" && definition.node.type === "VariableDeclarator"
+		? definition.node
+		: null;
+}
+
+function isStableConstVariable(variable: Variable, declarator: ESTree.VariableDeclarator): boolean {
+	return (
+		declarator.parent.type === "VariableDeclaration" &&
+		declarator.parent.kind === "const" &&
+		variable.references.every((reference) => reference.init || !reference.isWrite())
+	);
+}
+
+function hasKnownEvidence(
+	sourceCode: SourceCode,
+	expression: ESTree.Expression,
+	visitedVariables = new Set<Variable>(),
+): boolean {
+	if (isKnownEvidenceExpression(expression)) return true;
+	const unwrapped = unwrapExpression(expression);
+	if (unwrapped.type !== "Identifier") return false;
+	const variable = resolveVariable(sourceCode, unwrapped);
+	if (variable === null || visitedVariables.has(variable)) return false;
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.init === null ||
+		!isStableConstVariable(variable, declarator)
+	) {
+		return false;
+	}
+	visitedVariables.add(variable);
+	return hasKnownEvidence(sourceCode, declarator.init, visitedVariables);
+}
+
+function annotationTarget(
+	annotation: ESTree.TSTypeAnnotation | null | undefined,
+	environment: TypeEnvironment,
+): WideningTarget | null {
+	return annotation === null || annotation === undefined
+		? null
+		: classifyWideningTarget(annotation.typeAnnotation, environment);
+}
+
+function enclosingFunction(node: ESTree.Node): FunctionExpression | null {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (
+			current.type === "ArrowFunctionExpression" ||
+			current.type === "FunctionDeclaration" ||
+			current.type === "FunctionExpression"
+		) {
+			return current;
+		}
+		current = current.parent;
+	}
+	return null;
+}
+
+function sourceKeyName(sourceCode: SourceCode, key: ESTree.PropertyKey): string {
+	if (key.type === "Identifier" || key.type === "PrivateIdentifier") return key.name;
+	if (key.type === "Literal") return String(key.value);
+	return sourceCode.getText(key);
+}
+
+function functionName(sourceCode: SourceCode, owner: FunctionExpression | null): string {
+	if (owner === null) return "anonymous function";
+	if (owner.id !== null) return owner.id.name;
+	const parent = owner.parent;
+	if (parent.type === "VariableDeclarator" && parent.id.type === "Identifier")
+		return parent.id.name;
+	if (parent.type === "MethodDefinition") return sourceKeyName(sourceCode, parent.key);
+	return "anonymous function";
+}
+
+function isEmptyObjectExpression(expression: ESTree.Expression): boolean {
+	const unwrapped = unwrapExpression(expression);
+	return unwrapped.type === "ObjectExpression" && unwrapped.properties.length === 0;
+}
+
+function isDictionaryAccumulatorTarget(destination: WideningTarget): boolean {
+	return destination.kind === "open dictionary" || destination.kind === "generic container";
+}
+
+function hasParentAssertion(node: ESTree.Node): boolean {
+	return node.parent?.type === "TSAsExpression" || node.parent?.type === "TSTypeAssertion";
+}
+
+/** Detect sound syntactic cases where a known value is explicitly widened and loses evidence. */
+export const noKnownValueWideningRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow syntactically established values from flowing into explicitly broad or anonymous target types that discard useful evidence.",
+		},
+		messages: {
+			widening:
+				"The explicit {{target}} type on {{subject}} discards known type evidence. Keep inference, validate with `satisfies`, or use a named owner contract.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeEnvironment | null = null;
+
+		const reportFlow = (
+			expression: ESTree.Expression,
+			destination: WideningTarget | null,
+			subject: string,
+		) => {
+			if (destination === null) return;
+			if (
+				isDictionaryAccumulatorTarget(destination) &&
+				isEmptyObjectExpression(expression)
+			) {
+				return;
+			}
+			if (!hasKnownEvidence(context.sourceCode, expression)) return;
+			context.report({
+				node: expression,
+				messageId: "widening",
+				data: { subject, target: destination.kind },
+			});
+		};
+
+		const targetFromAnnotation = (annotation: ESTree.TSTypeAnnotation | null | undefined) =>
+			environment === null ? null : annotationTarget(annotation, environment);
+
+		return {
+			Program(node) {
+				environment = createTypeEnvironment(node);
+			},
+			VariableDeclarator(node) {
+				if (node.init === null || node.id.type !== "Identifier") return;
+				reportFlow(
+					node.init,
+					targetFromAnnotation(node.id.typeAnnotation),
+					`binding \`${node.id.name}\``,
+				);
+			},
+			PropertyDefinition(node) {
+				if (node.value === null) return;
+				reportFlow(
+					node.value,
+					targetFromAnnotation(node.typeAnnotation),
+					`property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+				);
+			},
+			AccessorProperty(node) {
+				if (node.value === null) return;
+				reportFlow(
+					node.value,
+					targetFromAnnotation(node.typeAnnotation),
+					`property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+				);
+			},
+			AssignmentExpression(node) {
+				if (node.operator !== "=" || node.left.type !== "Identifier") return;
+				const variable = resolveVariable(context.sourceCode, node.left);
+				if (variable === null) return;
+				const declarator = variableDeclarator(variable);
+				if (declarator === null || declarator.id.type !== "Identifier") return;
+				reportFlow(
+					node.right,
+					targetFromAnnotation(declarator.id.typeAnnotation),
+					`binding \`${declarator.id.name}\``,
+				);
+			},
+			ReturnStatement(node) {
+				if (node.argument === null) return;
+				const owner = enclosingFunction(node);
+				reportFlow(
+					node.argument,
+					targetFromAnnotation(owner?.returnType),
+					`return value of \`${functionName(context.sourceCode, owner)}\``,
+				);
+			},
+			ArrowFunctionExpression(node) {
+				if (node.body.type === "BlockStatement") return;
+				reportFlow(
+					node.body,
+					targetFromAnnotation(node.returnType),
+					`return value of \`${functionName(context.sourceCode, node)}\``,
+				);
+			},
+			TSAsExpression(node) {
+				if (environment === null || hasParentAssertion(node)) return;
+				reportFlow(
+					node.expression,
+					classifyWideningTarget(node.typeAnnotation, environment),
+					"assertion",
+				);
+			},
+			TSTypeAssertion(node) {
+				if (environment === null || hasParentAssertion(node)) return;
+				reportFlow(
+					node.expression,
+					classifyWideningTarget(node.typeAnnotation, environment),
+					"assertion",
+				);
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-module-mocking.ts
+++ b/tools/oxlint/anti-slop/rules/no-module-mocking.ts
@@ -1,0 +1,94 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+const moduleMockMethods = new Set(["doMock", "mock", "unstable_mockModule"]);
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function importedName(node: ESTree.Node): string | null {
+  if (node.type !== "ImportSpecifier") return null;
+  return node.imported.type === "Identifier" ? node.imported.name : node.imported.value;
+}
+
+function isTestFrameworkObject(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+): expression is ESTree.IdentifierReference {
+  if (expression.type !== "Identifier") return false;
+  if (
+    (expression.name === "vi" || expression.name === "jest") &&
+    sourceCode.isGlobalReference(expression)
+  ) {
+    return true;
+  }
+
+  const variable = resolveVariable(sourceCode, expression);
+  if (variable === null || variable.defs.length === 0) {
+    return expression.name === "vi" || expression.name === "jest";
+  }
+  return variable.defs.some((definition) => {
+    if (definition.type !== "ImportBinding" || definition.parent?.type !== "ImportDeclaration") {
+      return false;
+    }
+    const source = definition.parent.source.value;
+    const name = importedName(definition.node);
+    return (
+      ((source === "vitest" || source === "vite-plus/test") && name === "vi") ||
+      (source === "@jest/globals" && name === "jest")
+    );
+  });
+}
+
+function moduleMockCall(sourceCode: SourceCode, callee: ESTree.Expression): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isTestFrameworkObject(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  const method = callee.computed
+    ? property.type === "Literal" &&
+      (property.value === "doMock" ||
+        property.value === "mock" ||
+        property.value === "unstable_mockModule")
+      ? property.value
+      : null
+    : property.type === "Identifier"
+      ? property.name
+      : null;
+  return method !== null && moduleMockMethods.has(method);
+}
+
+/** Ban test framework module mocking in favor of real dependency seams. */
+export const noModuleMockingRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Vitest and Jest module mocking; tests must replace dependencies through real interfaces.",
+    },
+    messages: {
+      moduleMock:
+        "Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (moduleMockCall(context.sourceCode, node.callee)) {
+          context.report({ node, messageId: "moduleMock" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-object-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-object-parameters.ts
@@ -1,0 +1,136 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+type Parameter = ESTree.ParamPattern;
+type ParameterOwner =
+	| ESTree.ArrowFunctionExpression
+	| ESTree.Function
+	| ESTree.TSCallSignatureDeclaration
+	| ESTree.TSConstructSignatureDeclaration
+	| ESTree.TSConstructorType
+	| ESTree.TSFunctionType
+	| ESTree.TSMethodSignature;
+
+function parameterAnnotation(parameter: Parameter): ESTree.TSTypeAnnotation | null | undefined {
+	if (parameter.type === "TSParameterProperty") {
+		return parameterAnnotation(parameter.parameter);
+	}
+	if (parameter.type === "RestElement") {
+		return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
+	}
+	return parameter.typeAnnotation;
+}
+
+function parameterName(parameter: Parameter, sourceCode: SourceCode): string {
+	return parameter.type === "Identifier"
+		? parameter.name
+		: sourceCode.getText(parameter).replace(/\s*:\s*object\s*$/u, "");
+}
+
+function lexicalTypeParameterNames(node: ESTree.Node): ReadonlySet<string> {
+	const names = new Set<string>();
+	let current: ESTree.Node | null = node;
+	while (current !== null && current.type !== "Program") {
+		if ("typeParameters" in current) {
+			for (const parameter of current.typeParameters?.params ?? []) {
+				names.add(parameter.name.name);
+			}
+		}
+		if (current.type === "TSMappedType") names.add(current.key.name);
+		if (current.type === "TSInferType") names.add(current.typeParameter.name.name);
+		current = current.parent;
+	}
+	return names;
+}
+
+/** Ban the broad object type on function inputs, including local aliases to object. */
+export const noObjectParametersRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow object function parameters; inputs must use an owner-provided type and be parsed at their boundary.",
+		},
+		messages: {
+			objectParameter:
+				"Parameter `{{parameter}}` uses the broad `object` type. Accept a named owner type; parse external input at its boundary before calling this function.",
+		},
+	},
+	create(context) {
+		const aliases = new Map<string, ESTree.TSType>();
+
+		const resolvesToObject = (
+			type: ESTree.TSType,
+			shadowedAliases: ReadonlySet<string>,
+			visited = new Set<string>(),
+		): boolean => {
+			if (type.type === "TSObjectKeyword") return true;
+			if (type.type === "TSParenthesizedType")
+				return resolvesToObject(type.typeAnnotation, shadowedAliases, visited);
+			if (type.type === "TSUnionType") {
+				return type.types.some((member) =>
+					resolvesToObject(member, shadowedAliases, visited),
+				);
+			}
+			if (
+				type.type !== "TSTypeReference" ||
+				type.typeName.type !== "Identifier" ||
+				(type.typeArguments !== null &&
+					type.typeArguments !== undefined &&
+					type.typeArguments.params.length > 0) ||
+				visited.has(type.typeName.name) ||
+				shadowedAliases.has(type.typeName.name)
+			) {
+				return false;
+			}
+			const alias = aliases.get(type.typeName.name);
+			if (alias === undefined) return false;
+			const nextVisited = new Set(visited);
+			nextVisited.add(type.typeName.name);
+			return resolvesToObject(alias, shadowedAliases, nextVisited);
+		};
+
+		const checkParameters = (node: ParameterOwner) => {
+			const shadowedAliases = lexicalTypeParameterNames(node);
+			for (const parameter of node.params) {
+				const annotation = parameterAnnotation(parameter);
+				if (annotation === null || annotation === undefined) continue;
+				if (!resolvesToObject(annotation.typeAnnotation, shadowedAliases)) continue;
+				context.report({
+					node: annotation.typeAnnotation,
+					messageId: "objectParameter",
+					data: { parameter: parameterName(parameter, context.sourceCode) },
+				});
+			}
+		};
+
+		return {
+			Program(node) {
+				for (const statement of node.body) {
+					const declaration =
+						statement.type === "ExportNamedDeclaration" ? statement.declaration : statement;
+					if (
+						declaration?.type === "TSTypeAliasDeclaration" &&
+						(declaration.typeParameters === null || declaration.typeParameters === undefined)
+					) {
+						aliases.set(declaration.id.name, declaration.typeAnnotation);
+					}
+				}
+			},
+			ArrowFunctionExpression: checkParameters,
+			FunctionDeclaration: checkParameters,
+			FunctionExpression: checkParameters,
+			TSCallSignatureDeclaration: checkParameters,
+			TSConstructSignatureDeclaration: checkParameters,
+			TSConstructorType: checkParameters,
+			TSDeclareFunction: checkParameters,
+			TSEmptyBodyFunctionExpression: checkParameters,
+			TSFunctionType: checkParameters,
+			TSMethodSignature: checkParameters,
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.apply, which bypasses ordinary typed function calls. */
+export const noReflectApplyRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.apply; call typed functions directly or model dynamic dispatch behind an interface.",
+    },
+    messages: {
+      reflectApply:
+        "Replace `Reflect.apply` with a typed function call. Model dynamic dispatch behind a named interface.",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "apply")) {
+          context.report({ node, messageId: "reflectApply" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-get.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-get.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.get, which bypasses ordinary property access and useful type evidence. */
+export const noReflectGetRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.get; use typed property access or parse dynamic input into a domain type.",
+    },
+    messages: {
+      reflectGet:
+        "Replace `Reflect.get` with typed property access. Parse dynamic input into a named domain type before reading it.",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "get")) {
+          context.report({ node, messageId: "reflectGet" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
+++ b/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
@@ -1,0 +1,36 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+const equalityOperators = new Set(["==", "===", "!=", "!=="]);
+
+/** `typeof value === "function"` is capability detection, not representation parsing. */
+function isFunctionCapabilityCheck(node: ESTree.UnaryExpression): boolean {
+  const parent = node.parent;
+  if (parent.type !== "BinaryExpression" || !equalityOperators.has(parent.operator)) return false;
+  const counterpart = parent.left === node ? parent.right : parent.left;
+  return counterpart.type === "Literal" && counterpart.value === "function";
+}
+
+/** Disallow runtime typeof checks that narrow unparsed values instead of decoding them. */
+export const noRuntimeTypeofRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow runtime typeof checks; external values must be decoded into meaningful types at their I/O boundary.",
+    },
+    messages: {
+      runtimeTypeof:
+        "A `typeof` check narrows a representation without establishing its contract. Parse input at its I/O boundary, then branch on the domain value.",
+    },
+  },
+  create(context) {
+    return {
+      UnaryExpression(node) {
+        if (node.operator === "typeof" && !isFunctionCapabilityCheck(node)) {
+          context.report({ node, messageId: "runtimeTypeof" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
+++ b/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
@@ -1,0 +1,39 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+const FORBIDDEN_SYMBOL_NAME = "shape";
+
+function containsForbiddenSymbolName(name: string): boolean {
+  return name.toLowerCase().includes(FORBIDDEN_SYMBOL_NAME);
+}
+
+/** Ban the case-insensitive substring "shape" in every JavaScript and TypeScript symbol name. */
+export const noForbiddenTermInSymbolNamesRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        'Disallow the case-insensitive substring "shape" in JavaScript, TypeScript, private, and JSX symbol names.',
+    },
+    messages: {
+      forbiddenSymbolName:
+        'Rename symbol "{{name}}" for its domain role; "shape" describes structure rather than ownership.',
+    },
+  },
+  create(context) {
+    const reportForbiddenSymbolName = (node: ESTree.Node & { name: string }) => {
+      if (!containsForbiddenSymbolName(node.name)) return;
+      context.report({
+        node,
+        messageId: "forbiddenSymbolName",
+        data: { name: node.name },
+      });
+    };
+
+    return {
+      Identifier: reportForbiddenSymbolName,
+      PrivateIdentifier: reportForbiddenSymbolName,
+      JSXIdentifier: reportForbiddenSymbolName,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
@@ -1,0 +1,83 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+type Parameter = ESTree.ParamPattern;
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function parameterAnnotation(parameter: Parameter): ESTree.TSTypeAnnotation | null | undefined {
+  if (parameter.type === "TSParameterProperty") {
+    return parameterAnnotation(parameter.parameter);
+  }
+  if (parameter.type === "RestElement") {
+    return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
+  }
+  if (parameter.type === "AssignmentPattern") {
+    return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
+  }
+  return parameter.typeAnnotation;
+}
+
+function parameterName(parameter: Parameter, sourceText: string): string {
+  if (parameter.type === "TSParameterProperty") {
+    return parameterName(parameter.parameter, sourceText);
+  }
+  if (parameter.type === "AssignmentPattern") {
+    return parameterName(parameter.left, sourceText);
+  }
+  if (parameter.type === "RestElement") {
+    return parameterName(parameter.argument, sourceText);
+  }
+  return parameter.type === "Identifier"
+    ? parameter.name
+    : sourceText.replace(/\s*:\s*unknown\s*$/u, "");
+}
+
+/** Disallow unknown inputs except explicitly named error-cause enrichment. */
+export const noUnknownParametersRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow explicitly unknown function parameters except `cause`; decode unknown input at its I/O boundary instead.",
+    },
+    messages: {
+      unknownParameter:
+        "Parameter `{{parameter}}` leaves input unparsed. Accept a named domain type; run the expected schema or parser at the I/O boundary before calling this function.",
+    },
+  },
+  create(context) {
+    const checkParameters = (node: ParameterOwner) => {
+      for (const parameter of node.params) {
+        const annotation = parameterAnnotation(parameter);
+        if (annotation?.typeAnnotation.type !== "TSUnknownKeyword") continue;
+        const name = parameterName(parameter, context.sourceCode.getText(parameter));
+        if (name === "cause") continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: "unknownParameter",
+          data: { parameter: name },
+        });
+      }
+    };
+
+    return {
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
@@ -1,0 +1,119 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+type FunctionWithReturnType =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function referencedAliasName(type: ESTree.TSType): string | null {
+  if (type.type === "TSParenthesizedType") return referencedAliasName(type.typeAnnotation);
+  if (type.type !== "TSTypeReference" || type.typeName.type !== "Identifier") return null;
+  return type.typeArguments === null ||
+    type.typeArguments === undefined ||
+    type.typeArguments.params.length === 0
+    ? type.typeName.name
+    : null;
+}
+
+function lexicalTypeParameterNames(node: ESTree.Node): ReadonlySet<string> {
+  const names = new Set<string>();
+  let current: ESTree.Node | null = node;
+  while (current !== null && current.type !== "Program") {
+    if ("typeParameters" in current) {
+      for (const parameter of current.typeParameters?.params ?? []) {
+        names.add(parameter.name.name);
+      }
+    }
+    current = current.parent;
+  }
+  return names;
+}
+
+/** Ban function contracts that return unknown instead of a parsed domain type. */
+export const noUnknownReturnsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow functions whose explicit return contract is unknown or Promise<unknown>.",
+    },
+    messages: {
+      unknownReturn:
+        "This function exposes `unknown` to its caller. Parse the value at its boundary and return a named domain type.",
+    },
+  },
+  create(context) {
+    const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+
+    const resolvesToUnknown = (
+      type: ESTree.TSType,
+      shadowedAliases: ReadonlySet<string>,
+      visited = new Set<string>(),
+    ): boolean => {
+      if (type.type === "TSUnknownKeyword") return true;
+      if (type.type === "TSParenthesizedType") {
+        return resolvesToUnknown(type.typeAnnotation, shadowedAliases, visited);
+      }
+      if (type.type === "TSUnionType") {
+        return type.types.some((member) =>
+          resolvesToUnknown(member, shadowedAliases, visited),
+        );
+      }
+      if (
+        type.type === "TSTypeReference" &&
+        type.typeName.type === "Identifier" &&
+        (type.typeName.name === "Promise" || type.typeName.name === "PromiseLike")
+      ) {
+        const value = type.typeArguments?.params[0];
+        return value !== undefined && resolvesToUnknown(value, shadowedAliases, visited);
+      }
+      const name = referencedAliasName(type);
+      if (name === null || visited.has(name) || shadowedAliases.has(name)) return false;
+      const alias = aliases.get(name);
+      if (
+        alias === undefined ||
+        (alias.typeParameters !== null && alias.typeParameters !== undefined)
+      ) {
+        return false;
+      }
+      const nextVisited = new Set(visited);
+      nextVisited.add(name);
+      return resolvesToUnknown(alias.typeAnnotation, shadowedAliases, nextVisited);
+    };
+
+    const checkReturnType = (node: FunctionWithReturnType) => {
+      const annotation = node.returnType;
+      if (annotation === null || annotation === undefined) return;
+      if (!resolvesToUnknown(annotation.typeAnnotation, lexicalTypeParameterNames(node))) return;
+      context.report({ node: annotation.typeAnnotation, messageId: "unknownReturn" });
+    };
+
+    return {
+      Program(node) {
+        for (const statement of node.body) {
+          const declaration =
+            statement.type === "ExportNamedDeclaration" ? statement.declaration : statement;
+          if (declaration?.type === "TSTypeAliasDeclaration") {
+            aliases.set(declaration.id.name, declaration);
+          }
+        }
+      },
+      ArrowFunctionExpression: checkReturnType,
+      FunctionDeclaration: checkReturnType,
+      FunctionExpression: checkReturnType,
+      TSCallSignatureDeclaration: checkReturnType,
+      TSConstructSignatureDeclaration: checkReturnType,
+      TSConstructorType: checkReturnType,
+      TSDeclareFunction: checkReturnType,
+      TSEmptyBodyFunctionExpression: checkReturnType,
+      TSFunctionType: checkReturnType,
+      TSMethodSignature: checkReturnType,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
@@ -1,0 +1,69 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+function referencedAliasName(type: ESTree.TSType): string | null {
+	if (type.type === "TSParenthesizedType") return referencedAliasName(type.typeAnnotation);
+	if (type.type !== "TSTypeReference" || type.typeName.type !== "Identifier") return null;
+	return type.typeArguments === null ||
+		type.typeArguments === undefined ||
+		type.typeArguments.params.length === 0
+		? type.typeName.name
+		: null;
+}
+
+/** Ban named aliases that merely conceal TypeScript's unknown top type. */
+export const noUnknownTypeAliasesRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow type aliases whose resolved type is unknown; unknown must remain visible at an allowed boundary.",
+		},
+		messages: {
+			unknownAlias:
+				"Type alias `{{alias}}` hides `unknown`. Keep `unknown` explicit at the parsing boundary or on an allowed `cause` field; otherwise use the parsed owner type.",
+		},
+	},
+	create(context) {
+		const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+
+		const resolvesToUnknown = (type: ESTree.TSType, visited = new Set<string>()): boolean => {
+			if (type.type === "TSUnknownKeyword") return true;
+			if (type.type === "TSParenthesizedType")
+				return resolvesToUnknown(type.typeAnnotation, visited);
+			const name = referencedAliasName(type);
+			if (name === null || visited.has(name)) return false;
+			const alias = aliases.get(name);
+			if (
+				alias === undefined ||
+				(alias.typeParameters !== null && alias.typeParameters !== undefined)
+			) {
+				return false;
+			}
+			const nextVisited = new Set(visited);
+			nextVisited.add(name);
+			return resolvesToUnknown(alias.typeAnnotation, nextVisited);
+		};
+
+		return {
+			Program(node) {
+				for (const statement of node.body) {
+					const declaration =
+						statement.type === "ExportNamedDeclaration" ? statement.declaration : statement;
+					if (declaration?.type === "TSTypeAliasDeclaration") {
+						aliases.set(declaration.id.name, declaration);
+					}
+				}
+				for (const alias of aliases.values()) {
+					if (!resolvesToUnknown(alias.typeAnnotation, new Set([alias.id.name]))) continue;
+					context.report({
+						node: alias.id,
+						messageId: "unknownAlias",
+						data: { alias: alias.id.name },
+					});
+				}
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -1,0 +1,134 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	classifyUnsafeDictionary,
+	classifyUnsafeDictionaryValue,
+	createTypeEnvironment,
+	type TypeEnvironment,
+} from "../shared/dictionary-types.ts";
+
+import type { ESTree } from "@oxlint/plugins";
+
+const typeNodeKinds: ReadonlySet<string> = new Set([
+	"JSDocNonNullableType",
+	"JSDocNullableType",
+	"JSDocUnknownType",
+	"TSAnyKeyword",
+	"TSArrayType",
+	"TSBigIntKeyword",
+	"TSBooleanKeyword",
+	"TSConditionalType",
+	"TSConstructorType",
+	"TSFunctionType",
+	"TSImportType",
+	"TSIndexedAccessType",
+	"TSInferType",
+	"TSIntersectionType",
+	"TSIntrinsicKeyword",
+	"TSLiteralType",
+	"TSMappedType",
+	"TSNamedTupleMember",
+	"TSNeverKeyword",
+	"TSNullKeyword",
+	"TSNumberKeyword",
+	"TSObjectKeyword",
+	"TSParenthesizedType",
+	"TSStringKeyword",
+	"TSSymbolKeyword",
+	"TSTemplateLiteralType",
+	"TSThisType",
+	"TSTupleType",
+	"TSTypeLiteral",
+	"TSTypeOperator",
+	"TSTypePredicate",
+	"TSTypeQuery",
+	"TSTypeReference",
+	"TSUndefinedKeyword",
+	"TSUnionType",
+	"TSUnknownKeyword",
+	"TSVoidKeyword",
+]);
+
+function isTypeNode(node: ESTree.Node): node is ESTree.TSType {
+	return typeNodeKinds.has(node.type);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isInsideTypeAliasDeclaration(node: ESTree.Node): boolean {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (current.type === "TSTypeAliasDeclaration") return true;
+		current = current.parent;
+	}
+	return false;
+}
+
+function isPlainAliasConsumerUse(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (node.type !== "TSTypeReference" || node.typeArguments?.params.length) return false;
+	const name = typeReferenceName(node);
+	return name !== null && environment.aliases.has(name) && !isInsideTypeAliasDeclaration(node);
+}
+
+function shouldReportType(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (isPlainAliasConsumerUse(node, environment)) return false;
+	if (classifyUnsafeDictionary(node, environment) === null) return false;
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (isTypeNode(current) && classifyUnsafeDictionary(current, environment) !== null)
+			return false;
+		current = current.parent;
+	}
+	return true;
+}
+
+/** Disallow object-dictionary contracts whose direct value type is an unsafe escape hatch. */
+export const noUnsafeDictionaryTypeRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow object-dictionary contracts whose direct value type is unknown, any, object, {}, or a union/alias containing one of those escape hatches.",
+		},
+		messages: {
+			unsafeDictionary:
+				"This dictionary's {{value}} value type gives callers no concrete value contract. Use an owner/schema-derived value type; parse external payloads before insertion.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeEnvironment | null = null;
+		const report = (node: ESTree.Node, value: string) => {
+			context.report({ node, messageId: "unsafeDictionary", data: { value } });
+		};
+		const reportIfUnsafe = (node: ESTree.TSType) => {
+			if (environment === null || !shouldReportType(node, environment)) return;
+			const unsafe = classifyUnsafeDictionary(node, environment);
+			if (unsafe === null) return;
+			report(node, unsafe.unsafeValue);
+		};
+
+		return {
+			Program(node) {
+				environment = createTypeEnvironment(node);
+			},
+			TSTypeReference: reportIfUnsafe,
+			TSTypeLiteral: reportIfUnsafe,
+			TSMappedType: reportIfUnsafe,
+			TSIndexSignature(node) {
+				if (
+					environment === null ||
+					node.typeAnnotation === null ||
+					node.parent.type === "TSTypeLiteral"
+				)
+					return;
+				const unsafe = classifyUnsafeDictionaryValue(
+					node.typeAnnotation.typeAnnotation,
+					environment,
+				);
+				if (unsafe !== null) report(node, unsafe.unsafeValue);
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -1,0 +1,363 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, Variable } from "@oxlint/plugins";
+
+type BroadTypeKind = "top" | "object" | "record";
+
+type KnownValueEvidence = {
+  readonly type: ESTree.TSType | null;
+};
+
+const functionBoundaryTypes = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "TSDeclareFunction",
+  "TSEmptyBodyFunctionExpression",
+]);
+
+function unwrapExpressionParentheses(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") current = current.expression;
+  return current;
+}
+
+function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (current.type === "TSParenthesizedType") current = current.typeAnnotation;
+  return current;
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isUnknownOrAnyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  return unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword";
+}
+
+function isBroadRecordKeyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (
+    unwrapped.type === "TSStringKeyword" ||
+    unwrapped.type === "TSNumberKeyword" ||
+    unwrapped.type === "TSSymbolKeyword"
+  ) {
+    return true;
+  }
+  if (unwrapped.type === "TSUnionType") return unwrapped.types.every(isBroadRecordKeyType);
+  return unwrapped.type === "TSTypeReference" && typeReferenceName(unwrapped) === "PropertyKey";
+}
+
+function isBroadRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+
+  if (unwrapped.type === "TSTypeReference") {
+    if (typeReferenceName(unwrapped) === "Readonly") {
+      const [inner] = unwrapped.typeArguments?.params ?? [];
+      return inner !== undefined && isBroadRecordType(inner);
+    }
+
+    if (typeReferenceName(unwrapped) !== "Record") return false;
+    const parameters = unwrapped.typeArguments?.params ?? [];
+    return (
+      parameters.length === 2 &&
+      parameters[0] !== undefined &&
+      parameters[1] !== undefined &&
+      isBroadRecordKeyType(parameters[0]) &&
+      isUnknownOrAnyType(parameters[1])
+    );
+  }
+
+  if (unwrapped.type !== "TSTypeLiteral" || unwrapped.members.length !== 1) return false;
+  const [member] = unwrapped.members;
+  const [parameter] = member?.type === "TSIndexSignature" ? member.parameters : [];
+  return (
+    member?.type === "TSIndexSignature" &&
+    member.parameters.length === 1 &&
+    parameter !== undefined &&
+    isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+    isUnknownOrAnyType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function broadTypeKind(type: ESTree.TSType): BroadTypeKind | null {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword") return "top";
+  if (unwrapped.type === "TSObjectKeyword") return "object";
+  return isBroadRecordType(unwrapped) ? "record" : null;
+}
+
+function assertedExpression(
+  node: ESTree.TSAsExpression | ESTree.TSTypeAssertion,
+): ESTree.Expression {
+  return unwrapExpressionParentheses(node.expression);
+}
+
+function assertionFromExpression(
+  expression: ESTree.Expression,
+): ESTree.TSAsExpression | ESTree.TSTypeAssertion | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+  return unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion"
+    ? unwrapped
+    : null;
+}
+
+function normalizedTypeText(sourceText: string, type: ESTree.TSType): string {
+  return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, "");
+}
+
+function typesHaveSameSyntax(
+  sourceText: string,
+  left: ESTree.TSType | null,
+  right: ESTree.TSType,
+): boolean {
+  return (
+    left !== null &&
+    normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+      normalizedTypeText(sourceText, unwrapTypeParentheses(right))
+  );
+}
+
+function isDefinitelyObjectType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  switch (unwrapped.type) {
+    case "TSArrayType":
+    case "TSConstructorType":
+    case "TSFunctionType":
+    case "TSMappedType":
+    case "TSObjectKeyword":
+    case "TSTupleType":
+      return true;
+    case "TSTypeLiteral":
+      return unwrapped.members.length > 0;
+    case "TSIntersectionType":
+      return unwrapped.types.every(isDefinitelyObjectType);
+    case "TSTypeOperator":
+      return unwrapped.operator === "readonly" && isDefinitelyObjectType(unwrapped.typeAnnotation);
+    default:
+      return false;
+  }
+}
+
+function isDefinitelyNarrowerRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSTypeLiteral") {
+    return unwrapped.members.some((member) => member.type !== "TSIndexSignature");
+  }
+
+  if (unwrapped.type !== "TSTypeReference") return false;
+  if (typeReferenceName(unwrapped) === "Readonly") {
+    const [inner] = unwrapped.typeArguments?.params ?? [];
+    return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+  }
+  if (typeReferenceName(unwrapped) !== "Record") return false;
+
+  const parameters = unwrapped.typeArguments?.params ?? [];
+  return (
+    parameters.length === 2 && parameters[1] !== undefined && !isUnknownOrAnyType(parameters[1])
+  );
+}
+
+function functionBoundary(node: ESTree.Node): ESTree.Node | null {
+  let current = node.parent;
+  while (current !== null && current.type !== "Program") {
+    if (functionBoundaryTypes.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function resolvedVariableForIdentifier(
+  scopes: readonly {
+    readonly references: readonly {
+      readonly identifier: ESTree.Node;
+      readonly resolved: Variable | null;
+    }[];
+  }[],
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  for (const scope of scopes) {
+    const reference = scope.references.find(
+      (candidate) =>
+        candidate.identifier.start === identifier.start &&
+        candidate.identifier.end === identifier.end,
+    );
+    if (reference !== undefined) return reference.resolved;
+  }
+  return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+  for (const definition of variable.defs) {
+    if (definition.type === "Variable" && definition.node.type === "VariableDeclarator") {
+      return definition.node;
+    }
+  }
+  return null;
+}
+
+function knownValueEvidence(
+  expression: ESTree.Expression,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+  boundary: ESTree.Node | null,
+  visitedVariables: ReadonlySet<Variable>,
+): KnownValueEvidence | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+
+  if (unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion") {
+    if (broadTypeKind(unwrapped.typeAnnotation) !== null) return null;
+    return { type: unwrapped.typeAnnotation };
+  }
+
+  if (unwrapped.type === "Literal" || unwrapped.type === "TemplateLiteral") {
+    return { type: null };
+  }
+
+  if (
+    unwrapped.type === "ArrayExpression" ||
+    unwrapped.type === "ArrowFunctionExpression" ||
+    unwrapped.type === "ClassExpression" ||
+    unwrapped.type === "FunctionExpression" ||
+    unwrapped.type === "NewExpression" ||
+    unwrapped.type === "ObjectExpression"
+  ) {
+    return { type: null };
+  }
+
+  if (unwrapped.type !== "Identifier") return null;
+  const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return null;
+
+  const annotatedIdentifier = variable.identifiers.find(
+    (identifier) => identifier.typeAnnotation !== null && identifier.typeAnnotation !== undefined,
+  );
+  const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+  if (annotation !== undefined && annotatedIdentifier !== undefined) {
+    if (functionBoundary(annotatedIdentifier) !== boundary || broadTypeKind(annotation) !== null) {
+      return null;
+    }
+    return { type: annotation };
+  }
+
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init) ||
+    functionBoundary(declarator) !== boundary
+  ) {
+    return null;
+  }
+
+  return knownValueEvidence(
+    declarator.init,
+    scopes,
+    boundary,
+    new Set([...visitedVariables, variable]),
+  );
+}
+
+function widenedBinding(
+  variable: Variable,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+): {
+  readonly broadKind: BroadTypeKind;
+  readonly evidence: KnownValueEvidence;
+  readonly declaredAt: number;
+  readonly boundary: ESTree.Node | null;
+} | null {
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.id.type !== "Identifier" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init)
+  ) {
+    return null;
+  }
+
+  const boundary = functionBoundary(declarator);
+  const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+  const initializerAssertion = assertionFromExpression(declarator.init);
+  const initializerBroadKind =
+    initializerAssertion === null ? null : broadTypeKind(initializerAssertion.typeAnnotation);
+  const declaredBroadKind = declaredType === undefined ? null : broadTypeKind(declaredType);
+  const broadKind = declaredBroadKind ?? initializerBroadKind;
+  if (broadKind === null) return null;
+
+  const originalExpression =
+    initializerAssertion !== null && initializerBroadKind !== null
+      ? assertedExpression(initializerAssertion)
+      : declarator.init;
+  const evidence = knownValueEvidence(originalExpression, scopes, boundary, new Set([variable]));
+  return evidence === null ? null : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+
+function assertionIsNarrower(
+  sourceText: string,
+  broadKind: BroadTypeKind,
+  evidence: KnownValueEvidence,
+  assertedType: ESTree.TSType,
+): boolean {
+  if (broadTypeKind(assertedType) !== null) return false;
+  if (broadKind === "top") return true;
+  if (typesHaveSameSyntax(sourceText, evidence.type, assertedType)) return true;
+  if (broadKind === "object") return isDefinitelyObjectType(assertedType);
+  return isDefinitelyNarrowerRecordType(assertedType);
+}
+
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export const noWidenThenAssertRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.",
+    },
+    messages: {
+      widenThenAssert:
+        'Binding "{{name}}" discards type evidence and later recreates it with an assertion. Keep the precise type from initialization through use; parse boundary input once.',
+    },
+  },
+  create(context) {
+    const scopes = context.sourceCode.scopeManager.scopes;
+
+    const checkAssertion = (node: ESTree.TSAsExpression | ESTree.TSTypeAssertion) => {
+      const expression = assertedExpression(node);
+      if (expression.type !== "Identifier") return;
+
+      const variable = resolvedVariableForIdentifier(scopes, expression);
+      if (variable === null) return;
+      const widened = widenedBinding(variable, scopes);
+      if (
+        widened === null ||
+        node.start <= widened.declaredAt ||
+        functionBoundary(node) !== widened.boundary ||
+        !assertionIsNarrower(
+          context.sourceCode.text,
+          widened.broadKind,
+          widened.evidence,
+          node.typeAnnotation,
+        )
+      ) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: "widenThenAssert",
+        data: { name: expression.name },
+      });
+    };
+
+    return {
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
+++ b/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
@@ -1,0 +1,62 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+type TypeAssertion = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+const commentOwnerKinds = new Set([
+  "ExpressionStatement",
+  "PropertyDefinition",
+  "ReturnStatement",
+  "ThrowStatement",
+  "VariableDeclaration",
+]);
+
+function isConstAssertion(node: TypeAssertion): boolean {
+  return (
+    node.typeAnnotation.type === "TSTypeReference" &&
+    node.typeAnnotation.typeName.type === "Identifier" &&
+    node.typeAnnotation.typeName.name === "const"
+  );
+}
+
+function hasSafetyComment(sourceCode: SourceCode, node: TypeAssertion): boolean {
+  let current: ESTree.Node = node;
+  while (true) {
+    if (
+      sourceCode
+        .getCommentsBefore(current)
+        .some((comment) => comment.end <= node.start && /\bSAFETY\s*:/u.test(comment.value))
+    ) {
+      return true;
+    }
+    if (commentOwnerKinds.has(current.type) || current.parent.type === "Program") return false;
+    current = current.parent;
+  }
+}
+
+/** Require every non-const type assertion to state the invariant TypeScript cannot express. */
+export const requireSafetyCommentForTypeAssertionRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require a nearby SAFETY comment for every TypeScript type assertion except const assertions.",
+    },
+    messages: {
+      missingSafetyComment:
+        "This type assertion has no `SAFETY:` justification. State the checked invariant immediately before the assertion or its containing statement.",
+    },
+  },
+  create(context) {
+    const checkAssertion = (node: TypeAssertion) => {
+      if (isConstAssertion(node) || hasSafetyComment(context.sourceCode, node)) return;
+      context.report({ node, messageId: "missingSafetyComment" });
+    };
+
+    return {
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -1,0 +1,502 @@
+import type { ESTree } from "@oxlint/plugins";
+
+const BUILT_INS = new Set([
+	"Record",
+	"Readonly",
+	"Partial",
+	"Required",
+	"Pick",
+	"Omit",
+	"PropertyKey",
+	"NonNullable",
+]);
+const TRANSPARENT_WRAPPERS = new Set(["Readonly", "Partial", "Required", "NonNullable"]);
+
+type TypeAliasEnvironment = ReadonlyMap<string, ESTree.TSType>;
+
+type ResolvedType = {
+	readonly type: ESTree.TSType;
+	readonly substitutions: TypeAliasEnvironment;
+};
+
+export type UnsafeDictionary = {
+	readonly kind: "unsafe-dictionary";
+	readonly unsafeValue: "any" | "empty-object" | "object" | "union" | "unknown";
+};
+
+export type WideningTargetKind =
+	| "anonymous object"
+	| "generic container"
+	| "object"
+	| "open dictionary"
+	| "unknown";
+
+export type WideningTarget = {
+	readonly kind: WideningTargetKind;
+};
+
+export type TypeEnvironment = {
+	readonly aliases: ReadonlyMap<string, ESTree.TSTypeAliasDeclaration>;
+	readonly interfaces: ReadonlyMap<string, readonly ESTree.TSInterfaceDeclaration[]>;
+	readonly shadowedBuiltIns: ReadonlySet<string>;
+};
+
+function declaredStatement(statement: ESTree.Statement): ESTree.Node | null {
+	return statement.type === "ExportNamedDeclaration" ||
+		statement.type === "ExportDefaultDeclaration"
+		? (statement.declaration ?? null)
+		: statement;
+}
+
+export function createTypeEnvironment(program: ESTree.Program): TypeEnvironment {
+	const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+	const interfaces = new Map<string, ESTree.TSInterfaceDeclaration[]>();
+	const shadowedBuiltIns = new Set<string>();
+
+	for (const statement of program.body) {
+		const declaration = declaredStatement(statement);
+		if (declaration?.type === "ImportDeclaration") {
+			for (const specifier of declaration.specifiers) {
+				if (BUILT_INS.has(specifier.local.name)) shadowedBuiltIns.add(specifier.local.name);
+			}
+			continue;
+		}
+
+		if (declaration?.type === "TSTypeAliasDeclaration") {
+			const existing = aliases.get(declaration.id.name);
+			if (existing === undefined) aliases.set(declaration.id.name, declaration);
+			else shadowedBuiltIns.add(declaration.id.name);
+			if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+			continue;
+		}
+
+		if (declaration?.type === "TSInterfaceDeclaration") {
+			const declarations = interfaces.get(declaration.id.name) ?? [];
+			declarations.push(declaration);
+			interfaces.set(declaration.id.name, declarations);
+			if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+			continue;
+		}
+
+		if (declaration?.type === "TSEnumDeclaration") {
+			if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+			continue;
+		}
+
+		if (
+			(declaration?.type === "ClassDeclaration" ||
+				declaration?.type === "FunctionDeclaration") &&
+			declaration.id !== null
+		) {
+			if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+		}
+	}
+
+	return { aliases, interfaces, shadowedBuiltIns };
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isBuiltIn(name: string, environment: TypeEnvironment): boolean {
+	return BUILT_INS.has(name) && !environment.shadowedBuiltIns.has(name);
+}
+
+function isUnappliedReferenceTo(type: ESTree.TSType, name: string): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	return (
+		unwrapped.type === "TSTypeReference" &&
+		typeReferenceName(unwrapped) === name &&
+		(unwrapped.typeArguments === null ||
+			unwrapped.typeArguments === undefined ||
+			unwrapped.typeArguments.params.length === 0)
+	);
+}
+
+function unwrapTransparentType(type: ESTree.TSType): ESTree.TSType {
+	let current = type;
+	while (
+		current.type === "TSParenthesizedType" ||
+		(current.type === "TSTypeOperator" && current.operator === "readonly")
+	) {
+		current = current.typeAnnotation;
+	}
+	return current;
+}
+
+function isNeverType(type: ESTree.TSType): boolean {
+	return unwrapTransparentType(type).type === "TSNeverKeyword";
+}
+
+function isEffectivelyEmptyMember(member: ESTree.TSSignature): boolean {
+	return (
+		member.type === "TSPropertySignature" &&
+		member.optional === true &&
+		member.typeAnnotation !== null &&
+		member.typeAnnotation !== undefined &&
+		isNeverType(member.typeAnnotation.typeAnnotation)
+	);
+}
+
+function isEffectivelyEmptyTypeLiteral(type: ESTree.TSTypeLiteral): boolean {
+	return type.members.length === 0 || type.members.every(isEffectivelyEmptyMember);
+}
+
+function isEffectivelyEmptyInterface(
+	declarations: readonly ESTree.TSInterfaceDeclaration[],
+): boolean {
+	if (declarations.length !== 1) return false;
+	const [type] = declarations;
+	return (
+		type !== undefined &&
+		type.extends.length === 0 &&
+		(type.body.body.length === 0 || type.body.body.every(isEffectivelyEmptyMember))
+	);
+}
+
+function resolvedSubstitutionArgument(
+	type: ESTree.TSType,
+	base: TypeAliasEnvironment,
+	resolving: ReadonlySet<string> = new Set(),
+): ESTree.TSType {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type !== "TSTypeReference") return type;
+	const name = typeReferenceName(unwrapped);
+	if (name === null || resolving.has(name)) return type;
+	const substitution = base.get(name);
+	if (substitution === undefined) return type;
+	const nextResolving = new Set(resolving);
+	nextResolving.add(name);
+	return resolvedSubstitutionArgument(substitution, base, nextResolving);
+}
+
+function aliasSubstitution(
+	alias: ESTree.TSTypeAliasDeclaration,
+	type: ESTree.TSTypeReference,
+	base: TypeAliasEnvironment,
+): TypeAliasEnvironment | null {
+	const parameters = alias.typeParameters?.params ?? [];
+	const arguments_ = type.typeArguments?.params ?? [];
+	const next = new Map(base);
+	for (const [index, parameter] of parameters.entries()) {
+		const argument = arguments_[index] ?? parameter.default;
+		if (argument === null || argument === undefined) return null;
+		next.set(parameter.name.name, resolvedSubstitutionArgument(argument, next));
+	}
+	return next;
+}
+
+function unsafeDirectValue(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): UnsafeDictionary["unsafeValue"] | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return "unknown";
+	if (unwrapped.type === "TSAnyKeyword") return "any";
+	if (unwrapped.type === "TSObjectKeyword") return "object";
+	if (unwrapped.type === "TSTypeLiteral" && isEffectivelyEmptyTypeLiteral(unwrapped))
+		return "empty-object";
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.some(
+			(member) => unsafeDirectValue(member, environment, substitutions, resolvingAliases) !== null,
+		)
+			? "union"
+			: null;
+	}
+	if (unwrapped.type === "TSIntersectionType") {
+		const unsafeMembers = unwrapped.types.map((member) =>
+			unsafeDirectValue(member, environment, substitutions, resolvingAliases),
+		);
+		if (unsafeMembers.includes("any")) return "any";
+		return unsafeMembers.length > 0 && unsafeMembers.every((member) => member !== null)
+			? unsafeMembers[0]
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: unsafeDirectValue(wrapped, environment, substitutions, resolvingAliases);
+	}
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: unsafeDirectValue(substitution, environment, substitutions, resolvingAliases);
+	}
+	const interfaceDeclarations = environment.interfaces.get(name);
+	if (interfaceDeclarations !== undefined) {
+		return isEffectivelyEmptyInterface(interfaceDeclarations) ? "empty-object" : null;
+	}
+	const alias = environment.aliases.get(name);
+	if (alias === undefined || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return unsafeDirectValue(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+function dictionaryValueTypes(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): readonly ResolvedType[] {
+	const unwrapped = unwrapTransparentType(type);
+
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.flatMap((member): readonly ResolvedType[] =>
+			member.type === "TSIndexSignature" && member.typeAnnotation !== null
+				? [{ type: member.typeAnnotation.typeAnnotation, substitutions }]
+				: [],
+		);
+	}
+
+	if (unwrapped.type === "TSMappedType") {
+		return unwrapped.typeAnnotation === null
+			? []
+			: [{ type: unwrapped.typeAnnotation, substitutions }];
+	}
+
+	if (unwrapped.type !== "TSTypeReference") return [];
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return [];
+
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? []
+			: dictionaryValueTypes(substitution, environment, substitutions, resolvingAliases);
+	}
+
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? []
+			: dictionaryValueTypes(wrapped, environment, substitutions, resolvingAliases);
+	}
+
+	if (name === "Record" && isBuiltIn(name, environment)) {
+		const value = unwrapped.typeArguments?.params[1] ?? null;
+		return value === null ? [] : [{ type: value, substitutions }];
+	}
+
+	if ((name === "Pick" || name === "Omit") && isBuiltIn(name, environment)) {
+		const source = unwrapped.typeArguments?.params[0];
+		return source === undefined
+			? []
+			: dictionaryValueTypes(source, environment, substitutions, resolvingAliases);
+	}
+
+	const alias = environment.aliases.get(name);
+	if (alias === undefined || resolvingAliases.has(name)) return [];
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return [];
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return dictionaryValueTypes(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+export function classifyUnsafeDictionaryValue(
+	valueType: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	const unsafeValue = unsafeDirectValue(valueType, environment, new Map(), new Set());
+	return unsafeValue === null ? null : { kind: "unsafe-dictionary", unsafeValue };
+}
+
+export function classifyUnsafeDictionary(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	for (const valueType of dictionaryValueTypes(type, environment, new Map(), new Set())) {
+		const unsafeValue = unsafeDirectValue(
+			valueType.type,
+			environment,
+			valueType.substitutions,
+			new Set(),
+		);
+		if (unsafeValue !== null) return { kind: "unsafe-dictionary", unsafeValue };
+	}
+	return null;
+}
+
+function resolvesToDictionary(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): boolean {
+	return dictionaryValueTypes(type, environment, substitutions, resolvingAliases).length > 0;
+}
+
+export function classifyWideningTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: unwrapped.members.length > 0
+				? { kind: "anonymous object" }
+				: null;
+	}
+	if (unwrapped.type === "TSMappedType") return { kind: "open dictionary" };
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
+	}
+	if (name === "Record" && isBuiltIn(name, environment)) return { kind: "open dictionary" };
+	const alias = environment.aliases.get(name);
+	if (alias === undefined) return null;
+	if ((alias.typeParameters?.params.length ?? 0) > 0) {
+		const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+		return substitutions !== null &&
+			resolvesToDictionary(alias.typeAnnotation, environment, substitutions, new Set([name]))
+			? { kind: "generic container" }
+			: null;
+	}
+	const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+	if (substitutions === null) return null;
+	const resolved = classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		substitutions,
+		new Set([name]),
+	);
+	return resolved;
+}
+
+function isBroadMappedKey(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	if (
+		unwrapped.type === "TSStringKeyword" ||
+		unwrapped.type === "TSNumberKeyword" ||
+		unwrapped.type === "TSSymbolKeyword"
+	) {
+		return true;
+	}
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.every((member) =>
+			isBroadMappedKey(member, environment, substitutions),
+		);
+	}
+	if (unwrapped.type !== "TSTypeReference") return false;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return false;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined && !isUnappliedReferenceTo(substitution, name)) {
+		return isBroadMappedKey(substitution, environment, substitutions);
+	}
+	return name === "PropertyKey" && isBuiltIn(name, environment);
+}
+
+function classifyAliasBroadTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type === "TSMappedType") {
+		return isBroadMappedKey(unwrapped.constraint, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: classifyAliasBroadTarget(
+					substitution,
+					environment,
+					substitutions,
+					resolvingAliases,
+				);
+	}
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: classifyAliasBroadTarget(wrapped, environment, substitutions, resolvingAliases);
+	}
+	if (name === "Record" && isBuiltIn(name, environment)) {
+		return { kind: "open dictionary" };
+	}
+	const alias = environment.aliases.get(name);
+	if (alias === undefined || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		nextSubstitutions,
+		nextResolving,
+	);
+}
+
+export function isPopulatedObjectExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression"
+	) {
+		current = current.expression;
+	}
+	return current.type === "ObjectExpression" && current.properties.length > 0;
+}
+
+export function isKnownEvidenceExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression" ||
+		current.type === "TSSatisfiesExpression"
+	) {
+		current = current.expression;
+	}
+	if (current.type === "ObjectExpression") return true;
+	return (
+		current.type === "ArrayExpression" ||
+		current.type === "ArrowFunctionExpression" ||
+		current.type === "ClassExpression" ||
+		current.type === "FunctionExpression" ||
+		current.type === "NewExpression" ||
+		current.type === "Literal" ||
+		current.type === "TemplateLiteral" ||
+		current.type === "UnaryExpression"
+	);
+}

--- a/tools/oxlint/anti-slop/shared/reflect-method.ts
+++ b/tools/oxlint/anti-slop/shared/reflect-method.ts
@@ -1,0 +1,35 @@
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function isGlobalReflect(sourceCode: SourceCode, expression: ESTree.Expression): boolean {
+  if (expression.type !== "Identifier" || expression.name !== "Reflect") return false;
+  if (sourceCode.isGlobalReference(expression)) return true;
+  const variable = resolveVariable(sourceCode, expression);
+  return variable === null || variable.defs.length === 0;
+}
+
+/** Reports whether a call target names one method on the global Reflect object. */
+export function isGlobalReflectMethodCall(
+  sourceCode: SourceCode,
+  callee: ESTree.Expression,
+  methodName: string,
+): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isGlobalReflect(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  return callee.computed
+    ? property.type === "Literal" && property.value === methodName
+    : property.type === "Identifier" && property.name === methodName;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -108,24 +108,19 @@ export default defineConfig({
       "anti-slop/no-widen-then-assert": "error",
       "anti-slop/require-safety-comment-for-type-assertion": "error",
 
+      // `typeof` is valid for capability checks, SSR guards, and narrowing known unions.
+      "anti-slop/no-runtime-typeof": "off",
+
       // These opinionated rules expose existing design debt without forcing semantic rewrites.
       "anti-slop/no-conditional-empty-object-spread": "warn",
       "anti-slop/no-known-value-widening": "warn",
       "anti-slop/no-module-mocking": "warn",
       "anti-slop/no-object-parameters": "warn",
-      "anti-slop/no-runtime-typeof": "warn",
       "anti-slop/no-shape-in-symbol-names": "warn",
       "anti-slop/no-unknown-parameters": "warn",
       "anti-slop/no-unsafe-dictionary-type": "warn",
     },
     overrides: [
-      {
-        // These standalone JavaScript proxies perform their own allowlisted boundary validation.
-        files: ["cobalt-*.mjs"],
-        rules: {
-          "anti-slop/no-runtime-typeof": "off",
-        },
-      },
       {
         // These I/O adapters own parsers and predicates where unknown input is the honest contract.
         files: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,11 +15,11 @@ const libavDist = fileURLToPath(
 );
 const libavAssetFiles = ["libav-6.8.7.1-encode-cli.wasm.mjs", "libav-6.8.7.1-encode-cli.wasm.wasm"];
 
-const contentTypes: Record<string, string> = {
-  ".js": "text/javascript;charset=UTF-8",
-  ".mjs": "text/javascript;charset=UTF-8",
-  ".wasm": "application/wasm",
-};
+const contentTypes = new Map([
+  [".js", "text/javascript;charset=UTF-8"],
+  [".mjs", "text/javascript;charset=UTF-8"],
+  [".wasm", "application/wasm"],
+]);
 
 const libavAssets = (): Plugin => ({
   name: "tagium-libav-assets",
@@ -52,7 +52,7 @@ const libavAssets = (): Plugin => ({
             return;
           }
 
-          const contentType = contentTypes[extname(filePath)];
+          const contentType = contentTypes.get(extname(filePath));
           if (contentType) {
             response.setHeader("Content-Type", contentType);
           }
@@ -71,10 +71,16 @@ export default defineConfig({
     "*": "vp check --fix",
   },
   fmt: {
-    ignorePatterns: [".repos/*", ".agents/**", ".claude/**"],
+    ignorePatterns: [".repos/**", ".agents/**", ".claude/**", "tools/oxlint/anti-slop/**"],
   },
   lint: {
     plugins: ["oxc", "typescript", "unicorn", "react"],
+    jsPlugins: [
+      {
+        name: "anti-slop",
+        specifier: "./tools/oxlint/anti-slop/index.ts",
+      },
+    ],
     categories: {
       correctness: "warn",
     },
@@ -88,11 +94,45 @@ export default defineConfig({
       "node_modules",
       "playwright-report",
       "test-results",
-      ".repos/*",
+      ".repos/**",
       ".agents/**",
       ".claude/**",
+      "tools/oxlint/anti-slop/**",
     ],
+    rules: {
+      "anti-slop/no-chained-type-assertions": "error",
+      "anti-slop/no-reflect-apply": "error",
+      "anti-slop/no-reflect-get": "error",
+      "anti-slop/no-unknown-returns": "error",
+      "anti-slop/no-unknown-type-aliases": "error",
+      "anti-slop/no-widen-then-assert": "error",
+      "anti-slop/require-safety-comment-for-type-assertion": "error",
+
+      // These opinionated rules expose existing design debt without forcing semantic rewrites.
+      "anti-slop/no-conditional-empty-object-spread": "warn",
+      "anti-slop/no-known-value-widening": "warn",
+      "anti-slop/no-module-mocking": "warn",
+      "anti-slop/no-object-parameters": "warn",
+      "anti-slop/no-runtime-typeof": "warn",
+      "anti-slop/no-shape-in-symbol-names": "warn",
+      "anti-slop/no-unknown-parameters": "warn",
+      "anti-slop/no-unsafe-dictionary-type": "warn",
+    },
     overrides: [
+      {
+        // These standalone JavaScript proxies perform their own allowlisted boundary validation.
+        files: ["cobalt-*.mjs"],
+        rules: {
+          "anti-slop/no-runtime-typeof": "off",
+        },
+      },
+      {
+        // Test fixtures often cross framework-owned types; comments on every fixture cast add noise.
+        files: ["tests/**/*.{ts,tsx}"],
+        rules: {
+          "anti-slop/require-safety-comment-for-type-assertion": "off",
+        },
+      },
       {
         files: ["**/*.{ts,tsx}"],
         rules: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -127,6 +127,21 @@ export default defineConfig({
         },
       },
       {
+        // These I/O adapters own parsers and predicates where unknown input is the honest contract.
+        files: [
+          "server/utils/share-manifest-request.ts",
+          "src/features/import/cobaltAudio.ts",
+          "src/features/import/localAudioProcessor.ts",
+          "src/features/import/playlist.ts",
+          "src/features/import/trackMetadata.ts",
+          "src/features/share/shareManifest.ts",
+          "src/features/workspace/mobileWorkspaceNavigation.ts",
+        ],
+        rules: {
+          "anti-slop/no-unknown-parameters": "off",
+        },
+      },
+      {
         // Test fixtures often cross framework-owned types; comments on every fixture cast add noise.
         files: ["tests/**/*.{ts,tsx}"],
         rules: {


### PR DESCRIPTION
## problem

Tagium's lint setup did not catch several assertion-heavy and weakly parsed boundary patterns. Enabling anti-slop initially surfaced hundreds of findings, but treating every opinionated rule as an error also encouraged mechanical rewrites that changed behavior.

## solution

This vendors the MIT-licensed anti-slop Oxlint plugin, registers it through Vite+, and fixes the high-signal findings with typed object construction, Effect Schema decoding, and concrete test fixtures. The migration also preserves existing Cobalt, SoundCloud, analytics, mobile-history, metadata, and share-receipt behavior uncovered during adversarial review.

Rules with a clear safety invariant are errors. Broader design rules remain enabled while their findings are addressed deliberately. The warning inventory is now exactly 50 existing module mocks tracked in #172. The module-mock detector recognizes this repo's `vite-plus/test` imports, so that count is visible rather than falsely green. Honest `unknown` inputs are scoped out in the I/O adapter files that own their decoding.

## human review

Fast path:

1. Import one local audio file and one supported URL, edit metadata and cover art, then export. The same tracks and metadata should be produced as before.
2. With sharing configured, publish and reopen an album, then update or revoke it. A malformed legacy receipt beside a valid receipt must not hide the valid permission.
3. On mobile, open and close workspace views with browser back/forward navigation. Navigation should keep unrelated `history.state` fields intact.

No special test data is required beyond the normal local dev setup, a small audio file, and—when exercising URL/share flows—the existing Cobalt and share environment configuration.

Important failure cases:

- malformed Cobalt, SoundCloud, YouTube, and share-manifest payloads should be rejected at their boundaries;
- omitted optional metadata should stay omitted rather than becoming `undefined` fields;
- numeric provider error fields should not be silently accepted as strings;
- analytics still sends the PostHog `shape` property even though the internal domain field is named `linkKind`.

Reviewer decision: `no-module-mocking` stays at warning level until #172 replaces whole-module mocks with Effect dependency seams. `no-runtime-typeof` is disabled because valid capability checks, SSR guards, and known-union narrowing should not be rewritten to satisfy a syntax rule. Honest decoder inputs are scoped out from `no-unknown-parameters`; the other enabled anti-slop rules are clean. Test assertion comments remain disabled because they produced boilerplate.

## verification

- `bun run lint -- --silent`
- `bun run typecheck`
- `vp fmt --check .`
- `bun run test` — 114 files, 784 tests passed
- focused Chromium check for deleting title text without removing the selected track
- `bun run build`
- `git diff --check`
- independent adversarial diff review

The build passes with the existing bundle-size and WebAssembly fallback warnings. Manual browser verification of the flows above remains for review.

---

Generated with OpenAI gpt-5.6-sol in T3 Code using the Codex harness.
