### PR TITLE
fix: truncate long share titles

### DIFF
--- a/src/features/share/ShareAlbumDialog.tsx
+++ b/src/features/share/ShareAlbumDialog.tsx
@@ -148,7 +148,7 @@ function ShareAlbumDialogSession({
         showCloseButton={state.status !== "publishing" && !stopping}
       >
         <>
-          <DialogHeader className="border-b px-5 py-4 pr-12">
+          <DialogHeader className="min-w-0 border-b px-5 py-4 pr-12">
             <DialogTitle className="truncate text-left">
               {`share ${targetName}: ${state.preview.title}`}
             </DialogTitle>

--- a/src/features/share/ShareAlbumDialog.tsx
+++ b/src/features/share/ShareAlbumDialog.tsx
@@ -209,7 +209,7 @@ function ShareAlbumDialogSession({
             <div className="px-5 pb-4 text-left text-sm text-muted-foreground">
               {confirmStop ? (
                 <>
-                  {`the link will stop working immediately. anyone who already added the ${targetName} keeps their copy.`}
+                  the link will stop working immediately.
                   {stopError && (
                     <span role="alert" className="mt-1 block text-destructive">
                       {stopError}

--- a/tests/unit/features/share/shareAlbumDialog.test.tsx
+++ b/tests/unit/features/share/shareAlbumDialog.test.tsx
@@ -227,7 +227,6 @@ describe("share album dialog", () => {
     expect(before.filter((value) => value.includes("w-full"))).toHaveLength(2);
     expect(after.filter((value) => value.includes("w-full"))).toHaveLength(2);
     expect(text(renderer)).toContain("the link will stop working immediately.");
-    expect(text(renderer)).toContain("anyone who already added the album keeps their copy.");
     expect(text(renderer)).not.toContain("cover");
   });
 

--- a/tests/unit/features/share/shareAlbumDialog.test.tsx
+++ b/tests/unit/features/share/shareAlbumDialog.test.tsx
@@ -245,6 +245,41 @@ describe("share album dialog", () => {
     expect(renderer.root.findAllByProps({ "aria-label": "no album cover" })).toHaveLength(1);
   });
 
+  it("keeps long share titles within the dialog and truncates them", () => {
+    const longTitle = "TITLE".repeat(100);
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(
+        createElement(ShareAlbumDialog, {
+          state: {
+            status: "confirm",
+            preview: { ...preview, title: longTitle },
+          },
+          onClose: vi.fn(),
+          onPublish: vi.fn(),
+          onStopSharing: vi.fn(async () => undefined),
+        }),
+      );
+    });
+
+    const header = renderer.root.find(
+      (node) =>
+        node.type === "div" &&
+        Schema.is(Schema.String)(node.props.className) &&
+        node.props.className.includes("border-b"),
+    );
+    const title = renderer.root.find(
+      (node) =>
+        node.type === "div" &&
+        Schema.is(Schema.String)(node.props.className) &&
+        node.props.className.includes("truncate") &&
+        node.children.includes(`share album: ${longTitle}`),
+    );
+
+    expect(header.props.className).toContain("min-w-0");
+    expect(title.props.className).toContain("truncate");
+  });
+
   it("uses track-specific creator copy for a track publication", () => {
     let renderer!: ReactTestRenderer;
     act(() => {


### PR DESCRIPTION
## problem

very long track or album names give the share dialog header an intrinsic width larger than the dialog, causing horizontal overflow instead of an ellipsis. the stop-sharing confirmation also included an unnecessary sentence about copies already added.

## solution

allow the dialog header grid item to shrink so the existing single-line title truncation can take effect. simplify the stop-sharing confirmation to the immediate consequence: “the link will stop working immediately.” add a regression test with a long unbroken title and remove the obsolete copy assertion.

## review

- add or import a track or album with a title wider than the share dialog
- open its share screen
- expect the heading to stay on one line, end with an ellipsis, and keep the dialog within the viewport
- verify both track and album share screens, including a long unbroken title
- on a published share, choose “stop sharing”
- expect the confirmation text to say only “the link will stop working immediately.”
- expect ordinary titles, share actions, and the close control to remain unchanged

there are no business-logic changes. the full title remains in the rendered text; only its visual presentation is clipped.

automatically verified with `bun run typecheck`, `bun run build`, `bun run test` (787 tests before the copy-only follow-up), the focused share-dialog suite after both changes, `bun run lint` (pre-existing warnings only), and the impeccable UI detector. manual visual verification remains for review.

changes made by OpenAI Codex using gpt-5.6-sol in the T3 Code harness.