### PR TITLE
fix: keep metadata editing responsive

### DIFF
--- a/src/features/editor/useTrackEditorSession.ts
+++ b/src/features/editor/useTrackEditorSession.ts
@@ -27,17 +27,13 @@ import type {
 } from "@/features/library/types";
 import { audioFilename, getAudioFormat } from "@/features/audio/audioFormat";
 import { EDITABLE_METADATA_FIELDS } from "@/features/audio/metadataFields";
+import { sanitizeFilenameBase } from "@/features/library/filename";
+import {
+  createTrackFilenamePreviewStore,
+  type TrackFilenamePreviewStore,
+} from "@/features/library/trackFilenamePreview";
 
 type PreviewField = "filename" | "title" | "artist";
-
-// Keep keystrokes local to the form while coalescing the more expensive library/sidebar preview.
-const PREVIEW_COMMIT_DELAY_MS = 150;
-
-interface PendingPreview {
-  fileId: string;
-  field: PreviewField;
-  value: string;
-}
 
 const hasOwn = <Value, Key extends PropertyKey>(object: Value, key: Key) =>
   Object.prototype.hasOwnProperty.call(object, key);
@@ -128,6 +124,7 @@ const clearPendingMetadataPatch = (file: TagiumFile) => withPendingMetadataPatch
 export interface TrackEditorSession {
   selectedFile: TagiumFile | null;
   selectedFileAlbum: AlbumGroup | undefined;
+  filenamePreviewStore: TrackFilenamePreviewStore;
   isCoverProcessing: boolean;
   form: Pick<
     ReturnType<typeof useForm<AudioMetadata>>,
@@ -169,9 +166,8 @@ export const useTrackEditorSession = ({
   const lastResetFileIdRef = useRef<string | null>(null);
   const lastResetMetadataRef = useRef<AudioMetadata | null>(null);
   const formDirtyRef = useRef(false);
-  const pendingPreviewRef = useRef<PendingPreview | null>(null);
-  const previewTimerRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
   const latestMetadataWritesRef = useRef(new Map<string, symbol>());
+  const [filenamePreviewStore] = useState(createTrackFilenamePreviewStore);
   const [isCoverProcessing, setCoverProcessing] = useState(false);
   const {
     register,
@@ -185,12 +181,30 @@ export const useTrackEditorSession = ({
     subscribe,
     formState: { dirtyFields },
   } = useForm<AudioMetadata>();
+  const getLibrarySnapshot = library.getSnapshot;
   const formIsDirty = Object.keys(dirtyFields).length > 0;
   const dirtyFieldsRef = useRef(dirtyFields);
   useLayoutEffect(() => {
+    const syncFilenamesChanged = settingsRef.current.syncFilenames !== settings.syncFilenames;
+    const selectedId = selectedFileIdRef.current;
+    if (
+      syncFilenamesChanged &&
+      selectedId &&
+      (dirtyFieldsRef.current.title || dirtyFieldsRef.current.filename)
+    ) {
+      const currentFile = getLibrarySnapshot().files.find((file) => file.id === selectedId);
+      if (currentFile) {
+        const value = settings.syncFilenames ? getValues("title") : getValues("filename");
+        const filenameBase = sanitizeFilenameBase(value);
+        filenamePreviewStore.set(
+          selectedId,
+          filenameBase ? audioFilename(filenameBase, getAudioFormat(currentFile)) : undefined,
+        );
+      }
+    }
     settingsRef.current = settings;
     dirtyFieldsRef.current = dirtyFields;
-  }, [dirtyFields, settings]);
+  }, [dirtyFields, filenamePreviewStore, getLibrarySnapshot, getValues, settings]);
   const selectedFile = useMemo(
     () => library.state.files.find((file) => file.id === library.state.selectedFileId) ?? null,
     [library.state.files, library.state.selectedFileId],
@@ -204,6 +218,7 @@ export const useTrackEditorSession = ({
   );
 
   useLayoutEffect(() => {
+    const previousSelectedFileId = selectedFileIdRef.current;
     let nextFormIsDirty = formIsDirty;
     if (selectedFile?.metadata) {
       const selectedFileChanged = lastResetFileIdRef.current !== selectedFile.id;
@@ -217,9 +232,12 @@ export const useTrackEditorSession = ({
       }
       lastResetMetadataRef.current = selectedFile.metadata;
     }
+    if (previousSelectedFileId && previousSelectedFileId !== library.state.selectedFileId) {
+      filenamePreviewStore.set(previousSelectedFileId, undefined);
+    }
     selectedFileIdRef.current = library.state.selectedFileId;
     formDirtyRef.current = nextFormIsDirty;
-  }, [formIsDirty, library.state.selectedFileId, reset, selectedFile]);
+  }, [filenamePreviewStore, formIsDirty, library.state.selectedFileId, reset, selectedFile]);
 
   const isSingleAlbumLinkedForFile = useCallback(
     (fileId: string | null) => {
@@ -313,90 +331,40 @@ export const useTrackEditorSession = ({
     [applyCurrentFormMetadataToFiles, library],
   );
 
-  const cancelPendingPreview = useCallback(() => {
-    if (previewTimerRef.current !== null) {
-      globalThis.clearTimeout(previewTimerRef.current);
-      previewTimerRef.current = null;
-    }
-    pendingPreviewRef.current = null;
-  }, []);
-
-  const commitPendingPreview = useCallback(() => {
-    if (previewTimerRef.current !== null) {
-      globalThis.clearTimeout(previewTimerRef.current);
-      previewTimerRef.current = null;
-    }
-    const pendingPreview = pendingPreviewRef.current;
-    pendingPreviewRef.current = null;
-    if (!pendingPreview || selectedFileIdRef.current !== pendingPreview.fileId) return;
-
-    const snapshot = library.getSnapshot();
-    const currentFile = snapshot.files.find((file) => file.id === pendingPreview.fileId);
-    if (!currentFile) return;
-    const formValues = { ...getValues(), [pendingPreview.field]: pendingPreview.value };
-    const submittedData = getProjectableAudioMetadata(
-      getSubmittedMetadata(formValues, pendingPreview.fileId),
-      currentFile.metadata,
-      formValues,
-    );
-    const metadataPatch = createCurrentMetadataPatch(
-      submittedData,
-      dirtyFieldsRef.current,
-      pendingPreview.fileId,
-      [pendingPreview.field],
-    );
-    if (!metadataPatch) return;
-    const nextFiles = snapshot.files.map((file) =>
-      file.id === pendingPreview.fileId
-        ? withMergedPendingMetadataPatch(
-            {
-              ...file,
-              filename: getFilenameFromPatch(file, metadataPatch),
-              metadata: file.metadata
-                ? applyMetadataPatch(file.metadata, metadataPatch)
-                : submittedData,
-              status: file.status === "saved" ? "pending" : file.status,
-            },
-            metadataPatch,
-          )
-        : file,
-    );
-    library.dispatch({ type: "content-replaced", files: nextFiles });
-  }, [createCurrentMetadataPatch, getSubmittedMetadata, getValues, library]);
-
   const flush = useCallback(
     (trackIds?: string[]) => {
-      cancelPendingPreview();
       const currentFiles = library.getSnapshot().files;
       const nextFiles = projectFiles(trackIds);
       if (nextFiles !== currentFiles) {
         library.dispatch({ type: "content-replaced", files: nextFiles });
       }
+      const selectedId = selectedFileIdRef.current;
+      if (selectedId) filenamePreviewStore.set(selectedId, undefined);
       return nextFiles;
     },
-    [cancelPendingPreview, library, projectFiles],
+    [filenamePreviewStore, library, projectFiles],
   );
 
   const preview = useCallback(
     (field: PreviewField, value: string) => {
       const selectedId = selectedFileIdRef.current;
       if (!selectedId) return;
-
       formDirtyRef.current = true;
       dirtyFieldsRef.current = { ...dirtyFieldsRef.current, [field]: true };
-      pendingPreviewRef.current = { fileId: selectedId, field, value };
-      if (previewTimerRef.current !== null) {
-        globalThis.clearTimeout(previewTimerRef.current);
-      }
-      previewTimerRef.current = globalThis.setTimeout(
-        commitPendingPreview,
-        PREVIEW_COMMIT_DELAY_MS,
+
+      const previewsSyncedTitle = settingsRef.current.syncFilenames && field === "title";
+      const previewsFilename = !settingsRef.current.syncFilenames && field === "filename";
+      if (!previewsSyncedTitle && !previewsFilename) return;
+      const currentFile = library.getSnapshot().files.find((file) => file.id === selectedId);
+      if (!currentFile) return;
+      const filenameBase = sanitizeFilenameBase(value);
+      filenamePreviewStore.set(
+        selectedId,
+        filenameBase ? audioFilename(filenameBase, getAudioFormat(currentFile)) : undefined,
       );
     },
-    [commitPendingPreview],
+    [filenamePreviewStore, library],
   );
-
-  useLayoutEffect(() => cancelPendingPreview, [cancelPendingPreview]);
 
   const updateTags = useCallback(
     async (fileToUpdate: TagiumFile, newTags: AudioMetadata) => {
@@ -693,6 +661,7 @@ export const useTrackEditorSession = ({
   return {
     selectedFile,
     selectedFileAlbum,
+    filenamePreviewStore,
     isCoverProcessing,
     form: { register, control, getValues, setError, clearErrors, setFocus, reset, subscribe },
     commands: {

--- a/src/features/library/AlbumSidebar.tsx
+++ b/src/features/library/AlbumSidebar.tsx
@@ -26,11 +26,13 @@ import { useAlbumSidebarDragController } from "@/features/library/useAlbumSideba
 import type { ShareActionState } from "@/features/share/sharePublication";
 import { createAlbumActionItems } from "@/features/library/albumActionItems";
 import { createTrackActionItems } from "@/features/library/trackActionItems";
+import type { TrackFilenamePreviewStore } from "@/features/library/trackFilenamePreview";
 
 interface AlbumSidebarProps {
   albums: AlbumGroup[];
   looseTrackIds: string[];
   files: TagiumFile[];
+  filenamePreviewStore: TrackFilenamePreviewStore;
   selectedAlbumId: string | null;
   selectedFileId: string | null;
   selectedFileIds: Set<string>;
@@ -77,6 +79,7 @@ export default function AlbumSidebar({
   albums,
   looseTrackIds,
   files,
+  filenamePreviewStore,
   selectedAlbumId,
   selectedFileId,
   selectedFileIds,
@@ -197,6 +200,7 @@ export default function AlbumSidebar({
                 <SortableTrackRow
                   key={track.id}
                   track={track}
+                  filenamePreviewStore={filenamePreviewStore}
                   container="loose"
                   selectedTone={selectedTone(track.id)}
                   muted={track.downloadStatus === "downloading"}
@@ -281,6 +285,7 @@ export default function AlbumSidebar({
                             <SortableTrackRow
                               key={track.id}
                               track={track}
+                              filenamePreviewStore={filenamePreviewStore}
                               index={index + 1}
                               container="album"
                               albumId={album.id}

--- a/src/features/library/AlbumSidebarDnd.tsx
+++ b/src/features/library/AlbumSidebarDnd.tsx
@@ -39,11 +39,16 @@ import {
 import type { AlbumGroup, TagiumFile } from "@/features/library/types";
 import type { AlbumActionItem, AlbumActionItemId } from "@/features/library/albumActionItems";
 import type { TrackActionItem } from "@/features/library/trackActionItems";
+import {
+  type TrackFilenamePreviewStore,
+  useTrackFilenamePreview,
+} from "@/features/library/trackFilenamePreview";
 
 const artistLabel = (artist: string) => (artist ? artist : "unknown");
 
 type TrackRowBaseProps = {
   track: TagiumFile;
+  filenamePreviewStore: TrackFilenamePreviewStore;
   selectedTone: "primary" | "secondary" | null;
   muted: boolean;
   actions: TrackActionItem[];
@@ -66,6 +71,7 @@ const sortableStyle = (
 
 export function SortableTrackRow({
   track,
+  filenamePreviewStore,
   index,
   container,
   albumId,
@@ -74,6 +80,7 @@ export function SortableTrackRow({
   actions,
   onSelect,
 }: TrackRowProps) {
+  const filename = useTrackFilenamePreview(filenamePreviewStore, track.id, track.filename);
   const menuTriggerRef = useRef<HTMLButtonElement>(null);
   const previousStatusRef = useRef(track.status);
   const successTimerRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
@@ -158,7 +165,7 @@ export function SortableTrackRow({
             ) : (
               <span className="min-w-3 text-[11px] text-muted-foreground">{index}</span>
             )}
-            <span className="truncate text-sm flex-1">{track.filename}</span>
+            <span className="truncate text-sm flex-1">{filename}</span>
             {track.downloadStatus === "downloading" && (
               <HugeiconsIcon
                 icon={loaderCircleIcon}
@@ -205,7 +212,7 @@ export function SortableTrackRow({
             variant="ghost"
             size="icon"
             className="absolute right-2 top-1/2 size-7 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 data-[state=open]:opacity-100 [@media(pointer:coarse)]:right-0 [@media(pointer:coarse)]:size-11 [@media(pointer:coarse)]:opacity-100"
-            aria-label={`track actions for ${track.filename}`}
+            aria-label={`track actions for ${filename}`}
           >
             <HugeiconsIcon icon={MoreVerticalIcon} strokeWidth={2} className="size-3.5" />
           </Button>

--- a/src/features/library/TagSidebarPanel.tsx
+++ b/src/features/library/TagSidebarPanel.tsx
@@ -16,6 +16,7 @@ import { allTracksReadyForDownload } from "@/features/export/downloadLibrary";
 import { isValidFilenameBase } from "@/features/library/filename";
 import type { ShareActionState } from "@/features/share/sharePublication";
 import { useTheme } from "@/features/theme/useTheme";
+import type { TrackFilenamePreviewStore } from "@/features/library/trackFilenamePreview";
 
 export interface TagSidebarPanelProps {
   mobileOpen?: boolean;
@@ -23,6 +24,7 @@ export interface TagSidebarPanelProps {
   onMobileClose?: () => void;
   loading: boolean;
   files: TagiumFile[];
+  filenamePreviewStore: TrackFilenamePreviewStore;
   albums: AlbumGroup[];
   looseTrackIds: string[];
   selectedAlbumId: string | null;
@@ -80,6 +82,7 @@ export default function TagSidebarPanel({
   onMobileClose,
   loading,
   files,
+  filenamePreviewStore,
   albums,
   looseTrackIds,
   selectedAlbumId,
@@ -239,6 +242,7 @@ export default function TagSidebarPanel({
         albums={albums}
         looseTrackIds={looseTrackIds}
         files={files}
+        filenamePreviewStore={filenamePreviewStore}
         selectedAlbumId={selectedAlbumId}
         selectedFileId={selectedFileId}
         selectedFileIds={selectedFileIds}

--- a/src/features/library/trackFilenamePreview.ts
+++ b/src/features/library/trackFilenamePreview.ts
@@ -1,0 +1,46 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+type Listener = () => void;
+
+/** Keeps the selected track's live filename preview out of the structural library state. */
+export interface TrackFilenamePreviewStore {
+  getSnapshot: (trackId: string) => string | undefined;
+  subscribe: (trackId: string, listener: Listener) => () => void;
+  set: (trackId: string, filename: string | undefined) => void;
+}
+
+export const createTrackFilenamePreviewStore = (): TrackFilenamePreviewStore => {
+  const filenames = new Map<string, string>();
+  const listeners = new Map<string, Set<Listener>>();
+
+  return {
+    getSnapshot: (trackId) => filenames.get(trackId),
+    subscribe: (trackId, listener) => {
+      const trackListeners = listeners.get(trackId) ?? new Set<Listener>();
+      trackListeners.add(listener);
+      listeners.set(trackId, trackListeners);
+      return () => {
+        trackListeners.delete(listener);
+        if (trackListeners.size === 0) listeners.delete(trackId);
+      };
+    },
+    set: (trackId, filename) => {
+      if (filename === undefined) filenames.delete(trackId);
+      else filenames.set(trackId, filename);
+      listeners.get(trackId)?.forEach((listener) => listener());
+    },
+  };
+};
+
+export const useTrackFilenamePreview = (
+  store: TrackFilenamePreviewStore,
+  trackId: string,
+  fallback: string,
+) => {
+  const subscribe = useCallback(
+    (listener: Listener) => store.subscribe(trackId, listener),
+    [store, trackId],
+  );
+  const getSnapshot = useCallback(() => store.getSnapshot(trackId), [store, trackId]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot) ?? fallback;
+};

--- a/src/features/share/useShareWorkflow.ts
+++ b/src/features/share/useShareWorkflow.ts
@@ -141,9 +141,21 @@ export const useShareWorkflow = ({
     setProjectedFiles(projectFilesRef.current());
   }, [library.state.files]);
 
+  const selectedFileId = library.state.selectedFileId;
+  const selectedFileNeedsFingerprint = Boolean(
+    selectedFileId &&
+    (isActiveSharePublication(
+      library.state.files.find((file) => file.id === selectedFileId)?.sharePublication,
+    ) ||
+      library.state.albums.some(
+        (album) =>
+          album.trackIds.includes(selectedFileId) &&
+          isActiveSharePublication(album.sharePublication),
+      )),
+  );
   const subscribeToEditorForm = editor.form.subscribe;
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled || !selectedFileNeedsFingerprint) return;
     let timer: ReturnType<typeof globalThis.setTimeout> | undefined;
     const unsubscribe = subscribeToEditorForm({
       name: SHAREABLE_TRACK_METADATA_FIELDS,
@@ -160,7 +172,7 @@ export const useShareWorkflow = ({
       if (timer !== undefined) globalThis.clearTimeout(timer);
       unsubscribe();
     };
-  }, [enabled, subscribeToEditorForm]);
+  }, [enabled, selectedFileNeedsFingerprint, subscribeToEditorForm]);
 
   useEffect(() => {
     const expiries: number[] = [];

--- a/src/features/workspace/audioTagger.tsx
+++ b/src/features/workspace/audioTagger.tsx
@@ -170,6 +170,7 @@ export default function AudioTagger() {
           onMobileClose={mobileNavigation.closeDrawer}
           loading={busy}
           files={files}
+          filenamePreviewStore={editor.filenamePreviewStore}
           albums={albums}
           looseTrackIds={looseTrackIds}
           selectedAlbumId={activeView === "settings" ? null : selectedAlbumId}

--- a/tests/e2e/title-editing-performance.spec.ts
+++ b/tests/e2e/title-editing-performance.spec.ts
@@ -2,20 +2,20 @@ import { expect, test, type Locator, type Page } from "@playwright/test";
 import { Buffer } from "node:buffer";
 import { materializeFixture } from "./support/audioFixtures";
 
-const sampleText = "abcdefghijklmnopqrstuvwx";
+const textBursts = ["abcdef", "ghijkl", "mnopqr", "stuvwx"] as const;
+const sampleText = textBursts.join("");
+
+interface FrameProbe {
+  active: boolean;
+  gaps: number[];
+  previous: number;
+}
 
 declare global {
   interface Window {
-    __tagiumInputProcessing?: Array<{ id: string; processingMs: number }>;
+    __tagiumFrameProbe?: FrameProbe;
   }
 }
-
-const enableAdvancedMetadata = async (page: Page) => {
-  await page.getByRole("button", { name: "settings" }).click();
-  await page.getByRole("button", { name: "editing", exact: true }).click();
-  await page.getByRole("checkbox", { name: "show advanced fields" }).click();
-  await page.getByRole("button", { name: "back to workspace" }).click();
-};
 
 const uploadAlbum = async (page: Page) => {
   const fixture = await materializeFixture("mp3");
@@ -27,83 +27,89 @@ const uploadAlbum = async (page: Page) => {
     })),
   );
   await expect(page.locator("#track-title")).toBeVisible();
+  await expect(page.getByText("library (40)", { exact: true })).toBeVisible();
+  await page.waitForTimeout(500);
 };
 
-const typeMeasuredText = async (page: Page, input: Locator) => {
-  await input.fill("");
-  await input.focus();
-  const inputId = await input.getAttribute("id");
-  await page.evaluate((id) => {
-    const entries = window.__tagiumInputProcessing;
-    if (!entries) throw new Error("input processing measurement was not installed");
-    for (let index = entries.length - 1; index >= 0; index--) {
-      if (entries[index]?.id === id) entries.splice(index, 1);
-    }
-  }, inputId);
-  for (const character of sampleText) {
-    await page.keyboard.type(character);
-    await page.evaluate(
-      () =>
-        new Promise<void>((resolve) =>
-          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
-        ),
-    );
-  }
-  await page.waitForTimeout(100);
+const percentile = (values: readonly number[], fraction: number) => {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.ceil(sorted.length * fraction) - 1] ?? Number.POSITIVE_INFINITY;
 };
 
-const readP95ProcessingTime = async (page: Page, targetId: string) =>
-  page.evaluate(
-    ({ id, sampleCount }) => {
-      const entries = window.__tagiumInputProcessing;
-      if (!entries) throw new Error("input processing measurement was not installed");
-
-      const samples = entries.filter((entry) => entry.id === id).map((entry) => entry.processingMs);
-      if (samples.length !== sampleCount) {
-        throw new Error(`expected ${sampleCount} ${id} samples, received ${samples.length}`);
-      }
-      samples.sort((left, right) => left - right);
-      return samples[Math.ceil(samples.length * 0.95) - 1] ?? Number.POSITIVE_INFINITY;
-    },
-    { id: targetId, sampleCount: sampleText.length },
+const measureBurstMax = async (page: Page, input: Locator, text: string) => {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const probe: FrameProbe = { active: true, gaps: [], previous: 0 };
+        window.__tagiumFrameProbe = probe;
+        const sample = (now: number) => {
+          if (!probe.active) return;
+          probe.gaps.push(now - probe.previous);
+          probe.previous = now;
+          requestAnimationFrame(sample);
+        };
+        requestAnimationFrame(() =>
+          requestAnimationFrame((now) => {
+            probe.previous = now;
+            requestAnimationFrame(sample);
+            resolve();
+          }),
+        );
+      }),
   );
-
-test("keeps track title editing responsive in a large album", async ({ page, browserName }) => {
-  test.skip(browserName !== "chromium", "Event Timing is covered in Chromium");
-  await page.goto("/");
-  await enableAdvancedMetadata(page);
-  await uploadAlbum(page);
-  await page.evaluate(() => {
-    const startedAt = new WeakMap<Event, number>();
-    const entries: { id: string; processingMs: number }[] = [];
-    window.__tagiumInputProcessing = entries;
-    document.addEventListener(
-      "input",
-      (event) => {
-        startedAt.set(event, performance.now());
-      },
-      true,
-    );
-    document.addEventListener("input", (event) => {
-      const start = startedAt.get(event);
-      if (start === undefined) return;
-      entries.push({
-        id: event.target instanceof HTMLElement ? event.target.id : "",
-        processingMs: performance.now() - start,
-      });
-    });
+  await input.pressSequentially(text, { delay: 30 });
+  await page.waitForTimeout(250);
+  return page.evaluate(() => {
+    const probe = window.__tagiumFrameProbe;
+    if (!probe) throw new Error("frame probe was not installed");
+    probe.active = false;
+    return Math.max(...probe.gaps);
   });
+};
 
-  await typeMeasuredText(page, page.locator("#track-title"));
-  await page.getByRole("button", { name: "advanced" }).click();
-  await typeMeasuredText(page, page.locator("#track-comment"));
+const measureTyping = async (page: Page, input: Locator) => {
+  const maxima: number[] = [];
+  await input.fill("warmup");
+  await page.waitForTimeout(250);
 
-  const titleP95 = await readP95ProcessingTime(page, "track-title");
-  const commentP95 = await readP95ProcessingTime(page, "track-comment");
+  for (let repetition = 0; repetition < 3; repetition++) {
+    await input.fill("");
+    await page.waitForTimeout(250);
+    await input.focus();
+    for (const burst of textBursts) {
+      maxima.push(await measureBurstMax(page, input, burst));
+    }
+  }
+
+  return { maxima, p75Max: percentile(maxima, 0.75) };
+};
+
+test("keeps track title editing as responsive as album title editing", async ({
+  page,
+  browserName,
+}) => {
+  test.skip(browserName !== "chromium", "frame timing is covered in Chromium");
+  await page.goto("/");
+  await uploadAlbum(page);
+
+  await page
+    .getByRole("button", { name: /^album actions for /u })
+    .first()
+    .click();
+  await page.getByRole("menuitem", { name: "edit album" }).click();
+  const albumTitle = page.locator("#album-title");
+  await expect(albumTitle).toBeVisible();
+  await page.waitForTimeout(400);
+  const album = await measureTyping(page, albumTitle);
+  await page.getByRole("button", { name: "cancel" }).click();
+  await expect(albumTitle).toBeHidden();
+  await page.waitForTimeout(400);
+
+  const track = await measureTyping(page, page.locator("#track-title"));
   expect(
-    titleP95,
-    `title p95 ${titleP95.toFixed(1)} ms; comment p95 ${commentP95.toFixed(1)} ms`,
-  ).toBeLessThanOrEqual(commentP95 + 8);
+    track.p75Max,
+    `track burst maxima ${track.maxima.map((value) => value.toFixed(1)).join(", ")} ms; album burst maxima ${album.maxima.map((value) => value.toFixed(1)).join(", ")} ms`,
+  ).toBeLessThanOrEqual(album.p75Max + 16);
   await expect(
     page.getByRole("button", { name: new RegExp(`${sampleText}\\.mp3`, "u") }).first(),
   ).toBeVisible();

--- a/tests/unit/features/editor/useTrackEditorSession.test.ts
+++ b/tests/unit/features/editor/useTrackEditorSession.test.ts
@@ -131,11 +131,13 @@ describe("track editor session", () => {
     hook.unmount();
   });
 
-  it("coalesces sidebar previews until typing pauses", () => {
-    vi.useFakeTimers();
+  it("previews a synced filename outside the library until flush", () => {
     const hook = renderHook(() => {
       const library = useLibraryStore();
-      return { library, editor: useTrackEditorSession({ library, settings }) };
+      return {
+        library,
+        editor: useTrackEditorSession({ library, settings: { ...settings, syncFilenames: true } }),
+      };
     }, undefined);
     const file = readyFile("track", "Original");
     act(() => {
@@ -155,20 +157,50 @@ describe("track editor session", () => {
       });
     }
 
-    act(() => {
-      vi.advanceTimersByTime(149);
-    });
     expect(hook.result.library.getSnapshot().files[0]?.metadata?.title).toBe("Original");
+    expect(hook.result.editor.filenamePreviewStore.getSnapshot(file.id)).toBe("Edited.mp3");
     act(() => {
-      vi.advanceTimersByTime(1);
+      hook.result.editor.commands.flush();
     });
     expect(hook.result.library.getSnapshot().files[0]).toMatchObject({
       status: "pending",
-      metadata: { title: "Edited" },
-      pendingMetadataPatch: { title: "Edited" },
+      filename: "Edited.mp3",
+      metadata: { filename: "Edited", title: "Edited" },
+      pendingMetadataPatch: { filename: "Edited", title: "Edited" },
     });
+    expect(hook.result.editor.filenamePreviewStore.getSnapshot(file.id)).toBeUndefined();
     hook.unmount();
-    vi.useRealTimers();
+  });
+
+  it("updates and clears filename previews when editor context changes", () => {
+    const syncedSettings = { ...settings, syncFilenames: true };
+    const hook = renderHook((currentSettings: AppSettings) => {
+      const library = useLibraryStore();
+      return { library, editor: useTrackEditorSession({ library, settings: currentSettings }) };
+    }, syncedSettings);
+    const file = readyFile("original", "Original");
+    act(() => {
+      hook.result.library.dispatch({
+        type: "content-replaced",
+        files: [file],
+        looseTrackIds: [file.id],
+        selection: { selectedAlbumId: null, selectedFileId: file.id },
+      });
+    });
+
+    const title = hook.result.editor.form.register("title");
+    act(() => {
+      void title.onChange({ target: { name: "title", value: "Edited" }, type: "change" });
+      hook.result.editor.commands.preview("title", "Edited");
+    });
+    expect(hook.result.editor.filenamePreviewStore.getSnapshot(file.id)).toBe("Edited.mp3");
+
+    hook.rerender(settings);
+    expect(hook.result.editor.filenamePreviewStore.getSnapshot(file.id)).toBe("original.mp3");
+
+    act(() => hook.result.library.dispatch({ type: "selection-cleared" }));
+    expect(hook.result.editor.filenamePreviewStore.getSnapshot(file.id)).toBeUndefined();
+    hook.unmount();
   });
 
   it("preserves pending edits while hydrating a downloaded file", async () => {

--- a/tests/unit/features/import/downloadPresentation.test.tsx
+++ b/tests/unit/features/import/downloadPresentation.test.tsx
@@ -7,6 +7,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { SortableTrackRow } from "@/features/library/AlbumSidebarDnd";
 import PlaylistDownloadQueuePanel from "@/features/import/PlaylistDownloadQueuePanel";
 import type { TagiumFile } from "@/features/library/types";
+import { createTrackFilenamePreviewStore } from "@/features/library/trackFilenamePreview";
 
 vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenu: ({ children }: { children?: ReactNode }) => <>{children}</>,
@@ -23,9 +24,11 @@ afterEach(() => {
 });
 
 describe("download presentation", () => {
+  const filenamePreviewStore = createTrackFilenamePreviewStore();
   const renderTrackRow = (track: TagiumFile) => (
     <SortableTrackRow
       track={track}
+      filenamePreviewStore={filenamePreviewStore}
       index={1}
       container="album"
       albumId="album-1"
@@ -67,6 +70,7 @@ describe("download presentation", () => {
     const markup = renderToStaticMarkup(
       <SortableTrackRow
         track={track}
+        filenamePreviewStore={filenamePreviewStore}
         index={15}
         container="album"
         albumId="album-1"

--- a/tests/unit/features/library/AlbumSidebar.test.tsx
+++ b/tests/unit/features/library/AlbumSidebar.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import AlbumSidebar from "@/features/library/AlbumSidebar";
 import { LOOSE_CONTAINER_ID } from "@/features/library/sidebarDnd";
 import type { TrackActionItem } from "@/features/library/trackActionItems";
+import { createTrackFilenamePreviewStore } from "@/features/library/trackFilenamePreview";
 
 vi.mock("@dnd-kit/core", () => ({
   DndContext: ({ children }: { children?: ReactNode }) => <>{children}</>,
@@ -58,6 +59,7 @@ vi.mock("@/features/library/useAlbumSidebarDragController", () => ({
 }));
 
 const noOp = () => {};
+const filenamePreviewStore = createTrackFilenamePreviewStore();
 
 describe("AlbumSidebar", () => {
   it("does not add height to an empty loose area during a track drag", () => {
@@ -66,6 +68,7 @@ describe("AlbumSidebar", () => {
         albums={[{ id: "album-a", title: "Album A", artist: "Artist", genre: "", trackIds: [] }]}
         looseTrackIds={[]}
         files={[]}
+        filenamePreviewStore={filenamePreviewStore}
         selectedAlbumId={null}
         selectedFileId={null}
         selectedFileIds={new Set()}
@@ -124,6 +127,7 @@ describe("AlbumSidebar", () => {
             downloadStatus: "ready",
           },
         ]}
+        filenamePreviewStore={filenamePreviewStore}
         selectedAlbumId={null}
         selectedFileId={null}
         selectedFileIds={new Set()}

--- a/tests/unit/features/library/AlbumSidebarDnd.test.tsx
+++ b/tests/unit/features/library/AlbumSidebarDnd.test.tsx
@@ -12,6 +12,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { createAlbumActionItems } from "@/features/library/albumActionItems";
 import { createTrackActionItems } from "@/features/library/trackActionItems";
 import type { TagiumFile } from "@/features/library/types";
+import { createTrackFilenamePreviewStore } from "@/features/library/trackFilenamePreview";
 
 vi.mock("@dnd-kit/sortable", () => ({
   useSortable: () => ({
@@ -33,6 +34,7 @@ import {
 } from "@/features/library/AlbumSidebarDnd";
 
 const noOp = () => {};
+const filenamePreviewStore = createTrackFilenamePreviewStore();
 const renderIconContents = (icon: IconSvgElement) =>
   renderToStaticMarkup(<HugeiconsIcon icon={icon} strokeWidth={2} />)
     .replace(/^<svg[^>]*>/, "")
@@ -155,6 +157,7 @@ describe("SortableTrackRow action menu", () => {
     const markup = renderToStaticMarkup(
       <SortableTrackRow
         track={track}
+        filenamePreviewStore={filenamePreviewStore}
         container="loose"
         selectedTone={null}
         muted={false}

--- a/tests/unit/features/library/TagSidebarPanel.test.tsx
+++ b/tests/unit/features/library/TagSidebarPanel.test.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vite-plus/test";
 import TagSidebarPanel from "@/features/library/TagSidebarPanel";
+import { createTrackFilenamePreviewStore } from "@/features/library/trackFilenamePreview";
 
 vi.mock("@/features/library/AlbumSidebar", () => ({
   default: () => <div data-testid="album-sidebar" />,
@@ -18,6 +19,7 @@ vi.mock("@/components/ui/tooltip", () => ({
 }));
 
 const noOp = () => {};
+const filenamePreviewStore = createTrackFilenamePreviewStore();
 
 describe("TagSidebarPanel", () => {
   it("remains visible when the closed mobile drawer is rendered at desktop widths", () => {
@@ -25,6 +27,7 @@ describe("TagSidebarPanel", () => {
       <TagSidebarPanel
         loading={false}
         files={[]}
+        filenamePreviewStore={filenamePreviewStore}
         albums={[]}
         looseTrackIds={[]}
         selectedAlbumId={null}

--- a/tests/unit/features/share/useShareWorkflow.test.tsx
+++ b/tests/unit/features/share/useShareWorkflow.test.tsx
@@ -487,6 +487,35 @@ describe("share workflow publication lifecycle", () => {
     token: "old-token",
   };
 
+  it("skips form projection when the selected track has no active publication", () => {
+    const file: TagiumFile = structuredClone(creatorFile);
+    const state = {
+      ...createLibraryState(),
+      files: [file],
+      looseTrackIds: [file.id],
+      selectedFileId: file.id,
+    };
+    const library: LibraryStore = {
+      state,
+      getSnapshot: () => state,
+      dispatch: vi.fn(),
+    };
+    const editor = fakeEditor([file]);
+    const hook = renderHook(
+      () =>
+        useShareWorkflow({
+          library,
+          editor,
+          importing: fakeImporting(vi.fn()),
+          enabled: true,
+        }),
+      undefined,
+    );
+
+    expect(editor.form.subscribe).not.toHaveBeenCalled();
+    hook.unmount();
+  });
+
   it("replaces a stopped publication with a fresh link", async () => {
     const album = creatorAlbum({ ...oldPublication, status: "stopped" });
     const { hook } = creatorWorkflow(album, creatorFile);


### PR DESCRIPTION
Stacked on #171 — review that one first.

## problem

Editing track metadata paused the main thread after short typing bursts. The editor's transient sidebar preview replaced the full library after 150 ms, which normalized library structure and rerendered every draggable track row. Production builds also projected every form edit through the share workflow even when no active publication needed a fingerprint.

## solution

- Keep live filename previews in a small per-track subscription so only the edited sidebar row updates.
- Commit form metadata to library state only at the existing flush boundaries used by selection, export, sharing, and workspace operations.
- Subscribe to live share-fingerprint projection only when the selected track or its album has an active publication.
- Replace the event-handler timing test with a frame-gap benchmark that covers delayed work and paint.

## human review

1. Import a multi-track album, then edit a track title in short bursts with brief pauses. The input should remain smooth and the matching sidebar filename should update live.
2. Open the album editor and type in the album title. Track-title editing should feel at least as responsive as album-title editing.
3. With a track edit still buffered, select another track, go Home, or download. Return to the track and confirm the metadata was preserved.
4. Toggle filename syncing after editing a title or filename. The sidebar preview should immediately follow the active setting and should not retain a deleted or previously selected track's preview.
5. If an active share publication is available, edit its track metadata and confirm the action changes from “view share link” to “update shared track.” Unpublished tracks should not perform share fingerprint work while typing.

Important edge cases: empty filenames should keep the existing validation behavior; removing an edited track should not leave a stale preview; active album publications must still notice edits to contained tracks.

The main tradeoff is that transient form values no longer enter structural library state on a timer. The sidebar still previews the filename immediately, while consumers that need authoritative metadata use the existing synchronous flush boundary.

## verification

- `bun run test` — 114 files, 786 tests passed
- `bun run typecheck`
- `bun run lint` — passed with existing module-mocking warnings
- `bun run build`
- `VITE_PUBLIC_SHARE_LINKS_ENABLED=true bun run test:e2e -- --project=chromium tests/e2e/title-editing-performance.spec.ts --workers=1`
- Impeccable detector — no findings

The measured track-title burst p75 dropped from about 75 ms before the fix to roughly 10 ms in the post-fix diagnostic run. The strengthened regression compares twelve real typing bursts against album editing and passes with production sharing enabled.

Manual verification is still useful for subjective feel on lower-end hardware.

Changes made by OpenAI gpt-5.6-sol in T3 Code through the Codex harness.
